### PR TITLE
Fixes ClassCastException on WorkspacePanel

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -958,8 +958,8 @@ public class WorkspacePanel extends JPanel {
 
             private void handleScrollPanePopup(MouseEvent e) {
                 if (e.isPopupTrigger()) {
-                    // Get the scroll pane from the layered pane
-                    var scrollPane = (JScrollPane) workspaceLayeredPane.getComponent(0);
+                    // Use the scroll pane directly instead of getting it from the layered pane
+                    var scrollPane = tableScrollPane;
                     // Get the event point in view coordinates
                     var viewPoint = SwingUtilities.convertPoint(scrollPane, e.getPoint(),
                                                                   scrollPane.getViewport().getView());


### PR DESCRIPTION
This pull request simplifies the handling of popup triggers within the `WorkspacePanel`.

*   **Intent:** The change aims to directly access the `tableScrollPane` instead of retrieving it from the `workspaceLayeredPane`.
*   **Behavior Changes:** The code now directly uses `tableScrollPane` to get the scroll pane for popup events. This avoids an unnecessary lookup within the layered pane.
*   **Implementation:** The code replaces `workspaceLayeredPane.getComponent(0)` with `tableScrollPane`. This makes the code more direct and potentially more efficient.