### PR TITLE
feat: Show Workspace as un-editable when clicking on older entries in Activity history

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -343,6 +343,18 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
 
         SwingUtilities.invokeLater(() -> {
             workspacePanel.populateContextTable(ctx);
+            // Determine if the current context (ctx) is the latest one in the history
+            boolean isEditable = false;
+            Context latestContext = contextManager.getContextHistory().topContext();
+            if (latestContext != null) {
+                isEditable = ctx.equals(latestContext);
+            } else if (ctx.getId() == 1) { 
+                // If context history is somehow uninitialized but we are setting the initial welcome context (ID 1),
+                // consider it editable. This is a fallback.
+                isEditable = true; 
+            }
+            // workspacePanel is a final field initialized in the constructor, so it won't be null here.
+            workspacePanel.setWorkspaceEditable(isEditable);
             if (resetOutput) {
                 if (ctx.getParsedOutput() != null) {
                     historyOutputPanel.resetLlmOutput(ctx.getParsedOutput(), forceScrollToTop);

--- a/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -80,6 +80,7 @@ public class WorkspacePanel extends JPanel {
 
     private JTable contextTable;
     private JPanel locSummaryLabel;
+    private boolean workspaceCurrentlyEditable = true;
 
     // Buttons
     // Table popup menu (when no row is selected)
@@ -104,13 +105,14 @@ public class WorkspacePanel extends JPanel {
         buildContextPanel();
 
         ((JLabel) locSummaryLabel.getComponent(0)).setText(EMPTY_CONTEXT);
+        setWorkspaceEditable(true); // Set initial state
     }
 
     /**
      * Build the context panel (unified table + action buttons).
      */
     private void buildContextPanel() {
-        contextTable = new JTable(new DefaultTableModel(new Object[]{"LOC", "Description", "Files Referenced", "Fragment"}, 0) {
+        DefaultTableModel tableModel = new DefaultTableModel(new Object[]{"LOC", "Description", "Files Referenced", "Fragment"}, 0) {
             @Override
             public boolean isCellEditable(int row, int column) {
                 return false;
@@ -126,7 +128,18 @@ public class WorkspacePanel extends JPanel {
                     default -> Object.class;
                 };
             }
-        });
+        };
+
+        contextTable = new JTable(tableModel) {
+            @Override
+            public Component prepareRenderer(javax.swing.table.TableCellRenderer renderer, int row, int column) {
+                Component c = super.prepareRenderer(renderer, row, column);
+                if (c != null) {
+                    c.setEnabled(workspaceCurrentlyEditable);
+                }
+                return c;
+            }
+        };
 
         // Add custom cell renderer for the "Description" column
         contextTable.getColumnModel().getColumn(1).setCellRenderer(new javax.swing.table.DefaultTableCellRenderer() {
@@ -1430,5 +1443,19 @@ public class WorkspacePanel extends JPanel {
             logger.error("IOException during HEAD request to {}: {}", uri, e.getMessage());
         }
         return false;
+    }
+
+    /**
+     * Sets the editable state of the workspace panel.
+     *
+     * @param editable true to make the workspace editable, false otherwise.
+     */
+    public void setWorkspaceEditable(boolean editable) {
+        SwingUtilities.invokeLater(() -> {
+            this.workspaceCurrentlyEditable = editable;
+            if (contextTable != null) {
+                contextTable.repaint();
+            }
+        });
     }
 }


### PR DESCRIPTION
Workspace is shown as un-editable when an older entry is selected in Activity history.