### PR TITLE
Refactoring/theme setting

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -381,7 +381,6 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
 
     public void switchTheme(boolean isDark) {
         themeManager.applyTheme(isDark);
-        historyOutputPanel.updateTheme(isDark);
     }
 
     @Override

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -286,8 +286,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         String currentTheme = Project.getTheme();
         logger.trace("Applying theme from project settings: {}", currentTheme);
         boolean isDark = THEME_DARK.equalsIgnoreCase(currentTheme);
-        themeManager.applyTheme(isDark);
-        historyOutputPanel.updateTheme(isDark);
+        switchTheme(isDark);
     }
 
     /**
@@ -385,14 +384,6 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     public void switchTheme(boolean isDark) {
         themeManager.applyTheme(isDark);
         historyOutputPanel.updateTheme(isDark);
-        for (Window window : Window.getWindows()) {
-            if (window instanceof JFrame && window != frame) {
-                Container contentPane = ((JFrame) window).getContentPane();
-                if (contentPane instanceof PreviewTextPanel) {
-                    ((PreviewTextPanel) contentPane).updateTheme(themeManager);
-                }
-            }
-        }
     }
 
     @Override

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -285,7 +285,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         // Apply current theme based on project settings
         String currentTheme = Project.getTheme();
         logger.trace("Applying theme from project settings: {}", currentTheme);
-        boolean isDark = THEME_DARK.equalsIgnoreCase(currentTheme);
+        boolean isDark = GuiTheme.THEME_DARK.equalsIgnoreCase(currentTheme);
         switchTheme(isDark);
     }
 
@@ -378,8 +378,6 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
 
     // Theme manager and constants
     GuiTheme themeManager;
-    private static final String THEME_DARK = "dark";
-    private static final String THEME_LIGHT = "light";
 
     public void switchTheme(boolean isDark) {
         themeManager.applyTheme(isDark);

--- a/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
@@ -103,7 +103,7 @@ public class GuiTheme {
                 if (window instanceof JDialog dialog) {
                     // 1. ThemeAware dialogs can theme themselves
                     if (dialog instanceof ThemeAware aware) {
-                        aware.applyTheme(this, theme);
+                        aware.applyTheme(this);
                     }
                     applyThemeRecursively(dialog.getContentPane(), theme);
                 }
@@ -130,7 +130,7 @@ public class GuiTheme {
 
         switch (component) {
             // 1. Give ThemeAware components first crack at theming themselves
-            case ThemeAware aware -> aware.applyTheme(this, theme);
+            case ThemeAware aware -> aware.applyTheme(this);
             // 2. Plain RSyntaxTextArea
             case RSyntaxTextArea area -> theme.apply(area);
             // 3. Handle the common case of RSyntaxTextArea wrapped in a JScrollPane

--- a/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
@@ -104,7 +104,7 @@ public class GuiTheme {
                         if (dialog instanceof ThemeAware aware) {
                             aware.applyTheme(this);
                         }
-                        applyThemeRecursively(dialog.getContentPane(), theme);
+                        applyThemeToComponent(dialog.getContentPane(), theme);
                     }
                 }
             })
@@ -133,14 +133,16 @@ public class GuiTheme {
      * supplied frame.
      */
     private void applyThemeToFrame(JFrame frame, Theme theme) {
-        applyThemeRecursively(frame.getContentPane(), theme);
+        assert SwingUtilities.isEventDispatchThread() : "applyThemeToFrame must be called on EDT";
+        applyThemeToComponent(frame.getContentPane(), theme);
     }
 
     /**
      * Recursive depth-first traversal of the Swing component hierarchy that honours the
      * {@link io.github.jbellis.brokk.gui.ThemeAware} contract.
      */
-    private void applyThemeRecursively(Component component, Theme theme) {
+    private void applyThemeToComponent(Component component, Theme theme) {
+        assert SwingUtilities.isEventDispatchThread() : "applyThemeToComponent must be called on EDT";
         if (component == null) {
             return;
         }
@@ -153,7 +155,7 @@ public class GuiTheme {
             // 3. Handle the common case of RSyntaxTextArea wrapped in a JScrollPane
             case JScrollPane scrollPane -> {
                 Component view = scrollPane.getViewport().getView();
-                applyThemeRecursively(view, theme);
+                applyThemeToComponent(view, theme);
             }
             default -> { }
         }
@@ -161,7 +163,7 @@ public class GuiTheme {
         // 4. Recurse into child components (if any)
         if (component instanceof Container container) {
             for (Component child : container.getComponents()) {
-                applyThemeRecursively(child, theme);
+                applyThemeToComponent(child, theme);
             }
         }
     }

--- a/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
@@ -5,29 +5,31 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.Theme;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.Optional;
 
 /**
  * Manages UI theme settings and application across the application.
  */
 public class GuiTheme {
     private static final Logger logger = LogManager.getLogger(GuiTheme.class);
-    
+
     public static final String THEME_DARK = "dark";
     public static final String THEME_LIGHT = "light";
 
     private final JFrame frame;
     private final JScrollPane mainScrollPane;
     private final Chrome chrome;
-    
+
     // Track registered popup menus that need theme updates
     private final List<JPopupMenu> popupMenus = new ArrayList<>();
-    
+
     /**
      * Creates a new theme manager
      *
@@ -40,14 +42,14 @@ public class GuiTheme {
         this.mainScrollPane = mainScrollPane;
         this.chrome = chrome;
     }
-    
+
     /**
      * Applies the current theme to the application
-     * 
+     *
      * @param isDark true for dark theme, false for light theme
      */
     public void applyTheme(boolean isDark) {
-        String themeName = isDark ? THEME_DARK : THEME_LIGHT;
+        String themeName = getThemeName(isDark);
 
         try {
             // Save preference first so we know the value is stored
@@ -59,13 +61,13 @@ public class GuiTheme {
             } else {
                 com.formdev.flatlaf.FlatLightLaf.setup();
             }
-            
+
             // Apply theme to RSyntaxTextArea components
             applyThemeAsync(themeName);
-            
+
             // Update the UI
             SwingUtilities.updateComponentTreeUI(frame);
-            
+
             // Update registered popup menus
             for (JPopupMenu menu : popupMenus) {
                 SwingUtilities.updateComponentTreeUI(menu);
@@ -79,38 +81,53 @@ public class GuiTheme {
             chrome.toolErrorRaw("Failed to switch theme: " + e.getMessage());
         }
     }
-    
+
+    @NotNull
+    private static String getThemeName(boolean isDark) {
+        return isDark ? THEME_DARK : THEME_LIGHT;
+    }
+
     /**
      * Applies the appropriate theme to all RSyntaxTextArea components
      * @param themeName "dark" or "light"
      */
     private void applyThemeAsync(String themeName) {
-        String themeResource = "/org/fife/ui/rsyntaxtextarea/themes/%s".formatted(themeName.equals(THEME_DARK) ? "dark.xml" : "default.xml");
-        Theme theme;
-        try {
-            theme = Theme.load(getClass().getResourceAsStream(themeResource));
-        } catch (Exception e) {
-            logger.error("Could not load {} from {}", themeName, themeResource, e);
-            return;
-        }
-
-        // Apply to all RSyntaxTextArea components in open windows
-        SwingUtilities.invokeLater(() -> {
-            for (Window window : Window.getWindows()) {
-                if (window instanceof JFrame win) {
-                    applyThemeToFrame(win, theme);
-                }
-                if (window instanceof JDialog dialog) {
-                    // 1. ThemeAware dialogs can theme themselves
-                    if (dialog instanceof ThemeAware aware) {
-                        aware.applyTheme(this);
+        loadRSyntaxTheme(THEME_DARK.equals(themeName)).ifPresent(theme ->
+            // Apply to all RSyntaxTextArea components in open windows
+            SwingUtilities.invokeLater(() -> {
+                for (Window window : Window.getWindows()) {
+                    if (window instanceof JFrame win) {
+                        applyThemeToFrame(win, theme);
                     }
-                    applyThemeRecursively(dialog.getContentPane(), theme);
+                    if (window instanceof JDialog dialog) {
+                        // 1. ThemeAware dialogs can theme themselves
+                        if (dialog instanceof ThemeAware aware) {
+                            aware.applyTheme(this);
+                        }
+                        applyThemeRecursively(dialog.getContentPane(), theme);
+                    }
                 }
-            }
-        });
+            })
+        );
     }
-    
+
+    /**
+     * Loads an RSyntaxTextArea theme.
+     *
+     * @param isDark true for dark theme, false for light theme
+     * @return The loaded Theme object, or null if loading fails.
+     */
+    private static Optional<Theme> loadRSyntaxTheme(boolean isDark) {
+        String themeChoice = getThemeName(isDark);
+        String themeResource = String.format("/org/fife/ui/rsyntaxtextarea/themes/%s.xml", isDark ? "dark" : "default");
+        try {
+            return Optional.of(Theme.load(GuiTheme.class.getResourceAsStream(themeResource)));
+        } catch (IOException e) {
+            logger.error("Could not load {} RSyntaxTextArea theme from {}", themeChoice, themeResource, e);
+            return Optional.empty();
+        }
+    }
+
     /**
      * Applies the syntax theme to every relevant component contained in the
      * supplied frame.
@@ -156,7 +173,7 @@ public class GuiTheme {
     public boolean isDarkTheme() {
         return THEME_DARK.equalsIgnoreCase(Project.getTheme());
     }
-    
+
     /**
      * Registers a popup menu to receive theme updates
      * @param menu The popup menu to register
@@ -164,7 +181,7 @@ public class GuiTheme {
     public void registerPopupMenu(JPopupMenu menu) {
         if (!popupMenus.contains(menu)) {
             popupMenus.add(menu);
-            
+
             // Apply current theme immediately if already initialized
             SwingUtilities.invokeLater(() -> SwingUtilities.updateComponentTreeUI(menu));
         }
@@ -175,17 +192,8 @@ public class GuiTheme {
      * @param textArea The text area to apply theme to
      */
     public void applyCurrentThemeToComponent(RSyntaxTextArea textArea) {
-        SwingUtilities.invokeLater(() -> {
-            try {
-                String currentTheme = Project.getTheme();
-                String themeResource = "/org/fife/ui/rsyntaxtextarea/themes/" +
-                                      (currentTheme.equals(THEME_DARK) ? "dark.xml" : "default.xml");
-
-                Theme.load(getClass().getResourceAsStream(themeResource))
-                    .apply(textArea);
-            } catch (Exception e) {
-                logger.warn("Could not apply theme to RSyntaxTextArea component", e);
-            }
-        });
+        loadRSyntaxTheme(isDarkTheme()).ifPresent(theme ->
+            SwingUtilities.invokeLater(() -> theme.apply(textArea))
+        );
     }
 }

--- a/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -543,13 +543,6 @@ public class HistoryOutputPanel extends JPanel {
     }
 
     /**
-     * Updates the theme of the output components
-     */
-    public void updateTheme(boolean isDark) {
-        llmStreamArea.updateTheme(isDark);
-    }
-
-    /**
      * Shows the loading spinner with a message in the Markdown area.
      */
     public void showSpinner(String message) {

--- a/src/main/java/io/github/jbellis/brokk/gui/ThemeAware.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/ThemeAware.java
@@ -15,8 +15,6 @@ public interface ThemeAware {
      * @param guiTheme    reference to the central theme manager (handy for
      *                    delegating to helper methods such as
      *                    {@link GuiTheme#applyCurrentThemeToComponent})
-     * @param syntaxTheme a pre-loaded RSyntaxTextArea {@link Theme}.
-     *                    Implementations may ignore it and do their own thing.
      */
-    void applyTheme(GuiTheme guiTheme, Theme syntaxTheme);
+    void applyTheme(GuiTheme guiTheme);
 }

--- a/src/main/java/io/github/jbellis/brokk/gui/ThemeAware.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/ThemeAware.java
@@ -11,6 +11,8 @@ public interface ThemeAware {
 
     /**
      * Called by {@link GuiTheme} when the global theme changes.
+     * Implementations should call SwingUtilities.updateComponentTreeUI(this) on themselves
+     * This method is always called on the EDT
      *
      * @param guiTheme    reference to the central theme manager (handy for
      *                    delegating to helper methods such as

--- a/src/main/java/io/github/jbellis/brokk/gui/ThemeAware.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/ThemeAware.java
@@ -1,0 +1,22 @@
+package io.github.jbellis.brokk.gui;
+
+import org.fife.ui.rsyntaxtextarea.Theme;
+
+/**
+ * Components that know how to (re-)apply a syntax theme should implement this
+ * interface so that {@link GuiTheme} can delegate the work to them while
+ * walking the Swing component tree.
+ */
+public interface ThemeAware {
+
+    /**
+     * Called by {@link GuiTheme} when the global theme changes.
+     *
+     * @param guiTheme    reference to the central theme manager (handy for
+     *                    delegating to helper methods such as
+     *                    {@link GuiTheme#applyCurrentThemeToComponent})
+     * @param syntaxTheme a pre-loaded RSyntaxTextArea {@link Theme}.
+     *                    Implementations may ignore it and do their own thing.
+     */
+    void applyTheme(GuiTheme guiTheme, Theme syntaxTheme);
+}

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -45,6 +45,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import io.github.jbellis.brokk.analyzer.CodeUnit;
+import io.github.jbellis.brokk.gui.ThemeAware;
+import org.fife.ui.rsyntaxtextarea.Theme;
 
 /**
  * Displays text (typically code) using an {@link org.fife.ui.rsyntaxtextarea.RSyntaxTextArea}
@@ -52,7 +54,7 @@ import io.github.jbellis.brokk.analyzer.CodeUnit;
  *
  * <p>Supports editing {@link io.github.jbellis.brokk.analyzer.ProjectFile} content and capturing revisions.</p>
  */
-public class PreviewTextPanel extends JPanel {
+public class PreviewTextPanel extends JPanel implements ThemeAware {
     private static final Logger logger = LogManager.getLogger(PreviewTextPanel.class);
     private final PreviewTextArea textArea;
     private final JTextField searchField;
@@ -285,14 +287,12 @@ public class PreviewTextPanel extends JPanel {
     }
 
     /**
-     * Updates the theme of this panel. Called by Chrome when the theme changes.
-     *
-     * @param guiTheme The theme manager to use
+     * Implementation of {@link ThemeAware}. Delegates the actual work to
+     * {@link GuiTheme#applyCurrentThemeToComponent}.
      */
-    public void updateTheme(GuiTheme guiTheme) {
-        if (guiTheme != null) {
-            guiTheme.applyCurrentThemeToComponent(textArea);
-        }
+    @Override
+    public void applyTheme(GuiTheme guiTheme, Theme syntaxTheme) {
+        guiTheme.applyCurrentThemeToComponent(textArea);
     }
 
     /**

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -291,7 +291,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
      * {@link GuiTheme#applyCurrentThemeToComponent}.
      */
     @Override
-    public void applyTheme(GuiTheme guiTheme, Theme syntaxTheme) {
+    public void applyTheme(GuiTheme guiTheme) {
         guiTheme.applyCurrentThemeToComponent(textArea);
     }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -292,6 +292,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
      */
     @Override
     public void applyTheme(GuiTheme guiTheme) {
+        SwingUtilities.updateComponentTreeUI(this);
         guiTheme.applyCurrentThemeToComponent(textArea);
     }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
@@ -5,9 +5,12 @@ import io.github.jbellis.brokk.Project.DataRetentionPolicy;
 import io.github.jbellis.brokk.Service;
 import io.github.jbellis.brokk.agents.BuildAgent;
 import io.github.jbellis.brokk.gui.Chrome;
+import io.github.jbellis.brokk.gui.GuiTheme;
+import io.github.jbellis.brokk.gui.ThemeAware;
 import io.github.jbellis.brokk.gui.components.BrowserLabel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.fife.ui.rsyntaxtextarea.Theme;
 
 import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
@@ -24,7 +27,7 @@ import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.plaf.basic.BasicComboPopup;
 
-public class SettingsDialog extends JDialog {
+public class SettingsDialog extends JDialog implements ThemeAware {
     public static final String MODELS_TAB = "Models";
 
     private static final Logger logger = LogManager.getLogger(SettingsDialog.class);
@@ -979,6 +982,13 @@ public class SettingsDialog extends JDialog {
         dialog.add(new JScrollPane(checkBoxesPanel), BorderLayout.CENTER);
         dialog.add(buttonPanel, BorderLayout.SOUTH);
         dialog.setVisible(true);
+    }
+
+    @Override
+    public void applyTheme(GuiTheme guiTheme, Theme syntaxTheme) {
+        var previousSize = SettingsDialog.this.getSize();
+        SwingUtilities.updateComponentTreeUI(SettingsDialog.this);
+        SettingsDialog.this.setSize(previousSize); // Restore previous size
     }
 
 

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
@@ -985,7 +985,7 @@ public class SettingsDialog extends JDialog implements ThemeAware {
     }
 
     @Override
-    public void applyTheme(GuiTheme guiTheme, Theme syntaxTheme) {
+    public void applyTheme(GuiTheme guiTheme) {
         var previousSize = SettingsDialog.this.getSize();
         SwingUtilities.updateComponentTreeUI(SettingsDialog.this);
         SettingsDialog.this.setSize(previousSize); // Restore previous size

--- a/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
@@ -75,7 +75,7 @@ public class MarkdownOutputPanel extends JPanel implements Scrollable, ThemeAwar
 
 
     @Override
-    public void applyTheme(GuiTheme guiTheme, Theme syntaxTheme) {
+    public void applyTheme(GuiTheme guiTheme) {
         updateTheme(guiTheme.isDarkTheme());
     }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
@@ -110,6 +110,7 @@ public class MarkdownOutputPanel extends JPanel implements Scrollable, ThemeAwar
         // Extract existing messages to re-add them, which will apply the new theme
         var currentMessages = bubbles.stream().map(Bubble::message).toList();
         setText(currentMessages); // This will clear and re-add, applying the new theme
+        SwingUtilities.updateComponentTreeUI(this);
 
         revalidate();
         repaint();

--- a/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
@@ -4,11 +4,14 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.ContextFragment;
 import io.github.jbellis.brokk.TaskEntry;
+import io.github.jbellis.brokk.gui.GuiTheme;
 import io.github.jbellis.brokk.gui.SwingUtil;
+import io.github.jbellis.brokk.gui.ThemeAware;
 import io.github.jbellis.brokk.gui.mop.stream.IncrementalBlockRenderer;
 import io.github.jbellis.brokk.util.Messages;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.fife.ui.rsyntaxtextarea.Theme;
 
 import javax.swing.*;
 import java.awt.*;
@@ -39,7 +42,7 @@ import java.util.stream.Stream;
  * The panel updates incrementally when messages are appended, only re-rendering the affected message
  * rather than the entire content, which prevents flickering during streaming updates.
  */
-public class MarkdownOutputPanel extends JPanel implements Scrollable {
+public class MarkdownOutputPanel extends JPanel implements Scrollable, ThemeAware {
     private static final Logger logger = LogManager.getLogger(MarkdownOutputPanel.class);
     private static long compactionRoundIdCounter = 0;
 
@@ -68,6 +71,12 @@ public class MarkdownOutputPanel extends JPanel implements Scrollable {
             t.setDaemon(true);
             return t;
         });
+    }
+
+
+    @Override
+    public void applyTheme(GuiTheme guiTheme, Theme syntaxTheme) {
+        updateTheme(guiTheme.isDarkTheme());
     }
 
     /**


### PR DESCRIPTION
When trying to track down the issue with the file diff in dark mode, I started looking at how the theme is set ando noted some windows (settings dialog, output window) weren't switching themes properly.

This PR fixes that by:

* Replacing custom edge-case handling with recursive component traversal
* Adding `ThemeAware` interface for components to handle their own theme switching logic
* Ensuring all Swing components receive theme updates

The new approach seems cleaner and and it fixes cases where windows were not switching:


https://github.com/user-attachments/assets/bed26db2-a073-4741-993f-c0abed2efa7d


