### PR TITLE
enh: Clear code blocks out of taskMessage history (with guide)

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1170,7 +1170,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @param parser    The EditBlockParser to use for parsing.
      * @return An Optional containing the redacted AiMessage, or Optional.empty() if no message should be added.
      */
-    static Optional<AiMessage> redactAiMessage(AiMessage aiMessage, EditBlockParser parser) {
+    public static Optional<AiMessage> redactAiMessage(AiMessage aiMessage, EditBlockParser parser) {
         // Pass an empty set for trackedFiles as it's not needed for redaction.
         var parsedResult = parser.parse(aiMessage.text(), Collections.emptySet());
         // Check if there are actual S/R block objects, not just text parts

--- a/src/main/java/io/github/jbellis/brokk/agents/CodeAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/CodeAgent.java
@@ -183,6 +183,19 @@ public class CodeAgent {
             }
 
             // If we reach here, it means the LLM segment was considered complete and correct for now.
+            // Now that we're done with incomplete response processing, redact SEARCH/REPLACE blocks 
+            // from all AI messages to reduce bloat in subsequent requests
+            for (int i = taskMessages.size() - 1; i >= 0; i--) {
+                if (taskMessages.get(i) instanceof AiMessage aiMessage) {
+                    var redactedMessage = ContextManager.redactAiMessage(aiMessage, parser);
+                    if (redactedMessage.isPresent()) {
+                        taskMessages.set(i, redactedMessage.get());
+                    } else {
+                        taskMessages.remove(i);
+                    }
+                }
+            }
+
             // Proceed to apply accumulated `blocks`.
             logger.debug("{} total unapplied blocks", blocks.size());
 
@@ -667,10 +680,12 @@ public class CodeAgent {
                
                Please analyze the error message, review the conversation history for previous attempts, and provide SEARCH/REPLACE blocks to fix the error.
                
+               %s
+               
                IMPORTANT: If you determine that the build errors are not improving or are going in circles after reviewing the history,
                do your best to explain the problem but DO NOT provide any edits.
                Otherwise, provide the edits as usual.
-               """.stripIndent().formatted(latestBuildError);
+               """.stripIndent().formatted(latestBuildError, CodePrompts.ELIDED_BLOCKS_GUIDE);
     }
 
     /**

--- a/src/main/java/io/github/jbellis/brokk/prompts/CodePrompts.java
+++ b/src/main/java/io/github/jbellis/brokk/prompts/CodePrompts.java
@@ -48,6 +48,13 @@ public abstract class CodePrompts {
             before immediately jumping into taking further action.
             """.stripIndent();
 
+    public static final String ELIDED_BLOCKS_GUIDE = """
+            SEARCH/REPLACE blocks for the code changes that you propose are elided in subsequent messages in which
+            the history of the conversation is provided to you. The blocks are replaced with: [elided SEARCH/REPLACE block],
+            so you should always ignore this sequence of tokens in messages, and you should ALWAYS propose changes in proper
+            SEARCH/REPLACE blocks as shown in the examples.
+            """.stripIndent();
+
     // Now takes a Models instance
     public static String reminderForModel(Service service, StreamingChatLanguageModel model) {
         return service.isLazy(model)
@@ -74,6 +81,7 @@ public abstract class CodePrompts {
         messages.addAll(cm.getWorkspaceReadOnlyMessages());
         messages.addAll(originalWorkspaceEditableMessages);
         messages.addAll(parser.exampleMessages());
+        messages.add(elidedBlocksMessage());
         messages.addAll(cm.getHistoryMessages());
         messages.addAll(taskMessages);
         messages.addAll(getCurrentChangedFilesMessages(cm, changedFiles));
@@ -126,6 +134,16 @@ public abstract class CodePrompts {
           %s
           </style_guide>
           """.stripIndent().formatted(systemIntro(reminder), workspaceSummary, styleGuide).trim();
+
+        return new SystemMessage(text);
+    }
+
+    private SystemMessage elidedBlocksMessage() {
+        var text = """
+          <elided_blocks_guide>
+          %s
+          </elided_blocks_guide>
+          """.stripIndent().formatted(ELIDED_BLOCKS_GUIDE).trim();
 
         return new SystemMessage(text);
     }

--- a/src/main/java/io/github/jbellis/brokk/prompts/EditBlockParser.java
+++ b/src/main/java/io/github/jbellis/brokk/prompts/EditBlockParser.java
@@ -134,6 +134,8 @@ public class EditBlockParser {
         NEVER use smart quotes in your *SEARCH/REPLACE* blocks, not even in comments.  ALWAYS
         use vanilla ascii single and double quotes.
         
+        %s
+        
         # General
         Always write elegant, well-encapsulated code that is easy to maintain and use without mistakes.
        
@@ -145,7 +147,7 @@ public class EditBlockParser {
         <goal>
         %s
         </goal>
-        """.stripIndent().formatted(diffFormatInstructions(), reminder, input);
+        """.stripIndent().formatted(diffFormatInstructions(), CodePrompts.ELIDED_BLOCKS_GUIDE, reminder, input);
     }
 
     public String diffFormatInstructions() {


### PR DESCRIPTION
The guide:

> SEARCH/REPLACE blocks for the code changes that you propose will be elided in subsequent messages in which
   the history of the conversation is provided to you. The blocks are replaced with: [elided SEARCH/REPLACE block],
   so you should always ignore this sequence of tokens in messages, and you should ALWAYS propose changes in proper 
   SEARCH/REPLACE blocks as shown in the examples.