### PR TITLE
General improvements to the diff panel

### DIFF
--- a/.idea/sbt.xml
+++ b/.idea/sbt.xml
@@ -3,7 +3,7 @@
   <component name="ScalaSbtSettings">
     <option name="linkedExternalProjectsSettings">
       <SbtProjectSettings>
-        <option name="converterVersion" value="2" />
+        <option name="converterVersion" value="1" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
           <set>

--- a/src/main/java/io/github/jbellis/brokk/difftool/performance/PerformanceConstants.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/performance/PerformanceConstants.java
@@ -26,7 +26,7 @@ public final class PerformanceConstants {
     public static final int TYPING_STATE_TIMEOUT_MS = 150;
 
     // Scroll synchronization
-    public static final int SCROLL_SYNC_DEBOUNCE_MS = 50;
+    public static final int SCROLL_SYNC_DEBOUNCE_MS = 100;
 
     // Navigation highlighting reset delay
     public static final int NAVIGATION_RESET_DELAY_MS = 30;

--- a/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollDebouncer.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollDebouncer.java
@@ -1,0 +1,110 @@
+package io.github.jbellis.brokk.difftool.scroll;
+
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.Timer;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * Pure debouncing utility for scroll operations that can be easily tested
+ * without Swing dependencies. Handles timer management and debounce logic
+ * in a thread-safe, testable way.
+ */
+public final class ScrollDebouncer
+{
+    private final int debounceMs;
+    private final AtomicReference<Timer> currentTimer = new AtomicReference<>();
+    private final Object lock = new Object();
+
+    public ScrollDebouncer(int debounceMs)
+    {
+        this.debounceMs = debounceMs;
+    }
+
+    /**
+     * Request for a debounced action to be executed.
+     */
+    public record DebounceRequest<T>(T data, Consumer<T> action, @Nullable Runnable onComplete)
+    {
+        public DebounceRequest(T data, Consumer<T> action)
+        {
+            this(data, action, null);
+        }
+    }
+
+    /**
+     * Submits a request for debounced execution. If another request comes in
+     * before the debounce period expires, the previous request is cancelled
+     * and only the latest one will execute.
+     *
+     * @param request the debounced action request
+     */
+    public <T> void submit(DebounceRequest<T> request)
+    {
+        synchronized (lock) {
+            // Cancel any existing timer
+            Timer existing = currentTimer.get();
+            if (existing != null) {
+                existing.stop();
+            }
+
+            // Create new timer for this request
+            Timer newTimer = new Timer(debounceMs, e -> {
+                try {
+                    request.action().accept(request.data());
+                    var onComplete = request.onComplete();
+                    if (onComplete != null) {
+                        onComplete.run();
+                    }
+                } finally {
+                    // Clear the timer reference after execution
+                    currentTimer.compareAndSet((Timer) e.getSource(), null);
+                }
+            });
+
+            newTimer.setRepeats(false);
+            currentTimer.set(newTimer);
+            newTimer.start();
+        }
+    }
+
+    /**
+     * Cancels any pending debounced action.
+     */
+    public void cancel()
+    {
+        synchronized (lock) {
+            Timer existing = currentTimer.getAndSet(null);
+            if (existing != null) {
+                existing.stop();
+            }
+        }
+    }
+
+    /**
+     * Checks if there is a pending debounced action.
+     */
+    public boolean hasPending()
+    {
+        Timer current = currentTimer.get();
+        return current != null && current.isRunning();
+    }
+
+    /**
+     * Gets the configured debounce delay in milliseconds.
+     */
+    public int getDebounceMs()
+    {
+        return debounceMs;
+    }
+
+    /**
+     * Stops any running timer and cleans up resources.
+     * Should be called when the debouncer is no longer needed.
+     */
+    public void dispose()
+    {
+        cancel();
+    }
+}

--- a/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollDebouncer.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollDebouncer.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Timer;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 /**
@@ -11,24 +12,17 @@ import java.util.function.Consumer;
  * without Swing dependencies. Handles timer management and debounce logic
  * in a thread-safe, testable way.
  */
-public final class ScrollDebouncer
-{
+public final class ScrollDebouncer {
     private final int debounceMs;
     private final AtomicReference<Timer> currentTimer = new AtomicReference<>();
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
 
-    public ScrollDebouncer(int debounceMs)
-    {
+    public ScrollDebouncer(int debounceMs) {
         this.debounceMs = debounceMs;
     }
 
-    /**
-     * Request for a debounced action to be executed.
-     */
-    public record DebounceRequest<T>(T data, Consumer<T> action, @Nullable Runnable onComplete)
-    {
-        public DebounceRequest(T data, Consumer<T> action)
-        {
+    public record DebounceRequest<T>(T data, Consumer<T> action, @Nullable Runnable onComplete) {
+        public DebounceRequest(T data, Consumer<T> action) {
             this(data, action, null);
         }
     }
@@ -37,20 +31,18 @@ public final class ScrollDebouncer
      * Submits a request for debounced execution. If another request comes in
      * before the debounce period expires, the previous request is cancelled
      * and only the latest one will execute.
-     *
-     * @param request the debounced action request
      */
-    public <T> void submit(DebounceRequest<T> request)
-    {
-        synchronized (lock) {
+    public <T> void submit(DebounceRequest<T> request) {
+        lock.lock();
+        try {
             // Cancel any existing timer
-            Timer existing = currentTimer.get();
+            var existing = currentTimer.get();
             if (existing != null) {
                 existing.stop();
             }
 
             // Create new timer for this request
-            Timer newTimer = new Timer(debounceMs, e -> {
+            var newTimer = new Timer(debounceMs, e -> {
                 try {
                     request.action().accept(request.data());
                     var onComplete = request.onComplete();
@@ -66,45 +58,33 @@ public final class ScrollDebouncer
             newTimer.setRepeats(false);
             currentTimer.set(newTimer);
             newTimer.start();
+        } finally {
+            lock.unlock();
         }
     }
 
-    /**
-     * Cancels any pending debounced action.
-     */
-    public void cancel()
-    {
-        synchronized (lock) {
-            Timer existing = currentTimer.getAndSet(null);
+    public void cancel() {
+        lock.lock();
+        try {
+            var existing = currentTimer.getAndSet(null);
             if (existing != null) {
                 existing.stop();
             }
+        } finally {
+            lock.unlock();
         }
     }
 
-    /**
-     * Checks if there is a pending debounced action.
-     */
-    public boolean hasPending()
-    {
-        Timer current = currentTimer.get();
+    public boolean hasPending() {
+        var current = currentTimer.get();
         return current != null && current.isRunning();
-    }
-
-    /**
-     * Gets the configured debounce delay in milliseconds.
-     */
-    public int getDebounceMs()
-    {
-        return debounceMs;
     }
 
     /**
      * Stops any running timer and cleans up resources.
      * Should be called when the debouncer is no longer needed.
      */
-    public void dispose()
-    {
+    public void dispose() {
         cancel();
     }
 }

--- a/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollSyncState.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollSyncState.java
@@ -10,43 +10,26 @@ import java.util.concurrent.atomic.AtomicLong;
  * Tracks user scrolling state, programmatic scrolling, and timing information
  * to prevent race conditions and scroll jumping issues.
  */
-public final class ScrollSyncState
-{
+public final class ScrollSyncState {
     private final AtomicBoolean isUserScrolling = new AtomicBoolean(false);
     private final AtomicBoolean isProgrammaticScroll = new AtomicBoolean(false);
     private final AtomicBoolean hasPendingScroll = new AtomicBoolean(false);
     private final AtomicLong lastUserScrollTime = new AtomicLong(0);
 
-    /**
-     * Records that a user scroll event occurred.
-     */
-    public void recordUserScroll()
-    {
+    public void recordUserScroll() {
         isUserScrolling.set(true);
         lastUserScrollTime.set(System.currentTimeMillis());
     }
 
-    /**
-     * Clears the user scrolling state.
-     */
-    public void clearUserScrolling()
-    {
+    public void clearUserScrolling() {
         isUserScrolling.set(false);
     }
 
-    /**
-     * Sets whether a programmatic scroll is in progress.
-     */
-    public void setProgrammaticScroll(boolean inProgress)
-    {
+    public void setProgrammaticScroll(boolean inProgress) {
         isProgrammaticScroll.set(inProgress);
     }
 
-    /**
-     * Sets whether there is a pending scroll operation.
-     */
-    public void setPendingScroll(boolean pending)
-    {
+    public void setPendingScroll(boolean pending) {
         hasPendingScroll.set(pending);
     }
 
@@ -54,40 +37,23 @@ public final class ScrollSyncState
      * Atomically checks and clears the pending scroll flag.
      * @return true if there was a pending scroll, false otherwise
      */
-    public boolean getAndClearPendingScroll()
-    {
+    public boolean getAndClearPendingScroll() {
         return hasPendingScroll.getAndSet(false);
     }
 
-    /**
-     * Checks if user is currently scrolling.
-     */
-    public boolean isUserScrolling()
-    {
+    public boolean isUserScrolling() {
         return isUserScrolling.get();
     }
 
-    /**
-     * Checks if a programmatic scroll is in progress.
-     */
-    public boolean isProgrammaticScroll()
-    {
+    public boolean isProgrammaticScroll() {
         return isProgrammaticScroll.get();
     }
 
-    /**
-     * Checks if there is a pending scroll operation.
-     */
-    public boolean hasPendingScroll()
-    {
+    public boolean hasPendingScroll() {
         return hasPendingScroll.get();
     }
 
-    /**
-     * Gets the time since the last user scroll in milliseconds.
-     */
-    public long getTimeSinceLastUserScroll()
-    {
+    public long getTimeSinceLastUserScroll() {
         long lastTime = lastUserScrollTime.get();
         return lastTime == 0 ? Long.MAX_VALUE : System.currentTimeMillis() - lastTime;
     }
@@ -97,23 +63,19 @@ public final class ScrollSyncState
      * @param windowMs time window in milliseconds
      * @return true if user scrolled within the window
      */
-    public boolean isUserScrollingWithin(long windowMs)
-    {
+    public boolean isUserScrollingWithin(long windowMs) {
         return isUserScrolling() || getTimeSinceLastUserScroll() < windowMs;
     }
 
     /**
      * Result of checking whether scroll sync should be suppressed.
      */
-    public record SyncSuppressionResult(boolean shouldSuppress, @Nullable String reason)
-    {
-        public static SyncSuppressionResult allow()
-        {
+    public record SyncSuppressionResult(boolean shouldSuppress, @Nullable String reason) {
+        public static SyncSuppressionResult allow() {
             return new SyncSuppressionResult(false, null);
         }
 
-        public static SyncSuppressionResult suppress(String reason)
-        {
+        public static SyncSuppressionResult suppress(String reason) {
             return new SyncSuppressionResult(true, reason);
         }
     }
@@ -121,10 +83,8 @@ public final class ScrollSyncState
     /**
      * Comprehensive check for whether scroll synchronization should be suppressed.
      * @param userScrollWindowMs time window for considering user scrolling active
-     * @return result indicating whether to suppress and why
      */
-    public SyncSuppressionResult shouldSuppressSync(long userScrollWindowMs)
-    {
+    public SyncSuppressionResult shouldSuppressSync(long userScrollWindowMs) {
         if (isProgrammaticScroll()) {
             return SyncSuppressionResult.suppress("programmatic scroll in progress");
         }

--- a/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollSyncState.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollSyncState.java
@@ -1,0 +1,139 @@
+package io.github.jbellis.brokk.difftool.scroll;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Thread-safe state management for scroll synchronization.
+ * Tracks user scrolling state, programmatic scrolling, and timing information
+ * to prevent race conditions and scroll jumping issues.
+ */
+public final class ScrollSyncState
+{
+    private final AtomicBoolean isUserScrolling = new AtomicBoolean(false);
+    private final AtomicBoolean isProgrammaticScroll = new AtomicBoolean(false);
+    private final AtomicBoolean hasPendingScroll = new AtomicBoolean(false);
+    private final AtomicLong lastUserScrollTime = new AtomicLong(0);
+
+    /**
+     * Records that a user scroll event occurred.
+     */
+    public void recordUserScroll()
+    {
+        isUserScrolling.set(true);
+        lastUserScrollTime.set(System.currentTimeMillis());
+    }
+
+    /**
+     * Clears the user scrolling state.
+     */
+    public void clearUserScrolling()
+    {
+        isUserScrolling.set(false);
+    }
+
+    /**
+     * Sets whether a programmatic scroll is in progress.
+     */
+    public void setProgrammaticScroll(boolean inProgress)
+    {
+        isProgrammaticScroll.set(inProgress);
+    }
+
+    /**
+     * Sets whether there is a pending scroll operation.
+     */
+    public void setPendingScroll(boolean pending)
+    {
+        hasPendingScroll.set(pending);
+    }
+
+    /**
+     * Atomically checks and clears the pending scroll flag.
+     * @return true if there was a pending scroll, false otherwise
+     */
+    public boolean getAndClearPendingScroll()
+    {
+        return hasPendingScroll.getAndSet(false);
+    }
+
+    /**
+     * Checks if user is currently scrolling.
+     */
+    public boolean isUserScrolling()
+    {
+        return isUserScrolling.get();
+    }
+
+    /**
+     * Checks if a programmatic scroll is in progress.
+     */
+    public boolean isProgrammaticScroll()
+    {
+        return isProgrammaticScroll.get();
+    }
+
+    /**
+     * Checks if there is a pending scroll operation.
+     */
+    public boolean hasPendingScroll()
+    {
+        return hasPendingScroll.get();
+    }
+
+    /**
+     * Gets the time since the last user scroll in milliseconds.
+     */
+    public long getTimeSinceLastUserScroll()
+    {
+        long lastTime = lastUserScrollTime.get();
+        return lastTime == 0 ? Long.MAX_VALUE : System.currentTimeMillis() - lastTime;
+    }
+
+    /**
+     * Checks if user scrolling is active within the specified time window.
+     * @param windowMs time window in milliseconds
+     * @return true if user scrolled within the window
+     */
+    public boolean isUserScrollingWithin(long windowMs)
+    {
+        return isUserScrolling() || getTimeSinceLastUserScroll() < windowMs;
+    }
+
+    /**
+     * Result of checking whether scroll sync should be suppressed.
+     */
+    public record SyncSuppressionResult(boolean shouldSuppress, @Nullable String reason)
+    {
+        public static SyncSuppressionResult allow()
+        {
+            return new SyncSuppressionResult(false, null);
+        }
+
+        public static SyncSuppressionResult suppress(String reason)
+        {
+            return new SyncSuppressionResult(true, reason);
+        }
+    }
+
+    /**
+     * Comprehensive check for whether scroll synchronization should be suppressed.
+     * @param userScrollWindowMs time window for considering user scrolling active
+     * @return result indicating whether to suppress and why
+     */
+    public SyncSuppressionResult shouldSuppressSync(long userScrollWindowMs)
+    {
+        if (isProgrammaticScroll()) {
+            return SyncSuppressionResult.suppress("programmatic scroll in progress");
+        }
+
+        if (isUserScrollingWithin(userScrollWindowMs)) {
+            long timeSince = getTimeSinceLastUserScroll();
+            return SyncSuppressionResult.suppress("user scrolling active (" + timeSince + "ms ago)");
+        }
+
+        return SyncSuppressionResult.allow();
+    }
+}

--- a/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollSynchronizer.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/scroll/ScrollSynchronizer.java
@@ -215,8 +215,8 @@ public class ScrollSynchronizer
     {
         int offset = 0;
         for (AbstractDelta<String> delta : patch.getDeltas()) {
-            Chunk<String> source = delta.getSource(); // original
-            Chunk<String> target = delta.getTarget(); // revised
+            var source = delta.getSource(); // original
+            var target = delta.getTarget(); // revised
             int srcPos = source.getPosition();
             int tgtPos = target.getPosition();
             // The chunk ends at pos+size-1
@@ -387,10 +387,6 @@ public class ScrollSynchronizer
         logger.debug("showDelta completed - both panels scrolled");
     }
 
-    public void toNextDelta(boolean next)
-    {
-        // Moved to BufferDiffPanel. This is not used here any more.
-    }
 
     /**
      * Cleanup method to properly dispose of resources when the synchronizer is no longer needed.

--- a/src/main/java/io/github/jbellis/brokk/difftool/ui/DiffHighlightUtil.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/ui/DiffHighlightUtil.java
@@ -6,11 +6,9 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Small, pure helper for deciding whether a {@link AbstractDelta} should be
- * highlighted in a given viewport.  All state required is passed as parameters
- * so the methods are trivially unit–testable and 100 % thread-safe.
+ * highlighted in a given viewport.
  */
-public final class DiffHighlightUtil
-{
+public final class DiffHighlightUtil {
     private DiffHighlightUtil() {}
 
     /**
@@ -21,8 +19,7 @@ public final class DiffHighlightUtil
     /**
      * Returns the chunk for the specified side without any fallback logic.
      */
-    public static @Nullable Chunk<String> getRelevantChunk(AbstractDelta<String> delta, boolean originalSide)
-    {
+    public static @Nullable Chunk<String> getRelevantChunk(AbstractDelta<String> delta, boolean originalSide) {
         return originalSide ? delta.getSource() : delta.getTarget();
     }
 
@@ -30,8 +27,7 @@ public final class DiffHighlightUtil
      * Returns the chunk to use for highlighting purposes. For revised side DELETE deltas,
      * falls back to source chunk for positioning since target has size 0.
      */
-    public static @Nullable Chunk<String> getChunkForHighlight(AbstractDelta<String> delta, boolean originalSide)
-    {
+    public static @Nullable Chunk<String> getChunkForHighlight(AbstractDelta<String> delta, boolean originalSide) {
         var chunk = getRelevantChunk(delta, originalSide);
         // For revised side DELETE deltas (empty target), use source chunk for positioning
         return (chunk != null && chunk.size() == 0 && !originalSide) ? delta.getSource() : chunk;
@@ -39,15 +35,11 @@ public final class DiffHighlightUtil
 
     /**
      * Decide if a delta's chunk is visible in the viewport [startLine,endLine].
-     *
-     * This contains **no** Swing or document logic – it only needs the line
-     * numbers – so it can safely be called from any thread.
      */
     public static IntersectionResult isChunkVisible(AbstractDelta<String> delta,
                                                     int startLine,
                                                     int endLine,
-                                                    boolean originalSide)
-    {
+                                                    boolean originalSide) {
         if (startLine > endLine)
             return new IntersectionResult(false, "Invalid range: startLine " + startLine + " > endLine " + endLine);
 
@@ -61,9 +53,8 @@ public final class DiffHighlightUtil
         if (pos < 0)
             return new IntersectionResult(false, "Invalid negative position: " + pos);
 
-        int deltaStart = pos;
         int deltaEnd   = pos + Math.max(1, size) - 1;
-        boolean intersects = !(deltaEnd < startLine || deltaStart > endLine);
+        boolean intersects = !(deltaEnd < startLine || pos > endLine);
         return new IntersectionResult(intersects, null);
     }
 }

--- a/src/main/java/io/github/jbellis/brokk/difftool/ui/DiffHighlightUtil.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/ui/DiffHighlightUtil.java
@@ -1,0 +1,64 @@
+package io.github.jbellis.brokk.difftool.ui;
+
+import com.github.difflib.patch.AbstractDelta;
+import com.github.difflib.patch.Chunk;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Small, pure helper for deciding whether a {@link AbstractDelta} should be
+ * highlighted in a given viewport.  All state required is passed as parameters
+ * so the methods are trivially unit–testable and 100 % thread-safe.
+ */
+public final class DiffHighlightUtil
+{
+    private static final Logger logger = LogManager.getLogger(DiffHighlightUtil.class);
+
+    private DiffHighlightUtil() {}
+
+    /**
+     * Returns the *relevant* chunk for the requested side.  For the revised
+     * side a {@code null} target chunk (DELETE deltas) falls back to the
+     * source so the caller can still compute a sensible location.
+     */
+    public static @Nullable Chunk<String> getChunk(AbstractDelta<String> delta, boolean originalSide)
+    {
+        if (originalSide)
+            return delta.getSource();
+
+        // Revised side – prefer target but fall back to source so deleted lines
+        // still get a highlight placeholder on the right.
+        Chunk<String> target = delta.getTarget();
+        return target != null ? target : delta.getSource();
+    }
+
+    /**
+     * Decide if a delta’s chunk intersects the viewport [startLine,endLine].
+     *
+     * This contains **no** Swing or document logic – it only needs the line
+     * numbers – so it can safely be called from any thread.
+     */
+    public static boolean deltaIntersectsViewport(AbstractDelta<String> delta,
+                                                  int startLine,
+                                                  int endLine,
+                                                  boolean originalSide)
+    {
+        Chunk<String> chunk = getChunk(delta, originalSide);
+        if (chunk == null)
+            return false;   // nothing to draw on this side
+
+        int pos  = chunk.getPosition();
+        int size = chunk.size();
+
+        if (pos < 0)
+        {
+            logger.warn("Delta chunk has invalid (negative) position {} – skipping highlight", pos);
+            return false;
+        }
+
+        int deltaStart = pos;
+        int deltaEnd   = pos + Math.max(1, size) - 1;
+        return !(deltaEnd < startLine || deltaStart > endLine);
+    }
+}

--- a/src/main/java/io/github/jbellis/brokk/difftool/ui/FilePanel.java
+++ b/src/main/java/io/github/jbellis/brokk/difftool/ui/FilePanel.java
@@ -466,18 +466,22 @@ public class FilePanel implements BufferDocumentChangeListenerIF, ThemeAware {
     private boolean deltaIntersectsViewport(AbstractDelta<String> delta, int startLine, int endLine)
     {
         boolean originalSide = BufferDocumentIF.ORIGINAL.equals(name);
-        boolean intersects = DiffHighlightUtil.deltaIntersectsViewport(delta, startLine, endLine, originalSide);
+        var result = DiffHighlightUtil.isChunkVisible(delta, startLine, endLine, originalSide);
+
+        // Log any warnings from the utility
+        if (result.warning() != null)
+            logger.warn("{}: {}", name, result.warning());
 
         // Preserve existing detailed TRACE output for diagnostics
         if (logger.isTraceEnabled())
         {
-            var chunk = DiffHighlightUtil.getChunk(delta, originalSide);
+            var chunk = DiffHighlightUtil.getChunkForHighlight(delta, originalSide);
             int pos  = chunk == null ? -1 : chunk.getPosition();
             int size = chunk == null ? 0  : chunk.size();
             logger.trace("{}: Delta intersection check: pos={}, size={}, viewport=[{}-{}], intersects={}",
-                         name, pos, size, startLine, endLine, intersects);
+                         name, pos, size, startLine, endLine, result.intersects());
         }
-        return intersects;
+        return result.intersects();
     }
 
     /**

--- a/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollDebouncerTest.java
+++ b/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollDebouncerTest.java
@@ -1,0 +1,196 @@
+package io.github.jbellis.brokk.difftool.scroll;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ScrollDebouncer} timer and debouncing logic.
+ */
+class ScrollDebouncerTest
+{
+    private ScrollDebouncer debouncer;
+
+    @BeforeEach
+    void setUp()
+    {
+        debouncer = new ScrollDebouncer(50); // 50ms debounce for faster tests
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        debouncer.dispose();
+    }
+
+    @Test
+    void basicDebouncing() throws InterruptedException
+    {
+        AtomicInteger executeCount = new AtomicInteger(0);
+        AtomicReference<String> lastValue = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        var request = new ScrollDebouncer.DebounceRequest<>(
+            "test-value",
+            value -> {
+                executeCount.incrementAndGet();
+                lastValue.set(value);
+            },
+            latch::countDown
+        );
+
+        debouncer.submit(request);
+        assertTrue(debouncer.hasPending(), "Should have pending action");
+
+        // Wait for execution
+        assertTrue(latch.await(200, TimeUnit.MILLISECONDS), "Should execute within timeout");
+        
+        assertEquals(1, executeCount.get(), "Should execute exactly once");
+        assertEquals("test-value", lastValue.get(), "Should pass correct value");
+        assertFalse(debouncer.hasPending(), "Should not have pending action after execution");
+    }
+
+    @Test
+    void debouncingCancellation() throws InterruptedException
+    {
+        AtomicInteger executeCount = new AtomicInteger(0);
+        CountDownLatch executionLatch = new CountDownLatch(1);
+
+        // Submit first request
+        var firstRequest = new ScrollDebouncer.DebounceRequest<>(
+            "first",
+            value -> executeCount.incrementAndGet()
+        );
+        debouncer.submit(firstRequest);
+
+        // Small delay to ensure first request is queued
+        Thread.sleep(10);
+
+        // Submit second request before first executes (should cancel first)
+        var secondRequest = new ScrollDebouncer.DebounceRequest<>(
+            "second", 
+            value -> executeCount.incrementAndGet(),
+            executionLatch::countDown
+        );
+        debouncer.submit(secondRequest);
+
+        // Only second should execute
+        assertTrue(executionLatch.await(300, TimeUnit.MILLISECONDS), "Second request should execute");
+        
+        // Give some extra time to see if first executes (it shouldn't)
+        Thread.sleep(100);
+        
+        assertEquals(1, executeCount.get(), "Should execute exactly once (second request only)");
+        assertFalse(debouncer.hasPending(), "Should not have pending action");
+    }
+
+    @Test
+    void multipleRapidSubmissions() throws InterruptedException
+    {
+        AtomicInteger executeCount = new AtomicInteger(0);
+        AtomicReference<Integer> lastValue = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Submit multiple requests rapidly
+        for (int i = 0; i < 10; i++) {
+            final int value = i;
+            var request = new ScrollDebouncer.DebounceRequest<>(
+                value,
+                lastValue::set,
+                i == 9 ? latch::countDown : null // Only count down on last submission
+            );
+            debouncer.submit(request);
+            
+            // Small delay to simulate rapid user input
+            Thread.sleep(5);
+        }
+
+        // Wait for final execution
+        assertTrue(latch.await(200, TimeUnit.MILLISECONDS), "Should execute final request");
+        
+        // Should only execute the last request
+        assertEquals(Integer.valueOf(9), lastValue.get(), "Should execute with last submitted value");
+        assertFalse(debouncer.hasPending(), "Should not have pending action");
+    }
+
+    @Test
+    void manualCancellation() throws InterruptedException
+    {
+        AtomicInteger executeCount = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        var request = new ScrollDebouncer.DebounceRequest<>(
+            "test",
+            value -> {
+                executeCount.incrementAndGet();
+                latch.countDown();
+            }
+        );
+
+        debouncer.submit(request);
+        assertTrue(debouncer.hasPending(), "Should have pending action");
+
+        debouncer.cancel();
+        assertFalse(debouncer.hasPending(), "Should not have pending action after cancel");
+
+        // Wait to ensure it doesn't execute
+        assertFalse(latch.await(100, TimeUnit.MILLISECONDS), "Should not execute after cancel");
+        assertEquals(0, executeCount.get(), "Should not have executed");
+    }
+
+    @Test
+    void debounceConfiguration()
+    {
+        var customDebouncer = new ScrollDebouncer(123);
+        assertEquals(123, customDebouncer.getDebounceMs(), "Should return configured debounce time");
+        customDebouncer.dispose();
+    }
+
+    @Test
+    void disposeCleanup()
+    {
+        AtomicInteger executeCount = new AtomicInteger(0);
+        
+        var request = new ScrollDebouncer.DebounceRequest<>(
+            "test",
+            value -> executeCount.incrementAndGet()
+        );
+
+        debouncer.submit(request);
+        assertTrue(debouncer.hasPending(), "Should have pending action");
+
+        debouncer.dispose();
+        assertFalse(debouncer.hasPending(), "Should not have pending action after dispose");
+    }
+
+    @Test
+    void requestWithoutOnComplete() throws InterruptedException
+    {
+        AtomicInteger executeCount = new AtomicInteger(0);
+        AtomicReference<String> value = new AtomicReference<>();
+        
+        // Create request without onComplete callback
+        var request = new ScrollDebouncer.DebounceRequest<>("test", val -> {
+            executeCount.incrementAndGet();
+            value.set(val);
+        });
+
+        debouncer.submit(request);
+        
+        // Wait for execution (no latch to wait on, so use polling)
+        long start = System.currentTimeMillis();
+        while (executeCount.get() == 0 && System.currentTimeMillis() - start < 200) {
+            Thread.sleep(10);
+        }
+        
+        assertEquals(1, executeCount.get(), "Should execute without onComplete");
+        assertEquals("test", value.get(), "Should pass correct value");
+    }
+}

--- a/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollDebouncerTest.java
+++ b/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollDebouncerTest.java
@@ -146,14 +146,6 @@ class ScrollDebouncerTest
     }
 
     @Test
-    void debounceConfiguration()
-    {
-        var customDebouncer = new ScrollDebouncer(123);
-        assertEquals(123, customDebouncer.getDebounceMs(), "Should return configured debounce time");
-        customDebouncer.dispose();
-    }
-
-    @Test
     void disposeCleanup()
     {
         AtomicInteger executeCount = new AtomicInteger(0);

--- a/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollSyncStateTest.java
+++ b/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollSyncStateTest.java
@@ -1,0 +1,162 @@
+package io.github.jbellis.brokk.difftool.scroll;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ScrollSyncState} thread-safe state management.
+ */
+class ScrollSyncStateTest
+{
+    private ScrollSyncState state;
+
+    @BeforeEach
+    void setUp()
+    {
+        state = new ScrollSyncState();
+    }
+
+    @Test
+    void initialState()
+    {
+        assertFalse(state.isUserScrolling(), "Should not be user scrolling initially");
+        assertFalse(state.isProgrammaticScroll(), "Should not be programmatic scrolling initially");
+        assertFalse(state.hasPendingScroll(), "Should not have pending scroll initially");
+        assertEquals(Long.MAX_VALUE, state.getTimeSinceLastUserScroll(), "Should have no user scroll time initially");
+    }
+
+    @Test
+    void userScrollRecording()
+    {
+        state.recordUserScroll();
+        
+        assertTrue(state.isUserScrolling(), "Should be user scrolling after recording");
+        assertTrue(state.getTimeSinceLastUserScroll() < 100, "Time since scroll should be very recent");
+        assertTrue(state.isUserScrollingWithin(1000), "Should be within time window");
+        
+        state.clearUserScrolling();
+        assertFalse(state.isUserScrolling(), "Should not be user scrolling after clearing");
+    }
+
+    @Test
+    void programmaticScrollState()
+    {
+        state.setProgrammaticScroll(true);
+        assertTrue(state.isProgrammaticScroll(), "Should be programmatic scrolling");
+        
+        state.setProgrammaticScroll(false);
+        assertFalse(state.isProgrammaticScroll(), "Should not be programmatic scrolling");
+    }
+
+    @Test
+    void pendingScrollState()
+    {
+        state.setPendingScroll(true);
+        assertTrue(state.hasPendingScroll(), "Should have pending scroll");
+        
+        assertTrue(state.getAndClearPendingScroll(), "Should return true and clear");
+        assertFalse(state.hasPendingScroll(), "Should not have pending scroll after clearing");
+        assertFalse(state.getAndClearPendingScroll(), "Should return false when already cleared");
+    }
+
+    @Test
+    void timeBasedUserScrolling() throws InterruptedException
+    {
+        state.recordUserScroll();
+        assertTrue(state.isUserScrollingWithin(1000), "Should be within 1000ms window");
+        
+        Thread.sleep(100);
+        assertTrue(state.isUserScrollingWithin(1000), "Should still be within 1000ms window");
+        
+        // Clear the user scrolling flag and test timing only
+        state.clearUserScrolling();
+        
+        // Check the actual time since last scroll to make test more robust
+        long timeSince = state.getTimeSinceLastUserScroll();
+        assertTrue(timeSince >= 90, "Time since scroll should be at least 90ms, was: " + timeSince);
+        assertFalse(state.isUserScrollingWithin(50), "Should not be within 50ms window");
+    }
+
+    @Test
+    void syncSuppressionLogic()
+    {
+        // Initially should allow sync
+        var result = state.shouldSuppressSync(200);
+        assertFalse(result.shouldSuppress(), "Should allow sync initially");
+        assertNull(result.reason(), "Should have no reason initially");
+        
+        // Test programmatic scroll suppression
+        state.setProgrammaticScroll(true);
+        result = state.shouldSuppressSync(200);
+        assertTrue(result.shouldSuppress(), "Should suppress during programmatic scroll");
+        assertTrue(result.reason().contains("programmatic"), "Reason should mention programmatic");
+        
+        state.setProgrammaticScroll(false);
+        
+        // Test user scroll suppression
+        state.recordUserScroll();
+        result = state.shouldSuppressSync(200);
+        assertTrue(result.shouldSuppress(), "Should suppress during user scroll");
+        assertTrue(result.reason().contains("user scrolling"), "Reason should mention user scrolling");
+        
+        // Clear and test time window
+        state.clearUserScrolling();
+        result = state.shouldSuppressSync(0);
+        assertFalse(result.shouldSuppress(), "Should allow sync after clearing with 0ms window");
+    }
+
+    @Test
+    void concurrentAccess() throws InterruptedException
+    {
+        // Test thread safety with multiple threads
+        Thread userScrollThread = new Thread(() -> {
+            for (int i = 0; i < 100; i++) {
+                state.recordUserScroll();
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        });
+        
+        Thread programmaticThread = new Thread(() -> {
+            for (int i = 0; i < 100; i++) {
+                state.setProgrammaticScroll(i % 2 == 0);
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        });
+        
+        Thread pendingThread = new Thread(() -> {
+            for (int i = 0; i < 100; i++) {
+                state.setPendingScroll(true);
+                state.getAndClearPendingScroll();
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        });
+        
+        userScrollThread.start();
+        programmaticThread.start();
+        pendingThread.start();
+        
+        userScrollThread.join(1000);
+        programmaticThread.join(1000);
+        pendingThread.join(1000);
+        
+        // Should not crash and state should be consistent
+        assertNotNull(state.shouldSuppressSync(100), "Should be able to check suppression after concurrent access");
+    }
+}

--- a/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollSynchronizerTest.java
+++ b/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollSynchronizerTest.java
@@ -1,0 +1,377 @@
+package io.github.jbellis.brokk.difftool.scroll;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.patch.AbstractDelta;
+import com.github.difflib.patch.Patch;
+import io.github.jbellis.brokk.difftool.performance.PerformanceConstants;
+import io.github.jbellis.brokk.difftool.ui.BufferDiffPanel;
+import io.github.jbellis.brokk.difftool.ui.FilePanel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import javax.swing.*;
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * High-value, low-overhead tests for ScrollSynchronizer that focus on pure logic
+ * and minimal Swing component testing without requiring full UI hierarchy.
+ */
+class ScrollSynchronizerTest {
+
+    // Helper methods to create real deltas using DiffUtils
+    private Patch<String> createInsertPatch(int insertPosition, String... insertedLines) {
+        var original = createNumberedLines(10); // Start with 10 lines
+        var revised = new java.util.ArrayList<>(original);
+        
+        // Insert the new lines at the specified position
+        for (int i = 0; i < insertedLines.length; i++) {
+            revised.add(insertPosition + i, insertedLines[i]);
+        }
+        
+        return DiffUtils.diff(original, revised);
+    }
+
+    private Patch<String> createDeletePatch(int deletePosition, int deleteCount) {
+        var original = createNumberedLines(20); // Start with more lines for delete
+        var revised = new java.util.ArrayList<>(original);
+        
+        // Remove lines starting at deletePosition
+        for (int i = 0; i < deleteCount && deletePosition < revised.size(); i++) {
+            revised.remove(deletePosition);
+        }
+        
+        return DiffUtils.diff(original, revised);
+    }
+
+    private Patch<String> createChangePatch(int changePosition, int changeCount, String... newLines) {
+        var original = createNumberedLines(15);
+        var revised = new java.util.ArrayList<>(original);
+        
+        // Remove the old lines
+        for (int i = 0; i < changeCount && changePosition < revised.size(); i++) {
+            revised.remove(changePosition);
+        }
+        
+        // Insert the new lines
+        for (int i = 0; i < newLines.length; i++) {
+            revised.add(changePosition + i, newLines[i]);
+        }
+        
+        return DiffUtils.diff(original, revised);
+    }
+
+    private Patch<String> createMultiDeltaPatch() {
+        var original = createNumberedLines(30);
+        var revised = new java.util.ArrayList<>(original);
+        
+        // Insert 2 lines at position 5
+        revised.add(5, "inserted1");
+        revised.add(6, "inserted2");
+        
+        // Delete 1 line at position 17 (after accounting for inserts)
+        revised.remove(17);
+        
+        // Change 3 lines at position 27 to 1 line (after accounting for previous changes)
+        revised.remove(27);
+        revised.remove(27);
+        revised.remove(27);
+        revised.add(27, "changed_line");
+        
+        return DiffUtils.diff(original, revised);
+    }
+
+    private List<String> createNumberedLines(int count) {
+        return java.util.stream.IntStream.range(0, count)
+                .mapToObj(i -> "line_" + String.format("%02d", i))
+                .toList();
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Tests run on EDT when needed, otherwise just test pure logic
+    }
+
+    // =================================================================
+    // PURE LOGIC TESTS - Line Mapping Algorithm
+    // =================================================================
+
+    @Test
+    @DisplayName("Line mapping: simple insert delta")
+    void testApproximateLineMapping_insertDelta() throws Exception {
+        // Create patch with insert at line 5 (3 lines inserted)
+        var patch = createInsertPatch(5, "inserted_line1", "inserted_line2", "inserted_line3");
+        
+        // Test mapping from original side (original to revised)
+        assertEquals(3, callApproximateLineMapping(patch, 3, true), "Line before insert should map directly");
+        assertEquals(8, callApproximateLineMapping(patch, 5, true), "Line at insert should map to position after all inserts");
+        assertEquals(10, callApproximateLineMapping(patch, 7, true), "Line after insert should be offset by insert size");
+
+        // Test mapping from revised side (revised to original)
+        assertEquals(3, callApproximateLineMapping(patch, 3, false), "Line before insert maps directly");
+        assertEquals(5, callApproximateLineMapping(patch, 5, false), "Line at target start maps to source position");
+        assertEquals(5, callApproximateLineMapping(patch, 7, false), "Line in inserted region maps to source position");
+        assertEquals(5, callApproximateLineMapping(patch, 8, false), "Line after insert should map to source position");
+    }
+
+    @Test
+    @DisplayName("Line mapping: algorithm correctness")
+    void testApproximateLineMapping_algorithmCorrectness() throws Exception {
+        // Test basic properties of the line mapping algorithm
+        
+        // 1. Empty patch should return lines unchanged
+        var emptyPatch = DiffUtils.diff(createNumberedLines(5), createNumberedLines(5));
+        assertEquals(10, callApproximateLineMapping(emptyPatch, 10, true), "Empty patch should return line unchanged");
+        assertEquals(10, callApproximateLineMapping(emptyPatch, 10, false), "Empty patch should return line unchanged in reverse");
+        
+        // 2. Lines before any changes should map directly
+        var insertPatch = createInsertPatch(10, "new_line");
+        assertEquals(5, callApproximateLineMapping(insertPatch, 5, true), "Lines before changes should map directly");
+        assertEquals(5, callApproximateLineMapping(insertPatch, 5, false), "Lines before changes should map directly in reverse");
+        
+        // 3. Algorithm should handle negative lines gracefully  
+        assertEquals(-1, callApproximateLineMapping(insertPatch, -1, true), "Negative lines should be handled gracefully");
+        
+        // 4. Algorithm should not crash with various delta types
+        var deletePatch = createDeletePatch(5, 2);
+        var deleteResult = callApproximateLineMapping(deletePatch, 10, true);
+        assertTrue(deleteResult >= 0, "Delete mapping should produce valid result");
+        
+        var changePatch = createChangePatch(3, 1, "changed");
+        var changeResult = callApproximateLineMapping(changePatch, 10, true);
+        assertTrue(changeResult >= 0, "Change mapping should produce valid result");
+        
+        // 5. Multiple deltas should not cause crashes
+        var multiPatch = createMultiDeltaPatch();
+        var multiResult = callApproximateLineMapping(multiPatch, 20, true);
+        assertTrue(multiResult >= 0, "Multi-delta mapping should produce valid result");
+    }
+
+    // =================================================================
+    // STATE COORDINATION TESTS
+    // =================================================================
+
+    @Test
+    @DisplayName("State coordination: scroll suppression integration")
+    void testScrollStateCoordination() throws InterruptedException {
+        var state = new ScrollSyncState();
+        
+        // Test initial state allows sync
+        var suppressionResult = state.shouldSuppressSync(100);
+        assertFalse(suppressionResult.shouldSuppress(), "Initial state should allow sync");
+        
+        // Test programmatic scroll suppression
+        state.setProgrammaticScroll(true);
+        suppressionResult = state.shouldSuppressSync(100);
+        assertTrue(suppressionResult.shouldSuppress(), "Programmatic scroll should suppress sync");
+        assertEquals("programmatic scroll in progress", suppressionResult.reason());
+        
+        // Test user scroll suppression
+        state.setProgrammaticScroll(false);
+        state.recordUserScroll();
+        suppressionResult = state.shouldSuppressSync(100);
+        assertTrue(suppressionResult.shouldSuppress(), "Recent user scroll should suppress sync");
+        assertTrue(suppressionResult.reason().contains("user scrolling active"));
+        
+        // Test state clearing - but we need to wait for timing window too
+        state.clearUserScrolling();
+        
+        // Even after clearing the flag, timing-based suppression may still be active
+        // Let's wait for the timing window to pass completely
+        Thread.sleep(120); // Wait longer than the 100ms window
+        
+        suppressionResult = state.shouldSuppressSync(100);
+        assertFalse(suppressionResult.shouldSuppress(), "Cleared state should allow sync after timing window");
+    }
+
+    // Note: Timing-based tests can be flaky in CI environments
+    // The core timing logic is already tested in ScrollSyncStateTest
+    // This integration test is commented out to avoid CI flakiness
+    /*
+    @Test
+    @DisplayName("State coordination: timing-based suppression")
+    void testScrollStateTimingIntegration() throws InterruptedException {
+        var state = new ScrollSyncState();
+        
+        // Record user scroll and test timing window
+        state.recordUserScroll();
+        
+        // Should suppress within timing window
+        assertTrue(state.shouldSuppressSync(50).shouldSuppress(), "Should suppress within timing window");
+        
+        // Wait for timing window to pass completely
+        Thread.sleep(100);
+        
+        // Should allow sync after timing window - timing is based on timestamp, not just the flag
+        assertFalse(state.shouldSuppressSync(50).shouldSuppress(), "Should allow sync after timing window");
+    }
+    */
+
+    // =================================================================
+    // TIMER-BASED LOGIC TESTS WITH MINIMAL SWING
+    // =================================================================
+
+    @Test
+    @DisplayName("Timer logic: debouncer integration with scroll events")
+    void testDebouncerIntegrationWithScrollEvents() throws Exception {
+        var debouncer = new ScrollDebouncer(30); // Shorter debounce for faster test
+        var executionCount = new AtomicInteger(0);
+        var completionCount = new AtomicInteger(0);
+        var executionLatch = new CountDownLatch(1);
+        var completionLatch = new CountDownLatch(1);
+        
+        try {
+            // Create request that simulates scroll processing
+            var request = new ScrollDebouncer.DebounceRequest<>(
+                Boolean.TRUE, // leftScrolled flag
+                (leftScrolled) -> {
+                    executionCount.incrementAndGet();
+                    executionLatch.countDown();
+                },
+                () -> {
+                    completionCount.incrementAndGet();
+                    completionLatch.countDown();
+                }
+            );
+            
+            // Submit multiple rapid requests (simulating rapid scrolling)
+            debouncer.submit(request);
+            debouncer.submit(request);
+            debouncer.submit(request);
+            
+            // Wait for execution and completion with longer timeout
+            assertTrue(executionLatch.await(500, TimeUnit.MILLISECONDS), "Debounced action should execute");
+            assertTrue(completionLatch.await(500, TimeUnit.MILLISECONDS), "Completion callback should execute");
+            
+            // Should only execute once due to debouncing
+            assertEquals(1, executionCount.get(), "Should execute only once due to debouncing");
+            assertEquals(1, completionCount.get(), "Should complete only once");
+            
+        } finally {
+            debouncer.dispose();
+        }
+    }
+
+    @Test
+    @DisplayName("Timer logic: programmatic scroll flag timing")
+    void testProgrammaticScrollFlagTiming() throws Exception {
+        // Create minimal scroll bars for listener testing
+        var leftScrollBar = new JScrollBar();
+        var rightScrollBar = new JScrollBar();
+        var state = new ScrollSyncState();
+        
+        // Test listener behavior with programmatic scroll flag
+        var adjustmentCount = new AtomicInteger(0);
+        var suppressedCount = new AtomicInteger(0);
+        
+        AdjustmentListener testListener = e -> {
+            adjustmentCount.incrementAndGet();
+            
+            // Simulate the logic from ScrollSynchronizer's getVerticalAdjustmentListener
+            if (state.isProgrammaticScroll()) {
+                suppressedCount.incrementAndGet();
+                return;
+            }
+            
+            // Simulate user scroll handling
+            state.recordUserScroll();
+        };
+        
+        leftScrollBar.addAdjustmentListener(testListener);
+        
+        // Test normal scroll (should be processed)
+        SwingUtilities.invokeAndWait(() -> {
+            leftScrollBar.setValue(10);
+        });
+        
+        assertEquals(1, adjustmentCount.get(), "Adjustment event should be received");
+        assertEquals(0, suppressedCount.get(), "Normal scroll should not be suppressed");
+        
+        // Test programmatic scroll (should be suppressed)
+        state.setProgrammaticScroll(true);
+        SwingUtilities.invokeAndWait(() -> {
+            leftScrollBar.setValue(20);
+        });
+        
+        assertEquals(2, adjustmentCount.get(), "Second adjustment event should be received");
+        assertEquals(1, suppressedCount.get(), "Programmatic scroll should be suppressed");
+        
+        // Reset flag and test that suppression ends
+        state.setProgrammaticScroll(false);
+        SwingUtilities.invokeAndWait(() -> {
+            leftScrollBar.setValue(30);
+        });
+        
+        assertEquals(3, adjustmentCount.get(), "Third adjustment event should be received");
+        assertEquals(1, suppressedCount.get(), "Suppression should end when flag is cleared");
+    }
+
+    @Test
+    @DisplayName("Timer logic: reset timers in scroll synchronization")
+    void testScrollResetTimerLogic() throws Exception {
+        var resetExecuted = new AtomicBoolean(false);
+        var resetLatch = new CountDownLatch(1);
+        
+        // Simulate the reset timer logic from ScrollSynchronizer.performScroll()
+        SwingUtilities.invokeAndWait(() -> {
+            Timer resetTimer = new Timer(30, e -> { // Use short delay for testing
+                resetExecuted.set(true);
+                resetLatch.countDown();
+            });
+            resetTimer.setRepeats(false);
+            resetTimer.start();
+        });
+        
+        // Wait for timer to execute
+        assertTrue(resetLatch.await(100, TimeUnit.MILLISECONDS), "Reset timer should execute");
+        assertTrue(resetExecuted.get(), "Reset action should be executed");
+    }
+
+    @Test
+    @DisplayName("Timer logic: navigation reset delay")
+    void testNavigationResetDelayTiming() throws Exception {
+        var navigationResetExecuted = new AtomicBoolean(false);
+        var resetLatch = new CountDownLatch(1);
+        
+        // Simulate the navigation reset timer from ScrollSynchronizer.scrollToLine()
+        SwingUtilities.invokeAndWait(() -> {
+            Timer resetNavTimer = new Timer(PerformanceConstants.NAVIGATION_RESET_DELAY_MS, e -> {
+                navigationResetExecuted.set(true);
+                resetLatch.countDown();
+            });
+            resetNavTimer.setRepeats(false);
+            resetNavTimer.start();
+        });
+        
+        // Wait for timer to execute (should be very fast with NAVIGATION_RESET_DELAY_MS = 30)
+        assertTrue(resetLatch.await(100, TimeUnit.MILLISECONDS), "Navigation reset timer should execute");
+        assertTrue(navigationResetExecuted.get(), "Navigation reset should be executed");
+    }
+
+    // =================================================================
+    // HELPER METHODS
+    // =================================================================
+
+    /**
+     * Helper method to call the private approximateLineMapping method via reflection
+     */
+    private int callApproximateLineMapping(Patch<String> patch, int line, boolean fromOriginal) throws Exception {
+        // Use the test constructor that skips UI initialization
+        var testSynchronizer = new ScrollSynchronizer(null, null, null, true);
+        
+        Method method = ScrollSynchronizer.class.getDeclaredMethod("approximateLineMapping", 
+                Patch.class, int.class, boolean.class);
+        method.setAccessible(true);
+        
+        return (Integer) method.invoke(testSynchronizer, patch, line, fromOriginal);
+    }
+}

--- a/src/test/java/io/github/jbellis/brokk/difftool/ui/DiffHighlightUtilTest.java
+++ b/src/test/java/io/github/jbellis/brokk/difftool/ui/DiffHighlightUtilTest.java
@@ -1,0 +1,75 @@
+package io.github.jbellis.brokk.difftool.ui;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.patch.AbstractDelta;
+import com.github.difflib.patch.Patch;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link DiffHighlightUtil} which contains pure, thread–safe
+ * helper logic extracted from {@code FilePanel}.
+ */
+class DiffHighlightUtilTest
+{
+    /**
+     * Basic sanity-check that an INSERT delta on the *revised* side is detected
+     * as intersecting when the viewport clearly covers the chunk.
+     */
+    @Test
+    void intersectsViewport_insertRevisedSide()
+    {
+        List<String> original = List.of("A", "B");
+        List<String> revised  = List.of("A", "B", "C");   // +1 line at pos 2
+
+        Patch<String> patch = DiffUtils.diff(original, revised);
+        assertEquals(1, patch.getDeltas().size(), "Should have exactly one delta");
+
+        AbstractDelta<String> delta = patch.getDeltas().getFirst();
+
+        // The inserted line is at position 2 (0-based).  Viewport 0-10 definitely covers it.
+        boolean intersects = DiffHighlightUtil.deltaIntersectsViewport(delta, 0, 10, /*originalSide=*/false);
+        assertTrue(intersects, "Revised side should intersect viewport for INSERT delta");
+    }
+
+    /**
+     * A DELETE delta on the *original* side should be detected when the viewport
+     * covers the source chunk even though the revised chunk is empty.
+     */
+    @Test
+    void intersectsViewport_deleteOriginalSide()
+    {
+        List<String> original = List.of("A", "B", "C");
+        List<String> revised  = List.of("A", "C");   // removed line 1 ("B")
+
+        Patch<String> patch = DiffUtils.diff(original, revised);
+        assertEquals(1, patch.getDeltas().size(), "Should have exactly one delta");
+
+        AbstractDelta<String> delta = patch.getDeltas().getFirst();
+
+        // Source chunk starts at 1.  Viewport 0-10 covers it.
+        boolean intersects = DiffHighlightUtil.deltaIntersectsViewport(delta, 0, 10, /*originalSide=*/true);
+        assertTrue(intersects, "Original side should intersect viewport for DELETE delta");
+    }
+
+    /**
+     * Verify that a delta outside the viewport is correctly reported as *not*
+     * intersecting.
+     */
+    @Test
+    void noIntersectionOutsideViewport()
+    {
+        List<String> original = List.of("A", "B", "C");
+        List<String> revised  = List.of("A", "B", "C", "D");   // +1 at end
+
+        Patch<String> patch = DiffUtils.diff(original, revised);
+        AbstractDelta<String> delta = patch.getDeltas().getFirst();
+
+        // Viewport is lines 0-1, but insertion is at 3.
+        boolean intersects = DiffHighlightUtil.deltaIntersectsViewport(delta, 0, 1, /*originalSide=*/false);
+        assertFalse(intersects, "Delta should be outside viewport");
+    }
+}

--- a/src/test/java/io/github/jbellis/brokk/difftool/ui/DiffHighlightUtilTest.java
+++ b/src/test/java/io/github/jbellis/brokk/difftool/ui/DiffHighlightUtilTest.java
@@ -20,7 +20,7 @@ class DiffHighlightUtilTest
      * as intersecting when the viewport clearly covers the chunk.
      */
     @Test
-    void intersectsViewport_insertRevisedSide()
+    void isChunkVisible_insertRevisedSide()
     {
         List<String> original = List.of("A", "B");
         List<String> revised  = List.of("A", "B", "C");   // +1 line at pos 2
@@ -31,8 +31,9 @@ class DiffHighlightUtilTest
         AbstractDelta<String> delta = patch.getDeltas().getFirst();
 
         // The inserted line is at position 2 (0-based).  Viewport 0-10 definitely covers it.
-        boolean intersects = DiffHighlightUtil.deltaIntersectsViewport(delta, 0, 10, /*originalSide=*/false);
-        assertTrue(intersects, "Revised side should intersect viewport for INSERT delta");
+        var result = DiffHighlightUtil.isChunkVisible(delta, 0, 10, /*originalSide=*/false);
+        assertTrue(result.intersects(), "Revised side should intersect viewport for INSERT delta");
+        assertNull(result.warning(), "Should have no warning");
     }
 
     /**
@@ -40,7 +41,7 @@ class DiffHighlightUtilTest
      * covers the source chunk even though the revised chunk is empty.
      */
     @Test
-    void intersectsViewport_deleteOriginalSide()
+    void isChunkVisible_deleteOriginalSide()
     {
         List<String> original = List.of("A", "B", "C");
         List<String> revised  = List.of("A", "C");   // removed line 1 ("B")
@@ -51,8 +52,27 @@ class DiffHighlightUtilTest
         AbstractDelta<String> delta = patch.getDeltas().getFirst();
 
         // Source chunk starts at 1.  Viewport 0-10 covers it.
-        boolean intersects = DiffHighlightUtil.deltaIntersectsViewport(delta, 0, 10, /*originalSide=*/true);
-        assertTrue(intersects, "Original side should intersect viewport for DELETE delta");
+        var result = DiffHighlightUtil.isChunkVisible(delta, 0, 10, /*originalSide=*/true);
+        assertTrue(result.intersects(), "Original side should intersect viewport for DELETE delta");
+        assertNull(result.warning(), "Should have no warning");
+    }
+
+    /**
+     * A DELETE delta on the *revised* side should fall back to source chunk for positioning.
+     */
+    @Test
+    void isChunkVisible_deleteRevisedSideFallback()
+    {
+        List<String> original = List.of("A", "B", "C");
+        List<String> revised  = List.of("A", "C");   // removed line 1 ("B")
+
+        Patch<String> patch = DiffUtils.diff(original, revised);
+        AbstractDelta<String> delta = patch.getDeltas().getFirst();
+
+        // Revised side should fall back to source chunk for positioning
+        var result = DiffHighlightUtil.isChunkVisible(delta, 0, 10, /*originalSide=*/false);
+        assertTrue(result.intersects(), "Revised side should fall back to source chunk positioning");
+        assertNull(result.warning(), "Should have no warning");
     }
 
     /**
@@ -69,7 +89,53 @@ class DiffHighlightUtilTest
         AbstractDelta<String> delta = patch.getDeltas().getFirst();
 
         // Viewport is lines 0-1, but insertion is at 3.
-        boolean intersects = DiffHighlightUtil.deltaIntersectsViewport(delta, 0, 1, /*originalSide=*/false);
-        assertFalse(intersects, "Delta should be outside viewport");
+        var result = DiffHighlightUtil.isChunkVisible(delta, 0, 1, /*originalSide=*/false);
+        assertFalse(result.intersects(), "Delta should be outside viewport");
+        assertNull(result.warning(), "Should have no warning");
+    }
+
+    /**
+     * Test range validation - startLine > endLine should return warning.
+     */
+    @Test
+    void invalidRange()
+    {
+        List<String> original = List.of("A", "B");
+        List<String> revised  = List.of("A", "B", "C");
+
+        Patch<String> patch = DiffUtils.diff(original, revised);
+        AbstractDelta<String> delta = patch.getDeltas().getFirst();
+
+        var result = DiffHighlightUtil.isChunkVisible(delta, 5, 3, false);
+        assertFalse(result.intersects(), "Should not intersect with invalid range");
+        assertNotNull(result.warning(), "Should have warning for invalid range");
+        assertTrue(result.warning().contains("Invalid range"), "Warning should mention invalid range");
+    }
+
+    /**
+     * Test chunk separation - getRelevantChunk vs getChunkForHighlight.
+     */
+    @Test
+    void chunkMethods()
+    {
+        List<String> original = List.of("A", "B", "C");
+        List<String> revised  = List.of("A", "C");   // DELETE delta
+
+        Patch<String> patch = DiffUtils.diff(original, revised);
+        AbstractDelta<String> delta = patch.getDeltas().getFirst();
+
+        // Original side - both methods should return source
+        var relevantOrig = DiffHighlightUtil.getRelevantChunk(delta, true);
+        var highlightOrig = DiffHighlightUtil.getChunkForHighlight(delta, true);
+        assertSame(relevantOrig, highlightOrig, "Original side chunks should be same");
+        assertNotNull(relevantOrig, "Original chunk should exist");
+
+        // Revised side - relevant should have size 0 (DELETE), highlight should fall back to source
+        var relevantRev = DiffHighlightUtil.getRelevantChunk(delta, false);
+        var highlightRev = DiffHighlightUtil.getChunkForHighlight(delta, false);
+        assertNotNull(relevantRev, "Revised chunk should exist for DELETE");
+        assertEquals(0, relevantRev.size(), "Revised chunk should have size 0 for DELETE");
+        assertNotNull(highlightRev, "Highlight chunk should fall back to source");
+        assertSame(relevantOrig, highlightRev, "Highlight should fall back to source chunk");
     }
 }


### PR DESCRIPTION
I wasn't able to reproduce the bug on #391 but possible paths for it to happen were identified. Thus this PR focus on improving robustness

The code for diff highlighting and scrolling is asynchronous. To make testing easier some parts of the code were moved to separate classes that can be better tested without launching swing. some scenarios that could break painting were identified

A similar process was used to fix a few more issues related to scroll synchronization. I tested this with a file having many changes to be highlighted

fixes #391 