### PR TITLE
fix: allow for right clicking on a file's row to activate context dialog

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/ProjectTree.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/ProjectTree.java
@@ -116,6 +116,23 @@ public class ProjectTree extends JTree {
     private void handlePopupTrigger(MouseEvent e) {
         if (e.isPopupTrigger()) {
             TreePath path = getPathForLocation(e.getX(), e.getY());
+            if (path == null) {
+                // If exact hit detection failed, check if we're within any row's vertical bounds
+                int row = getRowForLocation(e.getX(), e.getY());
+                if (row >= 0) {
+                    path = getPathForRow(row);
+                } else {
+                    // Fallback: find the closest row by Y coordinate
+                    int rowCount = getRowCount();
+                    for (int i = 0; i < rowCount; i++) {
+                        Rectangle rowBounds = getRowBounds(i);
+                        if (rowBounds != null && e.getY() >= rowBounds.y && e.getY() < rowBounds.y + rowBounds.height) {
+                            path = getPathForRow(i);
+                            break;
+                        }
+                    }
+                }
+            }
             if (path != null) {
                 // If right-clicking on an item not in current selection, change selection to that item.
                 // Otherwise, keep current selection.


### PR DESCRIPTION
![Kapture 2025-06-12 at 16 18 12](https://github.com/user-attachments/assets/0b111b48-8299-4dbc-9f84-fd28d9ee3d51)
updated right click behavior on the file tree to allow for right clicking on the row to activate the context dialog.

previously, you had to click on the file name specifically