### PR TITLE
feat: Display reasoning tokens

### DIFF
--- a/src/main/java/dev/langchain4j/data/message/AiMessage.java
+++ b/src/main/java/dev/langchain4j/data/message/AiMessage.java
@@ -8,10 +8,9 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.Arrays.asList;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import java.util.List;
 import java.util.Objects;
-
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 
 /**
  * Represents a response message from an AI (language model).
@@ -21,6 +20,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 public class AiMessage implements ChatMessage {
 
     private final String text;
+    private final String reasoningContent;
     private final List<ToolExecutionRequest> toolExecutionRequests;
 
     /**
@@ -30,6 +30,7 @@ public class AiMessage implements ChatMessage {
      */
     public AiMessage(String text) {
         this.text = ensureNotNull(text, "text");
+        this.reasoningContent = null;
         this.toolExecutionRequests = List.of();
     }
 
@@ -40,6 +41,7 @@ public class AiMessage implements ChatMessage {
      */
     public AiMessage(List<ToolExecutionRequest> toolExecutionRequests) {
         this.text = null;
+        this.reasoningContent = null;
         this.toolExecutionRequests = ensureNotEmpty(toolExecutionRequests, "toolExecutionRequests");
     }
 
@@ -51,6 +53,32 @@ public class AiMessage implements ChatMessage {
      */
     public AiMessage(String text, List<ToolExecutionRequest> toolExecutionRequests) {
         this.text = text;
+        this.reasoningContent = null;
+        this.toolExecutionRequests = copy(toolExecutionRequests);
+    }
+
+    /**
+     * Create a new {@link AiMessage} with the given text and reasoning content.
+     *
+     * @param text             the text of the message.
+     * @param reasoningContent the reasoning content of the message.
+     */
+    public AiMessage(String text, String reasoningContent) {
+        this.text = text;
+        this.reasoningContent = reasoningContent;
+        this.toolExecutionRequests = List.of();
+    }
+
+    /**
+     * Create a new {@link AiMessage} with the given text, reasoning content and tool execution requests.
+     *
+     * @param text                  the text of the message.
+     * @param reasoningContent      the reasoning content of the message.
+     * @param toolExecutionRequests the tool execution requests of the message.
+     */
+    public AiMessage(String text, String reasoningContent, List<ToolExecutionRequest> toolExecutionRequests) {
+        this.text = text;
+        this.reasoningContent = reasoningContent;
         this.toolExecutionRequests = copy(toolExecutionRequests);
     }
 
@@ -61,6 +89,15 @@ public class AiMessage implements ChatMessage {
      */
     public String text() {
         return text;
+    }
+
+    /**
+     * Get the reasoning content of the message.
+     *
+     * @return the reasoning content of the message.
+     */
+    public String reasoningContent() {
+        return reasoningContent;
     }
 
     /**
@@ -92,20 +129,21 @@ public class AiMessage implements ChatMessage {
         if (o == null || getClass() != o.getClass()) return false;
         AiMessage that = (AiMessage) o;
         return Objects.equals(this.text, that.text)
+                && Objects.equals(this.reasoningContent, that.reasoningContent)
                 && Objects.equals(this.toolExecutionRequests, that.toolExecutionRequests);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(text, toolExecutionRequests);
+        return Objects.hash(text, reasoningContent, toolExecutionRequests);
     }
 
     @Override
     public String toString() {
-        return "AiMessage {" +
-                " text = " + quoted(text) +
-                " toolExecutionRequests = " + toolExecutionRequests +
-                " }";
+        return "AiMessage {" + " text = "
+                + quoted(text) + " reasoningContent = "
+                + quoted(reasoningContent) + " toolExecutionRequests = "
+                + toolExecutionRequests + " }";
     }
 
     public static Builder builder() {
@@ -143,6 +181,17 @@ public class AiMessage implements ChatMessage {
     }
 
     /**
+     * Create a new {@link AiMessage} with the given text and reasoning content.
+     *
+     * @param text             the text of the message.
+     * @param reasoningContent the reasoning content of the message.
+     * @return the new {@link AiMessage}.
+     */
+    public static AiMessage from(String text, String reasoningContent) {
+        return new AiMessage(text, reasoningContent);
+    }
+
+    /**
      * Create a new {@link AiMessage} with the given tool execution requests.
      *
      * @param toolExecutionRequests the tool execution requests of the message.
@@ -174,6 +223,19 @@ public class AiMessage implements ChatMessage {
     }
 
     /**
+     * Create a new {@link AiMessage} with the given text, reasoning content and tool execution requests.
+     *
+     * @param text                  the text of the message.
+     * @param reasoningContent      the reasoning content of the message.
+     * @param toolExecutionRequests the tool execution requests of the message.
+     * @return the new {@link AiMessage}.
+     */
+    public static AiMessage from(
+            String text, String reasoningContent, List<ToolExecutionRequest> toolExecutionRequests) {
+        return new AiMessage(text, reasoningContent, toolExecutionRequests);
+    }
+
+    /**
      * Create a new {@link AiMessage} with the given text.
      *
      * @param text the text of the message.
@@ -181,6 +243,17 @@ public class AiMessage implements ChatMessage {
      */
     public static AiMessage aiMessage(String text) {
         return from(text);
+    }
+
+    /**
+     * Create a new {@link AiMessage} with the given text and reasoning content.
+     *
+     * @param text             the text of the message.
+     * @param reasoningContent the reasoning content of the message.
+     * @return the new {@link AiMessage}.
+     */
+    public static AiMessage aiMessage(String text, String reasoningContent) {
+        return from(text, reasoningContent);
     }
 
     /**

--- a/src/main/java/dev/langchain4j/model/StreamingResponseHandler.java
+++ b/src/main/java/dev/langchain4j/model/StreamingResponseHandler.java
@@ -20,6 +20,14 @@ public interface StreamingResponseHandler<T> {
     void onNext(String token);
 
     /**
+     * Invoked each time the language model generates a new reasoning token in a textual response.
+     * If the model decides to start answering, this method will not be invoked; {@link #onNext} will be invoked instead.
+     *
+     * @param token The newly generated token, which is a part of the complete response.
+     */
+    default void onReasoning(String token) {}
+
+    /**
      * Invoked when the language model has finished streaming a response.
      * If the model executes one or multiple tools, it is accessible via {@link dev.langchain4j.data.message.AiMessage#toolExecutionRequests()}.
      *

--- a/src/main/java/dev/langchain4j/model/chat/StreamingChatModel.java
+++ b/src/main/java/dev/langchain4j/model/chat/StreamingChatModel.java
@@ -43,6 +43,11 @@ public interface StreamingChatModel {
             }
 
             @Override
+            public void onReasoningResponse(String reasoningContent) {
+                handler.onReasoningResponse(reasoningContent);
+            }
+
+            @Override
             public void onCompleteResponse(ChatResponse completeResponse) {
                 handler.onCompleteResponse(completeResponse);
             }

--- a/src/main/java/dev/langchain4j/model/chat/response/StreamingChatResponseHandler.java
+++ b/src/main/java/dev/langchain4j/model/chat/response/StreamingChatResponseHandler.java
@@ -20,6 +20,15 @@ public interface StreamingChatResponseHandler {
     void onPartialResponse(String partialResponse);
 
     /**
+     * Invoked each time the model generates a reasoning response (usually a single token) in a textual response.
+     * If the model decides to start answering, this method will not be invoked;
+     * {@link #onPartialResponse} will be invoked instead.
+     *
+     * @param reasoningContent The partial response (usually a single token), which is a part of the complete response.
+     */
+    default void onReasoningResponse(String reasoningContent) {}
+
+    /**
      * Invoked when the model has finished streaming a response.
      * If the model requests the execution of one or multiple tools,
      * this can be accessed via {@link ChatResponse#aiMessage()} -> {@link AiMessage#toolExecutionRequests()}.

--- a/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -171,6 +171,15 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
                 withLoggingExceptions(() -> handler.onError(e));
             }
         }
+
+        String reasoningContent = delta.reasoningContent();
+        if (!isNullOrEmpty(reasoningContent)) {
+            try {
+                handler.onReasoningResponse(reasoningContent);
+            } catch (Exception e) {
+                withLoggingExceptions(() -> handler.onError(e));
+            }
+        }
     }
 
     @Override

--- a/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -251,6 +251,7 @@ public class OpenAiUtils {
     public static AiMessage aiMessageFrom(ChatCompletionResponse response) {
         AssistantMessage assistantMessage = response.choices().get(0).message();
         String text = assistantMessage.content();
+        String reasoningContent = assistantMessage.reasoningContent();
 
         List<ToolCall> toolCalls = assistantMessage.toolCalls();
         if (!isNullOrEmpty(toolCalls)) {
@@ -260,7 +261,7 @@ public class OpenAiUtils {
                     .collect(toList());
             return isNullOrBlank(text)
                     ? AiMessage.from(toolExecutionRequests)
-                    : AiMessage.from(text, toolExecutionRequests);
+                    : AiMessage.from(text, reasoningContent, toolExecutionRequests);
         }
 
         FunctionCall functionCall = assistantMessage.functionCall();
@@ -271,10 +272,10 @@ public class OpenAiUtils {
                     .build();
             return isNullOrBlank(text)
                     ? AiMessage.from(toolExecutionRequest)
-                    : AiMessage.from(text, singletonList(toolExecutionRequest));
+                    : AiMessage.from(text, reasoningContent, singletonList(toolExecutionRequest));
         }
 
-        return AiMessage.from(text);
+        return AiMessage.from(text, reasoningContent);
     }
 
     private static ToolExecutionRequest toToolExecutionRequest(ToolCall toolCall) {

--- a/src/main/java/dev/langchain4j/model/openai/internal/chat/AssistantMessage.java
+++ b/src/main/java/dev/langchain4j/model/openai/internal/chat/AssistantMessage.java
@@ -26,6 +26,8 @@ public final class AssistantMessage implements Message {
     private final Role role = ASSISTANT;
     @JsonProperty
     private final String content;
+    @JsonProperty("reasoning_content")
+    private final String reasoningContent;
     @JsonProperty
     private final String name;
     @JsonProperty
@@ -39,6 +41,7 @@ public final class AssistantMessage implements Message {
     public AssistantMessage(Builder builder) {
         this.content = builder.content;
         this.name = builder.name;
+        this.reasoningContent = builder.reasoningContent;
         this.toolCalls = builder.toolCalls;
         this.refusal = builder.refusal;
         this.functionCall = builder.functionCall;
@@ -50,6 +53,10 @@ public final class AssistantMessage implements Message {
 
     public String content() {
         return content;
+    }
+
+    public String reasoningContent() {
+        return reasoningContent;
     }
 
     public String name() {
@@ -79,6 +86,7 @@ public final class AssistantMessage implements Message {
     private boolean equalTo(AssistantMessage another) {
         return Objects.equals(role, another.role)
                 && Objects.equals(content, another.content)
+                && Objects.equals(reasoningContent, another.reasoningContent)
                 && Objects.equals(name, another.name)
                 && Objects.equals(toolCalls, another.toolCalls)
                 && Objects.equals(refusal, another.refusal)
@@ -90,6 +98,7 @@ public final class AssistantMessage implements Message {
         int h = 5381;
         h += (h << 5) + Objects.hashCode(role);
         h += (h << 5) + Objects.hashCode(content);
+        h += (h << 5) + Objects.hashCode(reasoningContent);
         h += (h << 5) + Objects.hashCode(name);
         h += (h << 5) + Objects.hashCode(toolCalls);
         h += (h << 5) + Objects.hashCode(refusal);
@@ -102,6 +111,7 @@ public final class AssistantMessage implements Message {
         return "AssistantMessage{"
                 + "role=" + role
                 + ", content=" + content
+                + ", reasoningContent=" + reasoningContent
                 + ", name=" + name
                 + ", toolCalls=" + toolCalls
                 + ", refusal=" + refusal
@@ -126,6 +136,7 @@ public final class AssistantMessage implements Message {
 
         private String content;
         private String name;
+        private String reasoningContent;
         private List<ToolCall> toolCalls;
         private Boolean refusal;
         @Deprecated
@@ -133,6 +144,11 @@ public final class AssistantMessage implements Message {
 
         public Builder content(String content) {
             this.content = content;
+            return this;
+        }
+
+        public Builder reasoningContent(String reasoningContent) {
+            this.reasoningContent = reasoningContent;
             return this;
         }
 

--- a/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
+++ b/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
@@ -22,6 +22,8 @@ public final class Delta {
     private final String role;
     @JsonProperty
     private final String content;
+    @JsonProperty("reasoning_content")
+    private final String reasoningContent;
     @JsonProperty
     private final List<ToolCall> toolCalls;
     @JsonProperty
@@ -31,6 +33,7 @@ public final class Delta {
     public Delta(Builder builder) {
         this.role = builder.role;
         this.content = builder.content;
+        this.reasoningContent = builder.reasoningContent;
         this.toolCalls = builder.toolCalls;
         this.functionCall = builder.functionCall;
     }
@@ -41,6 +44,10 @@ public final class Delta {
 
     public String content() {
         return content;
+    }
+
+    public String reasoningContent() {
+        return reasoningContent;
     }
 
     public List<ToolCall> toolCalls() {
@@ -62,6 +69,7 @@ public final class Delta {
     private boolean equalTo(Delta another) {
         return Objects.equals(role, another.role)
                 && Objects.equals(content, another.content)
+                && Objects.equals(reasoningContent, another.reasoningContent)
                 && Objects.equals(toolCalls, another.toolCalls)
                 && Objects.equals(functionCall, another.functionCall);
     }
@@ -71,6 +79,7 @@ public final class Delta {
         int h = 5381;
         h += (h << 5) + Objects.hashCode(role);
         h += (h << 5) + Objects.hashCode(content);
+        h += (h << 5) + Objects.hashCode(reasoningContent);
         h += (h << 5) + Objects.hashCode(toolCalls);
         h += (h << 5) + Objects.hashCode(functionCall);
         return h;
@@ -81,6 +90,7 @@ public final class Delta {
         return "Delta{"
                 + "role=" + role
                 + ", content=" + content
+                + ", reasoningContent=" + reasoningContent
                 + ", toolCalls=" + toolCalls
                 + ", functionCall=" + functionCall
                 + "}";
@@ -97,6 +107,7 @@ public final class Delta {
 
         private String role;
         private String content;
+        private String reasoningContent;
         private List<ToolCall> toolCalls;
         @Deprecated
         private FunctionCall functionCall;
@@ -108,6 +119,11 @@ public final class Delta {
 
         public Builder content(String content) {
             this.content = content;
+            return this;
+        }
+
+        public Builder reasoningContent(String reasoningContent) {
+            this.reasoningContent = reasoningContent;
             return this;
         }
 

--- a/src/main/java/io/github/jbellis/brokk/Llm.java
+++ b/src/main/java/io/github/jbellis/brokk/Llm.java
@@ -180,6 +180,16 @@ public class Llm {
             }
 
             @Override
+            public void onReasoningResponse(String reasoningContent) {
+              ifNotCancelled.accept(() -> {
+                accumulatedTextBuilder.append(reasoningContent);
+                if (echo) {
+                  io.llmOutput(reasoningContent, ChatMessageType.AI);
+                }
+              });
+            }
+
+            @Override
             public void onCompleteResponse(@Nullable ChatResponse response) {
                 ifNotCancelled.accept(() -> {
                     if (response == null) {


### PR DESCRIPTION
As discussed in #352, added support for reading thinking tokens (took and adopted the changes from this [langchain4j PR](https://github.com/langchain4j/langchain4j/pull/2562)). For now, we just show the reasoning in llm output.

<img width="1840" height="1053" alt="image" src="https://github.com/user-attachments/assets/5194da96-ed1a-4a18-a162-53e41e796ca0" />
