### PR TITLE
fix/No longer cutoff file badges

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -26,6 +26,7 @@ import io.github.jbellis.brokk.util.HtmlToMarkdown;
 import io.github.jbellis.brokk.util.ImageUtil;
 import io.github.jbellis.brokk.util.Messages;
 import io.github.jbellis.brokk.util.StackTrace;
+import io.github.jbellis.brokk.util.DebugFlags;
 import okhttp3.OkHttpClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,6 +58,12 @@ import static org.checkerframework.checker.nullness.util.NullnessUtil.castNonNul
 
 public class WorkspacePanel extends JPanel {
     private static final Logger logger = LogManager.getLogger(WorkspacePanel.class);
+
+    private static void dbg(String fmt, Object... args) {
+        if (DebugFlags.FILE_BADGE_DIAGNOSTICS && logger.isDebugEnabled()) {
+            logger.debug("[FILE_BADGE] " + fmt, args);
+        }
+    }
     private final String EMPTY_CONTEXT = "Empty Workspace--use Edit or Read or Summarize to add content";
 
     private static final OkHttpClient httpClient = new OkHttpClient.Builder()
@@ -517,7 +524,9 @@ public class WorkspacePanel extends JPanel {
         private int calculatePreferredHeight(JPanel panel) {
             // Force layout to get accurate measurements
             panel.doLayout();
-            return (int) Math.ceil(panel.getPreferredSize().getHeight()) + 4; // Add small padding
+            var pref = (int) Math.ceil(panel.getPreferredSize().getHeight()) + 4; // Add small padding
+            dbg("rowHeightCalc: panelPref={}, finalPref={}", panel.getPreferredSize(), pref);
+            return pref;
         }
     }
 

--- a/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -508,7 +508,7 @@ public class WorkspacePanel extends JPanel {
             int preferredHeight = calculatePreferredHeight(panel);
 
             // Set row height if different from current
-            if (table.getRowHeight(row) != preferredHeight) {
+            if (table.getRowHeight(row) < preferredHeight) {
                 SwingUtilities.invokeLater(() -> table.setRowHeight(row, preferredHeight));
             }
 
@@ -518,7 +518,7 @@ public class WorkspacePanel extends JPanel {
         private int calculatePreferredHeight(JPanel panel) {
             // Force layout to get accurate measurements
             panel.doLayout();
-            return panel.getPreferredSize().height + 4; // Add small padding
+            return (int) Math.ceil(panel.getPreferredSize().getHeight()) + 4; // Add small padding
         }
     }
 

--- a/src/main/java/io/github/jbellis/brokk/util/DebugFlags.java
+++ b/src/main/java/io/github/jbellis/brokk/util/DebugFlags.java
@@ -1,0 +1,11 @@
+package io.github.jbellis.brokk.util;
+
+/**
+ * Compile-time-free flag container.
+ * Activate with  -Dbrokk.debugFileBadges=true
+ */
+public final class DebugFlags {
+    public static final boolean FILE_BADGE_DIAGNOSTICS =
+            Boolean.getBoolean("brokk.debugFileBadges");
+    private DebugFlags() {}
+}


### PR DESCRIPTION
This fix displays the full file badges in the workspace. The change should maybe be tested by someone on another dev platform to make sure no new issues popped up there since it seems from the issue title this problem was only showing up on OS X. I don't think this change should cause any issues for other platforms, but I cannot check them myself.

<img width="428" alt="Screenshot 2025-06-30 at 4 31 27 PM" src="https://github.com/user-attachments/assets/5b2f27b3-f591-4e38-834b-7c226996f7ee" />
<img width="427" alt="Screenshot 2025-06-30 at 4 35 30 PM" src="https://github.com/user-attachments/assets/f042a105-680e-4213-a4c7-4fbd75c3747a" />
