### PR TITLE
Remembers last Git merge mode, improving user experience and workflow efficiency

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -56,6 +56,8 @@ public final class MainProject extends AbstractProject {
     private static final String ARCHITECT_OPTIONS_JSON_KEY = "architectOptionsJson";
     private static final String ARCHITECT_RUN_IN_WORKTREE_KEY = "architectRunInWorktree";
 
+    private static final String LAST_MERGE_MODE_KEY = "lastMergeMode";
+
     // Old keys for migration
     private static final String OLD_ISSUE_PROVIDER_ENUM_KEY = "issueProvider"; // Stores the enum name (GITHUB, JIRA)
     private static final String JIRA_PROJECT_BASE_URL_KEY = "jiraProjectBaseUrl";
@@ -945,6 +947,24 @@ public final class MainProject extends AbstractProject {
             logger.error("Failed to serialize ArchitectOptions to JSON for workspace: {}. Settings not saved.", options, e);
             // Not re-throwing as this is a preference, not critical state.
         }
+    }
+
+    public Optional<GitRepo.MergeMode> getLastMergeMode() {
+        String modeName = mainWorkspaceProps.getProperty(LAST_MERGE_MODE_KEY);
+        if (modeName == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(GitRepo.MergeMode.valueOf(modeName));
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid merge mode '{}' in workspace properties, ignoring.", modeName);
+            return Optional.empty();
+        }
+    }
+
+    public void setLastMergeMode(GitRepo.MergeMode mode) {
+        mainWorkspaceProps.setProperty(LAST_MERGE_MODE_KEY, mode.name());
+        persistWorkspacePropertiesFile();
     }
 
     public static String getGitHubToken() {


### PR DESCRIPTION
### Pull Request Description

**Intent:** Improve user experience in Git merge operations by remembering the last selected merge mode, reducing repetitive selections and making the workflow more efficient.

**Behavior Changes:** 
- The merge dialog now defaults to the previously used merge mode (e.g., MERGE_COMMIT) instead of always starting with a fixed option.
- Changes to the merge mode in the dialog are persisted immediately, so future sessions reflect the user's preference.

**Key Implementation Ideas:** 
- Added `getLastMergeMode` and `setLastMergeMode` methods in `MainProject.java` to store/retrieve the mode via workspace properties.
- In `GitWorktreeTab.java` and `MergeBranchDialogPanel.java`, integrated an ActionListener to save the selected mode on change, using Optional for safe handling of absent values.

(85 words)

Wanted to try out the built in PRs some more, please let me know if you prefer just my writing in these. 