### PR TITLE
[C/C++] Pointer Parameter Linkage Bug Fix

### DIFF
--- a/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/CBuilder.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/CBuilder.scala
@@ -1,6 +1,7 @@
 package io.github.jbellis.brokk.analyzer.builder.languages
 
 import io.github.jbellis.brokk.analyzer.builder.CpgBuilder
+import io.github.jbellis.brokk.analyzer.builder.passes.cpp.PointerTypesPass
 import io.joern.c2cpg.astcreation.CGlobal
 import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.passes.*
@@ -9,6 +10,7 @@ import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.passes.frontend.TypeNodePass
 import io.joern.x2cpg.utils.Report
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
+import io.shiftleft.passes.CpgPassBase
 
 import scala.util.Try
 
@@ -37,6 +39,9 @@ object CBuilder {
       report.print()
       cpg
     }
+
+    override def basePasses(cpg: Cpg): Iterator[CpgPassBase] =
+      (super.basePasses(cpg).toList :+ new PointerTypesPass(cpg)).iterator
 
   }
 

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/builder/passes/cpp/PointerTypesPass.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/builder/passes/cpp/PointerTypesPass.scala
@@ -1,0 +1,76 @@
+package io.github.jbellis.brokk.analyzer.builder.passes.cpp
+
+import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
+import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}
+import io.shiftleft.passes.ForkJoinParallelCpgPass
+import io.shiftleft.semanticcpg.language.*
+
+import scala.collection.mutable
+
+/** Connects pointer types to the base type so that dynamically dispatched calls could be resolved.
+  *
+  * Requires [[io.joern.x2cpg.passes.base.TypeRefPass]] and [[io.joern.x2cpg.passes.base.TypeEvalPass]] as
+  * pre-requisites but must run before [[io.joern.x2cpg.passes.typerelations.TypeHierarchyPass]] and any call graph
+  * passes. Any orphaned pointer types will be pruned by [[PruneTypesPass]].
+  */
+class PointerTypesPass(cpg: Cpg) extends ForkJoinParallelCpgPass[TypeDecl](cpg) {
+
+  private val pointersToUnderlyingTypes = mutable.Map.empty[TypeDecl, TypeDecl]
+
+  override def init(): Unit = {
+    cpg.typeDecl
+      .filter(_.name.endsWith("*"))
+      .foreach { pointerTypeDecl =>
+        val strippedFullName = pointerTypeDecl.fullName.stripSuffix("*")
+        cpg.typeDecl
+          .isExternal(false) // only consider types where the declaration has been provided
+          .fullNameExact(strippedFullName)
+          .foreach { underlyingTypeDecl =>
+            pointersToUnderlyingTypes.put(pointerTypeDecl, underlyingTypeDecl)
+          }
+      }
+  }
+
+  /** Each part is a "pointer" that will be registered as some external type.
+    * @return
+    *   an array of all pointer types in the CPG.
+    */
+  override def generateParts(): Array[TypeDecl] = pointersToUnderlyingTypes.keys.toArray
+
+  /** Each task will begin by determining the type behind the pointer if it exists as a user-defined type. If this is
+    * the case, we will "re-wire" the expressions to the user-defined type.
+    *
+    * This may be an "imprecise" way to model this, but as far as open-source call graph support goes, pointers aren't
+    * handled explicitly anyway.
+    *
+    * @param builder
+    *   the diff graph builder.
+    * @param pointerTypeDecl
+    *   a pointer type declaration.
+    */
+  override def runOnPart(builder: DiffGraphBuilder, pointerTypeDecl: TypeDecl): Unit = {
+    pointersToUnderlyingTypes.get(pointerTypeDecl).foreach { underlyingTypeDecl =>
+      rewirePointerType(builder, pointerTypeDecl, underlyingTypeDecl)
+    }
+  }
+
+  private def rewirePointerType(
+    builder: DiffGraphBuilder,
+    pointerTypeDecl: TypeDecl,
+    underlyingTypeDecl: TypeDecl
+  ): Unit = {
+    pointerTypeDecl.referencingType.filter(_.name.endsWith("*")).foreach { pointerType =>
+      val pointerEvaluatedNodes = pointerType.evalTypeIn.l
+
+      underlyingTypeDecl.referencingType.foreach { underlyingType =>
+        pointerEvaluatedNodes.foreach { node =>
+          // 1) Prune away edges to the "pointer" type decl
+          node.outE(EdgeTypes.EVAL_TYPE).filter(_.dst == pointerType).foreach(builder.removeEdge)
+          // 2) Add edges to underlying type
+          builder.addEdge(node, underlyingType, EdgeTypes.EVAL_TYPE)
+        }
+      }
+    }
+  }
+
+}

--- a/src/test/scala/io/github/jbellis/brokk/analyzer/builder/cpp/CallGraphTest.scala
+++ b/src/test/scala/io/github/jbellis/brokk/analyzer/builder/cpp/CallGraphTest.scala
@@ -128,8 +128,6 @@ class CallGraphTest extends CpgTestFixture[c2cpg.Config] {
       inside(cpg.call.nameExact("greet").l) { case greetCall :: Nil =>
         greetCall.method.name shouldBe "doGreet"
         greetCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
-        // There is a bug in the frontend caused by `Greeter*` to be interpreted literally with the * resulting in
-        // no matched types
         greetCall.callee.fullName.l should contain theSameElementsAs List(
           "Greeter.greet:ANY()",
           "EnglishGreeter.greet:string()",

--- a/src/test/scala/io/github/jbellis/brokk/analyzer/builder/cpp/CallGraphTest.scala
+++ b/src/test/scala/io/github/jbellis/brokk/analyzer/builder/cpp/CallGraphTest.scala
@@ -128,12 +128,13 @@ class CallGraphTest extends CpgTestFixture[c2cpg.Config] {
       inside(cpg.call.nameExact("greet").l) { case greetCall :: Nil =>
         greetCall.method.name shouldBe "doGreet"
         greetCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
-      // There is a bug in the frontend caused by `Greeter*` to be interpreted literally with the * resulting in
-      // no matched types
-      //        greetCall.callee.fullName.l should contain theSameElementsAs List(
-      //          "EnglishGreeter.greet:std.string()",
-      //          "SpanishGreeter.greet:std.string()"
-      //        )
+        // There is a bug in the frontend caused by `Greeter*` to be interpreted literally with the * resulting in
+        // no matched types
+        greetCall.callee.fullName.l should contain theSameElementsAs List(
+          "Greeter.greet:ANY()",
+          "EnglishGreeter.greet:string()",
+          "SpanishGreeter.greet:string()"
+        )
       }
     }
   }


### PR DESCRIPTION
Fixes bug by rewiring pointer types to their underlying types. This also required modifying the `DynamicCallGraphLinker` to traverse the graph instead of string properties.

Chained dynamically dispatched calls are also tested for Java and C++ now.

TLDR: Dynamic dispatch on C++ code works now