### PR TITLE
Fix/empty head

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -258,7 +258,13 @@ public class GitRepo implements Closeable, IGitRepo {
         var trackedPaths = new HashSet<String>();
         try {
             // HEAD (unchanged) files
-            var headTreeId = resolve("HEAD^{tree}");
+            ObjectId headTreeId = null;
+            try {
+                headTreeId = resolve("HEAD^{tree}");
+            } catch (GitRepoException e) {
+                // HEAD^{tree} might not exist in empty repos - this is allowed
+                logger.debug("HEAD^{{tree}} not resolvable: {}", e.getMessage());
+            }
             if (headTreeId != null) {
                 try (var revWalk = new RevWalk(repository);
                      var treeWalk = new TreeWalk(repository)) {

--- a/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -5,6 +5,7 @@ import io.github.jbellis.brokk.analyzer.ProjectFile;
 import io.github.jbellis.brokk.util.Environment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jgit.api.errors.NoHeadException;
 import org.jetbrains.annotations.Nullable;
 import org.eclipse.jgit.api.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -29,6 +30,7 @@ import org.eclipse.jgit.treewalk.EmptyTreeIterator;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
 import org.eclipse.jgit.treewalk.filter.PathFilterGroup;
+import org.eclipse.jgit.treewalk.filter.TreeFilter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -312,88 +314,75 @@ public class GitRepo implements Closeable, IGitRepo {
     }
 
     /**
-     * Produces a combined diff of staged + unstaged changes, restricted to the given files.
+     * Performs git diff operation with the given filter group, handling NoHeadException for empty repositories.
      */
-    @Override
-    public synchronized String diffFiles(List<ProjectFile> files) throws GitAPIException {
+    private String performDiffWithFilter(TreeFilter filterGroup) throws GitAPIException {
         try (var out = new ByteArrayOutputStream()) {
-            var filters = files.stream()
-                    .map(file -> PathFilter.create(toRepoRelativePath(file)))
-                    .collect(Collectors.toCollection(ArrayList::new));
-            var filterGroup = PathFilterGroup.create(filters);
+            try {
+                // 1) staged changes
+                git.diff()
+                        .setCached(true)
+                        .setShowNameAndStatusOnly(false)
+                        .setPathFilter(filterGroup)
+                        .setOutputStream(out)
+                        .call();
+                var staged = out.toString(StandardCharsets.UTF_8);
+                out.reset();
 
-            // 1) staged changes
-            git.diff()
-                    .setCached(true)
-                    .setShowNameAndStatusOnly(false)
-                    .setPathFilter(filterGroup)
-                    .setOutputStream(out)
-                    .call();
-            var staged = out.toString(StandardCharsets.UTF_8);
-            out.reset();
+                // 2) unstaged changes
+                git.diff()
+                        .setCached(false)
+                        .setShowNameAndStatusOnly(false)
+                        .setPathFilter(filterGroup)
+                        .setOutputStream(out)
+                        .call();
+                var unstaged = out.toString(StandardCharsets.UTF_8);
 
-            // 2) unstaged changes
-            git.diff()
-                    .setCached(false)
-                    .setShowNameAndStatusOnly(false)
-                    .setPathFilter(filterGroup)
-                    .setOutputStream(out)
-                    .call();
-            var unstaged = out.toString(StandardCharsets.UTF_8);
-
-            return Stream.of(staged, unstaged)
-                    .filter(s -> !s.isEmpty())
-                    .collect(Collectors.joining("\n"));
+                return Stream.of(staged, unstaged)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.joining("\n"));
+            } catch (NoHeadException e) {
+                // Handle empty repository case - return empty diff for repositories with no commits
+                return "";
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
+    /**
+     * Produces a combined diff of staged + unstaged changes, restricted to the given files.
+     */
+    @Override
+    public synchronized String diffFiles(List<ProjectFile> files) throws GitAPIException {
+        var filters = files.stream()
+                .map(file -> PathFilter.create(toRepoRelativePath(file)))
+                .collect(Collectors.toCollection(ArrayList::new));
+        var filterGroup = PathFilterGroup.create(filters);
+        
+        return performDiffWithFilter(filterGroup);
+    }
+
     @Override
     public synchronized String diff() throws GitAPIException {
-        try (var out = new ByteArrayOutputStream()) {
-            var status = git.status().call();
-            var trackedPaths = new HashSet<String>();
-            trackedPaths.addAll(status.getModified());
-            trackedPaths.addAll(status.getChanged());
-            trackedPaths.addAll(status.getAdded());
-            trackedPaths.addAll(status.getRemoved());
-            trackedPaths.addAll(status.getMissing());
+        var status = git.status().call();
+        var trackedPaths = new HashSet<String>();
+        trackedPaths.addAll(status.getModified());
+        trackedPaths.addAll(status.getChanged());
+        trackedPaths.addAll(status.getAdded());
+        trackedPaths.addAll(status.getRemoved());
+        trackedPaths.addAll(status.getMissing());
 
-            if (trackedPaths.isEmpty()) {
-                return "";
-            }
-
-            var filters = trackedPaths.stream()
-                    .map(PathFilter::create)
-                    .collect(Collectors.toCollection(ArrayList::new));
-            var filterGroup = PathFilterGroup.create(filters);
-
-            // 1) staged changes
-            git.diff()
-                    .setCached(true)
-                    .setShowNameAndStatusOnly(false)
-                    .setPathFilter(filterGroup)
-                    .setOutputStream(out)
-                    .call();
-            var staged = out.toString(StandardCharsets.UTF_8);
-            out.reset();
-
-            // 2) unstaged changes
-            git.diff()
-                    .setCached(false)
-                    .setShowNameAndStatusOnly(false)
-                    .setPathFilter(filterGroup)
-                    .setOutputStream(out)
-                    .call();
-            var unstaged = out.toString(StandardCharsets.UTF_8);
-
-            return Stream.of(staged, unstaged)
-                    .filter(s -> !s.isEmpty())
-                    .collect(Collectors.joining("\n"));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        if (trackedPaths.isEmpty()) {
+            return "";
         }
+
+        var filters = trackedPaths.stream()
+                .map(PathFilter::create)
+                .collect(Collectors.toCollection(ArrayList::new));
+        var filterGroup = PathFilterGroup.create(filters);
+
+        return performDiffWithFilter(filterGroup);
     }
 
     /**

--- a/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -855,7 +855,11 @@ public class GitRepo implements Closeable, IGitRepo {
      */
     public void revertCommit(String commitId) throws GitAPIException {
         try {
-            git.revert().include(repository.resolve(commitId)).call();
+            var resolvedCommit = repository.resolve(commitId);
+            if (resolvedCommit == null) {
+                throw new GitRepoException("Unable to resolve commit: " + commitId, new NoSuchElementException());
+            }
+            git.revert().include(resolvedCommit).call();
         } catch (IOException e) {
             throw new GitRepoException("Unable to resolve" + commitId, e);
         }

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -27,6 +27,9 @@ import java.awt.event.*;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -566,9 +569,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     @Override
     public void toolError(String msg, String title) {
         logger.warn("%s: %s".formatted(msg, title));
-        SwingUtilities.invokeLater(() -> {
-            systemNotify(msg, title, JOptionPane.ERROR_MESSAGE);
-        });
+        SwingUtilities.invokeLater(() -> systemNotify(msg, title, JOptionPane.ERROR_MESSAGE));
     }
 
     @Override
@@ -580,7 +581,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     private void systemOutputInternal(String message) {
         SwingUtilities.invokeLater(() -> {
             // Format timestamp as HH:MM
-            String timestamp = java.time.LocalTime.now(java.time.ZoneId.systemDefault()).format(java.time.format.DateTimeFormatter.ofPattern("HH:mm"));
+            String timestamp = LocalTime.now(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern("HH:mm"));
             String timestampedMessage = timestamp + ": " + message;
 
             // Add to messages list

--- a/src/main/java/io/github/jbellis/brokk/gui/GitWorktreeTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitWorktreeTab.java
@@ -8,6 +8,7 @@ import io.github.jbellis.brokk.git.GitRepo;
 import io.github.jbellis.brokk.git.IGitRepo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jgit.api.MergeResult;
 import org.eclipse.jgit.api.RebaseCommand;
 import org.eclipse.jgit.api.RebaseResult;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -30,7 +31,6 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import javax.swing.JCheckBox;
 import javax.swing.JOptionPane;
-
 
 public class GitWorktreeTab extends JPanel {
     private static final Logger logger = LogManager.getLogger(GitWorktreeTab.class);
@@ -613,7 +613,7 @@ public class GitWorktreeTab extends JPanel {
                         return;
                     }
                 }
-                
+
                 chrome.systemOutput("Adding worktree for branch: " + branchForWorktree);
 
                 WorktreeSetupResult setupResult = setupNewGitWorktree(project, gitRepo, branchForWorktree, isCreatingNewBranch, sourceBranchForNew);
@@ -1140,9 +1140,17 @@ public class GitWorktreeTab extends JPanel {
                         }
                     }
 
-                    org.eclipse.jgit.api.MergeResult squashResult = parentGitRepo.getGit().merge()
+                    var resolvedBranch = parentGitRepo.resolve(worktreeBranchName);
+                    if (resolvedBranch == null) {
+                        String errorMessage = "Unable to resolve branch: " + worktreeBranchName;
+                        logger.error(errorMessage);
+                        chrome.toolError(errorMessage, "Branch Resolution Failed");
+                        return;
+                    }
+
+                    MergeResult squashResult = parentGitRepo.getGit().merge()
                         .setSquash(true)
-                        .include(parentGitRepo.resolve(worktreeBranchName))
+                        .include(resolvedBranch)
                         .call();
 
                     if (!squashResult.getMergeStatus().isSuccessful()) {
@@ -1178,8 +1186,16 @@ public class GitWorktreeTab extends JPanel {
 
                         // 3. Rebase the current branch (tempRebaseBranchName) onto the target branch.
                         logger.info("Rebasing current branch ({}) onto {}", tempRebaseBranchName, targetBranch);
+                        var resolvedTarget = parentGitRepo.resolve(targetBranch);
+                        if (resolvedTarget == null) {
+                            String errorMessage = "Unable to resolve target branch: " + targetBranch;
+                            logger.error(errorMessage);
+                            chrome.toolError(errorMessage, "Branch Resolution Failed");
+                            return;
+                        }
+
                         RebaseResult rebaseResult = parentGitRepo.getGit().rebase()
-                                .setUpstream(parentGitRepo.resolve(targetBranch)) // targetBranch is the new base
+                                .setUpstream(resolvedTarget) // targetBranch is the new base
                                 .call(); // Rebase acts on the current branch (tempRebaseBranchName)
 
                         if (!rebaseResult.getStatus().isSuccessful()) {

--- a/src/main/java/io/github/jbellis/brokk/gui/GitWorktreeTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitWorktreeTab.java
@@ -1145,7 +1145,7 @@ public class GitWorktreeTab extends JPanel {
                         String errorMessage = "Unable to resolve branch: " + worktreeBranchName;
                         logger.error(errorMessage);
                         chrome.toolError(errorMessage, "Branch Resolution Failed");
-                        return;
+                        return null;
                     }
 
                     MergeResult squashResult = parentGitRepo.getGit().merge()
@@ -1191,7 +1191,7 @@ public class GitWorktreeTab extends JPanel {
                             String errorMessage = "Unable to resolve target branch: " + targetBranch;
                             logger.error(errorMessage);
                             chrome.toolError(errorMessage, "Branch Resolution Failed");
-                            return;
+                            return null;
                         }
 
                         RebaseResult rebaseResult = parentGitRepo.getGit().rebase()


### PR DESCRIPTION
Related to #294

Handle correctly the case where there is a new repo without any history

I added checks for null on any place `resolve` is called