### PR TITLE
Implement `update` APIs According to Specification

### DIFF
--- a/src/main/scala/io/github/jbellis/brokk/analyzer/CppAnalyzer.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/CppAnalyzer.scala
@@ -1,6 +1,7 @@
 package io.github.jbellis.brokk.analyzer
 
-import io.github.jbellis.brokk.analyzer.builder.languages.given
+import io.github.jbellis.brokk.analyzer.builder.CpgBuilder
+import io.github.jbellis.brokk.analyzer.builder.languages.cBuilder
 import io.github.jbellis.brokk.analyzer.implicits.X2CpgConfigExt.*
 import io.joern.c2cpg.Config as CConfig
 import io.joern.x2cpg.Defines as X2CpgDefines
@@ -35,6 +36,8 @@ class CppAnalyzer private (sourcePath: Path, cpgInit: Cpg) extends JoernAnalyzer
   override val fullNameSeparators: Seq[String] = Seq(".", "::")
 
   override def defaultConfig: CConfig = CppAnalyzer.defaultConfig
+
+  override implicit val defaultBuilder: CpgBuilder[CConfig] = cBuilder
 
   // ---------------------------------------------------------------------
   // Language-specific helpers
@@ -818,9 +821,6 @@ class CppAnalyzer private (sourcePath: Path, cpgInit: Cpg) extends JoernAnalyzer
     }
     IAnalyzer.FunctionLocation(file, startLine, endLine, maybeCode.get)
   }
-
-  override def update(changedFiles: java.util.Set[ProjectFile]): IAnalyzer =
-    updateFilesInternal(CppAnalyzer.defaultConfig, changedFiles)
 
 }
 

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/JavaAnalyzer.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/JavaAnalyzer.scala
@@ -1,6 +1,7 @@
 package io.github.jbellis.brokk.analyzer
 
-import io.github.jbellis.brokk.analyzer.builder.languages.given
+import io.github.jbellis.brokk.analyzer.builder.CpgBuilder
+import io.github.jbellis.brokk.analyzer.builder.languages.javaSrcBuilder
 import io.github.jbellis.brokk.analyzer.implicits.X2CpgConfigExt.*
 import io.joern.javasrc2cpg.Config
 import io.joern.joerncli.CpgBasedTool
@@ -34,6 +35,8 @@ class JavaAnalyzer private (sourcePath: Path, cpgInit: Cpg) extends JoernAnalyze
   override val fullNameSeparators: Seq[String] = Seq(".", "$")
 
   override def defaultConfig: Config = JavaAnalyzer.defaultConfig
+
+  override implicit val defaultBuilder: CpgBuilder[Config] = javaSrcBuilder
 
   /** Java-specific method signature builder.
     */
@@ -387,9 +390,6 @@ class JavaAnalyzer private (sourcePath: Path, cpgInit: Cpg) extends JoernAnalyze
     Try(CodeUnit.field(file, pkg, s"$className.$fieldName")).toOption
   }
   // -----------------------------------------------------
-
-  override def update(changedFiles: util.Set[ProjectFile]): IAnalyzer =
-    updateFilesInternal(JavaAnalyzer.defaultConfig, changedFiles)
 }
 
 object JavaAnalyzer {

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/JoernAnalyzer.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/JoernAnalyzer.scala
@@ -11,7 +11,7 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.language.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import java.io.Closeable
 import java.nio.file.Path
@@ -38,7 +38,7 @@ abstract class JoernAnalyzer[R <: X2CpgConfig[R]] protected (sourcePath: Path, p
     with Closeable {
 
   // Logger instance for this class
-  protected val logger = LoggerFactory.getLogger(getClass)
+  protected val logger: Logger = LoggerFactory.getLogger(getClass)
 
   // Convert to absolute filename immediately and verify it's a directory
   protected val absolutePath: Path = {
@@ -47,8 +47,9 @@ abstract class JoernAnalyzer[R <: X2CpgConfig[R]] protected (sourcePath: Path, p
     path
   }
 
-  // The default configuration for this analyzer
+  // The default configuration and CPG builder for this analyzer
   protected def defaultConfig: R
+  protected implicit val defaultBuilder: CpgBuilder[R]
 
   // implicits at the top, you will regret it otherwise
   protected implicit val ec: ExecutionContext        = ExecutionContext.global
@@ -83,18 +84,23 @@ abstract class JoernAnalyzer[R <: X2CpgConfig[R]] protected (sourcePath: Path, p
 
   override def isCpg: Boolean = true
 
+  override def update(changedFiles: util.Set[ProjectFile]): IAnalyzer =
+    updateFilesInternal(defaultConfig, Option(changedFiles))
+
+  override def update(): IAnalyzer =
+    updateFilesInternal(defaultConfig, None)
+
   /** Given a language frontend-specific configuration and CPG builder, runs an incremental build of the CPG associated
     * with this analyzer and refreshes it.
     * @param config
     *   the configuration. The input and output paths are inferred from the CPG.
-    * @param changedFiles
-    *   the files changed, to be incrementally updated.
+    * @param maybeChangedFiles
+    *   the files changed, to be incrementally updated. If none are given, this will revert to hashing files itself to
+    *   determine changes manually.
     * @param builder
     *   the CPG builder.
-    * @tparam R
-    *   the configuration type.
     */
-  protected def updateFilesInternal[R <: X2CpgConfig[R]](config: R, changedFiles: util.Set[ProjectFile])(using
+  private def updateFilesInternal(config: R, maybeChangedFiles: Option[util.Set[ProjectFile]])(using
     builder: CpgBuilder[R]
   ): IAnalyzer = {
     Try(cpg.close()).failed.foreach(e => logger.error("Error encountered while closing CPG before update.", e))
@@ -102,7 +108,7 @@ abstract class JoernAnalyzer[R <: X2CpgConfig[R]] protected (sourcePath: Path, p
       config
         .withInputPath(cpg.projectRoot.toString)
         .withOutputPath(cpg.graph.storagePathMaybe.getOrElse("cpg.bin").toString)
-        .buildAndThrow(Option(changedFiles))
+        .buildAndThrow(maybeChangedFiles)
         .open
     ) match {
       case Success(newCpg)    => cpg = newCpg

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/builder/IncrementalUtils.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/builder/IncrementalUtils.scala
@@ -29,7 +29,9 @@ object IncrementalUtils {
     * @param sourceFileExtensions
     *   the source file extensions as per the language frontend.
     * @param maybeChangedFiles
-    *   any specifically changed files to compare with, if any.
+    *   any specifically changed files to compare with, if any. If none given, this will determine changes by manually
+    *   hashing every existing files at paths conflicting with [[io.shiftleft.codepropertygraph.generated.nodes.File]]
+    *   nodes in the CPG.
     * @return
     *   a sequence of file changes.
     */
@@ -57,7 +59,12 @@ object IncrementalUtils {
     val newFiles = maybeChangedFiles.map(_.asScala) match {
       case Some(changedFiles) =>
         logger.debug(s"${changedFiles.size} changed files have been given")
-        changedFiles.map(_.absPath()).map(path => PathAndHash(path.toString, path.sha1)).toList
+        changedFiles
+          .map(_.absPath())
+          // the corresponding File node will be hashed when inserted into the CPG later on, this just needs to be
+          // different to what is in the CPG if there is an existing node with the same Path.
+          .map(path => PathAndHash(path.toString, "<changed>"))
+          .toList
       case None =>
         val determinedChanges = SourceFiles
           .determine(

--- a/src/main/scala/io/github/jbellis/brokk/analyzer/implicits/X2CpgConfigExt.scala
+++ b/src/main/scala/io/github/jbellis/brokk/analyzer/implicits/X2CpgConfigExt.scala
@@ -39,7 +39,8 @@ object X2CpgConfigExt {
     /** Alias for [[build]] where exceptions are thrown if one occurs.
       *
       * @param maybeFileChanges
-      *   specific file changes if any are present.
+      *   specific file changes if any are present. If no changes are given then the analyzer determines changes if this
+      *   build is based from an existing CPG.
       * @param builder
       *   the builder associated with the frontend specified by the instance of 'config'.
       * @return


### PR DESCRIPTION
Incorporates the existing `updateFilesInternal` API to align with the `update` APIs where files are either given, or no files are given and the analyzer must determine changes.

Additionally, I updated comments to make it clear how this mechanism propagates into the Scala code.