### PR TITLE
Normalize Newlines Before Performing Offset-based Slicing

### DIFF
--- a/src/main/scala/io/github/jbellis/brokk/analyzer/implicits/AstNodeExt.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/implicits/AstNodeExt.scala
@@ -17,7 +17,9 @@ object AstNodeExt {
         val filePath = Cpg(node.graph).projectRoot.resolve(filename).toAbsolutePath.toString
         (node.offset, node.offsetEnd) match {
           case (Some(offset), Some(offsetEnd)) =>
-            Using(Source.fromFile(filePath))(_.slice(offset, offsetEnd).mkString).toOption
+            Using(Source.fromFile(filePath))(
+              _.mkString.replace(System.lineSeparator, "\n").slice(offset, offsetEnd)
+            ).toOption
           case _ => None
         }
       }


### PR DESCRIPTION
Normalises newlines before performing offset-based slicing to match what Joern may have calculated offsets from.