### PR TITLE
Capture Issues as Context

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -812,12 +812,28 @@ public class ContextManager implements IContextManager, AutoCloseable {
      *
      * @param image The java.awt.Image pasted from the clipboard.
      */
+    public ContextFragment.PasteImageFragment addPastedImageFragment(java.awt.Image image, String descriptionOverride) {
+        Future<String> descriptionFuture;
+        if (descriptionOverride != null && !descriptionOverride.isBlank()) {
+            descriptionFuture = CompletableFuture.completedFuture(descriptionOverride);
+        } else {
+            descriptionFuture = submitSummarizePastedImage(image);
+        }
+
+        // Must be final for lambda capture in pushContext
+        final var fragment = new ContextFragment.PasteImageFragment(this, image, descriptionFuture);
+        pushContext(currentLiveCtx -> currentLiveCtx.addVirtualFragment(fragment));
+        return fragment;
+    }
+
+    /**
+     * Handles pasting an image from the clipboard without a predefined description.
+     * This will trigger asynchronous summarization of the image.
+     *
+     * @param image The java.awt.Image pasted from the clipboard.
+     */
     public void addPastedImageFragment(java.awt.Image image) {
-        Future<String> descriptionFuture = submitSummarizePastedImage(image);
-        pushContext(currentLiveCtx -> {
-            var fragment = new ContextFragment.PasteImageFragment(this, image, descriptionFuture);
-            return currentLiveCtx.addVirtualFragment(fragment);
-        });
+        addPastedImageFragment(image, null); // Calls the overload with descriptionOverride as null
     }
 
     /**
@@ -1254,7 +1270,11 @@ public class ContextManager implements IContextManager, AutoCloseable {
         liveContext = fr.liveContext();
         var frozen = fr.frozenContext();
         contextHistory.addFrozenContextAndClearRedo(frozen); // Add frozen version to history
-        notifyContextListeners(frozen);
+
+        // Ensure listeners are notified on the EDT
+        Context finalFrozenContext = frozen; // Effectively final for lambda
+        SwingUtilities.invokeLater(() -> notifyContextListeners(finalFrozenContext));
+
         project.saveHistory(contextHistory, currentSessionId);    // Persist the history of frozen contexts
 
         // Check conversation history length on the new live context

--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -812,7 +812,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      *
      * @param image The java.awt.Image pasted from the clipboard.
      */
-    public ContextFragment.PasteImageFragment addPastedImageFragment(java.awt.Image image, String descriptionOverride) {
+    public ContextFragment.AnonymousImageFragment addPastedImageFragment(java.awt.Image image, String descriptionOverride) {
         Future<String> descriptionFuture;
         if (descriptionOverride != null && !descriptionOverride.isBlank()) {
             descriptionFuture = CompletableFuture.completedFuture(descriptionOverride);
@@ -821,7 +821,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         }
 
         // Must be final for lambda capture in pushContext
-        final var fragment = new ContextFragment.PasteImageFragment(this, image, descriptionFuture);
+        final var fragment = new ContextFragment.AnonymousImageFragment(this, image, descriptionFuture);
         pushContext(currentLiveCtx -> currentLiveCtx.addVirtualFragment(fragment));
         return fragment;
     }

--- a/src/main/java/io/github/jbellis/brokk/GitHubAuth.java
+++ b/src/main/java/io/github/jbellis/brokk/GitHubAuth.java
@@ -10,9 +10,13 @@ import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Handles GitHub authentication and API calls.
@@ -202,5 +206,33 @@ public class GitHubAuth
     {
         var pr = getGhRepository().getPullRequest(prNumber);
         return pr.listCommits().toList();
+    }
+
+    /**
+     * Creates an OkHttpClient configured with GitHub authentication.
+     *
+     * @return An authenticated OkHttpClient.
+     */
+    public OkHttpClient authenticatedClient() {
+        var builder = new OkHttpClient.Builder()
+                .connectTimeout(5, TimeUnit.SECONDS) // Sensible defaults
+                .readTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(5, TimeUnit.SECONDS)
+                .followRedirects(true);
+
+        var token = Project.getGitHubToken();
+        if (token != null && !token.isBlank()) {
+            builder.addInterceptor(chain -> {
+                Request originalRequest = chain.request();
+                Request authenticatedRequest = originalRequest.newBuilder()
+                        .header("Authorization", "token " + token)
+                        .build();
+                return chain.proceed(authenticatedRequest);
+            });
+            logger.debug("Authenticated OkHttpClient created with token.");
+        } else {
+            logger.debug("GitHub token not found or blank; OkHttpClient will be unauthenticated for direct image fetches.");
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
+++ b/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
@@ -798,17 +798,17 @@ public interface ContextFragment {
         }
     }
 
-    class PasteImageFragment extends PasteFragment {
+    class AnonymousImageFragment extends PasteFragment {
         private final Image image;
 
-        public PasteImageFragment(IContextManager contextManager, Image image, Future<String> descriptionFuture) {
+        public AnonymousImageFragment(IContextManager contextManager, Image image, Future<String> descriptionFuture) {
             super(contextManager, descriptionFuture);
             assert image != null;
             assert descriptionFuture != null;
             this.image = image;
         }
 
-        public PasteImageFragment(int existingId, IContextManager contextManager, Image image, Future<String> descriptionFuture) {
+        public AnonymousImageFragment(int existingId, IContextManager contextManager, Image image, Future<String> descriptionFuture) {
             super(existingId, contextManager, descriptionFuture);
             assert image != null;
             assert descriptionFuture != null;
@@ -853,6 +853,18 @@ public interface ContextFragment {
         @Override
         public Set<ProjectFile> files() {
             return Set.of();
+        }
+
+        @Override
+        public String description() {
+            if (descriptionFuture.isDone()) {
+                try {
+                    return descriptionFuture.get();
+                } catch (Exception e) {
+                    return "(Error summarizing paste)";
+                }
+            }
+            return "(Summarizing. This does not block LLM requests)";
         }
     }
 

--- a/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
+++ b/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
@@ -1249,6 +1249,11 @@ public interface ContextFragment {
 
     interface OutputFragment {
         List<TaskEntry> entries();
+
+        /** Should raw HTML inside markdown be escaped before rendering? */
+        default boolean isEscapeHtml() {
+            return true;
+        }
     }
 
     /**
@@ -1339,27 +1344,51 @@ public interface ContextFragment {
         private final EditBlockParser parser; // TODO this doesn't belong in TaskFragment anymore
         private final List<ChatMessage> messages; // Content is fixed once created
         private final String sessionName;
+        private final boolean escapeHtml;
 
-        public TaskFragment(IContextManager contextManager, EditBlockParser parser, List<ChatMessage> messages, String sessionName) {
+        public TaskFragment(IContextManager contextManager, EditBlockParser parser, List<ChatMessage> messages, String sessionName, boolean escapeHtml) {
             super(contextManager);
             this.parser = parser;
             this.messages = messages;
             this.sessionName = sessionName;
+            this.escapeHtml = escapeHtml;
+        }
+
+        public TaskFragment(IContextManager contextManager, EditBlockParser parser, List<ChatMessage> messages, String sessionName) {
+            this(contextManager, parser, messages, sessionName, true);
+        }
+
+        public TaskFragment(IContextManager contextManager, List<ChatMessage> messages, String sessionName, boolean escapeHtml) {
+            this(contextManager, EditBlockParser.instance, messages, sessionName, escapeHtml);
         }
 
         public TaskFragment(IContextManager contextManager, List<ChatMessage> messages, String sessionName) {
-            this(contextManager, EditBlockParser.instance, messages, sessionName);
+            this(contextManager, EditBlockParser.instance, messages, sessionName, true);
         }
 
-        public TaskFragment(int existingId, IContextManager contextManager, EditBlockParser parser, List<ChatMessage> messages, String sessionName) {
+        public TaskFragment(int existingId, IContextManager contextManager, EditBlockParser parser, List<ChatMessage> messages, String sessionName, boolean escapeHtml) {
             super(existingId, contextManager);
             this.parser = parser;
             this.messages = messages;
             this.sessionName = sessionName;
+            this.escapeHtml = escapeHtml;
+        }
+
+        public TaskFragment(int existingId, IContextManager contextManager, EditBlockParser parser, List<ChatMessage> messages, String sessionName) {
+            this(existingId, contextManager, parser, messages, sessionName, true);
+        }
+
+        public TaskFragment(int existingId, IContextManager contextManager, List<ChatMessage> messages, String sessionName, boolean escapeHtml) {
+            this(existingId, contextManager, EditBlockParser.instance, messages, sessionName, escapeHtml);
         }
 
         public TaskFragment(int existingId, IContextManager contextManager, List<ChatMessage> messages, String sessionName) {
-            this(existingId, contextManager, EditBlockParser.instance, messages, sessionName);
+            this(existingId, contextManager, EditBlockParser.instance, messages, sessionName, true);
+        }
+
+        @Override
+        public boolean isEscapeHtml() {
+            return escapeHtml;
         }
 
         @Override

--- a/src/main/java/io/github/jbellis/brokk/context/DtoMapper.java
+++ b/src/main/java/io/github/jbellis/brokk/context/DtoMapper.java
@@ -201,7 +201,7 @@ public class DtoMapper {
             case PasteTextFragmentDto pasteTextDto -> new ContextFragment.PasteTextFragment(pasteTextDto.id(), mgr, pasteTextDto.text(), CompletableFuture.completedFuture(pasteTextDto.description()));
             case PasteImageFragmentDto pasteImageDto -> {
                 Image image = base64ToImage(pasteImageDto.base64ImageData());
-                yield new ContextFragment.PasteImageFragment(pasteImageDto.id(), mgr, image, CompletableFuture.completedFuture(pasteImageDto.description()));
+                yield new ContextFragment.AnonymousImageFragment(pasteImageDto.id(), mgr, image, CompletableFuture.completedFuture(pasteImageDto.description()));
             }
             case StacktraceFragmentDto stacktraceDto -> {
                 var sources = stacktraceDto.sources().stream()
@@ -456,7 +456,7 @@ public class DtoMapper {
                 }
                 yield new PasteTextFragmentDto(pasteTextFragment.id(), pasteTextFragment.text(), description); // PasteTextFragment is non-dynamic
             }
-            case ContextFragment.PasteImageFragment pasteImageFragment -> {
+            case ContextFragment.AnonymousImageFragment pasteImageFragment -> {
                 // Block for up to 10 seconds to get the completed description
                 String description;
                 try {

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -889,7 +889,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             // 3. Image fragments (clipboard image or image file)
             if (!workingFragment.isText()) {
                 if (workingFragment.getType() == ContextFragment.FragmentType.PASTE_IMAGE) {
-                    var pif = (ContextFragment.PasteImageFragment) workingFragment;
+                    var pif = (ContextFragment.AnonymousImageFragment) workingFragment;
                     var imagePanel = new PreviewImagePanel(contextManager, null, themeManager);
                     imagePanel.setImage(pif.image());
                     showPreviewFrame(contextManager, title, imagePanel);

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -856,9 +856,10 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
 
                 var compactionFutures = new ArrayList<CompletableFuture<?>>();
                 var markdownPanels = new ArrayList<MarkdownOutputPanel>();
-                
+                boolean escapeHtml = outputFragment.isEscapeHtml();
+
                 for (TaskEntry entry : outputFragment.entries()) {
-                    var markdownPanel = new MarkdownOutputPanel();
+                    var markdownPanel = new MarkdownOutputPanel(escapeHtml);
                     markdownPanel.updateTheme(themeManager != null && themeManager.isDarkTheme());
                     markdownPanel.setText(entry);
                     markdownPanel.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, Color.GRAY));

--- a/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
@@ -736,9 +736,7 @@ public class GitIssuesTab extends JPanel {
                         }
                     }
                 } catch (IOException e) {
-                    // issue.getNumber() does not throw IOException
-                    String issueNumberForLog = String.valueOf(issue.getNumber());
-                    logger.warn("Could not get author for comment id {} on issue #{}", comment.getId(), issueNumberForLog, e);
+                    logger.warn("Could not get author for comment id {} on issue #{}", comment.getId(), String.valueOf(issue.getNumber()), e);
                 }
                 for (String url : commentImageUrls) {
                     // Associate the URL with this comment's author, potentially overwriting if URL is in multiple comments (rare)
@@ -757,20 +755,13 @@ public class GitIssuesTab extends JPanel {
                     java.awt.Image image = ImageUtil.downloadImage(imageUri, this.httpClient);
                     if (image != null) {
                         String description;
-                        // issue.getNumber() does not throw IOException
-                        String issueNumberForDesc = String.valueOf(issue.getNumber());
-
                         // Determine if the image URL was primarily from the issue body or a comment for description
                         boolean inIssueBody = issueBodyMarkdown != null && !issueBodyMarkdown.isBlank() && MarkdownImageParser.extractImageUrls(issueBodyMarkdown).contains(imageUrl);
                         if (inIssueBody) {
-                            description = String.format("Image from GitHub issue #%s body (%s)", issueNumberForDesc, imageUrl);
+                            description = String.format("Image from GitHub issue #%s body", issue.getNumber());
                         } else {
                             String commentAuthor = commentAuthors.getOrDefault(imageUrl, "unknown author");
-                            description = String.format("Image from comment by %s on GitHub issue #%s (%s)", commentAuthor, issueNumberForDesc, imageUrl);
-                        }
-
-                        if (description.length() > 150) { // Max length for description
-                            description = description.substring(0, 147) + "...";
+                            description = String.format("Image from comment by %s on GitHub issue #%s", commentAuthor, issue.getNumber());
                         }
                         contextManager.addPastedImageFragment(image, description);
                         capturedImageCount++;

--- a/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
@@ -817,10 +817,10 @@ public class GitIssuesTab extends JPanel {
                         // Determine if the image URL was primarily from the issue body or a comment for description
                         boolean inIssueBody = issueBodyMarkdown != null && !issueBodyMarkdown.isBlank() && MarkdownImageParser.extractImageUrls(issueBodyMarkdown).contains(imageUrl);
                         if (inIssueBody) {
-                            description = String.format("Image from GitHub issue #%s body", issue.getNumber());
+                            description = String.format("GitHub issue #%s: Image from Issue", issue.getNumber());
                         } else {
                             String commentAuthor = commentAuthors.getOrDefault(imageUrl, "unknown author");
-                            description = String.format("Image from comment by %s on GitHub issue #%s", commentAuthor, issue.getNumber());
+                            description = String.format("GitHub issue #%s: Image from comment by %s", commentAuthor, issue.getNumber());
                         }
                         contextManager.addPastedImageFragment(image, description);
                         capturedImageCount++;

--- a/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
@@ -576,9 +576,9 @@ public class GitIssuesTab extends JPanel {
         String originalMarkdownBody = (issue.getBody() == null || issue.getBody().isBlank()) ? "*No description provided.*" : issue.getBody();
 
         contextManager.submitContextTask("Capturing Issue #" + issue.getNumber(), () -> {
-            List<String> imageReferenceTexts = processImages(issue, originalMarkdownBody);
-            List<ChatMessage> messages = buildMarkdownContent(issue, capturedAuthorLogin, actualFinalLabelsStr, actualFinalAssigneesStr, originalMarkdownBody, imageReferenceTexts);
+            List<ChatMessage> messages = buildMarkdownContent(issue, capturedAuthorLogin, actualFinalLabelsStr, actualFinalAssigneesStr, originalMarkdownBody);
             createAndAddFragment(issue, messages);
+            List<String> imageReferenceTexts = processImages(issue, originalMarkdownBody);
             String imageMessage = imageReferenceTexts.isEmpty() ? "" : " with " + imageReferenceTexts.size() + " image(s) referenced";
             chrome.systemOutput("Issue #" + issue.getNumber() + " captured to workspace" + imageMessage + ".");
         });
@@ -637,42 +637,32 @@ public class GitIssuesTab extends JPanel {
         return imageReferenceTexts;
     }
 
-    private List<ChatMessage> buildMarkdownContent(GHIssue issue, String capturedAuthorLogin, String actualFinalLabelsStr, String actualFinalAssigneesStr, String originalMarkdownBody, List<String> imageReferenceTexts) {
-        var markdownContentBuilder = new StringBuilder();
-        markdownContentBuilder.append(String.format("""
-                                                    # Issue #%d: %s
-                                                    
-                                                    **Author:** %s
-                                                    **Status:** %s
-                                                    **URL:** %s
-                                                    **Labels:** %s
-                                                    **Assignees:** %s
-                                                    
-                                                    ---
-                                                    
-                                                    %s
-                                                    """.stripIndent(),
-                                                    issue.getNumber(),
-                                                    issue.getTitle(),
-                                                    capturedAuthorLogin,
-                                                    issue.getState().toString(),
-                                                    issue.getHtmlUrl().toString(),
-                                                    actualFinalLabelsStr.isEmpty() ? "None" : actualFinalLabelsStr,
-                                                    actualFinalAssigneesStr.isEmpty() ? "None" : actualFinalAssigneesStr,
-                                                    originalMarkdownBody
-        ));
+    private List<ChatMessage> buildMarkdownContent(GHIssue issue, String capturedAuthorLogin, String actualFinalLabelsStr, String actualFinalAssigneesStr, String originalMarkdownBody) {
+        String markdownContentBuilder = String.format("""
+                                                      # Issue #%d: %s
+                                                      
+                                                      **Author:** %s
+                                                      **Status:** %s
+                                                      **URL:** %s
+                                                      **Labels:** %s
+                                                      **Assignees:** %s
+                                                      
+                                                      ---
+                                                      
+                                                      %s
+                                                      """.stripIndent(),
+                                                      issue.getNumber(),
+                                                      issue.getTitle(),
+                                                      capturedAuthorLogin,
+                                                      issue.getState().toString(),
+                                                      issue.getHtmlUrl().toString(),
+                                                      actualFinalLabelsStr.isEmpty() ? "None" : actualFinalLabelsStr,
+                                                      actualFinalAssigneesStr.isEmpty() ? "None" : actualFinalAssigneesStr,
+                                                      originalMarkdownBody
+        );
 
         List<ChatMessage> messages = new ArrayList<>();
-        messages.add(new CustomMessage(Map.of("text", markdownContentBuilder.toString())));
-        
-        if (!imageReferenceTexts.isEmpty()) {
-            markdownContentBuilder = new StringBuilder();
-            markdownContentBuilder.append("## Referenced ImageFragments\n");
-            StringBuilder finalMarkdownContentBuilder = markdownContentBuilder;
-            imageReferenceTexts.forEach(ref -> finalMarkdownContentBuilder.append(ref).append("\n"));
-            messages.add(new CustomMessage(Map.of("text", finalMarkdownContentBuilder.toString())));
-        }
-        
+        messages.add(new CustomMessage(Map.of("text", markdownContentBuilder)));
         return messages;
     }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
@@ -189,6 +189,7 @@ public class GitIssuesTab extends JPanel {
         openInBrowserButton.setToolTipText("Open the selected issue in your web browser");
         openInBrowserButton.setEnabled(false);
         openInBrowserButton.addActionListener(e -> openSelectedIssueInBrowser());
+        openInBrowserButton.addActionListener(e -> openSelectedIssueInBrowser());
         issueButtonPanel.add(openInBrowserButton);
         issueButtonPanel.add(Box.createHorizontalStrut(new Constants().H_GAP));
 
@@ -585,14 +586,12 @@ public class GitIssuesTab extends JPanel {
                         Image image = ImageUtil.downloadImage(imageUri, this.httpClient);
                         if (image != null) {
                             // Manually create and add the ImageFragment
-                            String imageDescription = "Image from issue " + issue.getNumber() + ": " + imageUrl;
+                            String imageDescription = "Image from issue #" + issue.getNumber() + ": " + imageUrl;
                             // Ensure the description is not overly long for typical display, but provides uniqueness
                             if (imageDescription.length() > 150) { // Truncate if too long
                                 imageDescription = imageDescription.substring(0, 147) + "...";
                             }
-                            // Use the fully qualified nested class name, assuming ImageFragment is a static nested class of ContextFragment
-                            ContextFragment.ImageFragment imageFragment = new ContextFragment.ImageFragment(contextManager, image, imageDescription);
-                            contextManager.addVirtualFragment(imageFragment); // Add it to the context
+                            contextManager.addPastedImageFragment(image); // Add it to the context
 
                             // Now we have imageFragment.description() and imageFragment.id()
                             imageReferenceTexts.add(String.format("- %s (Fragment ID: %d)", imageFragment.description(), imageFragment.id()));
@@ -655,7 +654,6 @@ public class GitIssuesTab extends JPanel {
             this.contextManager.addVirtualFragment(taskFragment);
             String imageMessage = imageReferenceTexts.isEmpty() ? "" : " with " + imageReferenceTexts.size() + " image(s) referenced";
             chrome.systemOutput("Issue #" + issue.getNumber() + " captured to workspace" + imageMessage + ".");
-            return null; // Explicitly return null for Callable<Void>
         });
     }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitIssuesTab.java
@@ -759,7 +759,7 @@ public class GitIssuesTab extends JPanel {
     }
 
     private ContextFragment.TaskFragment createCommentsFragment(GHIssue issue, List<ChatMessage> commentMessages) {
-        String description = String.format("Comments for GitHub Issue #%d: %s", issue.getNumber(), issue.getTitle());
+        String description = String.format("GitHub Issue #%d: Comments", issue.getNumber());
         return new ContextFragment.TaskFragment(
                 this.contextManager,
                 commentMessages,
@@ -820,7 +820,7 @@ public class GitIssuesTab extends JPanel {
                             description = String.format("GitHub issue #%s: Image from Issue", issue.getNumber());
                         } else {
                             String commentAuthor = commentAuthors.getOrDefault(imageUrl, "unknown author");
-                            description = String.format("GitHub issue #%s: Image from comment by %s", commentAuthor, issue.getNumber());
+                            description = String.format("GitHub issue #%s: Image from comment by %s", issue.getNumber(), commentAuthor);
                         }
                         contextManager.addPastedImageFragment(image, description);
                         capturedImageCount++;

--- a/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
@@ -64,11 +64,13 @@ public class MarkdownOutputPanel extends JPanel implements Scrollable, ThemeAwar
     private boolean isDarkTheme = false;
     private boolean blockClearAndReset = false;
     private final ExecutorService compactExec;
+    private final boolean escapeHtml;
 
     // Global HtmlCustomizer applied to every renderer
     private HtmlCustomizer htmlCustomizer = HtmlCustomizer.DEFAULT;
 
-    public MarkdownOutputPanel() {
+    public MarkdownOutputPanel(boolean escapeHtml) {
+        this.escapeHtml = escapeHtml;
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setOpaque(true);
         this.compactExec = Executors.newSingleThreadExecutor(r -> {
@@ -78,6 +80,9 @@ public class MarkdownOutputPanel extends JPanel implements Scrollable, ThemeAwar
         });
     }
 
+    public MarkdownOutputPanel() {
+        this(true); // Default to escaping HTML
+    }
 
     @Override
     public void applyTheme(GuiTheme guiTheme) {
@@ -290,7 +295,7 @@ public class MarkdownOutputPanel extends JPanel implements Scrollable, ThemeAwar
         
         // Create a new renderer for this message - disable edit blocks for user messages
         boolean enableEditBlocks = message.type() != ChatMessageType.USER;
-        var renderer = new IncrementalBlockRenderer(isDarkTheme, enableEditBlocks);
+        var renderer = new IncrementalBlockRenderer(isDarkTheme, enableEditBlocks, escapeHtml);
         renderer.setHtmlCustomizer(htmlCustomizer);
 
         // Create a new worker for this message

--- a/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
@@ -2,6 +2,7 @@ package io.github.jbellis.brokk.gui.mop;
 
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
+import dev.langchain4j.data.message.UserMessage;
 import io.github.jbellis.brokk.context.ContextFragment;
 import io.github.jbellis.brokk.TaskEntry;
 import io.github.jbellis.brokk.gui.GuiTheme;
@@ -267,7 +268,11 @@ public class MarkdownOutputPanel extends JPanel implements Scrollable, ThemeAwar
                 highlightColor = ThemeColors.getColor(isDarkTheme, "message_border_ai");
                 break;
             case USER:
-                title = "You";
+                if (message instanceof UserMessage userMessage && userMessage.name() != null && !userMessage.name().isEmpty()) {
+                    title = userMessage.name();
+                } else {
+                    title = "You";
+                }
                 iconText = "\uD83D\uDCBB"; // Unicode for computer emoji
                 highlightColor = ThemeColors.getColor(isDarkTheme, "message_border_user");
                 break;

--- a/src/main/java/io/github/jbellis/brokk/gui/mop/stream/IncrementalBlockRenderer.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/stream/IncrementalBlockRenderer.java
@@ -530,7 +530,6 @@ public final class IncrementalBlockRenderer {
      * Returns the Swing component that displays the given marker id, if any.
      */
     public java.util.Optional<JComponent> findByMarkerId(int id) {
-        assert SwingUtilities.isEventDispatchThread() : "findByMarkerId must be called on EDT";
         return Optional.ofNullable(markerIndex.get(id));
     }
 
@@ -538,7 +537,6 @@ public final class IncrementalBlockRenderer {
      * Returns all marker ids currently known to this renderer.
      */
     public Set<Integer> getIndexedMarkerIds() {
-        assert SwingUtilities.isEventDispatchThread() : "getIndexedMarkerIds must be called on EDT";
         return Set.copyOf(markerIndex.keySet());
     }
     

--- a/src/main/java/io/github/jbellis/brokk/gui/mop/stream/IncrementalBlockRenderer.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/stream/IncrementalBlockRenderer.java
@@ -57,7 +57,6 @@ public final class IncrementalBlockRenderer {
     // Content tracking
     private String lastHtmlFingerprint = "";
     private String currentMarkdown = "";  // The current markdown content (always markdown, never HTML)
-    private String compactedHtml = "";    // HTML content after compaction (empty if not compacted)
     private boolean compacted = false;    // Whether content has been compacted for better text selection
 
     // Per-instance HTML customizer; defaults to NO_OP to avoid null checks
@@ -82,18 +81,23 @@ public final class IncrementalBlockRenderer {
      * @param dark true for dark theme, false for light theme
      */
     public IncrementalBlockRenderer(boolean dark) {
-        this(dark, true);
+        this(dark, true, true);
     }
-    
+
+    public IncrementalBlockRenderer(boolean dark, boolean enableEditBlocks) {
+        this(dark, enableEditBlocks, true);
+    }
+
     /**
-     * Creates a new incremental renderer with the given theme and edit block setting.
-     * 
+     * Creates a new incremental renderer with the given theme, edit block, and HTML escaping settings.
+     *
      * @param dark true for dark theme, false for light theme
      * @param enableEditBlocks true to enable edit block parsing and rendering, false to disable
+     * @param escapeHtml true to escape HTML within markdown, false to allow raw HTML
      */
-    public IncrementalBlockRenderer(boolean dark, boolean enableEditBlocks) {
+    public IncrementalBlockRenderer(boolean dark, boolean enableEditBlocks, boolean escapeHtml) {
         this.isDarkTheme = dark;
-        
+
         // Create root panel with vertical BoxLayout
         root = new JPanel();
         root.setLayout(new BoxLayout(root, BoxLayout.Y_AXIS));
@@ -110,9 +114,9 @@ public final class IncrementalBlockRenderer {
             .set(BrokkMarkdownExtension.ENABLE_EDIT_BLOCK, enableEditBlocks)
             .set(IdProvider.ID_PROVIDER, idProvider)
             .set(HtmlRenderer.SOFT_BREAK, "<br />\n")
-            .set(HtmlRenderer.ESCAPE_HTML, true)
+            .set(HtmlRenderer.ESCAPE_HTML, escapeHtml)
             .set(TablesExtension.MIN_SEPARATOR_DASHES, 1);
-            
+
         parser = Parser.builder(options).build();
         renderer = HtmlRenderer.builder(options).build();
         
@@ -415,10 +419,6 @@ public final class IncrementalBlockRenderer {
         compacted = true;
 
         // Store the compacted HTML for future reference
-        this.compactedHtml = mergedComponents.stream()
-                                         .filter(cd -> cd instanceof MarkdownComponentData)
-                                         .map(cd -> ((MarkdownComponentData) cd).html())
-                                         .collect(Collectors.joining("\n"));
         this.lastHtmlFingerprint = mergedComponents.stream().map(ComponentData::fp).collect(Collectors.joining("-"));
     }
 

--- a/src/main/java/io/github/jbellis/brokk/util/ImageUtil.java
+++ b/src/main/java/io/github/jbellis/brokk/util/ImageUtil.java
@@ -4,11 +4,22 @@ import javax.imageio.ImageIO;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Base64;
 
 public class ImageUtil {
+    private static final Logger logger = LogManager.getLogger(ImageUtil.class);
+
     public static BufferedImage toBuffered(Image img) {
         if (img == null) return null; // Handle null input
         if (img instanceof BufferedImage bi) {
@@ -47,6 +58,66 @@ public class ImageUtil {
                     .base64Data(base64)
                     .mimeType("image/png")
                     .build();
+        }
+    }
+
+    /**
+     * Checks if the given URI likely points to an image by sending a HEAD request
+     * and checking the Content-Type header.
+     *
+     * @param uri    The URI to check.
+     * @param client The OkHttpClient to use for the request.
+     * @return true if the URI content type starts with "image/", false otherwise.
+     */
+    public static boolean isImageUri(URI uri, OkHttpClient client) {
+        Request request = new Request.Builder()
+                .url(uri.toString())
+                .head() // Send a HEAD request
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                String contentType = response.header("Content-Type");
+                if (contentType != null) {
+                    logger.debug("URL {} Content-Type: {}", uri, contentType);
+                    return contentType.toLowerCase().startsWith("image/");
+                } else {
+                    logger.warn("URL {} did not return a Content-Type header.", uri);
+                }
+            } else {
+                logger.warn("HEAD request to {} failed with code: {}", uri, response.code());
+            }
+        } catch (IOException e) {
+            // Log common issues like UnknownHostException or ConnectTimeoutException at a less severe level
+            if (e instanceof java.net.UnknownHostException || e instanceof java.net.SocketTimeoutException) {
+                logger.warn("IOException during HEAD request to {}: {}", uri, e.getMessage());
+            } else {
+                logger.error("IOException during HEAD request to {}: {}", uri, e.getMessage());
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Downloads an image from the given URI.
+     *
+     * @param uri    The URI to download the image from.
+     * @param client The OkHttpClient to use for the request (though ImageIO uses its own mechanism).
+     *               It's included for consistency if we later switched to OkHttp for download.
+     * @return The downloaded Image, or null if an error occurred or it's not a valid image.
+     */
+    @Nullable
+    public static Image downloadImage(URI uri, OkHttpClient client) {
+        // Note: ImageIO.read(URL) handles its own connection.
+        // The OkHttpClient isn't directly used here for the download itself but is part of the API
+        // in case future implementations want to use it (e.g., for direct byte streaming with OkHttp).
+        try {
+            // It's good practice to ensure the URI is an image first using isImageUri if this method is called externally without prior check.
+            // However, ImageIO.read will also return null if it cannot decode the content.
+            return ImageIO.read(uri.toURL());
+        } catch (IOException e) {
+            logger.warn("Failed to fetch or decode image from URL {}: {}.", uri, e.getMessage());
+            return null;
         }
     }
 }

--- a/src/main/java/io/github/jbellis/brokk/util/MarkdownImageParser.java
+++ b/src/main/java/io/github/jbellis/brokk/util/MarkdownImageParser.java
@@ -1,0 +1,44 @@
+package io.github.jbellis.brokk.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class MarkdownImageParser {
+    private static final Pattern IMAGE_MARKDOWN_PATTERN = Pattern.compile("!\\[(?:[^\\]]*)\\]\\(([^\\)]+)\\)");
+    private static final Pattern HTML_IMG_TAG_PATTERN = Pattern.compile("<img\\s+[^>]*?src\\s*=\\s*[\"']([^\"']+)[\"'][^>]*?/?>", Pattern.CASE_INSENSITIVE);
+
+    private MarkdownImageParser() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Extracts image URLs from a given text content that might contain Markdown image syntax or HTML img tags.
+     *
+     * @param textContent The text content to parse.
+     * @return A set of unique image URLs found in the content. Returns an empty set if the content is null or blank.
+     */
+    public static @NotNull Set<String> extractImageUrls(@NotNull String textContent) {
+        if (textContent.isBlank()) {
+            return Set.of();
+        }
+
+        Set<String> uniqueImageUrls = new LinkedHashSet<>();
+
+        // Find and add URLs from Markdown image links
+        Matcher markdownMatcher = IMAGE_MARKDOWN_PATTERN.matcher(textContent);
+        while (markdownMatcher.find()) {
+            uniqueImageUrls.add(markdownMatcher.group(1));
+        }
+
+        // Find and add URLs from HTML <img> tags
+        Matcher htmlMatcher = HTML_IMG_TAG_PATTERN.matcher(textContent);
+        while (htmlMatcher.find()) {
+            uniqueImageUrls.add(htmlMatcher.group(1));
+        }
+        return uniqueImageUrls;
+    }
+}

--- a/src/test/java/io/github/jbellis/brokk/context/ContextSerializationTest.java
+++ b/src/test/java/io/github/jbellis/brokk/context/ContextSerializationTest.java
@@ -142,7 +142,7 @@ public class ContextSerializationTest {
 
         // Context 2: Image fragment, task history
         var image1 = createTestImage(Color.RED, 10, 10);
-        var pasteImageFragment1 = new ContextFragment.PasteImageFragment(mockContextManager, image1, CompletableFuture.completedFuture("Pasted Red Image"));
+        var pasteImageFragment1 = new ContextFragment.AnonymousImageFragment(mockContextManager, image1, CompletableFuture.completedFuture("Pasted Red Image"));
         
         var context2 = new Context(mockContextManager, "Context 2 started")
                 .addVirtualFragment(pasteImageFragment1);
@@ -181,7 +181,7 @@ public class ContextSerializationTest {
         byte[] imageBytesContent;
         if (loadedImageFragment instanceof FrozenFragment ff) {
             imageBytesContent = ff.imageBytesContent();
-        } else if (loadedImageFragment instanceof ContextFragment.PasteImageFragment pif) {
+        } else if (loadedImageFragment instanceof ContextFragment.AnonymousImageFragment pif) {
             imageBytesContent = imageToBytes(pif.image());
         } else {
             throw new AssertionError("Unexpected fragment type for pasted image: " + loadedImageFragment.getClass());
@@ -291,12 +291,12 @@ public class ContextSerializationTest {
         // Create two PasteImageFragments with identical content and description
         // This should result in the same FrozenFragment instance due to interning
         var sharedDescription = "Shared Blue Image";
-        var liveImageFrag1 = new ContextFragment.PasteImageFragment(
+        var liveImageFrag1 = new ContextFragment.AnonymousImageFragment(
             mockContextManager, 
             sharedImage, 
             CompletableFuture.completedFuture(sharedDescription)
         );
-        var liveImageFrag2 = new ContextFragment.PasteImageFragment(
+        var liveImageFrag2 = new ContextFragment.AnonymousImageFragment(
             mockContextManager, 
             sharedImage, 
             CompletableFuture.completedFuture(sharedDescription)
@@ -345,7 +345,7 @@ public class ContextSerializationTest {
         byte[] imageBytes1, imageBytes2;
         if (fragment1 instanceof FrozenFragment ff1) {
             imageBytes1 = ff1.imageBytesContent();
-        } else if (fragment1 instanceof ContextFragment.PasteImageFragment pif1) {
+        } else if (fragment1 instanceof ContextFragment.AnonymousImageFragment pif1) {
             imageBytes1 = imageToBytes(pif1.image());
         } else {
             throw new AssertionError("Unexpected fragment type for image in ctx1: " + fragment1.getClass());
@@ -353,7 +353,7 @@ public class ContextSerializationTest {
 
         if (fragment2 instanceof FrozenFragment ff2) {
             imageBytes2 = ff2.imageBytesContent();
-        } else if (fragment2 instanceof ContextFragment.PasteImageFragment pif2) {
+        } else if (fragment2 instanceof ContextFragment.AnonymousImageFragment pif2) {
             imageBytes2 = imageToBytes(pif2.image());
         } else {
             throw new AssertionError("Unexpected fragment type for image in ctx2: " + fragment2.getClass());

--- a/src/test/java/io/github/jbellis/brokk/context/ContextSerializationTest.java
+++ b/src/test/java/io/github/jbellis/brokk/context/ContextSerializationTest.java
@@ -173,7 +173,7 @@ public class ContextSerializationTest {
 
         // Verify image content from the image fragment in loadedCtx2
         var loadedImageFragmentOpt = loadedCtx2.virtualFragments()
-            .filter(f -> !f.isText() && "Paste of Pasted Red Image".equals(f.description()))
+            .filter(f -> !f.isText() && "Pasted Red Image".equals(f.description()))
             .findFirst();
         assertTrue(loadedImageFragmentOpt.isPresent(), "Pasted Red Image fragment not found in loaded context 2");
         var loadedImageFragment = loadedImageFragmentOpt.get();
@@ -333,12 +333,12 @@ public class ContextSerializationTest {
         
         // Find the image fragments in each context
         var fragment1 = loadedCtx1.virtualFragments()
-            .filter(f -> !f.isText() && "Paste of Shared Blue Image".equals(f.description()))
+            .filter(f -> !f.isText() && "Shared Blue Image".equals(f.description()))
             .findFirst()
             .orElseThrow(() -> new AssertionError("Image fragment not found in loaded context 1"));
             
         var fragment2 = loadedCtx2.virtualFragments()
-            .filter(f -> !f.isText() && "Paste of Shared Blue Image".equals(f.description()))
+            .filter(f -> !f.isText() && "Shared Blue Image".equals(f.description()))
             .findFirst()
             .orElseThrow(() -> new AssertionError("Image fragment not found in loaded context 2"));
         
@@ -376,8 +376,8 @@ public class ContextSerializationTest {
         assertEquals(8, reconstructedImage2.getHeight());
         
         // Verify descriptions
-        assertEquals("Paste of " + sharedDescription, fragment1.description());
-        assertEquals("Paste of " + sharedDescription, fragment2.description());
+        assertEquals(sharedDescription, fragment1.description());
+        assertEquals(sharedDescription, fragment2.description());
     }
 
     @Test


### PR DESCRIPTION
## ✨  Summary
This pull-request adds first-class support for capturing GitHub issues (including body, comments _and_ inline images) into the Brokk workspace, while tightening image/markdown handling, removing EDT violations and giving GUI renderers fine-grained control over HTML escaping.

![image](https://github.com/user-attachments/assets/66245eea-7c2d-4542-bf89-6beccc14df08)


Key themes
* Capture any GitHub issue from the new **Git Issues** tab into the workspace.
* Download and embed remote images (clipboard URL, issue body, comments) via a shared, authenticated `OkHttpClient`.
* Replace the ad-hoc `PasteImageFragment` with the more generic `AnonymousImageFragment`.
* Allow TaskFragments/Markdown renderers to opt-out of HTML escaping (needed for GitHub HTML in markdown).
* Fix several Swing thread-safety gaps.
* Centralise HTTP/image introspection in new `ImageUtil` & parsing in `MarkdownImageParser`.

---

## 📋  Detailed Change Log

### 1. Context / Fragments
* **`AnonymousImageFragment`**
    * Supersedes `PasteImageFragment`.
    * Always returns a sensible **placeholder description** until the async summary finishes.
* **`ContextManager`**
    * Overloaded `addPastedImageFragment(Image, String)` to allow callers to provide their own description (used by issue capture).
    * Listener notifications are now dispatched on the **EDT**.
* **`TaskFragment`**
    * New `escapeHtml` flag (+ multiple ctors) and `isEscapeHtml()` on `OutputFragment`.

### 2. GitHub & HTTP
* **`GitHubAuth.authenticatedClient()`** returns a pre-auth’d `OkHttpClient` for arbitrary REST calls (used for images).
* **`GitIssuesTab`**
    * Dynamic filters rebuilt with a single helper.
    * Adds right-click context menu.
    * **Capture** button/action:
        * Converts issue body → TaskFragment (no HTML escaping required).
        * Converts every comment → TaskFragment.
        * Parses markdown/HTML for `<img>` / `![ ]( )` links, downloads them and inserts `AnonymousImageFragment`s with meaningful descriptions.
    * Uses the shared `OkHttpClient` for range/HEAD checks and downloads.

### 3. Image utilities
* **`ImageUtil`**
    * `isImageUri(URI, OkHttpClient)` – HEAD + Range fallback; tolerant to mis-configured servers.
    * `downloadImage(URI, OkHttpClient)` wrapper.
    * Existing helpers untouched.
* **`MarkdownImageParser`** (new): Extracts URLs from both markdown image syntax and raw HTML tags.

### 4. GUI / Rendering
* **`MarkdownOutputPanel` & `IncrementalBlockRenderer`**
    * Accept `escapeHtml` constructor arg → wired all the way from `ContextFragment.TaskFragment.isEscapeHtml()`.
* **`Chrome`**
    * Passes `outputFragment.isEscapeHtml()` into new `MarkdownOutputPanel(escapeHtml)`.

### 5. Tests
* `ContextSerializationTest` updated to use `AnonymousImageFragment` and new description semantics.

---

## 🛠️  Reasoning & Benefits
* **Issue capture** greatly accelerates bug-triage workflows: a single click brings the full issue context (text + images) into the LLM conversation.
* **Shared HTTP client** avoids redundant connection pools and adds auth headers where possible.
* **Escape-HTML toggle** prevents double-escaping GitHub’s HTML-rich markdown whilst keeping default safe.
* **EDT fixes** remove sporadic `IllegalStateException`s and paint glitches.
* **ImageUtils** now centralises mime sniffing and downloading, replacing scattered `HEAD` logic.

---

## 🔍  Potential Impact / Migration
* `PasteImageFragment` is gone – any external code should migrate to `AnonymousImageFragment`.
* `TaskFragment` ctor additions: existing callers use defaults; no breakage expected.
* Rendering pipeline honours `isEscapeHtml()` – verify custom fragments if any.

---

## ✅  Verification
* Unit: `ContextSerializationTest` passes.
* Manual:
    1. Open Git Issues tab, filter & select an issue, click **Capture** → fragments appear in Workspace.
    2. Context round-trip (save/load) preserves new fragment types.
    3. Paste image URL – now recognised via `ImageUtil`.
    4. Dark/light theme still renders markdown correctly; HTML in GitHub bodies is preserved.

---

## 📌  Future Work
* Progress indicator while large images download.
* Support for GitHub PR review comments (similar pipeline).
* Deduplicate identical images via hash before storing.

---
