### PR TITLE
fix/disallowing Deep Scan Duplicates

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
@@ -484,8 +484,13 @@ public class ContextAgent {
     }
 
     private boolean isFileInWorkspace(ProjectFile file) {
-        return contextManager.getEditableFiles().contains(file) ||
-                contextManager.getReadonlyFiles().contains(file);
+        var targetPath = file.absPath().normalize();
+        return contextManager.getEditableFiles().stream()
+                             .map(f -> f.absPath().normalize())
+                             .anyMatch(targetPath::equals) ||
+               contextManager.getReadonlyFiles().stream()
+                             .map(f -> f.absPath().normalize())
+                             .anyMatch(targetPath::equals);
     }
 
     private boolean isClassInWorkspace(CodeUnit cls) {

--- a/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
@@ -484,13 +484,8 @@ public class ContextAgent {
     }
 
     private boolean isFileInWorkspace(ProjectFile file) {
-        var targetPath = file.absPath().normalize();
-        return contextManager.getEditableFiles().stream()
-                             .map(f -> f.absPath().normalize())
-                             .anyMatch(targetPath::equals) ||
-               contextManager.getReadonlyFiles().stream()
-                             .map(f -> f.absPath().normalize())
-                             .anyMatch(targetPath::equals);
+        return contextManager.getEditableFiles().contains(file) ||
+               contextManager.getReadonlyFiles().contains(file);
     }
 
     private boolean isClassInWorkspace(CodeUnit cls) {

--- a/src/main/java/io/github/jbellis/brokk/agents/ValidationAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/ValidationAgent.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -189,7 +190,7 @@ public class ValidationAgent {
                 
                 Is this test file relevant to the instructions? Conclude your explanation with %s or %s.
                 """.formatted(instructions, file, fileContent, RELEVANT_MARKER, IRRELEVANT_MARKER).stripIndent();
-        var messages = List.of(new SystemMessage(systemMessage), new UserMessage(userMessage));
+        var messages = new java.util.ArrayList<>(List.of(new SystemMessage(systemMessage), new UserMessage(userMessage)));
 
         for (int attempt = 1; attempt <= MAX_RELEVANCE_TRIES; attempt++) {
             logger.trace("Invoking quickModel via Coder for relevance check of file: {} (Attempt {}/{})", file, attempt, MAX_RELEVANCE_TRIES);


### PR DESCRIPTION
ContextAgent.isFileInWorkspace(..) previously used Set.contains(projectFile) to decide if a recommended file was already in the workspace. Because ProjectFile.equals() depends on the exact relPath string, trivial lexical differences in the path returned by the LLM (e.g. leading "./", mixed separators) produced distinct objects, allowing true duplicates through. The method now normalizes each candidate’s absPath() and the paths of every editable/readonly file, and compares those canonical Paths. This filters duplicates reliably without touching global equality logic or altering any other behavior.

o3 found and diagnosed the issue. Coded by Gemini 2.5 pro. o3 is extremely confident that this is the root cause of the issue and has found nothing else could be leading to it. After some testing I am also convinced, but I do think there is a very small chance the error is coming from somewhere else. If you are less than convinced, let me know and I'll head back to the drawing board. 