### PR TITLE
Syntax Highlighting in Diff View

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/difftool/ui/BufferDiffPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/ui/BufferDiffPanel.java
@@ -91,11 +91,12 @@ public class BufferDiffPanel extends AbstractContentPanel
         this.patch = diffNode.getPatch(); // new Patch or null
 
         // Set the documents into our file panels:
-        if (filePanels[LEFT] != null && leftDocument != null) {
-            filePanels[LEFT].setBufferDocument(leftDocument);
-        }
+        // Order is important, The left panel will use the left panel syntax type if it can't figure its own
         if (filePanels[RIGHT] != null && rightDocument != null) {
             filePanels[RIGHT].setBufferDocument(rightDocument);
+        }
+        if (filePanels[LEFT] != null && leftDocument != null) {
+            filePanels[LEFT].setBufferDocument(leftDocument);
         }
 
         reDisplay();

--- a/src/main/java/io/github/jbellis/brokk/difftool/ui/CompositeHighlighter.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/ui/CompositeHighlighter.java
@@ -1,0 +1,105 @@
+package io.github.jbellis.brokk.difftool.ui;
+
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextAreaHighlighter;
+
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Highlighter;
+import javax.swing.text.JTextComponent;
+import java.awt.*;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * A Highlighter that extends {@link RSyntaxTextAreaHighlighter} to provide
+ * base syntax highlighting and then delegates to a secondary {@link Highlighter}
+ * (typically {@link JMHighlighter}) for additional decorations like diff/search.
+ *
+ * Mutating operations (add/remove highlights) are forwarded to the
+ * secondary highlighter.
+ */
+public class CompositeHighlighter extends RSyntaxTextAreaHighlighter
+{
+    private final Highlighter secondary;
+
+    /**
+     * Creates a composite highlighter.
+     *
+     * @param secondaryHighlighter The secondary highlighter to use for additional decorations.
+     *                             This is typically a {@link JMHighlighter}. It must not be null.
+     */
+    public CompositeHighlighter(Highlighter secondaryHighlighter)
+    {
+        super(); // Initializes this as an RSyntaxTextAreaHighlighter
+        if (secondaryHighlighter == null) {
+            throw new IllegalArgumentException("Secondary highlighter cannot be null");
+        }
+        this.secondary = secondaryHighlighter;
+    }
+
+    /* -------------------------------------------------- install / de-install */
+
+    @Override
+    public void install(JTextComponent c)
+    {
+        super.install(c); // RSyntaxTextAreaHighlighter's install
+        // The 'secondary' highlighter should also be associated with the component
+        // if it tracks the component state independently (like JMHighlighter does).
+        secondary.install(c);
+    }
+
+    @Override
+    public void deinstall(JTextComponent c)
+    {
+        super.deinstall(c); // RSyntaxTextAreaHighlighter's deinstall
+        secondary.deinstall(c);
+    }
+
+    /* -------------------------------------------------- painting */
+
+    @Override
+    public void paint(Graphics g)
+    {
+        super.paint(g);     // RSyntaxTextAreaHighlighter paints syntax highlights
+        secondary.paint(g);   // Secondary paints diff/search highlights on top
+    }
+
+    /* -------------------------------------------------- highlight mutation
+       – forward to JMHighlighter (secondary) */
+    @Override
+    public Object addHighlight(int p0, int p1, HighlightPainter painter) throws BadLocationException
+    {
+        // Delegate to secondary for custom highlights (diffs, search results)
+        return secondary.addHighlight(p0, p1, painter);
+    }
+
+    @Override
+    public void removeHighlight(Object tag)
+    {
+        secondary.removeHighlight(tag);
+    }
+
+    @Override
+    public void removeAllHighlights()
+    {
+        secondary.removeAllHighlights();
+    }
+
+    @Override
+    public void changeHighlight(Object tag, int p0, int p1) throws BadLocationException
+    {
+        secondary.changeHighlight(tag, p0, p1);
+    }
+
+    @Override
+    public Highlight[] getHighlights()
+    {
+        // Highlights from RSyntaxTextAreaHighlighter (e.g., syntax, mark occurrences)
+        Highlight[] a = super.getHighlights();
+        // Highlights from JMHighlighter (diffs, search results)
+        Highlight[] b = secondary.getHighlights();
+
+        return Stream.concat(Arrays.stream(a), Arrays.stream(b))
+                     .toArray(Highlight[]::new);
+    }
+}

--- a/src/main/java/io/github/jbellis/brokk/difftool/ui/CompositeHighlighter.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/ui/CompositeHighlighter.java
@@ -1,6 +1,5 @@
 package io.github.jbellis.brokk.difftool.ui;
 
-import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextAreaHighlighter;
 
 import javax.swing.text.BadLocationException;
@@ -11,33 +10,22 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 /**
- * A Highlighter that extends {@link RSyntaxTextAreaHighlighter} to provide
- * base syntax highlighting and then delegates to a secondary {@link Highlighter}
- * (typically {@link JMHighlighter}) for additional decorations like diff/search.
- *
- * Mutating operations (add/remove highlights) are forwarded to the
- * secondary highlighter.
+ * Extends {@link RSyntaxTextAreaHighlighter} to provide base syntax highlighting and delegates
+ * to a secondary {@link Highlighter} (typically {@link JMHighlighter}) for additional decorations like diff/search.
+ * Mutating operations are forwarded to the secondary highlighter.
  */
 public class CompositeHighlighter extends RSyntaxTextAreaHighlighter
 {
     private final Highlighter secondary;
 
-    /**
-     * Creates a composite highlighter.
-     *
-     * @param secondaryHighlighter The secondary highlighter to use for additional decorations.
-     *                             This is typically a {@link JMHighlighter}. It must not be null.
-     */
     public CompositeHighlighter(Highlighter secondaryHighlighter)
     {
-        super(); // Initializes this as an RSyntaxTextAreaHighlighter
+        super();
         if (secondaryHighlighter == null) {
             throw new IllegalArgumentException("Secondary highlighter cannot be null");
         }
         this.secondary = secondaryHighlighter;
     }
-
-    /* -------------------------------------------------- install / de-install */
 
     @Override
     public void install(JTextComponent c)
@@ -51,25 +39,21 @@ public class CompositeHighlighter extends RSyntaxTextAreaHighlighter
     @Override
     public void deinstall(JTextComponent c)
     {
-        super.deinstall(c); // RSyntaxTextAreaHighlighter's deinstall
+        super.deinstall(c);
         secondary.deinstall(c);
     }
-
-    /* -------------------------------------------------- painting */
 
     @Override
     public void paint(Graphics g)
     {
         super.paint(g);     // RSyntaxTextAreaHighlighter paints syntax highlights
-        secondary.paint(g);   // Secondary paints diff/search highlights on top
+        secondary.paint(g); // Secondary paints diff/search highlights on top
     }
 
-    /* -------------------------------------------------- highlight mutation
-       – forward to JMHighlighter (secondary) */
     @Override
     public Object addHighlight(int p0, int p1, HighlightPainter painter) throws BadLocationException
     {
-        // Delegate to secondary for custom highlights (diffs, search results)
+        // forward to JMHighlighter (secondary)
         return secondary.addHighlight(p0, p1, painter);
     }
 

--- a/src/main/java/io/github/jbellis/brokk/difftool/ui/FilePanel.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/ui/FilePanel.java
@@ -30,6 +30,7 @@ import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import javax.swing.SwingUtilities;
 
 import io.github.jbellis.brokk.difftool.ui.CompositeHighlighter;
+import io.github.jbellis.brokk.util.SyntaxDetector;
 
 public class FilePanel implements BufferDocumentChangeListenerIF {
     private static final int MAXSIZE_CHANGE_DIFF = 1000;
@@ -399,20 +400,7 @@ public class FilePanel implements BufferDocumentChangeListenerIF {
                 var lastDot = candidate.lastIndexOf('.');
                 if (lastDot > 0 && lastDot < candidate.length() - 1) {
                     var ext = candidate.substring(lastDot + 1).toLowerCase();
-                    style = switch (ext) {
-                        case "java"            -> SyntaxConstants.SYNTAX_STYLE_JAVA;
-                        case "js", "jsx"       -> SyntaxConstants.SYNTAX_STYLE_JAVASCRIPT;
-                        case "json"            -> SyntaxConstants.SYNTAX_STYLE_JSON;
-                        case "xml"             -> SyntaxConstants.SYNTAX_STYLE_XML;
-                        case "html", "htm"     -> SyntaxConstants.SYNTAX_STYLE_HTML;
-                        case "py"              -> SyntaxConstants.SYNTAX_STYLE_PYTHON;
-                        case "sql"             -> SyntaxConstants.SYNTAX_STYLE_SQL;
-                        case "sh", "bash"      -> SyntaxConstants.SYNTAX_STYLE_UNIX_SHELL;
-                        case "yaml", "yml"     -> SyntaxConstants.SYNTAX_STYLE_YAML;
-                        case "css"             -> SyntaxConstants.SYNTAX_STYLE_CSS;
-                        case "md", "markdown"  -> SyntaxConstants.SYNTAX_STYLE_MARKDOWN;
-                        default                -> SyntaxConstants.SYNTAX_STYLE_NONE;
-                    };
+                    style = SyntaxDetector.fromExtension(ext);
                 }
             }
         }


### PR DESCRIPTION
Fixes issue #51 by implementing a composite highlighter (aided by brokks' suggestion) that extends `RSyntaxTextAreaHighlighter` while delegating to `JMHighlighter`. This approach enables sequential highlighting from both classes, thus showing syntax coloring and diff markers.
Implementation required document synchronization between `RSyntaxTextArea`'s internal model and Brokk's model to ensure consistency.

Some screenshots:
<img width="1405" alt="screenshot-Diff CompositeHighlighter java  Local vs HEAD -2025-05-27-16-44-43" src="https://github.com/user-attachments/assets/f821d439-2d5d-411a-8ac9-e1a26a368d71" />
<img width="1405" alt="screenshot-Diff CompositeHighlighter java  Local vs HEAD -2025-05-27-14-45-38" src="https://github.com/user-attachments/assets/0cade38c-ed72-4dd2-8fe4-5afcbcbf0481" />
