### PR TITLE
Implemented `Language::loadOrCreateAnalyzer`

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/AnalyzerWrapper.java
+++ b/src/main/java/io/github/jbellis/brokk/AnalyzerWrapper.java
@@ -268,7 +268,7 @@ public class AnalyzerWrapper implements AutoCloseable {
 
         /* ── 3.  Load or build the analyzer via the Language handle ─────────────────── */
         long start = System.currentTimeMillis();
-        IAnalyzer analyzer = langHandle.loadAnalyzer(project);
+        IAnalyzer analyzer = langHandle.loadOrCreateAnalyzer(project);
 
         if (needsRebuild && project.getAnalyzerRefresh() != IProject.CpgRefresh.MANUAL) {
             logger.debug("Building fresh analyzer (first build, rebuild required: {})", needsRebuild);


### PR DESCRIPTION
For analyzers that persist results, `Language::loadOrCreateAnalyzer` was created as a robust means to address possibly missing results. The default is to simply load the analyzer.

Additionally, a `CpgLanguage` interface was introduced to reduce code duplication on the handling here.

Do we need unit tests for this?