### PR TITLE
Check for Lomboked Files before Processing

### DIFF
--- a/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -137,7 +137,7 @@ object Delombok {
             .partition(containsLombokedJava(inputPath, _))
 
           logger.debug(
-            s"Found ${normalPackageRoots.size} packages without Lombok usage, and ${lombokedPackageRoots.size} that use Lombok. Given input path: $inputPath"
+            s"Found ${normalPackageRoots.size} packages without Lombok usage, and ${lombokedPackageRoots.size} that use Lombok."
           )
 
           // Delombok affected packages


### PR DESCRIPTION
Performs a simple check on each package to determine if a file contains `import lombok.`. If such a package is affected, it performs delombok; otherwise simply moves the contents to the target temporary directory.

I used [lombok-examples](https://github.com/ayonious/lombok-examples) to test alongside [netbeans](https://github.com/apache/netbeans). For my 16GB ram machine, netbeans OOMs, but at least I can confirm Delombok runs when it should.