### PR TITLE
fix: Project should load most-recently-active session which is not always most-recently-modified

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -151,11 +151,12 @@ public class ContextManager implements IContextManager, AutoCloseable {
             this.currentSessionId = newSessionInfo.id();
             logger.info("Created and loaded new session: {} ({})", newSessionInfo.name(), newSessionInfo.id());
         } else {
-            sessions.sort(java.util.Comparator.comparingLong(Project.SessionInfo::modified).reversed());
+            sessions.sort(java.util.Comparator.comparingLong(Project.SessionInfo::lastAccessed).reversed());
             var latestSession = sessions.get(0);
             this.currentSessionId = latestSession.id();
             logger.info("Loaded most recent session: {} ({})", latestSession.name(), latestSession.id());
         }
+        project.updateSessionLastAccessed(this.currentSessionId);
         
         this.contextHistory = new ContextHistory();
         this.service = new ServiceWrapper();
@@ -1746,6 +1747,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         var future = submitUserTask("Switching session", () -> {
             logger.info("Attempting to switch to session: {}", sessionId);
             this.currentSessionId = sessionId;
+            project.updateSessionLastAccessed(this.currentSessionId);
             String sessionName = project.listSessions().stream()
                     .filter(s -> s.id().equals(sessionId))
                     .findFirst()


### PR DESCRIPTION
Because `lastAccessed` property of Sessions wasn't presisted before, the first time Brokk is open with this change, a random Session would be picked as the active one, after that it would work as expected. 