### PR TITLE
Refactors component initialization to avoid NPEs

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -133,6 +133,8 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         this.globalCopyAction = new GlobalCopyAction("Copy");
         this.globalPasteAction = new GlobalPasteAction("Paste");
 
+        initializeThemeManager();
+
         loadWindowSizeAndPosition();
         // Load saved theme, window size, and position
         frame.setTitle("Brokk: " + getProject().getRoot());
@@ -174,8 +176,6 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         }
 
         bottomPanel.add(mainHorizontalSplitPane, BorderLayout.CENTER);
-
-        initializeThemeManager();
 
         // Force layout update for the bottom panel
         bottomPanel.revalidate();

--- a/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -121,7 +121,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
     }), e -> logger.error("Unexpected error", e));
     // Generation counter to identify the latest suggestion request
     private final AtomicLong suggestionGeneration = new AtomicLong(0);
-    private OverlayPanel commandInputOverlay; // Overlay to initially disable command input
+    private final OverlayPanel commandInputOverlay; // Overlay to initially disable command input
     private final UndoManager commandInputUndoManager;
     private boolean lowBalanceNotified = false;
     private boolean freeTierNotified = false;
@@ -140,6 +140,11 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         this.chrome = chrome;
         this.contextManager = chrome.getContextManager(); // Store potentially null CM
         this.commandInputUndoManager = new UndoManager();
+        commandInputOverlay = new OverlayPanel(
+                overlay -> activateCommandInput(),
+                "Click to enter your instructions"
+        );
+        commandInputOverlay.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
 
         // Initialize components
         instructionsArea = buildCommandInputField(); // Build first to add listener
@@ -272,11 +277,6 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                 checkAndHandleSuggestions();
             }
         });
-        commandInputOverlay = new OverlayPanel(
-                overlay -> activateCommandInput(),
-                "Click to enter your instructions"
-        );
-        commandInputOverlay.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
 
         SwingUtilities.invokeLater(() -> {
             if (chrome.getFrame() != null && chrome.getFrame().getRootPane() != null) {


### PR DESCRIPTION
This pull request refactors the initialization of the `ThemeManager` and `commandInputOverlay` to ensure they are initialized correctly and consistently.

Key changes:

*   **ThemeManager Initialization:** The `initializeThemeManager()` method is moved to the `Chrome` constructor to ensure it's initialized before any other components that might depend on it. This ensures that the theme is loaded and applied as early as possible.
*   **commandInputOverlay Initialization:** The `commandInputOverlay` is initialized in the `InstructionsPanel` constructor. This ensures that the overlay is created and ready to be displayed when the panel is created.
*   **Overlay Cursor:** Sets the cursor of the `commandInputOverlay` to a text cursor to provide better visual feedback to the user.

These changes improve the overall stability and responsiveness of the application by ensuring that critical components are initialized in a timely and predictable manner.