### PR TITLE
fix: Only allow editing of git-tracked project files

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/FileSelectionPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/FileSelectionPanel.java
@@ -519,45 +519,21 @@ public class FileSelectionPanel extends JPanel {
             Path absolutePath = path.toAbsolutePath().normalize();
 
             String pathForReplacement;
-            String summaryPathString;
-
-            if (!this.allowExternalFiles && this.project != null && absolutePath.startsWith(this.project.getRoot())) {
-                Path relativePath = this.project.getRoot().relativize(absolutePath);
-                if (relativePath.toString().isEmpty()) { // Path is the project root itself
-                    Path projectRootFileName = absolutePath.getFileName();
-                    String baseName = (projectRootFileName != null) ? projectRootFileName.toString() : ".";
-                    pathForReplacement = baseName;
-                    summaryPathString = baseName; //relative (or base name for root)
-                } else {
-                    pathForReplacement = relativePath.toString();
-                    summaryPathString = relativePath.toString(); // relative
-                }
+            if (!this.allowExternalFiles
+                    && this.project != null
+                    && absolutePath.startsWith(this.project.getRoot())) {
+                pathForReplacement = this.project.getRoot().relativize(absolutePath).toString();
             } else {
-                // Path is external, or project conditions for relative path not met.
-                // Both pathForReplacement and summaryPathString should be absolute.
                 pathForReplacement = absolutePath.toString();
-                summaryPathString = absolutePath.toString(); // absolute
             }
 
-            String displayFileName;
-            Path fileNamePath = absolutePath.getFileName();
-            if (fileNamePath == null) { // e.g. for root "C:/" or "/"
-                displayFileName = absolutePath.toString();
-            } else {
-                displayFileName = fileNamePath.toString();
-            }
+            String summaryPathString = pathForReplacement; // same as replacement target
+            String displayFileName = Objects.requireNonNull(absolutePath.getFileName()).toString();
 
-            if (Files.isDirectory(absolutePath)) {
-                String separator = absolutePath.getFileSystem().getSeparator();
-                if (!displayFileName.endsWith(separator)) {
-                    displayFileName += separator;
-                }
-                if (!pathForReplacement.endsWith(separator)) {
-                    pathForReplacement += separator;
-                }
-            }
+            String replacementText = multiSelectMode
+                    ? quotePathIfNecessary(pathForReplacement) + " "
+                    : pathForReplacement;
 
-            String replacementText = multiSelectMode ? quotePathIfNecessary(pathForReplacement) + " " : pathForReplacement;
             return new ShorthandCompletion(this, displayFileName, replacementText, summaryPathString);
         }
 


### PR DESCRIPTION
Adding files using wildcards on Edit dialog should not include files that are not tracked by git.