### PR TITLE
fix/157 Added mechanism to prune deleted projects from recent project list

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/Brokk.java
+++ b/src/main/java/io/github/jbellis/brokk/Brokk.java
@@ -285,6 +285,7 @@ public class Brokk {
     public static void main(String[] args) {
         logger.debug("Brokk starting");
         setupSystemPropertiesAndIcon();
+        MainProject.loadRecentProjects(); // Load and potentially clean recent projects list
         ParsedArgs parsedArgs = parseArguments(args);
 
         boolean isDark = MainProject.getTheme().equals("dark");

--- a/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -991,14 +991,16 @@ public final class MainProject extends AbstractProject {
             }
             String propertyValue = props.getProperty(key);
             try {
+                Path projectPath = Path.of(key); // Create path once
                 ProjectPersistentInfo persistentInfo = objectMapper.readValue(propertyValue, ProjectPersistentInfo.class);
-                result.put(Path.of(key), persistentInfo);
+                allLoadedEntries.put(projectPath, persistentInfo);
             } catch (JsonProcessingException e) {
                 // Likely old-format timestamp, try to parse as long
                 try {
+                    Path projectPath = Path.of(key); // Create path once
                     long parsedLongValue = Long.parseLong(propertyValue);
                     ProjectPersistentInfo persistentInfo = ProjectPersistentInfo.fromTimestamp(parsedLongValue);
-                    result.put(Path.of(key), persistentInfo);
+                    allLoadedEntries.put(projectPath, persistentInfo);
                 } catch (NumberFormatException nfe) {
                     logger.warn("Could not parse value for key '{}' in projects.properties as JSON or long: {}", key, propertyValue);
                 }


### PR DESCRIPTION
This fix resides in loadRecentProjects(), and just checks to see if the projects we are showing still exist. This commit also includes a call to the function within Brokk.java to ensure the project files are loaded correctly even before UI is seen. I think that run is most likely not necessary in the vast majority of cases, but it may be important for some edge cases. If you'd like it removed, that is very easy to do.