### PR TITLE
Fixed `astParent` issue on interface field lambdas

### DIFF
--- a/src/main/scala/io/github/jbellis/brokk/analyzer/JoernAnalyzer.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/JoernAnalyzer.scala
@@ -1174,6 +1174,8 @@ abstract class JoernAnalyzer[R <: X2CpgConfig[R]] protected (sourcePath: Path, p
         }
       }
 
+    import io.shiftleft.semanticcpg.language.*
+
     // Add global/namespace-level functions
     cpg.method
       .filenameExact(file.toString())
@@ -1181,6 +1183,12 @@ abstract class JoernAnalyzer[R <: X2CpgConfig[R]] protected (sourcePath: Path, p
         m.name == "<global>" || m.name.startsWith("<operator>")
       }
       .filterNot { m => // Filter out methods whose parent TypeDecl would have been filtered
+        try {
+          m.astParent
+        } catch {
+          case e: Exception =>
+            logger.error(s"Error on astParent for method ${m.start.toJsonPretty}")
+        }
         Option(m.astParent).collect { case td: TypeDecl => td }.exists { parentTd =>
           val name     = parentTd.name
           val fullName = parentTd.fullName

--- a/src/main/scala/io/joern/javasrc2cpg/astcreation/package.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/astcreation/package.scala
@@ -3,6 +3,7 @@ package io.joern.javasrc2cpg
 import io.joern.javasrc2cpg.scope.Scope
 import io.joern.javasrc2cpg.util.NameConstants
 import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.Method.PropertyDefaults
 
 package object astcreation {
 
@@ -13,7 +14,7 @@ package object astcreation {
         .map { scope =>
           (NodeTypes.METHOD, scope.method.fullName)
         }
-        .filter(_ => prioritizeMethodAstParent)
+        .filter((_, fullName) => prioritizeMethodAstParent && fullName != PropertyDefaults.FullName)
         .orElse {
           scope.enclosingTypeDecl
             .map { scope =>

--- a/src/test/resources/testcode-java/Interface.java
+++ b/src/test/resources/testcode-java/Interface.java
@@ -1,0 +1,8 @@
+import org.jsoup.nodes.Element;
+
+@FunctionalInterface
+public interface Interface {
+
+    Interface DEFAULT = root -> { };
+
+}

--- a/src/test/scala/io/github/jbellis/brokk/analyzer/JavaAnalyzerTest.scala
+++ b/src/test/scala/io/github/jbellis/brokk/analyzer/JavaAnalyzerTest.scala
@@ -429,7 +429,7 @@ class JavaAnalyzerTest {
     // Find classes matching "*E"
     val classMatches = analyzer.searchDefinitions(".*e")
     val classRefs    = asScala(classMatches).filter(_.isClass).map(_.fqName).toSet
-    assertEquals(Set("E", "UseE", "AnonymousUsage"), classRefs)
+    assertEquals(Set("E", "UseE", "AnonymousUsage", "Interface"), classRefs)
 
     // Find methods matching "method*"
     val methodMatches = analyzer.searchDefinitions("method.*1")
@@ -674,6 +674,11 @@ class JavaAnalyzerTest {
     // Call within a method in a nested class
     val printlnInMethod7Call = cpg.method.fullName(".*AInnerInner\\.method7.*").call.nameExact("println").head
     assertEquals("A$AInner$AInnerInner.method7", analyzer.parentMethodName(printlnInMethod7Call))
+
+    // A lambda assigned to a field within an interface
+    val interfaceField = cpg.method.where(_.file.name("Interface.java")).isLambda.head
+    // this is the last method we can show, further up is the type name, which is not a 'parentMethodName'
+    assertEquals("Interface.<lambda>0", analyzer.parentMethodName(interfaceField))
   }
 
   @Test


### PR DESCRIPTION
Fixed bug where AST parents of lambda fields to interfaces returned a method, but it was an `<empty>` method that did not exist. These entries are filtered out.

Will merge when CI/CD green