### PR TITLE
Enhances GitCommitTab UI: adds ellipses to stash button labels/tooltips for clarity

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/GitCommitTab.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GitCommitTab.java
@@ -187,8 +187,8 @@ public class GitCommitTab extends JPanel {
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
 
         // Stash Button
-        stashButton = new JButton("Stash All"); // Default label
-        stashButton.setToolTipText("Save your changes to the stash");
+        stashButton = new JButton("Stash All..."); // Default label
+        stashButton.setToolTipText("Save your changes to the stash...");
         stashButton.setEnabled(false);
         stashButton.addActionListener(e -> {
             List<ProjectFile> selectedFiles = getSelectedFilesFromTable();
@@ -347,13 +347,13 @@ public class GitCommitTab extends JPanel {
         if (selectedRowCount > 0) {
             commitButton.setText("Commit Selected...");
             commitButton.setToolTipText("Commit the selected files...");
-            stashButton.setText("Stash Selected");
-            stashButton.setToolTipText("Save selected changes to the stash");
+            stashButton.setText("Stash Selected...");
+            stashButton.setToolTipText("Save selected changes to the stash...");
         } else {
             commitButton.setText("Commit All...");
             commitButton.setToolTipText("Commit all files...");
-            stashButton.setText("Stash All");
-            stashButton.setToolTipText("Save all changes to the stash");
+            stashButton.setText("Stash All...");
+            stashButton.setToolTipText("Save all changes to the stash...");
         }
     }
 


### PR DESCRIPTION
### Pull Request Description

**Intent:** Improve user interface clarity for the stash button in the GitCommitTab, signaling that actions like stashing files may require additional input (e.g., prompts), making the GUI more intuitive and user-friendly.

**Behavior Changes:** 
- Button labels and tooltips for the stash action now include ellipses (e.g., "Stash All..." instead of "Stash All"), indicating potential follow-up steps.
- This applies to both the default state and when files are selected (e.g., "Stash Selected..." instead of "Stash Selected").
- No functional changes; only visual updates to enhance UX.

**Key Implementation Ideas:** 
- Updated string literals in the GitCommitTab class for button text and tooltips in the constructor and updateButtons method.
- Simple conditional logic ensures consistent application based on file selection status. (95 words)