### PR TITLE
Adds a "Fetch" button to Git log, fetching remote changes in the background

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -9,6 +9,7 @@ import org.eclipse.jgit.api.errors.NoHeadException;
 import org.jetbrains.annotations.Nullable;
 import org.eclipse.jgit.api.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ProgressMonitor;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
@@ -568,6 +569,23 @@ public class GitRepo implements Closeable, IGitRepo {
         refresh();
         
         return results;
+    }
+
+    /**
+     * Fetches all remotes with pruning, reporting progress to the given monitor.
+     *
+     * @param pm The progress monitor to report to.
+     * @throws GitAPIException if a Git error occurs.
+     */
+    public void fetchAll(ProgressMonitor pm) throws GitAPIException {
+        for (String remote : repository.getRemoteNames()) {
+            git.fetch()
+               .setRemote(remote)
+               .setRemoveDeletedRefs(true)   // --prune
+               .setProgressMonitor(pm)
+               .call();
+        }
+        refresh(); // Invalidate caches & ref-db
     }
 
     /**


### PR DESCRIPTION
This pull request adds a "Fetch" button to the Git log tab, enabling users to fetch all remote changes.

Key changes:

*   **Fetch Button:** A new button is added to the UI to trigger a `git fetch --prune --all` operation.
*   **Background Task:** The fetch operation is executed in a background thread to prevent UI freezing.
*   **Progress Reporting:**  A `ProgressMonitor` implementation (`IoProgressMonitor`) is used to display fetch progress in the console.
*   **Error Handling:**  Basic error handling is implemented to display fetch failures in the console.
*   **UI Updates:** The UI is updated after the fetch completes to reflect the changes.
*   **`fetchAll` method:** A new method is added to `GitRepo` to fetch all remotes with pruning.

![image](https://github.com/user-attachments/assets/0bfdab24-f045-4db5-b11e-92df0f6da8e8)

![image](https://github.com/user-attachments/assets/28dd2a78-d99c-4d03-89b4-5a60d75a7b76)
