### PR TITLE
enh: Upgrade Langchain4j to 1.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 joern = "4.0.379"
-langchain4j = "1.0.0-beta3"
+langchain4j = "1.1.0"
 junit = "5.10.2"
 scalatest = "3.2.18"
 log4j = "2.20.0"

--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1,7 +1,7 @@
 package io.github.jbellis.brokk;
 
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import io.github.jbellis.brokk.agents.BuildAgent;
 import io.github.jbellis.brokk.agents.BuildAgent.BuildDetails;
 import io.github.jbellis.brokk.analyzer.*;
@@ -498,7 +498,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
     /**
      * Returns the configured Architect model, falling back to the system model if unavailable.
      */
-    public StreamingChatLanguageModel getArchitectModel() {
+    public StreamingChatModel getArchitectModel() {
         var config = project.getArchitectModelConfig();
         return getModelOrDefault(config, "Architect");
     }
@@ -506,7 +506,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
     /**
      * Returns the configured Code model, falling back to the system model if unavailable.
      */
-    public StreamingChatLanguageModel getCodeModel() {
+    public StreamingChatModel getCodeModel() {
         var config = project.getCodeModelConfig();
         return getModelOrDefault(config, "Code");
     }
@@ -514,7 +514,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
     /**
      * Returns the configured Ask model, falling back to the system model if unavailable.
      */
-    public StreamingChatLanguageModel getAskModel() {
+    public StreamingChatModel getAskModel() {
         var config = project.getAskModelConfig();
         return getModelOrDefault(config, "Ask");
     }
@@ -522,13 +522,13 @@ public class ContextManager implements IContextManager, AutoCloseable {
     /**
      * Returns the configured Search model, falling back to the system model if unavailable.
      */
-    public StreamingChatLanguageModel getSearchModel() {
+    public StreamingChatModel getSearchModel() {
         var config = project.getSearchModelConfig();
         return getModelOrDefault(config, "Search");
     }
 
-    private StreamingChatLanguageModel getModelOrDefault(Service.ModelConfig config, String modelTypeName) {
-        StreamingChatLanguageModel model = service.getModel(config.name(), config.reasoning());
+    private StreamingChatModel getModelOrDefault(Service.ModelConfig config, String modelTypeName) {
+        StreamingChatModel model = service.getModel(config.name(), config.reasoning());
         if (model != null) {
             return model;
         }

--- a/src/main/java/io/github/jbellis/brokk/IContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/IContextManager.java
@@ -1,7 +1,7 @@
 package io.github.jbellis.brokk;
 
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import io.github.jbellis.brokk.analyzer.BrokkFile;
 import io.github.jbellis.brokk.analyzer.IAnalyzer;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
@@ -145,14 +145,14 @@ public interface IContextManager {
     /**
      * Create a new LLM instance for the given model and description
      */
-    default Llm getLlm(StreamingChatLanguageModel model, String taskDescription) {
+    default Llm getLlm(StreamingChatModel model, String taskDescription) {
         return getLlm(model, taskDescription, false);
     }
 
     /**
      * Create a new LLM instance for the given model and description
      */
-    default Llm getLlm(StreamingChatLanguageModel model, String taskDescription, boolean allowPartialResponses) {
+    default Llm getLlm(StreamingChatModel model, String taskDescription, boolean allowPartialResponses) {
         return new Llm(model, taskDescription, this, allowPartialResponses, getProject().getDataRetentionPolicy() == MainProject.DataRetentionPolicy.IMPROVE_BROKK);
     }
 }

--- a/src/main/java/io/github/jbellis/brokk/Llm.java
+++ b/src/main/java/io/github/jbellis/brokk/Llm.java
@@ -9,7 +9,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.*;
 import dev.langchain4j.exception.HttpException;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
@@ -75,11 +75,11 @@ public class Llm {
     private final Path taskHistoryDir; // Directory for this specific LLM task's history files
     final IContextManager contextManager;
     private final int MAX_ATTEMPTS = 8; // Keep retry logic for now
-    private final StreamingChatLanguageModel model;
+    private final StreamingChatModel model;
     private final boolean allowPartialResponses;
     private final boolean tagRetain;
 
-    public Llm(StreamingChatLanguageModel model, String taskDescription, IContextManager contextManager, boolean allowPartialResponses, boolean tagRetain) {
+    public Llm(StreamingChatModel model, String taskDescription, IContextManager contextManager, boolean allowPartialResponses, boolean tagRetain) {
         this.model = model;
         this.contextManager = contextManager;
         this.io = contextManager.getIo();
@@ -387,7 +387,7 @@ public class Llm {
      * function calling for these tools, we emulate it using a JSON Schema approach.
      * This method now also triggers writing the request to the history file.
      */
-    private StreamingResult doSingleSendMessage(StreamingChatLanguageModel model,
+    private StreamingResult doSingleSendMessage(StreamingChatModel model,
                                                 List<ChatMessage> messages,
                                                 List<ToolSpecification> tools,
                                                 ToolChoice toolChoice,
@@ -454,7 +454,7 @@ public class Llm {
      * 1. Schema-based: For models that support JSON schema in response_format
      * 2. Text-based: For models without schema support, using text instructions
      */
-    private StreamingResult emulateTools(StreamingChatLanguageModel model,
+    private StreamingResult emulateTools(StreamingChatModel model,
                                          List<ChatMessage> messages,
                                          List<ToolSpecification> tools,
                                          ToolChoice toolChoice,
@@ -998,7 +998,7 @@ public class Llm {
     /**
      * Writes history information to task-specific files.
      */
-    private synchronized void logRequest(StreamingChatLanguageModel model, ChatRequest request, @Nullable StreamingResult result) {
+    private synchronized void logRequest(StreamingChatModel model, ChatRequest request, @Nullable StreamingResult result) {
         try {
             var timestamp = LocalDateTime.now(java.time.ZoneId.systemDefault()); // timestamp finished, not started
 

--- a/src/main/java/io/github/jbellis/brokk/agents/ArchitectAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/ArchitectAgent.java
@@ -5,7 +5,7 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.output.TokenUsage;
 import io.github.jbellis.brokk.*;
@@ -65,7 +65,7 @@ public class ArchitectAgent {
     }
 
     private final ContextManager contextManager;
-    private final StreamingChatLanguageModel model;
+    private final StreamingChatModel model;
     private final ToolRegistry toolRegistry;
     private final String goal;
     private final ArchitectOptions options; // Store the options
@@ -83,7 +83,7 @@ public class ArchitectAgent {
      * @param options Configuration for which tools the agent can use.
      */
     public ArchitectAgent(ContextManager contextManager,
-                          StreamingChatLanguageModel model,
+                          StreamingChatModel model,
                           ToolRegistry toolRegistry,
                           String goal,
                           ArchitectOptions options)
@@ -465,7 +465,7 @@ public class ArchitectAgent {
             io.llmOutput("\n# Planning", ChatMessageType.AI, true);
 
             // Determine active models and their minimum input token limit
-            var models = new ArrayList<StreamingChatLanguageModel>();
+            var models = new ArrayList<StreamingChatModel>();
             models.add(this.model);
             if (options.includeCodeAgent) {
                 models.add(contextManager.getCodeModel());

--- a/src/main/java/io/github/jbellis/brokk/agents/CodeAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/CodeAgent.java
@@ -4,7 +4,7 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import io.github.jbellis.brokk.*;
 import io.github.jbellis.brokk.Llm.StreamingResult;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
@@ -44,14 +44,14 @@ public class CodeAgent {
     static final int MAX_APPLY_FAILURES_BEFORE_FALLBACK = 3;
 
     final IContextManager contextManager;
-    private final StreamingChatLanguageModel model;
+    private final StreamingChatModel model;
     private final IConsoleIO io;
 
-    public CodeAgent(IContextManager contextManager, StreamingChatLanguageModel model) {
+    public CodeAgent(IContextManager contextManager, StreamingChatModel model) {
         this(contextManager, model, contextManager.getIo());
     }
 
-    public CodeAgent(IContextManager contextManager, StreamingChatLanguageModel model, IConsoleIO io) {
+    public CodeAgent(IContextManager contextManager, StreamingChatModel model, IConsoleIO io) {
         this.contextManager = contextManager;
         this.model = model;
         this.io = io;

--- a/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
@@ -9,7 +9,7 @@ import io.github.jbellis.brokk.prompts.CodePrompts;
 import org.jetbrains.annotations.Nullable;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import io.github.jbellis.brokk.*;
 import io.github.jbellis.brokk.analyzer.CodeUnit;
@@ -53,7 +53,7 @@ public class ContextAgent {
     // Rule 1: Use all available summaries if they fit the smallest budget and meet the limit (if not deepScan)
     private int QUICK_TOPK = 10;
 
-    public ContextAgent(ContextManager contextManager, StreamingChatLanguageModel model, String goal, boolean deepScan) throws InterruptedException {
+    public ContextAgent(ContextManager contextManager, StreamingChatModel model, String goal, boolean deepScan) throws InterruptedException {
         this.contextManager = contextManager;
         this.llm = contextManager.getLlm(model, "ContextAgent: " + goal); // Coder for LLM interactions
         this.goal = goal;

--- a/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
@@ -8,7 +8,7 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.output.TokenUsage;
 import io.github.jbellis.brokk.*;
@@ -75,7 +75,7 @@ public class SearchAgent {
 
     public SearchAgent(String query,
                       ContextManager contextManager,
-                      StreamingChatLanguageModel model,
+                      StreamingChatModel model,
                       ToolRegistry toolRegistry,
                       int ordinal) throws InterruptedException
     {

--- a/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -6,7 +6,7 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import io.github.jbellis.brokk.*;
 import io.github.jbellis.brokk.agents.ArchitectAgent;
 import io.github.jbellis.brokk.agents.CodeAgent;
@@ -170,7 +170,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         codeButton.setMenuSupplier(() -> createModelSelectionMenu(
                 (modelName, reasoningLevel) -> {
                     var models = chrome.getContextManager().getService();
-                    StreamingChatLanguageModel selectedModel = models.getModel(modelName, reasoningLevel);
+                    StreamingChatModel selectedModel = models.getModel(modelName, reasoningLevel);
                     if (selectedModel != null) {
                         runCodeCommand(selectedModel);
                     } else {
@@ -186,7 +186,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         askButton.setMenuSupplier(() -> createModelSelectionMenu(
                 (modelName, reasoningLevel) -> {
                     var models = chrome.getContextManager().getService();
-                    StreamingChatLanguageModel selectedModel = models.getModel(modelName, reasoningLevel);
+                    StreamingChatModel selectedModel = models.getModel(modelName, reasoningLevel);
                     if (selectedModel != null) {
                         runAskCommand(selectedModel);
                     } else {
@@ -1118,7 +1118,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
      * Executes the core logic for the "Code" command.
      * This runs inside the Runnable passed to contextManager.submitUserTask.
      */
-    private void executeCodeCommand(StreamingChatLanguageModel model, String input) {
+    private void executeCodeCommand(StreamingChatModel model, String input) {
         var contextManager = chrome.getContextManager();
 
         contextManager.getAnalyzerWrapper().pause();
@@ -1140,7 +1140,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
      * Executes the core logic for the "Ask" command.
      * This runs inside the Runnable passed to contextManager.submitAction.
      */
-    private static TaskResult executeAskCommand(IContextManager cm, StreamingChatLanguageModel model, String question) {
+    private static TaskResult executeAskCommand(IContextManager cm, StreamingChatModel model, String question) {
         List<ChatMessage> messages;
         try {
             messages = CodePrompts.instance.collectAskMessages(cm, question);
@@ -1214,7 +1214,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
      * @param goal    The initial user instruction passed to the agent.
      * @param options The configured options for the agent's tools.
      */
-    private void executeArchitectCommand(StreamingChatLanguageModel model, String goal, ArchitectAgent.ArchitectOptions options) {
+    private void executeArchitectCommand(StreamingChatModel model, String goal, ArchitectAgent.ArchitectOptions options) {
         var contextManager = chrome.getContextManager();
         try {
             var agent = new ArchitectAgent(contextManager, model, contextManager.getToolRegistry(), goal, options);
@@ -1233,7 +1233,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
      * Executes the core logic for the "Search" command.
      * This runs inside the Runnable passed to contextManager.submitAction.
      */
-    private void executeSearchCommand(StreamingChatLanguageModel model, String query) {
+    private void executeSearchCommand(StreamingChatModel model, String query) {
         if (query.isBlank()) {
             chrome.toolError("Please provide a search query");
             return;
@@ -1456,12 +1456,12 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
     }
 
     // Public entry point for selected Code model from SplitButton
-    public void runCodeCommand(StreamingChatLanguageModel modelToUse) {
+    public void runCodeCommand(StreamingChatModel modelToUse) {
         prepareAndRunCodeCommand(modelToUse);
     }
 
     // Core method to prepare and submit the Code action
-    private void prepareAndRunCodeCommand(StreamingChatLanguageModel modelToUse) {
+    private void prepareAndRunCodeCommand(StreamingChatModel modelToUse) {
         var input = getInstructions();
         if (input.isBlank()) {
             chrome.toolError("Please enter a command or text");
@@ -1489,12 +1489,12 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
     }
 
     // Public entry point for selected Ask model from SplitButton
-    private void runAskCommand(StreamingChatLanguageModel modelToUse) {
+    private void runAskCommand(StreamingChatModel modelToUse) {
         prepareAndRunAskCommand(modelToUse, getInstructions());
     }
 
     // Core method to prepare and submit the Ask action
-    private void prepareAndRunAskCommand(StreamingChatLanguageModel modelToUse, String input) {
+    private void prepareAndRunAskCommand(StreamingChatModel modelToUse, String input) {
         if (input.isBlank()) {
             chrome.toolError("Please enter a question");
             return;

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/BlitzForgeProgressDialog.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/BlitzForgeProgressDialog.java
@@ -7,7 +7,7 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.IConsoleIO;
 import io.github.jbellis.brokk.Service;
@@ -136,7 +136,7 @@ public class BlitzForgeProgressDialog extends JDialog {
      */
     private FileProcessingResult processSingleFile(ProjectFile file,
                                                    ContextManager cm,
-                                                   StreamingChatLanguageModel model,
+                                                   StreamingChatModel model,
                                                    String instructions,
                                                    String action,
                                                    boolean includeWorkspace,

--- a/src/main/java/io/github/jbellis/brokk/prompts/CodePrompts.java
+++ b/src/main/java/io/github/jbellis/brokk/prompts/CodePrompts.java
@@ -3,7 +3,7 @@ package io.github.jbellis.brokk.prompts;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import com.google.common.collect.Streams;
 import dev.langchain4j.data.message.*;
 import io.github.jbellis.brokk.*;
@@ -54,7 +54,7 @@ public abstract class CodePrompts {
             """.stripIndent();
 
     // Now takes a Models instance
-    public static String reminderForModel(Service service, StreamingChatLanguageModel model) {
+    public static String reminderForModel(Service service, StreamingChatModel model) {
         return service.isLazy(model)
                 ? LAZY_REMINDER
                 : OVEREAGER_REMINDER;
@@ -100,7 +100,7 @@ public abstract class CodePrompts {
     }
 
     public final List<ChatMessage> collectCodeMessages(IContextManager cm,
-                                                       StreamingChatLanguageModel model,
+                                                       StreamingChatModel model,
                                                        EditBlockParser parser,
                                                        List<ChatMessage> taskMessages,
                                                        UserMessage request,

--- a/src/main/java/io/github/jbellis/brokk/util/Messages.java
+++ b/src/main/java/io/github/jbellis/brokk/util/Messages.java
@@ -2,7 +2,7 @@ package io.github.jbellis.brokk.util;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.openai.OpenAiTokenizer;
+import dev.langchain4j.model.openai.OpenAiTokenCountEstimator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -16,9 +16,9 @@ import static java.util.Objects.requireNonNull;
 public class Messages {
     private static final Logger logger = LogManager.getLogger(Messages.class);
 
-    // Simple OpenAI tokenizer for approximate counting
-    // Tokenizer can remain static as it's stateless based on model ID
-    private static final OpenAiTokenizer tokenizer = new OpenAiTokenizer("gpt-4o");
+    // Simple OpenAI token count estimator for approximate counting
+    // It can remain static as it's stateless based on model ID
+    private static final OpenAiTokenCountEstimator tokenCountEstimator = new OpenAiTokenCountEstimator("gpt-4o");
 
     public static void init() {
         // tokenizer is surprisingly heavyweigh to initialize, this is just to give a hook to force that early
@@ -125,13 +125,13 @@ public class Messages {
 
     /**
      * Estimates the token count of a text string.
-     * This can remain static as it only depends on the static tokenizer.
+     * This can remain static as it only depends on the static token count estimator.
      */
     public static int getApproximateTokens(String text) {
         if (text.isEmpty()) {
             return 0;
         }
-        return tokenizer.encode(text).size();
+        return tokenCountEstimator.encode(text).size();
     }
 
     public static int getApproximateTokens(Collection<ChatMessage> messages) {

--- a/src/main/java/io/github/jbellis/brokk/util/ServiceWrapper.java
+++ b/src/main/java/io/github/jbellis/brokk/util/ServiceWrapper.java
@@ -1,6 +1,6 @@
 package io.github.jbellis.brokk.util;
 
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import io.github.jbellis.brokk.IProject;
 import io.github.jbellis.brokk.Service;
 import org.jetbrains.annotations.Nullable;
@@ -28,19 +28,19 @@ public class ServiceWrapper {
     }
 
     @Nullable
-    public StreamingChatLanguageModel getModel(String modelName, Service.ReasoningLevel reasoning) {
+    public StreamingChatModel getModel(String modelName, Service.ReasoningLevel reasoning) {
         return get().getModel(modelName, reasoning);
     }
 
-    public StreamingChatLanguageModel quickModel() {
+    public StreamingChatModel quickModel() {
         return get().quickModel();
     }
 
-    public String nameOf(StreamingChatLanguageModel model) {
+    public String nameOf(StreamingChatModel model) {
         return get().nameOf(model);
     }
 
-    public StreamingChatLanguageModel quickestModel() {
+    public StreamingChatModel quickestModel() {
         return get().quickestModel();
     }
 }

--- a/src/test/java/io/github/jbellis/brokk/LlmTest.java
+++ b/src/test/java/io/github/jbellis/brokk/LlmTest.java
@@ -4,7 +4,7 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolSpecifications;
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import io.github.jbellis.brokk.testutil.NoOpConsoleIO;
 import io.github.jbellis.brokk.util.Messages;
@@ -81,7 +81,7 @@ public class LlmTest {
             try {
                 System.out.println("Testing model: " + modelName);
                 // Get model instance via the Models object
-                StreamingChatLanguageModel model = models.getModel(modelName, Service.ReasoningLevel.DEFAULT);
+                StreamingChatModel model = models.getModel(modelName, Service.ReasoningLevel.DEFAULT);
                 var coder = contextManager.getLlm(model, "testModels");
                 assertNotNull(model, "Failed to get model instance for: " + modelName);
 
@@ -138,7 +138,7 @@ public class LlmTest {
                 .forEach(modelName -> {
                     try {
                         System.out.println("Testing tool calling for model: " + modelName);
-                        StreamingChatLanguageModel model = models.getModel(modelName, Service.ReasoningLevel.DEFAULT);
+                        StreamingChatModel model = models.getModel(modelName, Service.ReasoningLevel.DEFAULT);
                         var coder = contextManager.getLlm(model, "testToolCalling");
                         assertNotNull(model, "Failed to get model instance for: " + modelName);
 

--- a/src/test/java/io/github/jbellis/brokk/agents/CodeAgentTest.java
+++ b/src/test/java/io/github/jbellis/brokk/agents/CodeAgentTest.java
@@ -3,7 +3,7 @@ package io.github.jbellis.brokk.agents;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CodeAgentTest {
 
-    private static class ScriptedLanguageModel implements StreamingChatLanguageModel {
+    private static class ScriptedLanguageModel implements StreamingChatModel {
         private final Queue<String> responses;
 
         ScriptedLanguageModel(String... cannedTexts) {

--- a/src/test/java/io/github/jbellis/brokk/testutil/StubService.java
+++ b/src/test/java/io/github/jbellis/brokk/testutil/StubService.java
@@ -1,7 +1,7 @@
 package io.github.jbellis.brokk.testutil;
 
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
@@ -26,23 +26,23 @@ public final class StubService extends Service {
     { }
 
     @Override
-    public String nameOf(@Nullable StreamingChatLanguageModel model) { return "stub-model"; }
+    public String nameOf(@Nullable StreamingChatModel model) { return "stub-model"; }
 
     @Override
-    public boolean isLazy(@Nullable StreamingChatLanguageModel model) { return false; }
+    public boolean isLazy(@Nullable StreamingChatModel model) { return false; }
 
     @Override
-    public boolean isReasoning(@Nullable StreamingChatLanguageModel model) { return false; }
+    public boolean isReasoning(@Nullable StreamingChatModel model) { return false; }
 
     @Override
-    public boolean requiresEmulatedTools(@Nullable StreamingChatLanguageModel model) { return false; }
+    public boolean requiresEmulatedTools(@Nullable StreamingChatModel model) { return false; }
 
     @Override
-    public boolean supportsJsonSchema(@Nullable StreamingChatLanguageModel model) { return true; }
+    public boolean supportsJsonSchema(@Nullable StreamingChatModel model) { return true; }
 
     @Override
-    public StreamingChatLanguageModel getModel(String modelName, Service.ReasoningLevel reasoningLevel) {
-        return new StreamingChatLanguageModel() {
+    public StreamingChatModel getModel(String modelName, Service.ReasoningLevel reasoningLevel) {
+        return new StreamingChatModel() {
             @Override
             public void doChat(ChatRequest request, StreamingChatResponseHandler handler) {
                 handler.onCompleteResponse(ChatResponse.builder()


### PR DESCRIPTION
Upgraded to the latest Langchain4j version (this is also in preparation for #352 as discussed).

Only two changes in Langchain4j API:
- `StreamingChatLanguageModel` renamed to `StreamingChatModel`.
- `OpenAiTokenizer` renamed to `OpenAiTokenCountEstimator`.

Tested with a simple code agent task example with every model, seems to be working fine.