### PR TITLE
Fix TypeScriptAnalyzer Windows Failures

### DIFF
--- a/src/test/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzerTest.java
+++ b/src/test/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzerTest.java
@@ -21,14 +21,14 @@ public class TypescriptAnalyzerTest {
 
     // Helper to normalize line endings and strip leading/trailing whitespace from each line
     private static final Function<String, String> normalize =
-        (String s) -> s.lines().map(String::strip).filter(line -> !line.isEmpty()).collect(Collectors.joining("\n"));
+            (String s) -> s.lines().map(String::strip).filter(line -> !line.isEmpty()).collect(Collectors.joining("\n"));
 
     @BeforeAll
     static void setUp(@TempDir Path tempDir) throws IOException {
         // Use a common TestProject setup method if available, or adapt TreeSitterAnalyzerTest.createTestProject
         Path testResourceRoot = Path.of("src/test/resources/testcode-ts");
         assertTrue(Files.exists(testResourceRoot) && Files.isDirectory(testResourceRoot),
-                   "Test resource directory 'testcode-ts' must exist.");
+                "Test resource directory 'testcode-ts' must exist.");
 
         // For TypescriptAnalyzerTest, we'll point the TestProject root directly to testcode-ts
         project = TestProject.createTestProject("testcode-ts", Language.TYPESCRIPT);
@@ -54,11 +54,11 @@ public class TypescriptAnalyzerTest {
 
         assertTrue(skeletons.containsKey(greeterClass), "Greeter class skeleton missing.");
         assertEquals(normalize.apply("""
-            export class Greeter {
-              greeting: string
-              constructor(message: string) { ... }
-              greet(): string { ... }
-            }"""), normalize.apply(skeletons.get(greeterClass)));
+                export class Greeter {
+                  greeting: string
+                  constructor(message: string) { ... }
+                  greet(): string { ... }
+                }"""), normalize.apply(skeletons.get(greeterClass)));
 
         assertTrue(skeletons.containsKey(globalFunc), "globalFunc skeleton missing.");
         assertEquals(normalize.apply("export function globalFunc(num: number): number { ... }"), normalize.apply(skeletons.get(globalFunc)));
@@ -69,21 +69,21 @@ public class TypescriptAnalyzerTest {
 
         assertTrue(skeletons.containsKey(pointInterface), "Point interface skeleton missing.");
         assertEquals(normalize.apply("""
-            export interface Point {
-              x: number
-              y: number
-              label?: string
-              readonly originDistance?: number
-              move(dx: number, dy: number): void
-            }"""), normalize.apply(skeletons.get(pointInterface)));
+                export interface Point {
+                  x: number
+                  y: number
+                  label?: string
+                  readonly originDistance?: number
+                  move(dx: number, dy: number): void
+                }"""), normalize.apply(skeletons.get(pointInterface)));
 
         assertTrue(skeletons.containsKey(colorEnum), "Color enum skeleton missing.");
         assertEquals(normalize.apply("""
-            export enum Color {
-              Red,
-              Green = 3,
-              Blue
-            }"""), normalize.apply(skeletons.get(colorEnum)));
+                export enum Color {
+                  Red,
+                  Green = 3,
+                  Blue
+                }"""), normalize.apply(skeletons.get(colorEnum)));
 
         assertTrue(skeletons.containsKey(stringOrNumberAlias), "StringOrNumber type alias skeleton missing.");
         assertEquals(normalize.apply("export type StringOrNumber = string | number"), normalize.apply(skeletons.get(stringOrNumberAlias)));
@@ -126,7 +126,7 @@ public class TypescriptAnalyzerTest {
         // then `reconstructFullSkeleton` called on `Greeter.greet` might only give its own signature.
         // Let's test `getSkeleton` on a top-level item:
         assertEquals(normalize.apply("export function globalFunc(num: number): number { ... }"),
-                     normalize.apply(analyzer.getSkeleton("globalFunc").orElse("")));
+                normalize.apply(analyzer.getSkeleton("globalFunc").orElse("")));
 
     }
 
@@ -171,29 +171,29 @@ public class TypescriptAnalyzerTest {
         assertTrue(skeletons.containsKey(myModule), "MyModule namespace skeleton missing.");
 
         String expectedMyModuleSkeleton = """
-            namespace MyModule {
-              export class InnerClass {
-                name: string = "Inner"
-                constructor() { ... }
-                doSomething(): void { ... }
-              }
-              export function innerFunc(): void { ... }
-              export const innerConst: number = 42
-              export interface InnerInterface {
-                id: number
-                describe(): string
-              }
-              export enum InnerEnum {
-                A,
-                B
-              }
-              export type InnerTypeAlias<V> = InnerInterface | V
-              namespace NestedNamespace {
-                export class DeeperClass {
-                }
-                export type DeepType = string
-              }
-            }""";
+                namespace MyModule {
+                  export class InnerClass {
+                    name: string = "Inner"
+                    constructor() { ... }
+                    doSomething(): void { ... }
+                  }
+                  export function innerFunc(): void { ... }
+                  export const innerConst: number = 42
+                  export interface InnerInterface {
+                    id: number
+                    describe(): string
+                  }
+                  export enum InnerEnum {
+                    A,
+                    B
+                  }
+                  export type InnerTypeAlias<V> = InnerInterface | V
+                  namespace NestedNamespace {
+                    export class DeeperClass {
+                    }
+                    export type DeepType = string
+                  }
+                }""";
         assertEquals(normalize.apply(expectedMyModuleSkeleton), normalize.apply(skeletons.get(myModule)));
 
         CodeUnit anotherClass = CodeUnit.cls(moduleTsFile, "", "AnotherClass");
@@ -219,12 +219,12 @@ public class TypescriptAnalyzerTest {
         // This might be unintuitive if one expects only the InnerClass part.
         // Let's test this behavior:
         assertEquals(normalize.apply(expectedMyModuleSkeleton), normalize.apply(innerClassSkel.get()),
-                     "getSkeleton for nested class should return the reconstructed parent skeleton.");
+                "getSkeleton for nested class should return the reconstructed parent skeleton.");
 
         Optional<String> innerTypeAliasSkelViaParent = analyzer.getSkeleton("MyModule.InnerTypeAlias");
         assertTrue(innerTypeAliasSkelViaParent.isPresent(), "Skeleton for MyModule.InnerTypeAlias should be part of MyModule's skeleton");
         assertEquals(normalize.apply(expectedMyModuleSkeleton), normalize.apply(innerTypeAliasSkelViaParent.get()),
-                     "getSkeleton for nested type alias should return reconstructed parent skeleton.");
+                "getSkeleton for nested type alias should return reconstructed parent skeleton.");
 
 
         Set<CodeUnit> declarations = analyzer.getDeclarationsInFile(moduleTsFile);
@@ -247,34 +247,34 @@ public class TypescriptAnalyzerTest {
 
         // With unified query, class-level decorators and method type parameters are not captured
         assertEquals(normalize.apply("""
-            export class DecoratedClass<T> {
-              @MyPropertyDecorator
-              decoratedProperty: string = "initial"
-              private _value: T
-              constructor(@MyParameterDecorator initialValue: T) { ... }
-              @MyMethodDecorator
-              genericMethod<U extends Point>(value: T, other: U): [T, U] { ... }
-              get value(): T { ... }
-              set value(val: T) { ... }
-            }"""), normalize.apply(skeletons.get(decoratedClass)));
+                export class DecoratedClass<T> {
+                  @MyPropertyDecorator
+                  decoratedProperty: string = "initial"
+                  private _value: T
+                  constructor(@MyParameterDecorator initialValue: T) { ... }
+                  @MyMethodDecorator
+                  genericMethod<U extends Point>(value: T, other: U): [T, U] { ... }
+                  get value(): T { ... }
+                  set value(val: T) { ... }
+                }"""), normalize.apply(skeletons.get(decoratedClass)));
 
         CodeUnit genericInterface = CodeUnit.cls(advancedTsFile, "", "GenericInterface");
         assertTrue(skeletons.containsKey(genericInterface));
         assertEquals(normalize.apply("""
-            export interface GenericInterface<T, U extends Point> {
-              item: T
-              point: U
-              process(input: T): U
-              new (param: T): GenericInterface<T,U>
-            }"""), normalize.apply(skeletons.get(genericInterface)));
+                export interface GenericInterface<T, U extends Point> {
+                  item: T
+                  point: U
+                  process(input: T): U
+                  new (param: T): GenericInterface<T,U>
+                }"""), normalize.apply(skeletons.get(genericInterface)));
 
         CodeUnit abstractBase = CodeUnit.cls(advancedTsFile, "", "AbstractBase");
         assertTrue(skeletons.containsKey(abstractBase));
         assertEquals(normalize.apply("""
-            export abstract class AbstractBase {
-              abstract performAction(name: string): void
-              concreteMethod(): string { ... }
-            }"""), normalize.apply(skeletons.get(abstractBase)));
+                export abstract class AbstractBase {
+                  abstract performAction(name: string): void
+                  concreteMethod(): string { ... }
+                }"""), normalize.apply(skeletons.get(abstractBase)));
 
         CodeUnit asyncArrow = CodeUnit.fn(advancedTsFile, "", "asyncArrowFunc");
         assertTrue(skeletons.containsKey(asyncArrow));
@@ -286,20 +286,20 @@ public class TypescriptAnalyzerTest {
 
         CodeUnit fieldTest = CodeUnit.cls(advancedTsFile, "", "FieldTest");
         assertTrue(skeletons.containsKey(fieldTest));
-         assertEquals(normalize.apply("""
-            export class FieldTest {
-              public name: string
-              private id: number = 0
-              protected status?: string
-              readonly creationDate: Date
-              static version: string = "1.0"
-              #trulyPrivateField: string = "secret"
-              constructor(name: string) { ... }
-              public publicMethod() { ... }
-              private privateMethod() { ... }
-              protected protectedMethod() { ... }
-              static staticMethod() { ... }
-            }"""), normalize.apply(skeletons.get(fieldTest)));
+        assertEquals(normalize.apply("""
+                export class FieldTest {
+                  public name: string
+                  private id: number = 0
+                  protected status?: string
+                  readonly creationDate: Date
+                  static version: string = "1.0"
+                  #trulyPrivateField: string = "secret"
+                  constructor(name: string) { ... }
+                  public publicMethod() { ... }
+                  private privateMethod() { ... }
+                  protected protectedMethod() { ... }
+                  static staticMethod() { ... }
+                }"""), normalize.apply(skeletons.get(fieldTest)));
 
         CodeUnit pointyAlias = CodeUnit.field(advancedTsFile, "", "_module_.Pointy");
         assertTrue(skeletons.containsKey(pointyAlias), "Pointy type alias skeleton missing. Found: " + skeletons.keySet());
@@ -307,11 +307,11 @@ public class TypescriptAnalyzerTest {
 
         CodeUnit overloadedFunc = CodeUnit.fn(advancedTsFile, "", "processInput");
         assertEquals(normalize.apply("""
-            export function processInput(input: string): string[]
-            export function processInput(input: number): number[]
-            export function processInput(input: boolean): boolean[]
-            export function processInput(input: any): any[] { ... }"""),
-                     normalize.apply(skeletons.get(overloadedFunc)));
+                        export function processInput(input: string): string[]
+                        export function processInput(input: number): number[]
+                        export function processInput(input: boolean): boolean[]
+                        export function processInput(input: any): any[] { ... }"""),
+                normalize.apply(skeletons.get(overloadedFunc)));
 
 
         // Test interface Point that follows a comment (regression test for interface appearing as free fields)
@@ -334,9 +334,9 @@ public class TypescriptAnalyzerTest {
 
         // Verify no top-level fields with names x or y exist (the original bug would create these)
         boolean hasTopLevelXField = declarations.stream()
-            .anyMatch(cu -> cu.kind() == CodeUnitType.FIELD && cu.identifier().equals("x") && !cu.shortName().contains("."));
+                .anyMatch(cu -> cu.kind() == CodeUnitType.FIELD && cu.identifier().equals("x") && !cu.shortName().contains("."));
         boolean hasTopLevelYField = declarations.stream()
-            .anyMatch(cu -> cu.kind() == CodeUnitType.FIELD && cu.identifier().equals("y") && !cu.shortName().contains("."));
+                .anyMatch(cu -> cu.kind() == CodeUnitType.FIELD && cu.identifier().equals("y") && !cu.shortName().contains("."));
         assertFalse(hasTopLevelXField, "x should not appear as a top-level field - original bug created free fields instead of interface properties");
         assertFalse(hasTopLevelYField, "y should not appear as a top-level field - original bug created free fields instead of interface properties");
 
@@ -358,13 +358,13 @@ public class TypescriptAnalyzerTest {
 
         // Verify the complete ambient namespace skeleton structure
         String expectedThirdPartyNamespace = """
-            declare namespace ThirdPartyLib {
-              doWork(): void;
-              interface LibOptions {
-              }
-            }""";
+                declare namespace ThirdPartyLib {
+                  doWork(): void;
+                  interface LibOptions {
+                  }
+                }""";
         assertEquals(normalize.apply(expectedThirdPartyNamespace), normalize.apply(skeletons.get(thirdPartyNamespace)),
-                     "Ambient namespace should have complete structure with contents");
+                "Ambient namespace should have complete structure with contents");
 
         // Verify ambient namespace function member
         CodeUnit doWorkFunc = CodeUnit.fn(advancedTsFile, "", "ThirdPartyLib.doWork");
@@ -376,13 +376,13 @@ public class TypescriptAnalyzerTest {
 
         // Verify no duplicate captures for ambient declarations
         long dollarVarCount = declarations.stream()
-            .filter(cu -> cu.identifier().equals("$"))
-            .count();
+                .filter(cu -> cu.identifier().equals("$"))
+                .count();
         assertEquals(1, dollarVarCount, "$ variable should only be captured once");
 
         long fetchFuncCount = declarations.stream()
-            .filter(cu -> cu.identifier().equals("fetch") && cu.kind() == CodeUnitType.FUNCTION)
-            .count();
+                .filter(cu -> cu.identifier().equals("fetch") && cu.kind() == CodeUnitType.FUNCTION)
+                .count();
         assertEquals(1, fetchFuncCount, "fetch function should only be captured once");
 
         // Test getSkeleton for individual ambient declarations
@@ -416,25 +416,25 @@ public class TypescriptAnalyzerTest {
         CodeUnit defaultClass = CodeUnit.cls(defaultExportFile, "", "MyDefaultClass");
         assertTrue(skeletons.containsKey(defaultClass), "MyDefaultClass (default export) skeleton missing. Found: " + skeletons.keySet());
         assertEquals(normalize.apply("""
-            export default class MyDefaultClass {
-              constructor() { ... }
-              doSomething(): void { ... }
-              get value(): string { ... }
-            }"""), normalize.apply(skeletons.get(defaultClass)));
+                export default class MyDefaultClass {
+                  constructor() { ... }
+                  doSomething(): void { ... }
+                  get value(): string { ... }
+                }"""), normalize.apply(skeletons.get(defaultClass)));
 
         // Default exported function
         CodeUnit defaultFunction = CodeUnit.fn(defaultExportFile, "", "myDefaultFunction");
         assertTrue(skeletons.containsKey(defaultFunction), "myDefaultFunction (default export) skeleton missing.");
         assertEquals(normalize.apply("export default function myDefaultFunction(param: string): string { ... }"),
-                     normalize.apply(skeletons.get(defaultFunction)));
+                normalize.apply(skeletons.get(defaultFunction)));
 
         // Named export in the same file
         CodeUnit anotherNamedClass = CodeUnit.cls(defaultExportFile, "", "AnotherNamedClass");
         assertTrue(skeletons.containsKey(anotherNamedClass));
         assertEquals(normalize.apply("""
-            export class AnotherNamedClass {
-              name: string = "Named"
-            }"""), normalize.apply(skeletons.get(anotherNamedClass)));
+                export class AnotherNamedClass {
+                  name: string = "Named"
+                }"""), normalize.apply(skeletons.get(anotherNamedClass)));
 
         CodeUnit utilityRateConst = CodeUnit.field(defaultExportFile, "", "_module_.utilityRate");
         assertTrue(skeletons.containsKey(utilityRateConst));
@@ -478,15 +478,15 @@ public class TypescriptAnalyzerTest {
 
         // Build expected based on actual separator used (without semicolons for overload signatures)
         String expectedOverloadedSource = String.join("\n",
-            "export function processInput(input: string): string[]",
-            "export function processInput(input: number): number[]",
-            "export function processInput(input: boolean): boolean[]",
-            "export function processInput(input: any): any[] {",
-            "if (typeof input === \"string\") return [`s-${input}`];",
-            "if (typeof input === \"number\") return [`n-${input}`];",
-            "if (typeof input === \"boolean\") return [`b-${input}`];",
-            "return [input];",
-            "}"
+                "export function processInput(input: string): string[]",
+                "export function processInput(input: number): number[]",
+                "export function processInput(input: boolean): boolean[]",
+                "export function processInput(input: any): any[] {",
+                "if (typeof input === \"string\") return [`s-${input}`];",
+                "if (typeof input === \"number\") return [`n-${input}`];",
+                "if (typeof input === \"boolean\") return [`b-${input}`];",
+                "return [input];",
+                "}"
         );
 
         assertEquals(expectedOverloadedSource, actualNormalized, "processInput overloaded source mismatch.");
@@ -550,51 +550,51 @@ public class TypescriptAnalyzerTest {
         CodeUnit dollarVar = CodeUnit.field(advancedTsFile, "", "_module_.$");
         assertTrue(skeletons.containsKey(dollarVar), "Ambient var $ should be captured");
         assertEquals(normalize.apply("declare var $: any"), normalize.apply(skeletons.get(dollarVar)),
-                     "Ambient var should have correct skeleton with 'declare var' keywords");
+                "Ambient var should have correct skeleton with 'declare var' keywords");
 
         // Test 2: Ambient function declaration with proper 'function' keyword
         CodeUnit fetchFunc = CodeUnit.fn(advancedTsFile, "", "fetch");
         assertTrue(skeletons.containsKey(fetchFunc), "Ambient function fetch should be captured");
         assertEquals(normalize.apply("declare function fetch(url:string): Promise<any>;"),
-                     normalize.apply(skeletons.get(fetchFunc)),
-                     "Ambient function should include 'function' keyword in skeleton");
+                normalize.apply(skeletons.get(fetchFunc)),
+                "Ambient function should include 'function' keyword in skeleton");
 
         // Test 3: Ambient namespace with contents
         CodeUnit thirdPartyNamespace = CodeUnit.cls(advancedTsFile, "", "ThirdPartyLib");
         assertTrue(skeletons.containsKey(thirdPartyNamespace), "Ambient namespace should be captured");
 
         String expectedNamespace = """
-            declare namespace ThirdPartyLib {
-              doWork(): void;
-              interface LibOptions {
-              }
-            }""";
+                declare namespace ThirdPartyLib {
+                  doWork(): void;
+                  interface LibOptions {
+                  }
+                }""";
         assertEquals(normalize.apply(expectedNamespace), normalize.apply(skeletons.get(thirdPartyNamespace)),
-                     "Ambient namespace should contain all its member declarations");
+                "Ambient namespace should contain all its member declarations");
 
         // Test 4: Ambient namespace members are captured as separate CodeUnits
         CodeUnit doWorkFunc = CodeUnit.fn(advancedTsFile, "", "ThirdPartyLib.doWork");
         assertTrue(declarations.contains(doWorkFunc),
-                   "Function inside ambient namespace should be captured as separate CodeUnit");
+                "Function inside ambient namespace should be captured as separate CodeUnit");
 
         CodeUnit libOptionsInterface = CodeUnit.cls(advancedTsFile, "", "ThirdPartyLib$LibOptions");
         assertTrue(declarations.contains(libOptionsInterface),
-                   "Interface inside ambient namespace should be captured as separate CodeUnit");
+                "Interface inside ambient namespace should be captured as separate CodeUnit");
 
         // Test 5: No duplicate captures
         long ambientVarCount = declarations.stream()
-            .filter(cu -> cu.kind() == CodeUnitType.FIELD && cu.identifier().equals("$"))
-            .count();
+                .filter(cu -> cu.kind() == CodeUnitType.FIELD && cu.identifier().equals("$"))
+                .count();
         assertEquals(1, ambientVarCount, "Ambient variable should only be captured once");
 
         long ambientFuncCount = declarations.stream()
-            .filter(cu -> cu.kind() == CodeUnitType.FUNCTION && cu.identifier().equals("fetch"))
-            .count();
+                .filter(cu -> cu.kind() == CodeUnitType.FUNCTION && cu.identifier().equals("fetch"))
+                .count();
         assertEquals(1, ambientFuncCount, "Ambient function should only be captured once");
 
         long ambientNamespaceCount = declarations.stream()
-            .filter(cu -> cu.kind() == CodeUnitType.CLASS && cu.identifier().equals("ThirdPartyLib"))
-            .count();
+                .filter(cu -> cu.kind() == CodeUnitType.CLASS && cu.identifier().equals("ThirdPartyLib"))
+                .count();
         assertEquals(1, ambientNamespaceCount, "Ambient namespace should only be captured once");
 
         // Test 6: Different types of ambient declarations
@@ -617,10 +617,11 @@ public class TypescriptAnalyzerTest {
 
         // Test with Point interface from Hello.ts
         final String pointSource = normalize.apply(analyzer.getClassSource("Point"));
+        final var sourceParts = pointSource.split("\n");
         assertNotNull(pointSource);
-        assertTrue(pointSource.startsWith("export interface Point"), () -> String.format("'%s' did not start with the expected prefix.", pointSource));
+        assertTrue(pointSource.startsWith("export interface Point"), () -> String.format("'%s' did not start with the expected prefix.", sourceParts[0]));
         assertTrue(pointSource.contains("x: number;"));
         assertTrue(pointSource.contains("move(dx: number, dy: number): void;"));
-        assertTrue(pointSource.endsWith("}"), () -> String.format("'%s' did not end with the expected prefix.", pointSource));
+        assertTrue(pointSource.endsWith("}"), () -> String.format("'%s' did not end with the expected prefix.", sourceParts[sourceParts.length - 1]));
     }
 }

--- a/src/test/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzerTest.java
+++ b/src/test/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzerTest.java
@@ -8,9 +8,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -618,12 +616,11 @@ public class TypescriptAnalyzerTest {
         assertTrue(greeterSource.endsWith("}"));
 
         // Test with Point interface from Hello.ts
-        String pointSource = normalize.apply(analyzer.getClassSource("Point"));
+        final String pointSource = normalize.apply(analyzer.getClassSource("Point"));
         assertNotNull(pointSource);
-        System.out.println(pointSource);
-        assertTrue(pointSource.startsWith("export interface Point"));
+        assertTrue(pointSource.startsWith("export interface Point"), () -> String.format("'%s' did not start with the expected prefix.", pointSource));
         assertTrue(pointSource.contains("x: number;"));
         assertTrue(pointSource.contains("move(dx: number, dy: number): void;"));
-        assertTrue(pointSource.endsWith("}"));
+        assertTrue(pointSource.endsWith("}"), () -> String.format("'%s' did not end with the expected prefix.", pointSource));
     }
 }


### PR DESCRIPTION
Aims to fix a Windows error in `TypeScriptAnalyzerTest::testGetClassSource`. This seems to be failing on 
`assertTrue(pointSource.startsWith("export interface Point"));`