### PR TITLE
Improved Markdown rendering in previews and URL imports for better formatting

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/tools/WorkspaceTools.java
+++ b/src/main/java/io/github/jbellis/brokk/tools/WorkspaceTools.java
@@ -161,7 +161,7 @@ public class WorkspaceTools {
         // Use the ContextManager's method to add the string fragment
         String description = "Content from " + urlString;
         // ContextManager handles pushing the context update
-        var fragment = new ContextFragment.StringFragment(contextManager, content, description, SyntaxConstants.SYNTAX_STYLE_NONE); // Pass contextManager
+        var fragment = new ContextFragment.StringFragment(contextManager, content, description, SyntaxConstants.SYNTAX_STYLE_MARKDOWN); // Pass contextManager
         contextManager.pushContext(ctx -> ctx.addVirtualFragment(fragment));
 
         return "Added content from URL [%s] as a read-only text fragment.".formatted(urlString);


### PR DESCRIPTION
### Pull Request Description

**Intent:**  
Enhance the rendering of Markdown content in previews and URL imports to provide better formatting and readability, ensuring Markdown fragments are displayed as intended rather than plain text.

**Behaviour Changes:**  
- Previews for Markdown fragments now render with proper formatting using a Markdown panel, improving visual output for users viewing text fragments.  
- Content imported from URLs is treated as Markdown by default, so it will be previewed with syntax highlighting and formatting instead of as plain text.

**Key Implementation Ideas:**  
- In `Chrome.java`, added a conditional check for Markdown syntax in fragments, using `MarkdownOutputPanel` with a minimal `TaskEntry` wrapper for rendering; otherwise, fall back to the standard text panel.  
- In `WorkspaceTools.java`, updated the fragment creation to specify `SYNTAX_STYLE_MARKDOWN` for URL content, enabling consistent Markdown handling across the application. (92 words)