### PR TITLE
Reintroduced `TYPESCRIPT::getDependencyCandidates`

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/analyzer/Language.java
+++ b/src/main/java/io/github/jbellis/brokk/analyzer/Language.java
@@ -751,11 +751,10 @@ public interface Language {
             return name();
         }
 
-        // TODO: Implement getDependencyCandidates for TypeScript (e.g. node_modules, similar to JAVASCRIPT)
-        /*@Override public List<Path> getDependencyCandidates(Project project) {
-            // Leveraging JAVASCRIPT's logic for node_modules as a starting point
-            return JAVASCRIPT.getDependencyCandidates(project);
-        }*/
+        @Override
+        public List<Path> getDependencyCandidates(IProject project) {
+            return NodeJsDependencyHelper.getDependencyCandidates(project);
+        }
 
         @Override
         public boolean isAnalyzed(IProject project, Path pathToImport) {


### PR DESCRIPTION
A regression was introduced by https://github.com/BrokkAi/brokk/commit/ea867b7f04f9a9c2679809c14816a3b994a13cf7#diff-7b73daccb7cf261e91d8e085a56d7fd4fc5d640d37896f3f3e9c82a98bcc4784L497-L498 which commented out the implementation for `getDependencyCandidates`. This has been rolled back