### PR TITLE
Enhanced CommitDialog GUI: split pane for file visibility and commit message input (closes #356)

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/CommitDialog.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/CommitDialog.java
@@ -52,7 +52,23 @@ public class CommitDialog extends JDialog {
         commitMessageArea.setEnabled(false);
         commitMessageArea.setText(PLACEHOLDER_INFERRING);
 
-        JScrollPane scrollPane = new JScrollPane(commitMessageArea);
+        var messageScrollPane = new JScrollPane(commitMessageArea);
+
+        // File list panel
+        var fileListModel = new DefaultListModel<String>();
+        filesToCommit.stream()
+                .map(ProjectFile::toString)
+                .sorted()
+                .forEach(fileListModel::addElement);
+        var fileList = new JList<>(fileListModel);
+        fileList.setToolTipText("Files that will be included in this commit");
+
+        var fileListPanel = new JPanel(new BorderLayout(0, 5));
+        fileListPanel.add(new JLabel("Files to Commit (" + filesToCommit.size() + "):"), BorderLayout.NORTH);
+        fileListPanel.add(new JScrollPane(fileList), BorderLayout.CENTER);
+
+        var splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, messageScrollPane, fileListPanel);
+        splitPane.setResizeWeight(0.65);
 
         commitButton = new JButton("Commit");
         commitButton.setEnabled(false); // Initially disabled until message is ready or user types
@@ -68,7 +84,7 @@ public class CommitDialog extends JDialog {
         // Add padding around the dialog content
         JPanel contentPanel = new JPanel(new BorderLayout(0, 10));
         contentPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        contentPanel.add(scrollPane, BorderLayout.CENTER);
+        contentPanel.add(splitPane, BorderLayout.CENTER);
         contentPanel.add(buttonPanel, BorderLayout.SOUTH);
 
         add(contentPanel, BorderLayout.CENTER);


### PR DESCRIPTION
### Pull Request Description

**Intent:** Enhance the CommitDialog GUI to provide better visibility into files being committed, helping users verify changes before finalizing a commit and reducing errors.

**Behavior Changes:** The dialog now features a horizontal split pane, displaying the commit message area on one side and a sorted list of files to commit on the other. This replaces the previous single-pane layout, allowing users to see file details (e.g., via tooltips) alongside the message input.

**Key Implementation Ideas:** 
- Used `JSplitPane` with a resize weight of 0.65 to allocate more space to the message area.
- Created a `JList` backed by a `DefaultListModel`, populated with sorted strings from `ProjectFile` objects.
- Added a labeled panel for the file list to clearly indicate the number of files involved.

This update improves usability without altering core commit functionality (approx. 120 words).