### PR TITLE
fix: Tables not always rendered properly in MOP

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/mop/stream/IncrementalBlockRenderer.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/stream/IncrementalBlockRenderer.java
@@ -92,7 +92,8 @@ public final class IncrementalBlockRenderer {
             .set(BrokkMarkdownExtension.ENABLE_EDIT_BLOCK, enableEditBlocks)
             .set(IdProvider.ID_PROVIDER, idProvider)
             .set(HtmlRenderer.SOFT_BREAK, "<br />\n")
-            .set(HtmlRenderer.ESCAPE_HTML, true);
+            .set(HtmlRenderer.ESCAPE_HTML, true)
+            .set(TablesExtension.MIN_SEPARATOR_DASHES, 1);
             
         parser = Parser.builder(options).build();
         renderer = HtmlRenderer.builder(options).build();


### PR DESCRIPTION
This content (with two dashes `|--|`) is rendered properly now:
```
| | JSONL | Split |
|--|-------|-------|
| Implementation complexity | Minimal; one mapper. | Need: • second-level manifest (index) or id–path convention • fallback when an entry is missing • ref-count/dedup management. |
| Atomicity | One write = one logical file; easy to reason about corruption. | Must ensure all pieces are written or roll back on error. |
| Backward compatibility | Already in place. | New layout must still read old archives (code & maintenance overhead). |
| Future evolution | Harder to change schema without re-serialising huge blob. | Easier: add new entry type without touching history.jsonl. |
```
![image](https://github.com/user-attachments/assets/37419855-5441-41c9-899c-d001a2f72af4)
