### PR TITLE
Fixed Accidental Pruning of Unchanged Files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -219,7 +219,7 @@ tasks.withType<Test> {
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
         showExceptions = false
         showCauses = false
-        showStackTraces = true
+        showStackTraces = false
         showStandardStreams = false
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -219,7 +219,7 @@ tasks.withType<Test> {
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
         showExceptions = false
         showCauses = false
-        showStackTraces = false
+        showStackTraces = true
         showStandardStreams = false
     }
 

--- a/joern-analyzers/build.gradle.kts
+++ b/joern-analyzers/build.gradle.kts
@@ -14,7 +14,7 @@ scala {
 
 tasks.compileScala {
   // this is what is set by default but adding seems to improve incremental compilation
-  destinationDirectory = file("${layout.buildDirectory}/classes/scala/main")
+  destinationDirectory = file("$buildDir/classes/scala/main")
 }
 
 repositories {

--- a/joern-analyzers/build.gradle.kts
+++ b/joern-analyzers/build.gradle.kts
@@ -14,7 +14,7 @@ scala {
 
 tasks.compileScala {
   // this is what is set by default but adding seems to improve incremental compilation
-  destinationDirectory = file("$buildDir/classes/scala/main")
+  destinationDirectory = file("${layout.buildDirectory}/classes/scala/main")
 }
 
 repositories {
@@ -89,9 +89,9 @@ tasks.withType<Test> {
     testLogging {
         events("passed", "skipped")  // Only show passed/skipped during execution
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-        showExceptions = false
+        showExceptions = true
         showCauses = false
-        showStackTraces = false
+        showStackTraces = true
         showStandardStreams = false
     }
 }

--- a/joern-analyzers/build.gradle.kts
+++ b/joern-analyzers/build.gradle.kts
@@ -84,6 +84,16 @@ tasks.withType<Test> {
         "-XX:+HeapDumpOnOutOfMemoryError",
         "-XX:HeapDumpPath=./build/test-heap-dumps/"
     )
+
+    // Test execution settings
+    testLogging {
+        events("passed", "skipped")  // Only show passed/skipped during execution
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showExceptions = false
+        showCauses = false
+        showStackTraces = false
+        showStandardStreams = false
+    }
 }
 
 // Handle duplicate files in JAR

--- a/joern-analyzers/src/main/scala/io/github/jbellis/brokk/analyzer/builder/IncrementalUtils.scala
+++ b/joern-analyzers/src/main/scala/io/github/jbellis/brokk/analyzer/builder/IncrementalUtils.scala
@@ -59,12 +59,15 @@ object IncrementalUtils {
     val newFiles = maybeChangedFiles.map(_.asScala) match {
       case Some(changedFiles) =>
         logger.debug(s"${changedFiles.size} changed files have been given")
-        changedFiles
+        val newFilesWithHash = changedFiles
           .map(_.absPath())
           // the corresponding File node will be hashed when inserted into the CPG later on, this just needs to be
           // different to what is in the CPG if there is an existing node with the same Path.
           .map(path => PathAndHash(path.toString, "<changed>"))
           .toList
+        val pathSet = newFilesWithHash.map(_.path).toSet
+        // We must include existing files, otherwise they are interpreted as removed later
+        existingFiles.filterNot(p => pathSet.contains(p.path)) ++ newFilesWithHash
       case None =>
         val determinedChanges = SourceFiles
           .determine(

--- a/joern-analyzers/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/CBuilder.scala
+++ b/joern-analyzers/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/CBuilder.scala
@@ -57,7 +57,7 @@ object CBuilder {
         .determine(
           config.inputPath,
           Set(FileDefaults.PreprocessedExt),
-          ignoredDefaultRegex = Option(C2Cpg.DefaultIgnoredFolders),
+          ignoredDefaultRegex = Option(config.defaultIgnoredFilesRegex),
           ignoredFilesRegex = Option(config.ignoredFilesRegex),
           ignoredFilesPath = Option(config.ignoredFiles)
         )

--- a/joern-analyzers/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/CBuilder.scala
+++ b/joern-analyzers/src/main/scala/io/github/jbellis/brokk/analyzer/builder/languages/CBuilder.scala
@@ -2,10 +2,10 @@ package io.github.jbellis.brokk.analyzer.builder.languages
 
 import io.github.jbellis.brokk.analyzer.builder.CpgBuilder
 import io.github.jbellis.brokk.analyzer.builder.passes.cpp.PointerTypesPass
+import io.joern.c2cpg.Config as CConfig
 import io.joern.c2cpg.astcreation.CGlobal
 import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.passes.*
-import io.joern.c2cpg.{C2Cpg, Config as CConfig}
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.passes.frontend.TypeNodePass
 import io.joern.x2cpg.utils.Report

--- a/joern-analyzers/src/main/scala/io/github/jbellis/brokk/analyzer/builder/passes/incremental/PruneTypesPass.scala
+++ b/joern-analyzers/src/main/scala/io/github/jbellis/brokk/analyzer/builder/passes/incremental/PruneTypesPass.scala
@@ -12,7 +12,10 @@ class PruneTypesPass(cpg: Cpg) extends CpgPass(cpg) {
   private val logger = LoggerFactory.getLogger(getClass)
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
-    val typesToPrune = cpg.typ.whereNot(_.and(_.evalTypeIn, _.referencedTypeDecl.isExternal(false))).l
+    val typesToPrune = cpg.typ
+      .whereNot(_.evalTypeIn) // no usages
+      .where(_.referencedTypeDecl.isExternal(true)) // is not a user-defined type, i.e., is external
+      .l
     logger.info(s"Found ${typesToPrune.size} types no longer referenced")
     typesToPrune
       .flatMap { t =>

--- a/joern-analyzers/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-analyzers/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 The Joern Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Modifications copyright 2025 Brokk, Inc. and made available under the GPLv3.
+ *
+ * The original file can be found at https://github.com/joernio/joern/blob/3e923e15368e64648e6c5693ac014a2cac83990a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+ */
+package io.joern.c2cpg.passes
+
+import io.joern.c2cpg.Config
+import io.joern.c2cpg.astcreation.AstCreator
+import io.joern.c2cpg.astcreation.CGlobal
+import io.joern.c2cpg.parser.CdtParser
+import io.joern.c2cpg.parser.FileDefaults
+import io.joern.c2cpg.parser.HeaderFileFinder
+import io.joern.c2cpg.parser.JSONCompilationDatabaseParser
+import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CompilationDatabase
+import io.joern.c2cpg.C2Cpg
+import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.utils.Report
+import io.joern.x2cpg.utils.TimeUtils
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.passes.ForkJoinParallelCpgPass
+import org.apache.commons.lang3.StringUtils
+import org.eclipse.cdt.core.model.ILanguage
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+class AstCreationPass(
+                       cpg: Cpg,
+                       preprocessedFiles: List[String],
+                       fileExtensions: Set[String],
+                       config: Config,
+                       global: CGlobal,
+                       report: Report = new Report()
+                     ) extends ForkJoinParallelCpgPass[(Path, ILanguage)](cpg) {
+
+  private val compilationDatabase: Option[CompilationDatabase] =
+    config.compilationDatabaseFilename.flatMap(JSONCompilationDatabaseParser.parse)
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
+
+  private val headerFileFinder: HeaderFileFinder = new HeaderFileFinder(config)
+  private val parser: CdtParser                  = new CdtParser(config, headerFileFinder, compilationDatabase, global)
+
+  override def generateParts(): Array[(Path, ILanguage)] = {
+    val sourceFiles = if (config.compilationDatabaseFilename.isEmpty) {
+      sourceFilesFromDirectory()
+    } else {
+      sourceFilesFromCompilationDatabase(config.compilationDatabaseFilename.get)
+    }
+    sourceFiles.flatMap { file =>
+      val path = Paths.get(file).toAbsolutePath
+      CdtParser.languageMappingForSourceFile(path, global, config)
+    }
+  }
+
+  private def sourceFilesFromDirectory(): Array[String] = {
+    val allSourceFiles = SourceFiles
+      .determine(
+        config.inputPath,
+        fileExtensions,
+        ignoredDefaultRegex = Option(config.defaultIgnoredFilesRegex),
+        ignoredFilesRegex = Option(config.ignoredFilesRegex),
+        ignoredFilesPath = Option(config.ignoredFiles)
+      )
+      .toArray
+    if (config.withPreprocessedFiles) {
+      allSourceFiles.filter {
+        case f if !FileDefaults.hasPreprocessedFileExtension(f) =>
+          val fAsPreprocessedFile = s"${f.substring(0, f.lastIndexOf("."))}${FileDefaults.PreprocessedExt}"
+          !preprocessedFiles.exists { sourceFile => f != sourceFile && sourceFile == fAsPreprocessedFile }
+        case _ => true
+      }
+    } else {
+      allSourceFiles
+    }
+  }
+
+  private def sourceFilesFromCompilationDatabase(compilationDatabaseFile: String): Array[String] = {
+    compilationDatabase match {
+      case Some(db) =>
+        val files         = db.commands.map(_.compiledFile()).toList
+        val filteredFiles = files.filter(f => fileExtensions.exists(StringUtils.endsWithIgnoreCase(f, _)))
+        SourceFiles
+          .filterFiles(
+            filteredFiles,
+            config.inputPath,
+            ignoredDefaultRegex = Option(C2Cpg.DefaultIgnoredFolders),
+            ignoredFilesRegex = Option(config.ignoredFilesRegex),
+            ignoredFilesPath = Option(config.ignoredFiles)
+          )
+          .toArray
+      case None =>
+        logger.warn(s"'$compilationDatabaseFile' contains no source files. CPG will be empty.")
+        Array.empty
+    }
+  }
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, fileAndLanguage: (Path, ILanguage)): Unit = {
+    val (path, language) = fileAndLanguage
+    val relPath          = SourceFiles.toRelativePath(path.toString, config.inputPath)
+    val (gotCpg, duration) = TimeUtils.time {
+      val parseResult = parser.parse(path, language)
+      parseResult match {
+        case Some(translationUnit) =>
+          val fileLOC = translationUnit.getRawSignature.linesIterator.size
+          report.addReportInfo(relPath, fileLOC, parsed = true)
+          Try {
+            val localDiff = new AstCreator(relPath, global, config, translationUnit, headerFileFinder).createAst()
+            diffGraph.absorb(localDiff)
+            logger.debug(s"Generated a CPG for: '$relPath'")
+          } match {
+            case Failure(exception) =>
+              logger.warn(s"Failed to generate a CPG for: '$relPath'", exception)
+              false
+            case Success(_) => true
+          }
+        case None =>
+          report.addReportInfo(relPath, -1)
+          false
+      }
+    }
+    report.updateReport(relPath, gotCpg, duration)
+  }
+
+}

--- a/joern-analyzers/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-analyzers/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -198,6 +198,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
         .name(lambdaMethodNode.name)
         .inheritsFromTypeFullName(inheritsFromTypeFullName)
         .genericSignature(binarySignatureCalculator.unspecifiedClassType)
+        .isExternal(false)
     scope.addLocalDecl(Ast(lambdaTypeDeclNode))
 
     lambdaTypeDeclNode

--- a/joern-analyzers/src/test/scala/io/github/jbellis/brokk/analyzer/builder/cpp/IncrementalBuildTest.scala
+++ b/joern-analyzers/src/test/scala/io/github/jbellis/brokk/analyzer/builder/cpp/IncrementalBuildTest.scala
@@ -1,12 +1,20 @@
 package io.github.jbellis.brokk.analyzer.builder.cpp
 
+import io.github.jbellis.brokk.analyzer.ProjectFile
 import io.github.jbellis.brokk.analyzer.builder.languages.given
 import io.github.jbellis.brokk.analyzer.builder.{CpgTestFixture, IncrementalBuildTestFixture}
 import io.joern.c2cpg.Config
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.Literal
+import io.shiftleft.semanticcpg.language.*
+
+import java.nio.file.Path
 
 class IncrementalBuildTest extends CpgTestFixture[Config] with IncrementalBuildTestFixture[Config] {
 
   override implicit def defaultConfig: Config = Config()
+
+  // Automatically detected changed files tests
 
   "an incremental build from an empty project" in {
     withIncrementalTestConfig { (configA, configB) =>
@@ -230,4 +238,162 @@ class IncrementalBuildTest extends CpgTestFixture[Config] with IncrementalBuildT
     }
   }
 
+  // Specified change tests
+
+  def printlnLiteral(cpg: Cpg, fileName: String = "Foo.cpp"): Literal =
+    cpg.method
+      .where(_.file.nameExact(fileName))
+      .nameExact("main")
+      .call
+      .nameExact(Operators.shiftLeft)
+      .argument
+      .isLiteral
+      .head
+
+  "an incremental build that specifies no changes, albeit changes have occurred, should not change the CPG" in {
+    withIncrementalTestConfig { (configA, configB) =>
+      val projectA = project(
+        configA,
+        """
+          |#include <iostream>
+          |
+          |int main() {
+          |  std::cout << "Hello, world!" << std::endl;
+          |  return 0;
+          |}
+          |""".stripMargin,
+        "Foo.cpp"
+      )
+      val projectB = project(
+        configB,
+        """
+          |#include <iostream>
+          |
+          |int main() {
+          |  std::cout << "Hello, my incremental world!" << std::endl;
+          |  return 0;
+          |}
+          |""".stripMargin,
+        "Foo.cpp"
+      )
+
+      testSpecifiedChanges(
+        projectA,
+        projectB,
+        Set.empty,
+        { (original, updated) =>
+          val originalLiteral = printlnLiteral(original)
+          val updatedLiteral  = printlnLiteral(updated)
+
+          originalLiteral.code shouldBe updatedLiteral.code
+        }
+      )
+    }
+  }
+
+  "an incremental build that specifies the changed file should update it" in {
+    withIncrementalTestConfig { (configA, configB) =>
+      val projectA = project(
+        configA,
+        """
+          |#include <iostream>
+          |
+          |int main() {
+          |  std::cout << "Hello, world!" << std::endl;
+          |  return 0;
+          |}
+          |""".stripMargin,
+        "Foo.cpp"
+      )
+      val projectB = project(
+        configB,
+        """
+          |#include <iostream>
+          |
+          |int main() {
+          |  std::cout << "Hello, my incremental world!" << std::endl;
+          |  return 0;
+          |}
+          |""".stripMargin,
+        "Foo.cpp"
+      )
+
+      testSpecifiedChanges(
+        projectA,
+        projectB,
+        Set(ProjectFile(Path.of(configA.inputPath), "Foo.cpp")),
+        { (original, updated) =>
+          val originalLiteral = printlnLiteral(original)
+          val updatedLiteral  = printlnLiteral(updated)
+
+          originalLiteral.code shouldBe "\"Hello, world!\""
+          updatedLiteral.code shouldBe "\"Hello, my incremental world!\""
+        }
+      )
+    }
+  }
+
+  "an incremental build that specifies the changed file should update it, but not other files" in {
+    withIncrementalTestConfig { (configA, configB) =>
+      val projectA = project(
+        configA,
+        """
+          |#include <iostream>
+          |
+          |int main() {
+          |  std::cout << "Hello, world!" << std::endl;
+          |  return 0;
+          |}
+          |""".stripMargin,
+        "Foo.cpp"
+      ).moreCode(
+        """#include <iostream>
+          |
+          |namespace test {
+          | int main() {
+          |   std::cout << "Hello, from Bar!" << std::endl;
+          |   return 0;
+          | }
+          |}
+          |""".stripMargin,
+        "test/Bar.cpp"
+      )
+      val projectB = project(
+        configB,
+        """
+          |#include <iostream>
+          |
+          |int main() {
+          |  std::cout << "Hello, my incremental world!" << std::endl;
+          |  return 0;
+          |}
+          |""".stripMargin,
+        "Foo.cpp"
+      ).moreCode(
+        """#include <iostream>
+          |
+          |namespace test {
+          | int main() {
+          |   std::cout << "Hello, from incremental Bar!" << std::endl;
+          |   return 0;
+          | }
+          |}
+          |""".stripMargin,
+        "test/Bar.cpp"
+      )
+
+      testSpecifiedChanges(
+        projectA,
+        projectB,
+        Set(ProjectFile(Path.of(configA.inputPath), "Foo.cpp")),
+        { (original, updated) =>
+          printlnLiteral(original).code shouldBe "\"Hello, world!\""
+          printlnLiteral(updated).code shouldBe "\"Hello, my incremental world!\""
+
+          printlnLiteral(original, "test/Bar.cpp").code shouldBe "\"Hello, from Bar!\""
+          printlnLiteral(updated, "test/Bar.cpp").code shouldBe "\"Hello, from Bar!\""
+        }
+      )
+    }
+  }
 }

--- a/joern-analyzers/src/test/scala/io/github/jbellis/brokk/analyzer/builder/cpp/IncrementalBuildTest.scala
+++ b/joern-analyzers/src/test/scala/io/github/jbellis/brokk/analyzer/builder/cpp/IncrementalBuildTest.scala
@@ -4,8 +4,8 @@ import io.github.jbellis.brokk.analyzer.ProjectFile
 import io.github.jbellis.brokk.analyzer.builder.languages.given
 import io.github.jbellis.brokk.analyzer.builder.{CpgTestFixture, IncrementalBuildTestFixture}
 import io.joern.c2cpg.Config
-import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.semanticcpg.language.*
 
 import java.nio.file.Path
@@ -242,7 +242,7 @@ class IncrementalBuildTest extends CpgTestFixture[Config] with IncrementalBuildT
 
   def printlnLiteral(cpg: Cpg, fileName: String = "Foo.cpp"): Literal =
     cpg.method
-      .where(_.file.nameExact(fileName))
+      .where(_.file.nameExact(Path.of(fileName).toString))
       .nameExact("main")
       .call
       .nameExact(Operators.shiftLeft)

--- a/joern-analyzers/src/test/scala/io/github/jbellis/brokk/analyzer/builder/javasrc/IncrementalBuildTest.scala
+++ b/joern-analyzers/src/test/scala/io/github/jbellis/brokk/analyzer/builder/javasrc/IncrementalBuildTest.scala
@@ -1,12 +1,20 @@
 package io.github.jbellis.brokk.analyzer.builder.javasrc
 
+import io.github.jbellis.brokk.analyzer.ProjectFile
 import io.github.jbellis.brokk.analyzer.builder.languages.given
 import io.github.jbellis.brokk.analyzer.builder.{CpgTestFixture, IncrementalBuildTestFixture}
 import io.joern.javasrc2cpg.Config
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Literal
+import io.shiftleft.semanticcpg.language.*
+
+import java.nio.file.Path
 
 class IncrementalBuildTest extends CpgTestFixture[Config] with IncrementalBuildTestFixture[Config] {
 
   override implicit def defaultConfig: Config = Config()
+
+  // Automatically detected changed files tests
 
   "an incremental build from an empty project" in {
     withIncrementalTestConfig { (configA, configB) =>
@@ -186,6 +194,152 @@ class IncrementalBuildTest extends CpgTestFixture[Config] with IncrementalBuildT
       )
 
       testIncremental(projectA, projectB)
+    }
+  }
+
+  // Specified change tests
+
+  def printlnLiteral(cpg: Cpg, fileName: String = "Foo.java"): Literal =
+    cpg.method.where(_.file.nameExact(fileName)).nameExact("main").call.nameExact("println").argument.isLiteral.head
+
+  "an incremental build that specifies no changes, albeit changes have occurred, should not change the CPG" in {
+    withIncrementalTestConfig { (configA, configB) =>
+      val projectA = project(
+        configA,
+        """
+          |public class Foo {
+          | public static void main(String[] args) {
+          |   System.out.println("Hello, world!");
+          | }
+          |}
+          |""".stripMargin,
+        "Foo.java"
+      )
+      val projectB = project(
+        configB,
+        """
+          |public class Foo {
+          | public static void main(String[] args) {
+          |   System.out.println("Hello, my incremental world!");
+          | }
+          |}
+          |""".stripMargin,
+        "Foo.java"
+      )
+
+      testSpecifiedChanges(
+        projectA,
+        projectB,
+        Set.empty,
+        { (original, updated) =>
+          val originalLiteral = printlnLiteral(original)
+          val updatedLiteral  = printlnLiteral(updated)
+
+          originalLiteral.code shouldBe updatedLiteral.code
+        }
+      )
+    }
+  }
+
+  "an incremental build that specifies the changed file should update it" in {
+    withIncrementalTestConfig { (configA, configB) =>
+      val projectA = project(
+        configA,
+        """
+          |public class Foo {
+          | public static void main(String[] args) {
+          |   System.out.println("Hello, world!");
+          | }
+          |}
+          |""".stripMargin,
+        "Foo.java"
+      )
+      val projectB = project(
+        configB,
+        """
+          |public class Foo {
+          | public static void main(String[] args) {
+          |   System.out.println("Hello, my incremental world!");
+          | }
+          |}
+          |""".stripMargin,
+        "Foo.java"
+      )
+
+      testSpecifiedChanges(
+        projectA,
+        projectB,
+        Set(ProjectFile(Path.of(configA.inputPath), "Foo.java")),
+        { (original, updated) =>
+          val originalLiteral = printlnLiteral(original)
+          val updatedLiteral  = printlnLiteral(updated)
+
+          originalLiteral.code shouldBe "\"Hello, world!\""
+          updatedLiteral.code shouldBe "\"Hello, my incremental world!\""
+        }
+      )
+    }
+  }
+
+  "an incremental build that specifies the changed file should update it, but not other files" in {
+    withIncrementalTestConfig { (configA, configB) =>
+      val projectA = project(
+        configA,
+        """
+            |public class Foo {
+            | public static void main(String[] args) {
+            |   System.out.println("Hello, world!");
+            | }
+            |}
+            |""".stripMargin,
+        "Foo.java"
+      ).moreCode(
+        """
+            |package test;
+            |
+            |public class Bar {
+            | public static void main() {
+            |   System.out.println("Hello, from Bar!");
+            | }
+            |}
+            |""".stripMargin,
+        "test/Bar.java"
+      )
+      val projectB = project(
+        configB,
+        """
+            |public class Foo {
+            | public static void main(String[] args) {
+            |   System.out.println("Hello, my incremental world!");
+            | }
+            |}
+            |""".stripMargin,
+        "Foo.java"
+      ).moreCode(
+        """
+            |package test;
+            |
+            |public class Bar {
+            | public static void main() {
+            |   System.out.println("Hello, from incremental Bar!");
+            | }
+            |}
+            |""".stripMargin,
+        "test/Bar.java"
+      )
+
+      testSpecifiedChanges(
+        projectA,
+        projectB,
+        Set(ProjectFile(Path.of(configA.inputPath), "Foo.java")),
+        { (original, updated) =>
+          printlnLiteral(original).code shouldBe "\"Hello, world!\""
+          printlnLiteral(updated).code shouldBe "\"Hello, my incremental world!\""
+
+          printlnLiteral(original, "test/Bar.java").code shouldBe "\"Hello, from Bar!\""
+          printlnLiteral(updated, "test/Bar.java").code shouldBe "\"Hello, from Bar!\""
+        }
+      )
     }
   }
 

--- a/joern-analyzers/src/test/scala/io/github/jbellis/brokk/analyzer/builder/javasrc/IncrementalBuildTest.scala
+++ b/joern-analyzers/src/test/scala/io/github/jbellis/brokk/analyzer/builder/javasrc/IncrementalBuildTest.scala
@@ -200,7 +200,14 @@ class IncrementalBuildTest extends CpgTestFixture[Config] with IncrementalBuildT
   // Specified change tests
 
   def printlnLiteral(cpg: Cpg, fileName: String = "Foo.java"): Literal =
-    cpg.method.where(_.file.nameExact(fileName)).nameExact("main").call.nameExact("println").argument.isLiteral.head
+    cpg.method
+      .where(_.file.nameExact(Path.of(fileName).toString))
+      .nameExact("main")
+      .call
+      .nameExact("println")
+      .argument
+      .isLiteral
+      .head
 
   "an incremental build that specifies no changes, albeit changes have occurred, should not change the CPG" in {
     withIncrementalTestConfig { (configA, configB) =>


### PR DESCRIPTION
When files are changed, and they are given to the analyzer, the analyzer assumed every other file was removed. However, these "removed" files are also not included from the subsequent rebuild, thus every other file was then pruned. This is fixed by adding every other path to the comparison that was not given by the file watcher.

Misc:
* Made it clear how the pruning works by separating query steps and adding comments
* Anonymous type decls on Joern `master` were being set as external types, this was fixed.
* Discovered that the C++ frontend did not respect the configured `defaultIgnoreRegex`. It is now patched.
* Configured Gradle to show exceptions in `joern-analyzers` for easier debugging