### PR TITLE
fix: add UI scale support in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,12 @@ javaOptions ++= Seq(
   "-Dbrokk.devmode=true",
   "-Dbrokk.prtab=true",
   "-Dbrokk.issuetab=true"
-)
+) ++ sys.env.get("UI_SCALE").map { scale =>
+  Seq(
+    s"-Dsun.java2d.uiScale=$scale",
+    "-Dsun.java2d.dpiaware=true"
+  )
+}.getOrElse(Seq.empty)
 
 testFrameworks += new TestFramework("com.github.sbt.junit.JupiterFramework")
 Test / javacOptions := (Compile / javacOptions).value.filterNot(_.contains("-Xplugin:ErrorProne"))


### PR DESCRIPTION
I use an UI scale of 150% in my Ubuntu 25.04 version (X11).
Swing seems not to respect this in all areas:

![image](https://github.com/user-attachments/assets/ea0eaa0b-8318-4c6b-a8eb-fe100d556f5c)

With the changes in place I can start the app with env var UI_SCALE=2

`UI_SCALE=2.0 sbt run`
 then it looks correct:
 
 
![image](https://github.com/user-attachments/assets/f1b6709d-bc56-4f2a-95a7-ab8a988f2ba2)

Maybe you have a better idea?