### PR TITLE
feat: Auto-rename Sessions

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1978,7 +1978,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
                 return "Summarization failed.";
             }
             var summary = result.chatResponse().aiMessage().text().trim();
-            if (words == SummarizerPrompts.WORD_BUDGET_5 && summary.endsWith(".")) {
+            if (summary.endsWith(".")) {
                 return summary.substring(0, summary.length() - 1);
             }
             return summary;

--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -63,6 +63,8 @@ public class ContextManager implements IContextManager, AutoCloseable {
     private static final Pattern TEST_FILE_PATTERN = Pattern.compile(
             "(?i).*(?:[/\\\\.]|\\b|_|(?<=[a-z])(?=[A-Z]))tests?(?:[/\\\\.]|\\b|_|(?=[A-Z][a-z])|$).*"
     );
+
+    public static final String DEFAULT_SESSION_NAME = "New Session";
     
     public static boolean isTestFile(ProjectFile file) {
         return TEST_FILE_PATTERN.matcher(file.toString()).matches();
@@ -145,7 +147,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         // Initialize session management
         var sessions = project.listSessions();
         if (sessions.isEmpty()) {
-            var newSessionInfo = project.newSession("New Session");
+            var newSessionInfo = project.newSession(DEFAULT_SESSION_NAME);
             this.currentSessionId = newSessionInfo.id();
             logger.info("Created and loaded new session: {} ({})", newSessionInfo.name(), newSessionInfo.id());
         } else {
@@ -1641,11 +1643,35 @@ public class ContextManager implements IContextManager, AutoCloseable {
         Future<String> actionFuture = submitSummarizeTaskForConversation(action);
 
         // pushContext will apply addHistoryEntry to the current liveContext,
-        // then liveContext will be updated, and a frozen version added to history.
-        var newLiveContext = pushContext(currentLiveCtx ->
-            currentLiveCtx.addHistoryEntry(finalEntry, result.output(), actionFuture)
-        );
-        return newLiveContext.getTaskHistory().getLast();
+    // then liveContext will be updated, and a frozen version added to history.
+    var newLiveContext = pushContext(currentLiveCtx ->
+        currentLiveCtx.addHistoryEntry(finalEntry, result.output(), actionFuture)
+    );
+    
+    // Auto-rename session if this is the first task and session has default name
+    if (newEntry.sequence() == 1) {
+        var sessions = project.listSessions();
+        var currentSession = sessions.stream()
+                .filter(s -> s.id().equals(currentSessionId))
+                .findFirst();
+        
+        if (currentSession.isPresent() && DEFAULT_SESSION_NAME.equals(currentSession.get().name())) {
+            try {
+                var summary = actionFuture.get();
+                renameSessionAsync(currentSessionId, summary).thenRun(() -> {
+                    SwingUtilities.invokeLater(() -> {
+                        if (io instanceof Chrome chrome) {
+                            chrome.getHistoryOutputPanel().updateSessionComboBox();
+                        }
+                    });
+                });
+            } catch (Exception e) {
+                logger.warn("Error renaming Session", e);
+            }
+        }
+    }
+    
+    return newLiveContext.getTaskHistory().getLast();
     }
 
     public List<Context> getContextHistoryList() {
@@ -1687,7 +1713,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
             logger.info("Switched to new session: {} ({})", newSessionInfo.name(), newSessionInfo.id());
             ContextHistory loadedCh = project.loadHistory(currentSessionId, this);
             if (loadedCh.getHistory().isEmpty()) {
-                liveContext = new Context(this, "Welcome to session: " + newSessionInfo.name());
+                liveContext = new Context(this, "Welcome to the new session!");
                 contextHistory.setInitialContext(liveContext.freeze().frozenContext());
             } else {
                 contextHistory.setInitialContext(loadedCh.getHistory().getFirst());
@@ -1790,7 +1816,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
             if (sessionIdToDelete.equals(currentActiveSessionId)) {
                 List<Project.SessionInfo> remainingSessions = project.listSessions();
                 if (remainingSessions.isEmpty()) {
-                    Project.SessionInfo newDefaultSession = project.newSession("New Session");
+                    Project.SessionInfo newDefaultSession = project.newSession(DEFAULT_SESSION_NAME);
                     this.currentSessionId = newDefaultSession.id();
                     logger.info("Current session was deleted. Created and switched to new default session: {} ({})", newDefaultSession.name(), newDefaultSession.id());
                     liveContext = new Context(this, "Welcome to session: " + newDefaultSession.name());
@@ -1951,7 +1977,11 @@ public class ContextManager implements IContextManager, AutoCloseable {
                 logger.warn("Summarization failed or was cancelled.");
                 return "Summarization failed.";
             }
-            return result.chatResponse().aiMessage().text().trim();
+            var summary = result.chatResponse().aiMessage().text().trim();
+            if (words == SummarizerPrompts.WORD_BUDGET_5 && summary.endsWith(".")) {
+                return summary.substring(0, summary.length() - 1);
+            }
+            return summary;
         }
     }
 }

--- a/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -168,7 +168,7 @@ public class HistoryOutputPanel extends JPanel {
         newSessionButton.setMinimumSize(newSessionSize);
         newSessionButton.setMaximumSize(newSessionSize);
         newSessionButton.addActionListener(e -> {
-            contextManager.createNewSessionAsync("New Session").thenRun(() ->
+            contextManager.createNewSessionAsync(ContextManager.DEFAULT_SESSION_NAME).thenRun(() ->
                 SwingUtilities.invokeLater(this::updateSessionComboBox)
             );
         });

--- a/src/main/java/io/github/jbellis/brokk/gui/ManageSessionsDialog.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/ManageSessionsDialog.java
@@ -189,19 +189,19 @@ public class ManageSessionsDialog extends JDialog {
         mopPanel.setBorder(BorderFactory.createTitledBorder("Output"));
         mopPanel.add(markdownScrollPane, BorderLayout.CENTER);
 
-        // Create top row with Sessions (20%), Activity (40%), and MOP (40%) horizontal space
+        // Create top row with Sessions (30%), Activity (30%), and MOP (40%) horizontal space
         JSplitPane topFirstSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, sessionsPanel, activityPanel);
-        topFirstSplit.setResizeWeight(1.0/3.0); // Sessions gets 20%, Activity gets 40%, so 20/(20+40) = 1/3
+        topFirstSplit.setResizeWeight(0.5); // Sessions gets 30%, Activity gets 30%, so 30/(30+30) = 0.5
 
         JSplitPane topSecondSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, topFirstSplit, mopPanel);
         topSecondSplit.setResizeWeight(0.6); // Sessions+Activity get 60%, MOP gets 40%
 
-        // Set divider locations after the dialog is shown to achieve 20%/40%/40% split
+        // Set divider locations after the dialog is shown to achieve 30%/30%/40% split
         SwingUtilities.invokeLater(() -> {
             int totalWidth = topSecondSplit.getWidth();
             if (totalWidth > 0) {
-                // Set first divider at 20% of the way (between Sessions and Activity)
-                topFirstSplit.setDividerLocation(totalWidth / 5);
+                // Set first divider at 30% of the way (between Sessions and Activity)
+                topFirstSplit.setDividerLocation((3 * totalWidth) / 10);
                 // Set second divider at 60% of the way (between Activity and MOP)
                 topSecondSplit.setDividerLocation((3 * totalWidth) / 5);
             }

--- a/src/main/java/io/github/jbellis/brokk/prompts/SummarizerPrompts.java
+++ b/src/main/java/io/github/jbellis/brokk/prompts/SummarizerPrompts.java
@@ -43,7 +43,7 @@ public class SummarizerPrompts {
         """;
         var exampleRequest = getRequest(example, wordBudget);
         var exampleResponse = wordBudget == WORD_BUDGET_12
-                ? "Brokk: agentic code search and retrieval, usage summarization, stacktrace parsing, build integration."
+                ? "Brokk: agentic code search and retrieval, usage summarization, stacktrace parsing, build integration"
                 : "Brokk: context management, agentic search";
 
         var request = getRequest(actionTxt, wordBudget);

--- a/src/main/java/io/github/jbellis/brokk/prompts/SummarizerPrompts.java
+++ b/src/main/java/io/github/jbellis/brokk/prompts/SummarizerPrompts.java
@@ -11,12 +11,15 @@ import java.util.List;
 public class SummarizerPrompts {
     public static final SummarizerPrompts instance = new SummarizerPrompts() {};
     
+    public static final int WORD_BUDGET_5 = 5; 
+    public static final int WORD_BUDGET_12 = 12; 
+    
     private SummarizerPrompts() {}
 
     public List<ChatMessage> collectMessages(String actionTxt, int wordBudget) {
         assert actionTxt != null;
         assert !actionTxt.isBlank();
-        assert wordBudget == 5 || wordBudget == 12 : wordBudget;
+        assert wordBudget == WORD_BUDGET_5 || wordBudget == WORD_BUDGET_12 : wordBudget;
 
         var example = """
         # What Brokk can do
@@ -39,7 +42,7 @@ public class SummarizerPrompts {
         - "Here are the usages of Foo.bar.  Is parameter zep always loaded from cache?"
         """;
         var exampleRequest = getRequest(example, wordBudget);
-        var exampleResponse = wordBudget == 12
+        var exampleResponse = wordBudget == WORD_BUDGET_12
                 ? "Brokk: agentic code search and retrieval, usage summarization, stacktrace parsing, build integration."
                 : "Brokk: context management, agentic search";
 


### PR DESCRIPTION
Took the approach to name the session after the first interaction. Since it is the summary of the same text as the task history entry in the activity log, just took that as the session name.