### PR TITLE
Override Joern Classes at Classpath Level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,12 +114,12 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.20.0",
 
   // Joern dependencies
-  "io.joern" %% "x2cpg" % "4.0.369",
-  "io.joern" %% "c2cpg" % "4.0.369",
-  "io.joern" %% "javasrc2cpg" % "4.0.369",
-  "io.joern" %% "pysrc2cpg" % "4.0.369",
-  "io.joern" %% "joern-cli" % "4.0.369",
-  "io.joern" %% "semanticcpg" % "4.0.369",
+  "io.joern" %% "x2cpg" % "4.0.379",
+  "io.joern" %% "c2cpg" % "4.0.379",
+  "io.joern" %% "javasrc2cpg" % "4.0.379",
+  "io.joern" %% "pysrc2cpg" % "4.0.379",
+  "io.joern" %% "joern-cli" % "4.0.379",
+  "io.joern" %% "semanticcpg" % "4.0.379",
 
   // Utilities
   "com.formdev" % "flatlaf" % "3.6",
@@ -175,6 +175,7 @@ assembly / assemblyMergeStrategy := {
       case "MANIFEST.MF" => MergeStrategy.discard
       case _ => MergeStrategy.first
     }
+  // This project's classes come first on the classpath, thus our version will be selected.
   case _ => MergeStrategy.first
 }
 assembly / mainClass := Some("io.github.jbellis.brokk.Brokk")

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/builder/CpgBuilder.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/builder/CpgBuilder.scala
@@ -1,7 +1,6 @@
 package io.github.jbellis.brokk.analyzer.builder
 
 import io.github.jbellis.brokk.analyzer.builder.IncrementalUtils.*
-import io.github.jbellis.brokk.analyzer.builder.passes.idempotent
 import io.github.jbellis.brokk.analyzer.builder.passes.incremental.{HashFilesPass, PruneTypesPass}
 import io.github.jbellis.brokk.analyzer.implicits.CpgExt.*
 import io.joern.x2cpg.X2CpgConfig
@@ -162,12 +161,12 @@ trait CpgBuilder[R <: X2CpgConfig[R]] {
       // Stub creators are moved up as these create nodes that interact with [File|Namespace]CreationPass
       new MethodStubCreator(cpg),
       new TypeDeclStubCreator(cpg),
-      new idempotent.base.FileCreationPass(cpg),
-      new idempotent.base.NamespaceCreator(cpg),
+      new FileCreationPass(cpg),
+      new NamespaceCreator(cpg),
       new ParameterIndexCompatPass(cpg),
       new MethodDecoratorPass(cpg),
       new AstLinkerPass(cpg),
-      new idempotent.base.ContainsEdgePass(cpg),
+      new ContainsEdgePass(cpg),
       new TypeRefPass(cpg),
       new TypeEvalPass(cpg)
     )
@@ -180,8 +179,8 @@ trait CpgBuilder[R <: X2CpgConfig[R]] {
   protected def callGraphPasses(cpg: Cpg): Iterator[CpgPassBase] = {
     Iterator(
       new MethodRefLinker(cpg),
-      new idempotent.callgraph.StaticCallLinker(cpg),
-      new idempotent.callgraph.DynamicCallLinker(cpg)
+      new StaticCallLinker(cpg),
+      new DynamicCallLinker(cpg)
     )
   }
 

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/builder/CpgBuilder.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/builder/CpgBuilder.scala
@@ -177,11 +177,7 @@ trait CpgBuilder[R <: X2CpgConfig[R]] {
   }
 
   protected def callGraphPasses(cpg: Cpg): Iterator[CpgPassBase] = {
-    Iterator(
-      new MethodRefLinker(cpg),
-      new StaticCallLinker(cpg),
-      new DynamicCallLinker(cpg)
-    )
+    Iterator(new MethodRefLinker(cpg), new StaticCallLinker(cpg), new DynamicCallLinker(cpg))
   }
 
   protected def postProcessingPasses(cpg: Cpg): Iterator[CpgPassBase] = {

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/CBuilder.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/CBuilder.scala
@@ -1,12 +1,12 @@
 package io.github.jbellis.brokk.analyzer.builder.languages
 
 import io.github.jbellis.brokk.analyzer.builder.CpgBuilder
-import io.github.jbellis.brokk.analyzer.builder.passes.idempotent
 import io.joern.c2cpg.astcreation.CGlobal
 import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.passes.*
 import io.joern.c2cpg.{C2Cpg, Config as CConfig}
 import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.passes.frontend.TypeNodePass
 import io.joern.x2cpg.utils.Report
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 
@@ -30,7 +30,7 @@ object CBuilder {
         .createAndApply()
       new AstCreationPass(cpg, preprocessedFiles, Set(FileDefaults.CHeaderFileExtension), config, global, report)
         .createAndApply()
-      idempotent.frontend.TypeNodePass.withRegisteredTypes(global.typesSeen(), cpg).createAndApply()
+      TypeNodePass.withRegisteredTypes(global.typesSeen(), cpg).createAndApply()
       new TypeDeclNodePass(cpg, config).createAndApply()
       new FunctionDeclNodePass(cpg, global.unhandledMethodDeclarations(), config).createAndApply()
       new FullNameUniquenessPass(cpg).createAndApply()

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/JavaSrcBuilder.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/JavaSrcBuilder.scala
@@ -1,10 +1,9 @@
 package io.github.jbellis.brokk.analyzer.builder.languages
 
 import io.github.jbellis.brokk.analyzer.builder.CpgBuilder
-import io.github.jbellis.brokk.analyzer.builder.passes.idempotent
 import io.joern.javasrc2cpg.passes.{AstCreationPass, OuterClassRefPass, TypeInferencePass}
 import io.joern.javasrc2cpg.{JavaSrc2Cpg, Config as JavaSrcConfig}
-import io.joern.x2cpg.passes.frontend.JavaConfigFileCreationPass
+import io.joern.x2cpg.passes.frontend.{JavaConfigFileCreationPass, TypeNodePass}
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 
 import scala.jdk.CollectionConverters.*
@@ -27,7 +26,7 @@ object JavaSrcBuilder {
       new OuterClassRefPass(cpg).createAndApply()
       JavaConfigFileCreationPass(cpg).createAndApply()
       if (!config.skipTypeInfPass) {
-        idempotent.frontend.TypeNodePass
+        TypeNodePass
           .withRegisteredTypes(astCreationPass.global.usedTypes.keys().asScala.toList, cpg)
           .createAndApply()
         new TypeInferencePass(cpg).createAndApply()

--- a/src/main/scala/io/joern/x2cpg/passes/base/ContainsEdgePass.scala
+++ b/src/main/scala/io/joern/x2cpg/passes/base/ContainsEdgePass.scala
@@ -18,7 +18,7 @@
  *
  * The original file can be found at https://github.com/joernio/joern/blob/3e923e15368e64648e6c5693ac014a2cac83990a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ContainsEdgePass.scala
  */
-package io.github.jbellis.brokk.analyzer.builder.passes.idempotent.base
+package io.joern.x2cpg.passes.base
 
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes, NodeTypes}

--- a/src/main/scala/io/joern/x2cpg/passes/base/FileCreationPass.scala
+++ b/src/main/scala/io/joern/x2cpg/passes/base/FileCreationPass.scala
@@ -18,7 +18,7 @@
  *
  * The original file can be found at https://github.com/joernio/joern/blob/3e923e15368e64648e6c5693ac014a2cac83990a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/FileCreationPass.scala
  */
-package io.github.jbellis.brokk.analyzer.builder.passes.idempotent.base
+package io.joern.x2cpg.passes.base
 
 import io.joern.x2cpg.utils.LinkingUtil
 import io.shiftleft.codepropertygraph.generated.nodes.*

--- a/src/main/scala/io/joern/x2cpg/passes/base/NamespaceCreator.scala
+++ b/src/main/scala/io/joern/x2cpg/passes/base/NamespaceCreator.scala
@@ -18,7 +18,7 @@
  *
  * The original file can be found at https://github.com/joernio/joern/blob/3e923e15368e64648e6c5693ac014a2cac83990a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/NamespaceCreator.scala
  */
-package io.github.jbellis.brokk.analyzer.builder.passes.idempotent.base
+package io.joern.x2cpg.passes.base
 
 import io.shiftleft.codepropertygraph.generated.nodes.NewNamespace
 import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}

--- a/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -18,7 +18,7 @@
  *
  * The original file can be found at https://github.com/joernio/joern/blob/3e923e15368e64648e6c5693ac014a2cac83990a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
  */
-package io.github.jbellis.brokk.analyzer.builder.passes.idempotent.callgraph
+package io.joern.x2cpg.passes.callgraph
 
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, StoredNode, TypeDecl}

--- a/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
+++ b/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
@@ -18,7 +18,7 @@
  *
  * The original file can be found at https://github.com/joernio/joern/blob/3e923e15368e64648e6c5693ac014a2cac83990a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
  */
-package io.github.jbellis.brokk.analyzer.builder.passes.idempotent.callgraph
+package io.joern.x2cpg.passes.callgraph
 
 import io.joern.x2cpg.utils.LinkingUtil
 import io.shiftleft.codepropertygraph.generated.nodes.*

--- a/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
+++ b/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
@@ -18,7 +18,7 @@
  *
  * The original file can be found at https://github.com/joernio/joern/blob/3e923e15368e64648e6c5693ac014a2cac83990a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
  */
-package io.github.jbellis.brokk.analyzer.builder.passes.idempotent.frontend
+package io.joern.x2cpg.passes.frontend
 
 import io.shiftleft.codepropertygraph.generated.nodes.NewType
 import io.shiftleft.codepropertygraph.generated.{Cpg, Properties}


### PR DESCRIPTION
* Moves our overridden classes to the same path as where they would be in Joern, but these will be assembled first according to our merge strategy. The benefit is that if changes ever enter the dependency we have a clean refactor, as well as not carrying around duplicates of classes in the JAR.
* Adds the (modified) `Delombok` changes from https://github.com/joernio/joern/pull/5566 so that they take effect. The modification largely keeps things more "Scala"-like by instead instructing `.par` on which Executor to use.
* Upgrades Joern to a minimal version in order to be compatible with https://github.com/joernio/joern/pull/5566 

Resolves #407 (possibly?)