### PR TITLE
feat: Add isNewMessage parameter to llmOutput to visually distinct su…

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -179,7 +179,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
             }
 
             @Override
-            public void llmOutput(String token, ChatMessageType type) {
+            public void llmOutput(String token, ChatMessageType type, boolean isNewMessage) {
                 // pass
             }
         };

--- a/src/main/java/io/github/jbellis/brokk/IConsoleIO.java
+++ b/src/main/java/io/github/jbellis/brokk/IConsoleIO.java
@@ -43,7 +43,11 @@ public interface IConsoleIO {
         CommandOutput
     }
 
-    void llmOutput(String token, ChatMessageType type);
+    void llmOutput(String token, ChatMessageType type, boolean isNewMessage);
+
+    default void llmOutput(String token, ChatMessageType type) {
+        llmOutput(token, type, false);
+    }
 
     default void setLlmOutput(ContextFragment.TaskFragment newOutput) {
         var firstMessage = newOutput.messages().getFirst();

--- a/src/main/java/io/github/jbellis/brokk/agents/ArchitectAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/ArchitectAgent.java
@@ -96,7 +96,7 @@ public class ArchitectAgent {
     {
         var msg = "# Architect complete\n\n%s".formatted(finalExplanation);
         logger.debug(msg);
-        io.llmOutput(msg, ChatMessageType.AI);
+        io.llmOutput(msg, ChatMessageType.AI, true);
 
         return finalExplanation;
     }
@@ -112,7 +112,7 @@ public class ArchitectAgent {
     {
         var msg = "# Architect aborted\n\n%s".formatted(reason);
         logger.debug(msg);
-        io.llmOutput(msg, ChatMessageType.AI);
+        io.llmOutput(msg, ChatMessageType.AI, true);
 
         return reason;
     }
@@ -149,7 +149,7 @@ public class ArchitectAgent {
         }
 
         // TODO label this Architect
-        io.setLlmOutput(new ContextFragment.TaskFragment(contextManager, List.of(Messages.customSystem(instructions)), "Code (Architect)"));
+        io.llmOutput("Code Agent engaged: " + instructions, ChatMessageType.CUSTOM, true);
         var result = new CodeAgent(contextManager, contextManager.getCodeModel()).runTask(instructions, true);
         var stopDetails = result.stopDetails();
         var reason = stopDetails.reason();
@@ -224,7 +224,7 @@ public class ArchitectAgent {
         logger.debug("callSearchAgent invoked with query: {}", query);
 
         // Instantiate and run SearchAgent
-        io.setLlmOutput(new ContextFragment.TaskFragment(contextManager, List.of(Messages.customSystem(query)), "Search (Architect)"));
+        io.llmOutput("Search Agent engaged: " +query, ChatMessageType.CUSTOM);
         var searchAgent = new SearchAgent(query, contextManager, model, toolRegistry, searchAgentId.getAndIncrement());
         var result = searchAgent.execute();
         if (result.stopDetails().reason() == TaskResult.StopReason.LLM_ERROR) {
@@ -267,7 +267,7 @@ public class ArchitectAgent {
         var modelsService = contextManager.getService();
 
         while (true) {
-            io.llmOutput("\n# Planning", ChatMessageType.AI);
+            io.llmOutput("\n# Planning", ChatMessageType.AI, true);
 
             // Determine active models and their minimum input token limit
             var models = new ArrayList<StreamingChatLanguageModel>();
@@ -380,7 +380,7 @@ public class ArchitectAgent {
 
             var deduplicatedRequests = new LinkedHashSet<>(aiMessage.toolExecutionRequests());
             logger.debug("Unique tool requests are {}", deduplicatedRequests);
-            io.llmOutput("\nTool calls: [%s]".formatted(deduplicatedRequests.stream().map(ToolExecutionRequest::name).collect(Collectors.joining(", "))), ChatMessageType.AI);
+            io.llmOutput("\nTool call(s): %s".formatted(deduplicatedRequests.stream().map(req -> "`" + req.name() + "`").collect(Collectors.joining(", "))), ChatMessageType.AI);
 
             // execute tool calls in the following order:
             // 1. projectFinished

--- a/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
@@ -357,8 +357,8 @@ public class SearchAgent {
     }
 
     private void llmOutput(String output) {
-        var ordinalText = ordinal > 0 ? "[Search #%d] ".formatted(ordinal) : "";
-        io.llmOutput("\n%s%s".formatted(ordinalText, output), ChatMessageType.AI);
+        var ordinalText = ordinal > 0 ? "`Search #%d` ".formatted(ordinal) : "";
+        io.llmOutput("\n\n%s%s".formatted(ordinalText, output), ChatMessageType.AI);
     }
 
     private boolean isInteractive() {

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -552,11 +552,10 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     public void actionComplete() {
         SwingUtilities.invokeLater(() -> instructionsPanel.clearCommandResultText());
     }
-
+    
     @Override
-    public void llmOutput(String token, ChatMessageType type) {
-        // TODO: use messageSubType later on
-        SwingUtilities.invokeLater(() -> historyOutputPanel.appendLlmOutput(token, type));
+    public void llmOutput(String token, ChatMessageType type, boolean isNewMessage) {
+        SwingUtilities.invokeLater(() -> historyOutputPanel.appendLlmOutput(token, type, isNewMessage));
     }
 
     @Override

--- a/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -721,9 +721,9 @@ public class HistoryOutputPanel extends JPanel {
     /**
      * Appends text to the LLM output area
      */
-    public void appendLlmOutput(String text, ChatMessageType type) {
-        llmStreamArea.append(text, type);
-        activeStreamingWindows.forEach(window -> window.getMarkdownOutputPanel().append(text, type));
+    public void appendLlmOutput(String text, ChatMessageType type, boolean isNewMessage) {
+        llmStreamArea.append(text, type, isNewMessage);
+        activeStreamingWindows.forEach(window -> window.getMarkdownOutputPanel().append(text, type, isNewMessage));
     }
 
     /**

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -609,7 +609,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
             }
 
             @Override
-            public void llmOutput(String token, ChatMessageType type) {
+            public void llmOutput(String token, ChatMessageType type, boolean isNewMessage) {
                 appendSystemMessage(token);
             }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
@@ -203,20 +203,20 @@ public class MarkdownOutputPanel extends JPanel implements Scrollable, ThemeAwar
      * @param text The text content to append
      * @param type The type of message being appended
      */
-    public void append(String text, ChatMessageType type) {
+    public void append(String text, ChatMessageType type, boolean isNewMessage) {
         assert text != null && type != null;
         if (text.isEmpty()) {
             return;
         }
 
-        // Check if we're appending to an existing message of the same type
-        if (!bubbles.isEmpty() && bubbles.getLast().message().type() == type) {
-            // Append to existing message
-            updateLastMessage(text);
-        } else {
+        // isNewMessage parameter takes precedence over type matching
+        if (isNewMessage || bubbles.isEmpty() || bubbles.getLast().message().type() != type) {
             // Create a new message
             ChatMessage newMessage = Messages.create(text, type);
             addNewMessageBubble(newMessage);
+        } else {
+            // Append to existing message
+            updateLastMessage(text);
         }
 
         textChangeListeners.forEach(Runnable::run);

--- a/src/test/java/io/github/jbellis/brokk/EditBlockTest.java
+++ b/src/test/java/io/github/jbellis/brokk/EditBlockTest.java
@@ -56,7 +56,7 @@ class EditBlockTest {
                 }
 
                 @Override
-                public void llmOutput(String token, ChatMessageType type) {
+                public void llmOutput(String token, ChatMessageType type, boolean isNewMessage) {
                 }
             };
         }

--- a/src/test/java/io/github/jbellis/brokk/LlmTest.java
+++ b/src/test/java/io/github/jbellis/brokk/LlmTest.java
@@ -33,7 +33,7 @@ public class LlmTest {
         public void toolError(String msg, String title) {
             System.out.println(title + ": " + msg);
         }
-        @Override public void llmOutput(String token, ChatMessageType type) {}
+        @Override public void llmOutput(String token, ChatMessageType type, boolean isNewMessage) {}
         @Override public void systemOutput(String message) {}
     }
 

--- a/src/test/java/io/github/jbellis/brokk/TestConsoleIO.java
+++ b/src/test/java/io/github/jbellis/brokk/TestConsoleIO.java
@@ -17,7 +17,7 @@ class TestConsoleIO implements IConsoleIO {
     }
 
     @Override
-    public void llmOutput(String token, ChatMessageType type) {
+    public void llmOutput(String token, ChatMessageType type, boolean isNewMessage) {
         // not needed for these tests
     }
 


### PR DESCRIPTION
…b-agents output in Architect mode

closes #249 

Here a sample of a long flow:

![image](https://github.com/user-attachments/assets/f444bfb4-0afa-44d3-98e2-1fcef93e4cfc)
![image](https://github.com/user-attachments/assets/c525867c-dd63-4cfa-bc42-2bb8f30cd285)
![image](https://github.com/user-attachments/assets/e2f03853-f93d-445a-9448-e4b1eaacbc5d)
![image](https://github.com/user-attachments/assets/02450609-b665-4b26-a95f-056be8cf7638)
![image](https://github.com/user-attachments/assets/f8df5cb8-e2e4-4991-bff5-dd19ce9d3f15)
![image](https://github.com/user-attachments/assets/53e6a158-bd92-46c3-b6c3-6eb1a680081b)

