### PR TITLE
Extracts Method Name from Lambda Signature in `StackTraceElement`

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1083,7 +1083,8 @@ public class ContextManager implements IContextManager, AutoCloseable {
         IAnalyzer localAnalyzer = getAnalyzerUninterrupted();
 
         for (var element : stacktrace.getFrames()) {
-            var methodFullName = element.getClassName() + "." + element.getMethodName();
+            var methodFullName = StackTrace.methodFullNameFromStacktraceElement(element);
+
             var methodSource = localAnalyzer.getMethodSource(methodFullName);
             if (methodSource.isPresent()) {
                 String className = ContextFragment.toClassname(methodFullName);

--- a/src/test/java/io/github/jbellis/brokk/StackTraceTest.java
+++ b/src/test/java/io/github/jbellis/brokk/StackTraceTest.java
@@ -69,4 +69,12 @@ public class StackTraceTest {
         assertEquals(2, st2.getFrames().size());
         assertEquals(2, st2.getFrames("io.github.jbellis.brokk.gui").size());
     }
+    
+    @Test
+    public void testStackTraceElementMethodFullNameLambdaParsing() {
+        var stackTraceElement = new StackTraceElement("io.github.jbellis.brokk.gui.GitCommitTab", "lambda$rollbackChangesWithUndo$19", "GitCommitTab.java", 565);
+        var fullName = StackTrace.methodFullNameFromStacktraceElement(stackTraceElement);
+        assertEquals("io.github.jbellis.brokk.gui.GitCommitTab.rollbackChangesWithUndo", fullName);
+                
+    }
 }


### PR DESCRIPTION
Uses regex to extract method name if it starts with `lambda`. 

**Questions**
* I've placed this in the `StackTrace` class - is this the right place?
* Should my solution rather extract the method name, and be applied to other places in `StackTrace`?