### PR TITLE
feat: Add Bouncy Castle provider support for ssh (JGit)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,9 @@ libraryDependencies ++= Seq(
   "com.jgoodies" % "jgoodies-forms" % "1.9.0",
   "com.github.spullara.mustache.java" % "compiler" % "0.9.10",
 
+  // Bouncy Castle for JGit SSH
+  "org.bouncycastle" % "bcprov-jdk18on" % "1.80",
+
   // TreeSitter Java parser
   "io.github.bonede" % "tree-sitter" % "0.25.3",
   "io.github.bonede" % "tree-sitter-c-sharp" % "0.23.1",

--- a/src/main/java/io/github/jbellis/brokk/Brokk.java
+++ b/src/main/java/io/github/jbellis/brokk/Brokk.java
@@ -13,6 +13,7 @@ import io.github.jbellis.brokk.gui.dialogs.SettingsDialog;
 import io.github.jbellis.brokk.gui.dialogs.StartupDialog;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
@@ -24,16 +25,12 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.security.Security;
+import java.util.*;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -55,6 +52,15 @@ public class Brokk {
     // Helper record for key validation result
     private record KeyValidationResult(boolean isValid, Path dialogProjectPath) {}
 
+    static {
+        // Register Bouncy Castle provider for JGit SSH operations if not already present.
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+            logger.info("Bouncy Castle security provider registered.");
+        } else {
+            logger.info("Bouncy Castle security provider was already registered.");
+        }
+    }
 
     static {
         embeddingModelFuture = CompletableFuture.supplyAsync(() -> {


### PR DESCRIPTION
**Problem**  
Git operations over SSH fail (on my machine) with

```
publickey: no keys to try
```

because Apache MINA-SSHD (used by JGit 7.2.x) cannot find an `ED25519` signature implementation.  
Several “full” JDK builds on Ubuntu 25.04 (Oracle, Temurin, Corretto, etc.) also expose this gap, likely due to the way those packages are stripped or configured.

**Fix**  
1. Ship **Bouncy Castle** (`bcprov-jdk18on 1.80`) as a runtime dependency.  
2. Register the provider once at application start-up:

   ```java
   static {
       if (Security.getProvider("BC") == null)
           Security.addProvider(new BouncyCastleProvider());
   }
   ```

With BC present, MINA-SSHD successfully creates the `ssh-ed25519` signature and authentication works.

**Impact**  
• Pull / Fetch / Push now work
• No behaviour change on systems that already had ED25519; BC is simply ignored there.  
