### PR TITLE
feat: GitHub Issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,8 @@ javaOptions ++= Seq(
   "-ea",
   "--add-modules=jdk.incubator.vector",
   "-Dbrokk.devmode=true",
-  "-Dbrokk.prtab=true"
+  "-Dbrokk.prtab=true",
+  "-Dbrokk.issuetab=true"
 )
 
 testFrameworks += new TestFramework("com.github.sbt.junit.JupiterFramework")

--- a/src/main/java/io/github/jbellis/brokk/GitHubAuth.java
+++ b/src/main/java/io/github/jbellis/brokk/GitHubAuth.java
@@ -94,6 +94,19 @@ public class GitHubAuth
         return instance;
     }
 
+    /**
+     * Invalidates the current GitHubAuth instance.
+     * This is typically called when a GitHub token changes or an explicit reset is needed.
+     */
+    public static synchronized void invalidateInstance() {
+        if (instance != null) {
+            logger.info("Invalidating GitHubAuth instance for {}/{} due to token change or explicit request.", instance.getOwner(), instance.getRepoName());
+            instance = null;
+        } else {
+            logger.info("GitHubAuth instance is already null. No action taken for invalidation request.");
+        }
+    }
+
     public String getOwner()
     {
         return owner;

--- a/src/main/java/io/github/jbellis/brokk/GitHubAuth.java
+++ b/src/main/java/io/github/jbellis/brokk/GitHubAuth.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
+import io.github.jbellis.brokk.git.GitRepo;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHRepository;
@@ -20,19 +21,77 @@ import java.util.List;
 public class GitHubAuth
 {
     private static final Logger logger = LogManager.getLogger(GitHubAuth.class);
+    private static GitHubAuth instance;
 
-    private final Project project;
     private final String owner;
     private final String repoName;
 
     private GitHub githubClient;
     private GHRepository ghRepository;
 
-    public GitHubAuth(Project project, String owner, String repoName)
+    public GitHubAuth(String owner, String repoName)
     {
-        this.project = project;
         this.owner = owner;
         this.repoName = repoName;
+    }
+
+    /**
+     * Gets the existing GitHubAuth instance, or creates a new one if not already created
+     * or if the instance is outdated (e.g., remote URL changed for the current project).
+     *
+     * @param project The current project, used to determine repository details.
+     * @return A GitHubAuth instance.
+     * @throws IOException If the Git repository is not available, the remote URL cannot be parsed,
+     *                     or connection to GitHub fails.
+     * @throws IllegalArgumentException If the project is null.
+     */
+    public static synchronized GitHubAuth getOrCreateInstance(Project project) throws IOException {
+        if (project == null) {
+            throw new IllegalArgumentException("Project cannot be null for GitHubAuth.");
+        }
+
+        var repo = (GitRepo) project.getRepo();
+        if (repo == null) {
+            if (instance != null) {
+                logger.info("Git repository not available for project '{}'. Invalidating GitHubAuth instance for {}/{}.",
+                            project.getRoot().getFileName().toString(), instance.getOwner(), instance.getRepoName());
+                instance = null;
+            }
+            throw new IOException("Git repository not available from project '" + project.getRoot().getFileName().toString() + "' for GitHubAuth.");
+        }
+
+        var remoteUrl = repo.getRemoteUrl();
+        // Use GitUiUtil for parsing owner/repo from URL
+        var currentOwnerRepo = io.github.jbellis.brokk.gui.GitUiUtil.parseOwnerRepoFromUrl(remoteUrl);
+
+        if (currentOwnerRepo == null) {
+            if (instance != null) {
+                logger.warn("Could not parse current owner/repo from remote URL for project '{}': {}. Invalidating GitHubAuth instance for {}/{}.",
+                            project.getRoot().getFileName().toString(), remoteUrl, instance.getOwner(), instance.getRepoName());
+                instance = null;
+            }
+            throw new IOException("Could not parse 'owner/repo' from remote: " + remoteUrl + " for GitHubAuth (project: " + project.getRoot().getFileName().toString() + ").");
+        }
+
+        if (instance != null &&
+                instance.getOwner().equals(currentOwnerRepo.owner()) &&
+                instance.getRepoName().equals(currentOwnerRepo.repo())) {
+            logger.debug("Using existing GitHubAuth instance for {}/{} (project {})", instance.getOwner(), instance.getRepoName(), project.getRoot().getFileName().toString());
+            return instance;
+        }
+
+        if (instance != null) {
+            logger.info("GitHubAuth instance for {}/{} (project {}) is outdated (current remote {}/{}). Re-creating.",
+                        instance.getOwner(), instance.getRepoName(), project.getRoot().getFileName().toString(), currentOwnerRepo.owner(), currentOwnerRepo.repo());
+        } else {
+            logger.info("No existing GitHubAuth instance. Creating new instance for {}/{} (project {})",
+                        currentOwnerRepo.owner(), currentOwnerRepo.repo(), project.getRoot().getFileName().toString());
+        }
+
+        GitHubAuth newAuth = new GitHubAuth(currentOwnerRepo.owner(), currentOwnerRepo.repo());
+        instance = newAuth;
+        logger.info("Created and set new GitHubAuth instance for {}/{} (project {})", newAuth.getOwner(), newAuth.getRepoName(), project.getRoot().getFileName().toString());
+        return instance;
     }
 
     public String getOwner()

--- a/src/main/java/io/github/jbellis/brokk/GitHubAuth.java
+++ b/src/main/java/io/github/jbellis/brokk/GitHubAuth.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
@@ -109,6 +110,16 @@ public class GitHubAuth
     public List<GHPullRequest> listOpenPullRequests(GHIssueState state) throws IOException
     {
         return getGhRepository().getPullRequests(state);
+    }
+
+    /**
+     * Lists issues for the connected repository based on the given state.
+     * Note: This may include Pull Requests as they are a type of Issue in GitHub's API.
+     * Filtering to exclude PRs can be done by checking `issue.isPullRequest()`.
+     */
+    public List<GHIssue> listIssues(GHIssueState state) throws IOException
+    {
+        return getGhRepository().getIssues(state);
     }
 
     /**

--- a/src/main/java/io/github/jbellis/brokk/Project.java
+++ b/src/main/java/io/github/jbellis/brokk/Project.java
@@ -683,6 +683,35 @@ public class Project implements IProject, AutoCloseable {
         return repo instanceof GitRepo;
     }
 
+    /**
+     * Checks if the project's Git repository is hosted on GitHub by inspecting the "origin" remote URL.
+     *
+     * @return {@code true} if the "origin" remote URL contains "github.com", {@code false} otherwise,
+     *         or if the remote URL is not set or the project doesn't use Git.
+     */
+    public boolean isGitHubRepo() {
+        if (!hasGit()) {
+            return false;
+        }
+        // We can safely cast to GitRepo because hasGit() checks this.
+        // However, getRemoteUrl is available on IGitRepo, which GitRepo implements.
+        // But getRemoteUrl is specific to GitRepo, not on IGitRepo in general.
+        // The IGitRepo interface in the provided context does not have getRemoteUrl.
+        // The GitRepo class *does* have getRemoteUrl("origin").
+        // So, we need to ensure 'repo' is indeed a GitRepo instance if we want to call that specific method.
+        // The current getRepo() returns IGitRepo.
+        // Let's assume getRepo() returns a GitRepo instance when hasGit() is true.
+        // If getRemoteUrl("origin") was on IGitRepo, we wouldn't need the cast.
+        // Given the context, if hasGit() is true, repo *is* a GitRepo.
+        var gitRepo = (GitRepo) getRepo(); // Assuming getRepo() returns GitRepo when hasGit() is true
+        String remoteUrl = gitRepo.getRemoteUrl("origin");
+
+        if (remoteUrl == null || remoteUrl.isBlank()) {
+            return false;
+        }
+        return remoteUrl.contains("github.com");
+    }
+
     public enum CpgRefresh {
         AUTO,
         ON_RESTART,

--- a/src/main/java/io/github/jbellis/brokk/gui/AutoScalingHtmlPane.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/AutoScalingHtmlPane.java
@@ -1,0 +1,69 @@
+package io.github.jbellis.brokk.gui;
+
+import javax.swing.text.*;
+import javax.swing.text.html.*;
+import java.awt.*;
+
+public class AutoScalingHtmlPane {
+
+    /** Plug-in editor kit */
+    static class ScalingHTMLEditorKit extends HTMLEditorKit {
+        // we keep the default parser, just swap the factory
+        @Override public ViewFactory getViewFactory() {
+            return new HTMLFactory() {
+                @Override public View create(Element elem) {
+                    View v = super.create(elem);
+                    return (v instanceof ImageView) ? new ScalingImageView(elem) : v;
+                }
+            };
+        }
+    }
+
+    /** The view that does the work */
+    static class ScalingImageView extends ImageView {
+        ScalingImageView(Element e) { super(e); }
+
+        /** Paint the image shrunk if necessary */
+        @Override public void paint(Graphics g, Shape a) {
+            Rectangle r = (a instanceof Rectangle) ? (Rectangle) a : a.getBounds();
+            Image img = getImage();
+            if (img == null) return;
+
+            int imgW = img.getWidth(null);
+            int imgH = img.getHeight(null);
+            if (imgW <= 0 || imgH <= 0) return;
+
+            int avail = getContainer().getWidth()
+                    - getContainer().getInsets().left
+                    - getContainer().getInsets().right;
+            float s = Math.min(1f, avail / (float) imgW);
+
+            int w = Math.round(imgW * s);
+            int h = Math.round(imgH * s);
+
+            g.drawImage(img, r.x, r.y, w, h, getContainer());
+        }
+
+        /** Tell the layout engine about the scaled size */
+        @Override public float getPreferredSpan(int axis) {
+            Image img = getImage();
+            if (img == null) return 0;
+
+            int imgW = img.getWidth(null);
+            int imgH = img.getHeight(null);
+
+            // width is 0 the first time the view is laid out
+            int avail = getContainer() == null ? 0
+                                               : getContainer().getWidth()
+                                - getContainer().getInsets().left
+                                - getContainer().getInsets().right;
+
+            if (avail <= 0) {              // pane not yet sized → skip scaling
+                return axis == View.X_AXIS ? imgW : imgH;
+            }
+
+            float scale = Math.min(1f, avail / (float) imgW);
+            return axis == View.X_AXIS ? imgW * scale : imgH * scale;
+        }
+    }
+}

--- a/src/main/java/io/github/jbellis/brokk/gui/CheckThreadViolationRepaintManager.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/CheckThreadViolationRepaintManager.java
@@ -25,12 +25,16 @@ public class CheckThreadViolationRepaintManager extends RepaintManager {
             return;
         }
 
-        // 2) Allow the JVM's animated-image thread (e.g. spinner GIFs)
-        //    The thread is created by sun.awt.image.ImageFetcher and is
-        //    named "AWT-Image" (older JDKs) or "Image Animator" (JDK 21+).
+        // 2) Allow the JVM's image loading threads (e.g., for animated GIFs).
+        //    These threads are typically created by sun.awt.image.ImageFetcher and may be named
+        //    "AWT-Image-%d" (older JDKs), "Image Animator %d" (JDK 21+), or "Image Fetcher %d".
         var threadName = Thread.currentThread().getName();
-        if (threadName != null && (threadName.startsWith("AWT-Image") || threadName.startsWith("Image Animator"))) {
-            // Updates driven by the image loader are thread-safe as they only call repaint(), which is documented as thread-safe.
+        if (threadName != null &&
+            (threadName.startsWith("AWT-Image") ||
+             threadName.startsWith("Image Animator") ||
+             threadName.startsWith("Image Fetcher"))) {
+            // Updates driven by the image loader (like ImageView.imageUpdate calling repaint)
+            // are generally safe as repaint() itself is documented as thread-safe.
             return;
         }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/GfmRenderer.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GfmRenderer.java
@@ -1,0 +1,56 @@
+package io.github.jbellis.brokk.gui;
+
+import com.vladsch.flexmark.ext.emoji.EmojiExtension;
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import com.vladsch.flexmark.util.misc.Extension;
+
+import java.util.List;
+
+/**
+ * Handles rendering of GitHub Flavored Markdown (GFM) to HTML.
+ * This class encapsulates the flexmark-java library setup for parsing and rendering
+ * with common GFM extensions like tables, strikethrough, and emoji.
+ * The parser and renderer instances are created once and reused for efficiency.
+ */
+public class GfmRenderer {
+    private final Parser flexmarkParser;
+    private final HtmlRenderer flexmarkRenderer;
+
+    /**
+     * Constructs a GfmRenderer, initializing the flexmark parser and renderer
+     * with GFM-specific extensions (Tables, Strikethrough, Emoji).
+     */
+    public GfmRenderer() {
+        List<Extension> extensions = List.of(
+                TablesExtension.create(),
+                StrikethroughExtension.create(),
+                EmojiExtension.create()
+        );
+        MutableDataSet options = new MutableDataSet()
+                .set(TablesExtension.MIN_SEPARATOR_DASHES, 1);
+
+        this.flexmarkParser = Parser.builder(options)
+                .extensions(extensions)
+                .build();
+        this.flexmarkRenderer = HtmlRenderer.builder(options)
+                .extensions(extensions)
+                .build();
+    }
+
+    /**
+     * Renders the given Markdown text to HTML.
+     * If the input markdownText is null, it will be treated as an empty string.
+     *
+     * @param markdownText The Markdown text to render.
+     * @return The rendered HTML string.
+     */
+    public String render(String markdownText) {
+        Node document = this.flexmarkParser.parse(markdownText == null ? "" : markdownText);
+        return this.flexmarkRenderer.render(document);
+    }
+}

--- a/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
@@ -74,7 +74,7 @@ public class GitIssuesTab extends JPanel {
         this.gitPanel = gitPanel;
         this.gfmRenderer = new GfmRenderer();
 
-        // Split panel with Issues on left (larger) and issue details on right (smaller)
+        // Split panel with Issues on left (larger) and issue description on right (smaller)
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         splitPane.setResizeWeight(0.6); // 60% for Issue list, 40% for details
 
@@ -184,7 +184,7 @@ public class GitIssuesTab extends JPanel {
 
         // Right side - Details of the selected issue
         JPanel issueDetailPanel = new JPanel(new BorderLayout());
-        issueDetailPanel.setBorder(BorderFactory.createTitledBorder("Issue Details"));
+        issueDetailPanel.setBorder(BorderFactory.createTitledBorder("Issue Description"));
 
         issueBodyTextPane = new JTextPane();
         issueBodyTextPane.setEditorKit(new AutoScalingHtmlPane.ScalingHTMLEditorKit());

--- a/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
@@ -1,0 +1,634 @@
+package io.github.jbellis.brokk.gui;
+
+import io.github.jbellis.brokk.ContextManager;
+import io.github.jbellis.brokk.GitHubAuth;
+import io.github.jbellis.brokk.git.GitRepo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHUser;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.awt.datatransfer.StringSelection;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+public class GitIssuesTab extends JPanel {
+    private static final Logger logger = LogManager.getLogger(GitIssuesTab.class);
+
+    // Issue Table Column Indices
+    private static final int ISSUE_COL_NUMBER    = 0;
+    private static final int ISSUE_COL_TITLE     = 1;
+    private static final int ISSUE_COL_AUTHOR    = 2;
+    private static final int ISSUE_COL_UPDATED   = 3;
+    private static final int ISSUE_COL_LABELS    = 4;
+    private static final int ISSUE_COL_ASSIGNEES = 5;
+    private static final int ISSUE_COL_STATUS    = 6;
+
+    private final Chrome chrome;
+    private final ContextManager contextManager;
+    private final GitPanel gitPanel;
+
+    private JTable issueTable;
+    private DefaultTableModel issueTableModel;
+    private JTextPane issueBodyTextPane;
+    private JButton copyIssueDescriptionButton;
+    private JButton openInBrowserButton;
+
+    private FilterBox statusFilter;
+    private FilterBox authorFilter;
+    private FilterBox labelFilter;
+    private FilterBox assigneeFilter;
+
+    private List<GHIssue> allIssuesFromApi = new ArrayList<>();
+    private List<GHIssue> displayedIssues = new ArrayList<>();
+
+    // Store default options for static filters to easily reset them
+    private static final List<String> STATUS_FILTER_OPTIONS = List.of("Open", "Closed"); // "All" is null selection
+
+    // Lists to hold choices for dynamic filters
+    private List<String> authorChoices = new ArrayList<>();
+    private List<String> labelChoices = new ArrayList<>();
+    private List<String> assigneeChoices = new ArrayList<>();
+
+    private GitHubAuth gitHubAuth;
+    private final GfmRenderer gfmRenderer;
+
+
+    public GitIssuesTab(Chrome chrome, ContextManager contextManager, GitPanel gitPanel) {
+        super(new BorderLayout());
+        this.chrome = chrome;
+        this.contextManager = contextManager;
+        this.gitPanel = gitPanel;
+        this.gfmRenderer = new GfmRenderer();
+
+        // Split panel with Issues on left (larger) and issue details on right (smaller)
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+        splitPane.setResizeWeight(0.6); // 60% for Issue list, 40% for details
+
+        // --- Left side - Issues table and filters ---
+        // This mainIssueAreaPanel will hold filters on WEST and table+buttons on CENTER
+        JPanel mainIssueAreaPanel = new JPanel(new BorderLayout(Constants.H_GAP, 0));
+        mainIssueAreaPanel.setBorder(BorderFactory.createTitledBorder("Issues"));
+
+        // Vertical Filter Panel
+        JPanel verticalFilterPanel = new JPanel();
+        verticalFilterPanel.setLayout(new BoxLayout(verticalFilterPanel, BoxLayout.Y_AXIS));
+
+        JLabel filterLabel = new JLabel("Filter:");
+        filterLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        verticalFilterPanel.add(filterLabel);
+        verticalFilterPanel.add(Box.createVerticalStrut(Constants.V_GAP)); // Space after label
+
+        statusFilter = new FilterBox(this.chrome, "Status", () -> STATUS_FILTER_OPTIONS, "Open");
+        statusFilter.setToolTipText("Filter by issue status");
+        statusFilter.setAlignmentX(Component.LEFT_ALIGNMENT);
+        statusFilter.addPropertyChangeListener("value", e -> {
+            // Status filter change triggers a new API fetch
+            updateIssueList();
+        });
+        verticalFilterPanel.add(statusFilter);
+
+        authorFilter = new FilterBox(this.chrome, "Author", this::getAuthorFilterOptions);
+        authorFilter.setToolTipText("Filter by author");
+        authorFilter.setAlignmentX(Component.LEFT_ALIGNMENT);
+        authorFilter.addPropertyChangeListener("value", e -> filterAndDisplayIssues());
+        verticalFilterPanel.add(authorFilter);
+
+        labelFilter = new FilterBox(this.chrome, "Label", this::getLabelFilterOptions);
+        labelFilter.setToolTipText("Filter by label");
+        labelFilter.setAlignmentX(Component.LEFT_ALIGNMENT);
+        labelFilter.addPropertyChangeListener("value", e -> filterAndDisplayIssues());
+        verticalFilterPanel.add(labelFilter);
+
+        assigneeFilter = new FilterBox(this.chrome, "Assignee", this::getAssigneeFilterOptions);
+        assigneeFilter.setToolTipText("Filter by assignee");
+        assigneeFilter.setAlignmentX(Component.LEFT_ALIGNMENT);
+        assigneeFilter.addPropertyChangeListener("value", e -> filterAndDisplayIssues());
+        verticalFilterPanel.add(assigneeFilter);
+
+        verticalFilterPanel.add(Box.createVerticalGlue()); // Pushes filters to the top
+
+        mainIssueAreaPanel.add(verticalFilterPanel, BorderLayout.WEST);
+
+        // Panel for Issue Table (CENTER) and Issue Buttons (SOUTH)
+        JPanel issueTableAndButtonsPanel = new JPanel(new BorderLayout());
+
+        // Issue Table
+        issueTableModel = new DefaultTableModel(
+                new Object[]{"#", "Title", "Author", "Updated", "Labels", "Assignees", "Status"}, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return String.class;
+            }
+        };
+        issueTable = new JTable(issueTableModel);
+        issueTable.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+        issueTable.setRowHeight(18);
+        issueTable.getColumnModel().getColumn(ISSUE_COL_NUMBER).setPreferredWidth(50);    // #
+        issueTable.getColumnModel().getColumn(ISSUE_COL_TITLE).setPreferredWidth(350);   // Title
+        issueTable.getColumnModel().getColumn(ISSUE_COL_AUTHOR).setPreferredWidth(100);   // Author
+        issueTable.getColumnModel().getColumn(ISSUE_COL_UPDATED).setPreferredWidth(120); // Updated
+        issueTable.getColumnModel().getColumn(ISSUE_COL_LABELS).setPreferredWidth(150);    // Labels
+        issueTable.getColumnModel().getColumn(ISSUE_COL_ASSIGNEES).setPreferredWidth(150); // Assignees
+        issueTable.getColumnModel().getColumn(ISSUE_COL_STATUS).setPreferredWidth(70);    // Status
+
+        // Ensure tooltips are enabled for the table
+        ToolTipManager.sharedInstance().registerComponent(issueTable);
+
+        issueTableAndButtonsPanel.add(new JScrollPane(issueTable), BorderLayout.CENTER);
+
+        // Button panel for Issues
+        JPanel issueButtonPanel = new JPanel();
+        issueButtonPanel.setBorder(BorderFactory.createEmptyBorder(new Constants().V_GLUE, 0, 0, 0));
+        issueButtonPanel.setLayout(new BoxLayout(issueButtonPanel, BoxLayout.X_AXIS));
+
+        copyIssueDescriptionButton = new JButton("Copy Description");
+        copyIssueDescriptionButton.setToolTipText("Copy the selected issue's description to the clipboard");
+        copyIssueDescriptionButton.setEnabled(false);
+        copyIssueDescriptionButton.addActionListener(e -> copySelectedIssueDescription());
+        issueButtonPanel.add(copyIssueDescriptionButton);
+        issueButtonPanel.add(Box.createHorizontalStrut(new Constants().H_GAP));
+
+        openInBrowserButton = new JButton("Open in Browser");
+        openInBrowserButton.setToolTipText("Open the selected issue in your web browser");
+        openInBrowserButton.setEnabled(false);
+        openInBrowserButton.addActionListener(e -> openSelectedIssueInBrowser());
+        issueButtonPanel.add(openInBrowserButton);
+
+        issueButtonPanel.add(Box.createHorizontalGlue()); // Pushes refresh button to the right
+
+        JButton refreshButton = new JButton("Refresh");
+        refreshButton.addActionListener(e -> updateIssueList());
+        issueButtonPanel.add(refreshButton);
+
+        issueTableAndButtonsPanel.add(issueButtonPanel, BorderLayout.SOUTH);
+        mainIssueAreaPanel.add(issueTableAndButtonsPanel, BorderLayout.CENTER);
+
+        // Right side - Details of the selected issue
+        JPanel issueDetailPanel = new JPanel(new BorderLayout());
+        issueDetailPanel.setBorder(BorderFactory.createTitledBorder("Issue Details"));
+
+        issueBodyTextPane = new JTextPane();
+        issueBodyTextPane.setEditorKit(new AutoScalingHtmlPane.ScalingHTMLEditorKit());
+        issueBodyTextPane.setEditable(false);
+        issueBodyTextPane.setContentType("text/html"); // For rendering HTML
+        // JTextPane handles line wrapping and word wrapping by default with HTML.
+        // Basic HTML like <p> and <br> will control flow.
+        // For plain text, setContentType("text/plain") would make setLineWrap relevant if it were a JTextArea.
+        JScrollPane issueBodyScrollPane = new JScrollPane(issueBodyTextPane);
+        issueBodyScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        issueDetailPanel.add(issueBodyScrollPane, BorderLayout.CENTER);
+
+        // Add the panels to the split pane
+        splitPane.setLeftComponent(mainIssueAreaPanel);
+        splitPane.setRightComponent(issueDetailPanel);
+
+        add(splitPane, BorderLayout.CENTER);
+
+        // Listen for Issue selection changes
+        issueTable.getSelectionModel().addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting() && issueTable.getSelectedRow() != -1) {
+                int viewRow = issueTable.getSelectedRow();
+                if (viewRow != -1) {
+                    int modelRow = issueTable.convertRowIndexToModel(viewRow);
+                    if (modelRow < 0 || modelRow >= displayedIssues.size()) {
+                        logger.warn("Selected row {} (model {}) is out of bounds for displayed issues size {}", viewRow, modelRow, displayedIssues.size());
+                        disableIssueActionsAndClearDetails();
+                        return;
+                    }
+                    GHIssue selectedIssue = displayedIssues.get(modelRow);
+                    loadAndRenderIssueBody(selectedIssue);
+                    copyIssueDescriptionButton.setEnabled(true);
+                    openInBrowserButton.setEnabled(true);
+                } else { // No selection or invalid row
+                    disableIssueActionsAndClearDetails();
+                }
+            } else if (issueTable.getSelectedRow() == -1) { // if selection is explicitly cleared
+                disableIssueActionsAndClearDetails();
+            }
+        });
+
+        updateIssueList(); // async
+    }
+
+    private void disableIssueActionsAndClearDetails() {
+        copyIssueDescriptionButton.setEnabled(false);
+        openInBrowserButton.setEnabled(false);
+        issueBodyTextPane.setContentType("text/html");
+        issueBodyTextPane.setText("");
+    }
+
+    private void loadAndRenderIssueBody(GHIssue issue) {
+        assert SwingUtilities.isEventDispatchThread();
+
+        if (issue == null) {
+            issueBodyTextPane.setContentType("text/html");
+            issueBodyTextPane.setText("");
+            return;
+        }
+
+        String rawMarkdownBody = issue.getBody();
+
+        if (rawMarkdownBody == null || rawMarkdownBody.isBlank()) {
+            issueBodyTextPane.setContentType("text/html");
+            issueBodyTextPane.setText("<html><body><p>No description provided.</p></body></html>");
+            return;
+        }
+
+        // Show loading message
+        issueBodyTextPane.setContentType("text/html");
+        issueBodyTextPane.setText("<html><body><p><i>Loading description...</i></p></body></html>");
+
+        contextManager.submitBackgroundTask("Rendering Issue Description", () -> {
+            try {
+                String htmlBody = this.gfmRenderer.render(rawMarkdownBody);
+                SwingUtilities.invokeLater(() -> {
+                    issueBodyTextPane.setContentType("text/html");
+                    issueBodyTextPane.setText(htmlBody);
+                    issueBodyTextPane.setCaretPosition(0); // Scroll to top
+                });
+            } catch (Exception e) {
+                logger.error("Failed to render markdown for issue #{}: {}", issue.getNumber(), e.getMessage(), e);
+                SwingUtilities.invokeLater(() -> {
+                    // Display raw markdown with an error message
+                    issueBodyTextPane.setContentType("text/plain"); // Switch to plain text for raw markdown
+                    issueBodyTextPane.setText("Failed to render description. Showing raw markdown:\n\n" + rawMarkdownBody);
+                    issueBodyTextPane.setCaretPosition(0);
+                });
+            }
+            return null;
+        });
+    }
+
+    private GitRepo getRepo() {
+        return (GitRepo) contextManager.getProject().getRepo();
+    }
+
+    /**
+     * Holds a parsed "owner" and "repo" from a Git remote URL
+     */
+    private record OwnerRepo(String owner, String repo) {
+    }
+
+    /**
+     * Parse a Git remote URL of form:
+     * - https://github.com/OWNER/REPO.git
+     * - git@github.com:OWNER/REPO.git
+     * - ssh://github.com/OWNER/REPO
+     * - or any variant that ends with OWNER/REPO(.git)
+     * This attempts to extract the last two path segments
+     * as "owner" and "repo". Returns null if it cannot.
+     */
+    private OwnerRepo parseOwnerRepoFromUrl(String remoteUrl) {
+        if (remoteUrl == null || remoteUrl.isBlank()) {
+            logger.warn("Remote URL is blank or null");
+            return null;
+        }
+
+        // Strip trailing ".git" if present
+        String cleaned = remoteUrl.endsWith(".git")
+                         ? remoteUrl.substring(0, remoteUrl.length() - 4)
+                         : remoteUrl;
+        logger.debug("Cleaned repo url is {}", cleaned);
+
+        cleaned = cleaned.replace('\\', '/');
+
+        int protocolIndex = cleaned.indexOf("://");
+        if (protocolIndex >= 0) {
+            cleaned = cleaned.substring(protocolIndex + 3);
+        }
+
+        int atIndex = cleaned.indexOf('@');
+        if (atIndex >= 0) {
+            cleaned = cleaned.substring(atIndex + 1);
+        }
+
+        var segments = cleaned.split("[/:]+");
+
+        if (segments.length < 2) {
+            logger.warn("Unable to parse owner/repo from remote URL: {}", remoteUrl);
+            return null;
+        }
+
+        String repo = segments[segments.length - 1];
+        String owner = segments[segments.length - 2];
+        logger.debug("Parsed repo as {} owned by {}", repo, owner);
+
+        if (owner.isBlank() || repo.isBlank()) {
+            logger.warn("Parsed blank owner/repo from remote URL: {}", remoteUrl);
+            return null;
+        }
+
+        return new OwnerRepo(owner, repo);
+    }
+
+    private synchronized GitHubAuth getGitHubAuthInstance() throws IOException {
+        var repo = getRepo(); // GitRepo instance
+        if (repo == null) {
+            throw new IOException("Git repository not available.");
+        }
+        var remoteUrl = repo.getRemoteUrl();
+        var ownerRepo = parseOwnerRepoFromUrl(remoteUrl);
+        if (ownerRepo == null) {
+            throw new IOException("Could not parse 'owner/repo' from remote: " + remoteUrl);
+        }
+
+        if (this.gitHubAuth == null ||
+            !this.gitHubAuth.getOwner().equals(ownerRepo.owner()) ||
+            !this.gitHubAuth.getRepoName().equals(ownerRepo.repo())) {
+            logger.info("Creating or updating GitHubAuth instance for {}/{}", ownerRepo.owner(), ownerRepo.repo());
+            this.gitHubAuth = new GitHubAuth(contextManager.getProject(), ownerRepo.owner(), ownerRepo.repo());
+        }
+        return this.gitHubAuth;
+    }
+
+    /**
+     * Fetches open GitHub issues and populates the issue table.
+     */
+    private void updateIssueList() {
+        contextManager.submitBackgroundTask("Fetching GitHub Issues", () -> {
+            List<GHIssue> fetchedIssues;
+            try {
+                GitHubAuth auth = getGitHubAuthInstance();
+
+                String selectedStatusOption = statusFilter.getSelected();
+                GHIssueState apiState;
+                if ("Open".equals(selectedStatusOption)) {
+                    apiState = GHIssueState.OPEN;
+                } else if ("Closed".equals(selectedStatusOption)) {
+                    apiState = GHIssueState.CLOSED;
+                } else { // null or any other string implies ALL for safety, though options are limited
+                    apiState = GHIssueState.ALL;
+                }
+
+                // This method needs to be added to GitHubAuth.java
+                fetchedIssues = auth.listIssues(apiState)
+                        .stream()
+                        .filter(issue -> !issue.isPullRequest())
+                        .toList();
+                logger.debug("Fetched {} issues", fetchedIssues.size());
+            } catch (Exception ex) {
+                logger.error("Failed to fetch issues", ex);
+                SwingUtilities.invokeLater(() -> {
+                    allIssuesFromApi.clear();
+                    displayedIssues.clear();
+                    issueTableModel.setRowCount(0);
+                    issueTableModel.addRow(new Object[]{
+                            "", "Error fetching issues: " + ex.getMessage(), "", "", "", "", ""
+                    });
+                    disableIssueActionsAndClearDetails();
+                    authorChoices.clear();
+                    labelChoices.clear();
+                    assigneeChoices.clear();
+                });
+                return null;
+            }
+
+            // Process fetched issues on EDT
+            List<GHIssue> finalFetchedIssues = fetchedIssues;
+            SwingUtilities.invokeLater(() -> {
+                allIssuesFromApi = new ArrayList<>(finalFetchedIssues);
+                populateDynamicFilterChoices(allIssuesFromApi);
+                filterAndDisplayIssues(); // Apply current filters
+            });
+            return null;
+        });
+    }
+
+    private List<String> getAuthorFilterOptions() {
+        return authorChoices;
+    }
+
+    private List<String> getLabelFilterOptions() {
+        return labelChoices;
+    }
+
+    private List<String> getAssigneeFilterOptions() {
+        return assigneeChoices;
+    }
+
+    private void populateDynamicFilterChoices(List<GHIssue> issues) {
+        // Author Filter
+        Map<String, Integer> authorCounts = new HashMap<>();
+        for (var issue : issues) {
+            try {
+                GHUser user = issue.getUser();
+                if (user != null) {
+                    String login = user.getLogin();
+                    if (login != null && !login.isBlank()) {
+                        authorCounts.merge(login, 1, Integer::sum);
+                    }
+                }
+            } catch (IOException e) {
+                logger.warn("Could not get user or login for issue #{}", issue.getNumber(), e);
+            }
+        }
+        authorChoices = generateFilterOptionsList(authorCounts);
+
+        // Label Filter
+        Map<String, Integer> labelCounts = new HashMap<>();
+        for (var issue : issues) {
+            for (GHLabel label : issue.getLabels()) {
+                if (!label.getName().isBlank()) {
+                    labelCounts.merge(label.getName(), 1, Integer::sum);
+                }
+            }
+        }
+        labelChoices = generateFilterOptionsList(labelCounts);
+
+        // Assignee Filter
+        Map<String, Integer> assigneeCounts = new HashMap<>();
+        for (var issue : issues) {
+            for (GHUser assignee : issue.getAssignees()) {
+                String login = assignee.getLogin(); // Does not throw IOException
+                if (login != null && !login.isBlank()) {
+                    assigneeCounts.merge(login, 1, Integer::sum);
+                }
+            }
+        }
+        assigneeChoices = generateFilterOptionsList(assigneeCounts);
+    }
+
+    private List<String> generateFilterOptionsList(Map<String, Integer> counts) {
+        List<String> options = new ArrayList<>();
+        List<String> sortedItems = new ArrayList<>(counts.keySet());
+        Collections.sort(sortedItems, String.CASE_INSENSITIVE_ORDER);
+
+        for (String item : sortedItems) {
+            options.add(String.format("%s (%d)", item, counts.get(item)));
+        }
+        return options;
+    }
+
+    private void filterAndDisplayIssues() {
+        assert SwingUtilities.isEventDispatchThread();
+        displayedIssues.clear();
+        String selectedAuthorDisplay = authorFilter.getSelected();
+        String selectedLabelDisplay = labelFilter.getSelected();
+        String selectedAssigneeDisplay = assigneeFilter.getSelected();
+
+        String selectedAuthorActual = getBaseFilterValue(selectedAuthorDisplay);
+        String selectedLabelActual = getBaseFilterValue(selectedLabelDisplay);
+        String selectedAssigneeActual = getBaseFilterValue(selectedAssigneeDisplay);
+
+        for (var issue : allIssuesFromApi) {
+            boolean matches = true;
+            try {
+                // Author filter
+                if (selectedAuthorActual != null && (issue.getUser() == null || !selectedAuthorActual.equals(issue.getUser().getLogin()))) {
+                    matches = false;
+                }
+                // Label filter
+                if (matches && selectedLabelActual != null) {
+                    matches = issue.getLabels().stream().anyMatch(l -> selectedLabelActual.equals(l.getName()));
+                }
+                // Assignee filter
+                if (matches && selectedAssigneeActual != null) {
+                    boolean assigneeMatch = false;
+                    for (GHUser assignee : issue.getAssignees()) {
+                        String login = assignee.getLogin(); // Can throw IOException
+                        if (selectedAssigneeActual.equals(login)) {
+                            assigneeMatch = true;
+                            break;
+                        }
+                    }
+                    matches = assigneeMatch;
+                }
+            } catch (IOException e) {
+                logger.warn("Error accessing issue data during filtering for issue #{}", issue.getNumber(), e);
+                matches = false; // Skip issue if data can't be accessed
+            }
+
+            if (matches) {
+                displayedIssues.add(issue);
+            }
+        }
+
+        // Update table model
+        issueTableModel.setRowCount(0);
+        var today = LocalDate.now();
+        if (displayedIssues.isEmpty()) {
+            issueTableModel.addRow(new Object[]{"", "No matching issues found", "", "", "", "", ""});
+            disableIssueActions();
+        } else {
+            // Sort issues by update date, newest first
+            displayedIssues.sort(Comparator.comparing(issue -> {
+                try {
+                    return issue.getUpdatedAt();
+                } catch (IOException e) {
+                    return new Date(0); // Oldest on error
+                }
+            }, Comparator.nullsLast(Comparator.reverseOrder())));
+
+            for (var issue : displayedIssues) {
+                String author = "";
+                String formattedUpdated = "";
+                String labels = "";
+                String assignees = "";
+                String statusValue = "";
+                try {
+                    if (issue.getUser() != null) author = issue.getUser().getLogin();
+                    if (issue.getUpdatedAt() != null) {
+                        formattedUpdated = gitPanel.formatCommitDate(issue.getUpdatedAt(), today);
+                    }
+                    labels = issue.getLabels().stream().map(GHLabel::getName).collect(Collectors.joining(", "));
+                    assignees = issue.getAssignees().stream()
+                                     .map(GHUser::getLogin) // GHUser.getLogin() does not throw IOException
+                                     .filter(login -> login != null && !login.isBlank())
+                                     .collect(Collectors.joining(", "));
+                    statusValue = issue.getState().toString();
+                } catch (IOException ex) { // This catch is for outer operations like issue.getUser(), issue.getUpdatedAt() etc.
+                    logger.warn("Could not get metadata for issue #{}", issue.getNumber(), ex);
+                }
+
+                issueTableModel.addRow(new Object[]{
+                        "#" + issue.getNumber(), issue.getTitle(), author, formattedUpdated,
+                        labels, assignees, statusValue
+                });
+            }
+        }
+        // Buttons state will be managed by selection listener or if selection is empty
+        if (issueTable.getSelectedRow() == -1) {
+            disableIssueActions();
+        } else {
+            // Trigger selection listener to update button states correctly for the (potentially new) selection
+            issueTable.getSelectionModel().setValueIsAdjusting(true); // force re-evaluation
+            issueTable.getSelectionModel().setValueIsAdjusting(false);
+        }
+    }
+
+    private String getBaseFilterValue(String displayOptionWithCount) {
+        if (displayOptionWithCount == null) {
+            return null; // This is the "All" case (FilterBox name shown)
+        }
+        // For dynamic items like "John Doe (5)"
+        int parenthesisIndex = displayOptionWithCount.lastIndexOf(" (");
+        if (parenthesisIndex != -1) {
+            // Ensure the part in parenthesis is a number to avoid stripping part of a name
+            String countPart = displayOptionWithCount.substring(parenthesisIndex + 2, displayOptionWithCount.length() - 1);
+            if (countPart.matches("\\d+")) {
+                return displayOptionWithCount.substring(0, parenthesisIndex);
+            }
+        }
+        return displayOptionWithCount; // For simple string options like "Open", "Closed", or names without counts
+    }
+
+    private void disableIssueActions() {
+        copyIssueDescriptionButton.setEnabled(false);
+        openInBrowserButton.setEnabled(false);
+    }
+
+    private void copySelectedIssueDescription() {
+        int selectedRow = issueTable.getSelectedRow();
+        if (selectedRow == -1 || selectedRow >= displayedIssues.size()) {
+            return;
+        }
+        GHIssue issue = displayedIssues.get(selectedRow);
+        String body = issue.getBody();
+        if (body != null && !body.isBlank()) {
+            StringSelection stringSelection = new StringSelection(body);
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
+            chrome.systemOutput("Issue #" + issue.getNumber() + " description copied to clipboard.");
+        } else {
+            chrome.systemOutput("Issue #" + issue.getNumber() + " has no description to copy.");
+        }
+    }
+
+    private void openSelectedIssueInBrowser() {
+        int selectedRow = issueTable.getSelectedRow();
+        if (selectedRow == -1 || selectedRow >= displayedIssues.size()) {
+            return;
+        }
+        GHIssue issue = displayedIssues.get(selectedRow);
+        try {
+            String url = issue.getHtmlUrl().toString();
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                Desktop.getDesktop().browse(new java.net.URI(url));
+            } else {
+                chrome.toolError("Cannot open browser. Desktop API not supported.");
+                logger.warn("Desktop.Action.BROWSE not supported, cannot open issue URL: {}", url);
+            }
+        } catch (Exception e) {
+            chrome.toolErrorRaw("Error opening issue in browser: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/io/github/jbellis/brokk/gui/GitPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitPanel.java
@@ -31,7 +31,10 @@ public class GitPanel extends JPanel
     private final GitLogTab gitLogTab;
 
     // The "Pull Requests" tab - conditionally added
-    private GitPullRequestsTab pullRequestsTab;
+    private GitPullRequestsTab pullRequestsTab; // Keep if you still want PRs
+
+    // The "Issues" tab - conditionally added
+    private GitIssuesTab issuesTab;
 
     // Tracks open file-history tabs by file path
     private final Map<String, GitHistoryTab> fileHistoryTabs = new HashMap<>();
@@ -86,9 +89,16 @@ public class GitPanel extends JPanel
         tabbedPane.addTab("Log", gitLogTab);
 
         // 3) Pull Requests tab (conditionally added)
-        if (Boolean.getBoolean("brokk.prtab")) {
+        if (Boolean.getBoolean("brokk.prtab")) { // If you keep PRs
             pullRequestsTab = new GitPullRequestsTab(chrome, contextManager, this);
             tabbedPane.addTab("Pull Requests", pullRequestsTab);
+        }
+
+        // 4) Issues tab (conditionally added)
+        // Ensure this property ("brokk.issuetab") is set if you want this tab to appear.
+        if (Boolean.getBoolean("brokk.issuetab")) {
+            issuesTab = new GitIssuesTab(chrome, contextManager, this);
+            tabbedPane.addTab("Issues", issuesTab);
         }
     }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/GitPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitPanel.java
@@ -88,15 +88,18 @@ public class GitPanel extends JPanel
         gitLogTab = new GitLogTab(chrome, contextManager);
         tabbedPane.addTab("Log", gitLogTab);
 
+        // Get project for GitHub specific tabs
+        var project = contextManager.getProject();
+
         // 3) Pull Requests tab (conditionally added)
-        if (Boolean.getBoolean("brokk.prtab")) { // If you keep PRs
+        if (project != null && project.isGitHubRepo() && Boolean.getBoolean("brokk.prtab")) {
             pullRequestsTab = new GitPullRequestsTab(chrome, contextManager, this);
             tabbedPane.addTab("Pull Requests", pullRequestsTab);
         }
 
         // 4) Issues tab (conditionally added)
         // Ensure this property ("brokk.issuetab") is set if you want this tab to appear.
-        if (Boolean.getBoolean("brokk.issuetab")) {
+        if (project != null && project.isGitHubRepo() && Boolean.getBoolean("brokk.issuetab")) {
             issuesTab = new GitIssuesTab(chrome, contextManager, this);
             tabbedPane.addTab("Issues", issuesTab);
         }

--- a/src/main/java/io/github/jbellis/brokk/gui/GitUiUtil.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitUiUtil.java
@@ -396,4 +396,64 @@ public final class GitUiUtil
             return null;
         });
     }
+
+    /**
+     * Holds a parsed "owner" and "repo" from a Git remote URL.
+     */
+    public record OwnerRepo(String owner, String repo) {
+    }
+    /**
+     * Parse a Git remote URL of form:
+     * - https://github.com/OWNER/REPO.git
+     * - git@github.com:OWNER/REPO.git
+     * - ssh://github.com/OWNER/REPO
+     * - or any variant that ends with OWNER/REPO(.git)
+     * This attempts to extract the last two path segments
+     * as "owner" and "repo". Returns null if it cannot.
+     */
+    public static OwnerRepo parseOwnerRepoFromUrl(String remoteUrl) {
+        if (remoteUrl == null || remoteUrl.isBlank()) {
+            logger.warn("Remote URL is blank or null for parsing owner/repo.");
+            return null;
+        }
+
+        // Strip trailing ".git" if present
+        String cleaned = remoteUrl.endsWith(".git")
+                         ? remoteUrl.substring(0, remoteUrl.length() - 4)
+                         : remoteUrl;
+
+        cleaned = cleaned.replace('\\', '/'); // Normalize path separators
+
+        // Remove protocol part (e.g., "https://", "ssh://")
+        int protocolIndex = cleaned.indexOf("://");
+        if (protocolIndex >= 0) {
+            cleaned = cleaned.substring(protocolIndex + 3);
+        }
+
+        // Remove user@ part (e.g., "git@")
+        int atIndex = cleaned.indexOf('@');
+        if (atIndex >= 0) {
+            cleaned = cleaned.substring(atIndex + 1);
+        }
+
+        // Split by '/' or ':' treating multiple delimiters as one
+        var segments = cleaned.split("[/:]+");
+
+        if (segments.length < 2) {
+            logger.warn("Unable to parse owner/repo from cleaned remote URL: {} (original: {})", cleaned, remoteUrl);
+            return null;
+        }
+
+        // The repository name is the last segment
+        String repo = segments[segments.length - 1];
+        // The owner is the second to last segment
+        String owner = segments[segments.length - 2];
+
+        if (owner.isBlank() || repo.isBlank()) {
+            logger.warn("Parsed blank owner or repo from remote URL: {} (owner: '{}', repo: '{}')", remoteUrl, owner, repo);
+            return null;
+        }
+        logger.debug("Parsed owner '{}' and repo '{}' from URL '{}'", owner, repo, remoteUrl);
+        return new OwnerRepo(owner, repo);
+    }
 }

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
@@ -1,5 +1,6 @@
 package io.github.jbellis.brokk.gui.dialogs;
 
+import io.github.jbellis.brokk.GitHubAuth;
 import io.github.jbellis.brokk.Project;
 import io.github.jbellis.brokk.Project.DataRetentionPolicy;
 import io.github.jbellis.brokk.Service;
@@ -1716,6 +1717,7 @@ public class SettingsDialog extends JDialog implements ThemeAware {
             String oldToken = Project.getGitHubToken();
             if (!newToken.equals(oldToken)) {
                 Project.setGitHubToken(newToken);
+                GitHubAuth.invalidateInstance();
                 logger.debug("Applied GitHub Token");
             }
         }

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
@@ -195,9 +195,11 @@ public class SettingsDialog extends JDialog implements ThemeAware {
         var quickModelsPanel = createQuickModelsPanel();
         globalSubTabbedPane.addTab("Quick Models", null, quickModelsPanel, "Define model aliases (shortcuts)");
 
-        // GitHub Tab
-        var gitHubPanel = createGitHubPanel();
-        globalSubTabbedPane.addTab("GitHub", null, gitHubPanel, "GitHub integration settings");
+        // GitHub Tab (conditionally added)
+        if (project != null && project.isGitHubRepo()) {
+            var gitHubPanel = createGitHubPanel();
+            globalSubTabbedPane.addTab("GitHub", null, gitHubPanel, "GitHub integration settings");
+        }
 
 
         // Enable/disable components within the Default Models panel based on project state


### PR DESCRIPTION
Closes #67. Also closes #121, it was a small change and was easier to implement together to avoid conflicts as I refactored GitHub-related logic by extracting it in one place used by both PRs and Issues (and any other GitHub-related features in the future).

![image](https://github.com/user-attachments/assets/58b67458-578d-4fd7-8f53-2dec485f5220)
