### PR TITLE
Make `JoernAnalyzer::parentMethodName` More Defensive

### DIFF
--- a/src/main/scala/io/github/jbellis/brokk/analyzer/JoernAnalyzer.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/JoernAnalyzer.scala
@@ -151,10 +151,10 @@ abstract class JoernAnalyzer[R <: X2CpgConfig[R]] protected (sourcePath: Path, p
         method.astParent match {
           case parentMethod: Method => _parentMethodName(parentMethod)
           case other: Expression    => _parentMethodName(other.method)
-          case unsupported =>
-            throw new SchemaViolationException(
-              s"Unexpected node type ${unsupported.getClass} encountered while resolving method name!"
-            )
+          case astNode: AstNode =>
+            astNode.inAst.collectFirst { case m: Method => _parentMethodName(m) }.getOrElse {
+              throw new SchemaViolationException(s"Unable to determine parent method for lambda ${method.fullName}!")
+            }
         }
       else {
         // The most language agnostic way to do this as C++ ASTs are vastly different to Java ones


### PR DESCRIPTION
When resolving the parent of a lambda method, the function will traverse further up the AST before throwing an exception. Addresses the following exception
```
Exception in thread "DirectoryWatcher@36" flatgraph.SchemaViolationException: Unexpected node type class io.shiftleft.codepropertygraph.generated.nodes.TypeDecl encountered while resolving method name!
        at io.github.jbellis.brokk.analyzer.JoernAnalyzer._parentMethodName$1(JoernAnalyzer.scala:156)
        at io.github.jbellis.brokk.analyzer.JoernAnalyzer.parentMethodName(JoernAnalyzer.scala:167)
        at io.github.jbellis.brokk.analyzer.JavaAnalyzer.parentMethodName(JavaAnalyzer.scala:105)
        at io.github.jbellis.brokk.analyzer.JoernAnalyzer.getDeclarationsInFile$$anonfun$2$$anonfun$3(JoernAnalyzer.scala:1167)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
```       