### PR TITLE
feat(import): auto-download sources JARs on dependency import (fallback to Fernflower)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
     // Java Decompiler
     implementation(libs.java.decompiler)
 
+    // Maven Resolver for dependency import
+    implementation(libs.bundles.maven.resolver)
+
     implementation(libs.checker.util)
 
     // Testing

--- a/app/src/main/java/io/github/jbellis/brokk/util/Decompiler.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/Decompiler.java
@@ -10,17 +10,46 @@ import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 import javax.swing.*;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipFile;
 
 public class Decompiler {
     private static final Logger logger = LogManager.getLogger(Decompiler.class);
+
+    /**
+     * Extracts Maven coordinates from a {@code pom.properties} file found under {@code META-INF/maven/}.
+     */
+    private static Optional<String> getMavenCoordinatesFromPomProperties(Path jarPath) {
+        try (var zip = new ZipFile(jarPath.toFile())) {
+            var entries = zip.entries();
+            while (entries.hasMoreElements()) {
+                var entry = entries.nextElement();
+                var name = entry.getName();
+                if (!entry.isDirectory() && name.startsWith("META-INF/maven/") && name.endsWith("/pom.properties")) {
+                    var props = new Properties();
+                    try (var in = zip.getInputStream(entry)) {
+                        props.load(in);
+                    }
+                    var groupId = props.getProperty("groupId");
+                    var artifactId = props.getProperty("artifactId");
+                    var version = props.getProperty("version");
+                    if (groupId != null && artifactId != null && version != null) {
+                        var coords = String.format("%s:%s:%s", groupId, artifactId, version);
+                        logger.debug("Determined Maven coordinates for {} as {} from pom.properties", jarPath, coords);
+                        return Optional.of(coords);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("Could not read pom.properties from {}: {}", jarPath, e.getMessage());
+        }
+        return Optional.empty();
+    }
 
     /**
      * Performs the decompilation of the selected JAR file.
@@ -40,143 +69,151 @@ public class Decompiler {
                                     Path jarPath,
                                     ContextManager.TaskRunner runner,
                                     @Nullable Runnable onComplete) {
-        try {
-            String jarName = jarPath.getFileName().toString();
-            // Use the *original* project's root to determine the .brokk directory
-            Path originalProjectRoot = io.getContextManager().getRoot();
-            Path brokkDir = originalProjectRoot.resolve(".brokk");
-            Path depsDir = brokkDir.resolve("dependencies");
-            Path outputDir = depsDir.resolve(jarName.replaceAll("\\.jar$", "")); // Decompile target dir
+        String jarName = jarPath.getFileName().toString();
+        Path originalProjectRoot = io.getContextManager().getRoot();
+        Path brokkDir = originalProjectRoot.resolve(".brokk");
+        Path depsDir = brokkDir.resolve("dependencies");
+        Path outputDir = depsDir.resolve(jarName.replaceAll("\\.jar$", ""));
 
-            logger.debug("Original project root: {}", originalProjectRoot);
-            logger.debug("Decompile output directory: {}", outputDir);
+        io.systemOutput("Importing " + jarName + "...");
 
-            Files.createDirectories(depsDir);
+        runner.submit("Importing " + jarName, () -> {
+            try {
+                // Attempt to download sources if we can determine Maven coordinates
+                var coordsOpt = getMavenCoordinatesFromPomProperties(jarPath);
 
-            // Check if already decompiled
-            if (Files.exists(outputDir)) {
+                Optional<Path> sourcesJarPathOpt = Optional.empty();
+                if (coordsOpt.isPresent()) {
+                    var coords = coordsOpt.get();
+                    io.systemOutput("Detected Maven coordinates: " + coords + ". Attempting to download sources...");
+                    var fetcher = new MavenArtifactFetcher();
+                    sourcesJarPathOpt = fetcher.fetch(coords, "sources");
+                }
+
+                // If not downloaded, check for a local sibling
+                if (sourcesJarPathOpt.isEmpty()) {
+                    if (coordsOpt.isEmpty()) {
+                        logger.info("No pom.properties found in {}. Checking for local *-sources.jar before decompiling.", jarPath.getFileName());
+                    }
+                    Path localSources = jarPath.resolveSibling(jarName.replace(".jar", "-sources.jar"));
+                    if (Files.exists(localSources)) {
+                        sourcesJarPathOpt = Optional.of(localSources);
+                    }
+                }
+
+                // Prepare output directory, asking for overwrite if necessary
+                if (!prepareOutputDirectory(io, outputDir)) {
+                    logger.debug("User chose not to overwrite existing dependency directory {}", outputDir);
+                    return null;
+                }
+
+                if (sourcesJarPathOpt.isPresent()) {
+                    Path sourcesJarPath = sourcesJarPathOpt.get();
+                    io.systemOutput("Found sources JAR. Unpacking " + sourcesJarPath.getFileName() + "...");
+                    extractJarToTemp(sourcesJarPath, outputDir);
+                    io.systemOutput("Sources unpacked. Reopen project to incorporate the new source files.");
+                } else {
+                    if (coordsOpt.isPresent()) {
+                        logger.info("Could not find sources for {}. Falling back to decompilation.", coordsOpt.get());
+                    }
+                    decompile(io, jarPath, outputDir);
+                }
+
+                if (onComplete != null) {
+                    SwingUtilities.invokeLater(onComplete);
+                }
+            } catch (Exception e) {
+                io.toolError("Error during import process: " + e.getMessage());
+                logger.error("Error processing JAR {}", jarPath, e);
+            }
+            return null;
+        });
+    }
+
+    private static boolean prepareOutputDirectory(Chrome io, Path outputDir) throws Exception {
+        Files.createDirectories(outputDir.getParent());
+
+        if (Files.exists(outputDir)) {
+            var proceed = new AtomicBoolean(false);
+            SwingUtilities.invokeAndWait(() -> {
                 int choice = JOptionPane.showConfirmDialog(
-                        io.getFrame(), // Use current IO frame
+                        io.getFrame(),
                         """
-                        This JAR appears to have been decompiled previously.
+                        This dependency appears to exist already.
                         Output directory: %s
 
-                        Delete output directory and decompile again?
-                        (Choosing 'No' will leave the existing decompiled files unchanged.)
+                        Delete output directory and import again?
+                        (Choosing 'No' will leave the existing files unchanged.)
                         """.formatted(outputDir.toString()),
                         "Dependency exists",
                         JOptionPane.YES_NO_OPTION,
                         JOptionPane.QUESTION_MESSAGE
                 );
+                proceed.set(choice == JOptionPane.YES_OPTION);
+            });
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    logger.debug("Removing old decompiled contents at {}", outputDir);
-                    try {
-                        Decompiler.deleteDirectoryRecursive(outputDir);
-                    } catch (IOException e) {
-                        io.toolError("Error deleting existing decompiled directory: " + e.getMessage());
-                        return; // Stop if deletion fails
-                    }
-                    // Recreate the directory after deletion
-                    Files.createDirectories(outputDir);
-                } else if (choice == JOptionPane.NO_OPTION) {
-                    logger.debug("Opening previously decompiled dependency at {}", outputDir);
-                    return;
-                }
+            if (proceed.get()) {
+                logger.debug("Removing old dependency contents at {}", outputDir);
+                deleteDirectoryRecursive(outputDir);
             } else {
-                // Create the output directory if it didn't exist
-                Files.createDirectories(outputDir);
+                return false;
             }
+        }
 
+        Files.createDirectories(outputDir);
+        return true;
+    }
 
-            io.systemOutput("Decompiling " + jarName + "...");
+    private static void decompile(Chrome io, Path jarPath, Path outputDir) throws Exception {
+        io.systemOutput("Decompiling " + jarPath.getFileName() + "...");
+        logger.debug("Starting decompilation in background thread for {}", jarPath);
+        Path tempDir = null;
 
-            // Submit the decompilation task to the provided executor
-            runner.submit("Decompiling " + jarName, () -> {
-                logger.debug("Starting decompilation in background thread for {}", jarPath);
-                Path tempDir = null; // To store the path of the temporary directory
+        try {
+            tempDir = Files.createTempDirectory("fernflower-extracted-");
+            extractJarToTemp(jarPath, tempDir);
 
-                try {
-                    // 1. Create a temporary directory
-                    tempDir = Files.createTempDirectory("fernflower-extracted-");
-                    logger.debug("Created temporary directory: {}", tempDir);
-
-                    // 2. Extract the JAR contents to the temporary directory
-                    Decompiler.extractJarToTemp(jarPath, tempDir);
-                    logger.debug("Extracted JAR contents to temporary directory.");
-
-                    // 3. Set up Decompiler with the *final* output directory
-                    Map<String, Object> options = Map.of("hes", "1", // hide empty super
-                                                         "hdc", "1", // hide default constructor
-                                                         "dgs", "1", // decompile generic signature
-                                                         "ren", "1" /* rename ambiguous */);
-                    ConsoleDecompiler decompiler = new ConsoleDecompiler(
-                            outputDir.toFile(), // Use the final desired output directory here
-                            options,
-                            new org.jetbrains.java.decompiler.main.extern.IFernflowerLogger() {
-                                @Override
-                                public void writeMessage(String message, Severity severity) {
-                                    switch (severity) {
-                                        case ERROR -> logger.error("Fernflower: {}", message);
-                                        case WARN  -> logger.warn("Fernflower: {}", message);
-                                        case INFO  -> logger.info("Fernflower: {}", message);
-                                        case TRACE -> logger.trace("Fernflower: {}", message);
-                                        default    -> logger.debug("Fernflower: {}", message);
-                                    }
-                                }
-
-                                @Override
-                                public void writeMessage(String message, Severity severity, Throwable t) {
-                                    switch (severity) {
-                                        case ERROR -> logger.error("Fernflower: {}", message, t);
-                                        case WARN  -> logger.warn("Fernflower: {}", message, t);
-                                        case INFO  -> logger.info("Fernflower: {}", message, t);
-                                        case TRACE -> logger.trace("Fernflower: {}", message, t);
-                                        default   -> logger.debug("Fernflower: {}", message, t);
-                                    }
-                                }
+            Map<String, Object> options = Map.of("hes", "1", "hdc", "1", "dgs", "1", "ren", "1");
+            ConsoleDecompiler decompiler = new ConsoleDecompiler(
+                    outputDir.toFile(),
+                    options,
+                    new org.jetbrains.java.decompiler.main.extern.IFernflowerLogger() {
+                        @Override
+                        public void writeMessage(String message, Severity severity) {
+                            switch (severity) {
+                                case ERROR -> logger.error("Fernflower: {}", message);
+                                case WARN  -> logger.warn("Fernflower: {}", message);
+                                case INFO  -> logger.info("Fernflower: {}", message);
+                                case TRACE -> logger.trace("Fernflower: {}", message);
+                                default    -> logger.debug("Fernflower: {}", message);
                             }
-                    );
+                        }
 
-                    // 4. Add the *temporary directory* as the source
-                    decompiler.addSource(tempDir.toFile());
-
-                    // 5. Decompile
-                    logger.info("Starting decompilation process...");
-                    decompiler.decompileContext();
-                    logger.info("Decompilation process finished.");
-
-                    // Notify user of success
-                    if (onComplete != null) {
-                        SwingUtilities.invokeLater(onComplete);
-                    }
-                    // Log final directory structure for troubleshooting
-                    logger.debug("Final contents of {} after decompilation:", outputDir);
-                    try (var pathStream = Files.walk(outputDir, 1)) { // Walk only one level deep for brevity
-                        pathStream.forEach(path -> logger.debug("   {}", path.getFileName()));
-                    } catch (IOException e) {
-                        logger.warn("Error listing output directory contents", e);
-                    }
-                } catch (Exception e) {
-                    // Handle exceptions within the task
-                    io.toolError("Error during decompilation process: " + e.getMessage());
-                } finally {
-                    // 6. Clean up the temporary directory
-                    if (tempDir != null) {
-                        try {
-                            logger.debug("Cleaning up temporary directory: {}", tempDir);
-                            Decompiler.deleteDirectoryRecursive(tempDir);
-                            logger.debug("Temporary directory deleted.");
-                        } catch (IOException e) {
-                            logger.error("Failed to delete temporary directory: {}", tempDir, e);
+                        @Override
+                        public void writeMessage(String message, Severity severity, Throwable t) {
+                            switch (severity) {
+                                case ERROR -> logger.error("Fernflower: {}", message, t);
+                                case WARN  -> logger.warn("Fernflower: {}", message, t);
+                                case INFO  -> logger.info("Fernflower: {}", message, t);
+                                case TRACE -> logger.trace("Fernflower: {}", message, t);
+                                default   -> logger.debug("Fernflower: {}", message, t);
+                            }
                         }
                     }
+            );
+
+            decompiler.addSource(tempDir.toFile());
+            decompiler.decompileContext();
+
+            io.systemOutput("Decompilation completed. Reopen project to incorporate the new source files.");
+        } finally {
+            if (tempDir != null) {
+                try {
+                    deleteDirectoryRecursive(tempDir);
+                } catch (IOException e) {
+                    logger.error("Failed to delete temporary directory: {}", tempDir, e);
                 }
-                return null;
-            });
-        } catch (IOException e) {
-            // Error *before* starting the worker (e.g., creating directories)
-            io.toolError("Error preparing decompilation: " + e.getMessage());
+            }
         }
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/util/MavenArtifactFetcher.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/MavenArtifactFetcher.java
@@ -1,0 +1,124 @@
+package io.github.jbellis.brokk.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.DefaultServiceLocator;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.transfer.AbstractTransferListener;
+import org.eclipse.aether.transfer.TransferEvent;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+public class MavenArtifactFetcher
+{
+    private static final Logger logger = LogManager.getLogger(MavenArtifactFetcher.class);
+
+    private final RepositorySystem system;
+    private final RepositorySystemSession session;
+    private final List<RemoteRepository> repositories;
+
+    public MavenArtifactFetcher() {
+        this.system = newRepositorySystem();
+        this.session = newRepositorySystemSession(system);
+        this.repositories = List.of(new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2/").build());
+    }
+
+    @SuppressWarnings("deprecation")
+    private static RepositorySystem newRepositorySystem() {
+        var locator = MavenRepositorySystemUtils.newServiceLocator();
+        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
+        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
+        locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
+            @Override
+            public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {
+                logger.error("Service creation failed for type {} with implementation {}", type, impl, exception);
+            }
+        });
+        return locator.getService(RepositorySystem.class);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static RepositorySystemSession newRepositorySystemSession(RepositorySystem system) {
+        var session = MavenRepositorySystemUtils.newSession();
+        var localRepoPath = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        var localRepo = new LocalRepository(localRepoPath.toFile());
+        session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
+        session.setTransferListener(new LoggingTransferListener());
+        return session;
+    }
+
+    public Optional<Path> fetch(String coordinates, @Nullable String classifier) {
+        Artifact artifact;
+        try {
+            var baseArtifact = new DefaultArtifact(coordinates);
+            if (classifier != null && !classifier.isBlank()) {
+                artifact = new DefaultArtifact(baseArtifact.getGroupId(),
+                                               baseArtifact.getArtifactId(),
+                                               classifier,
+                                               baseArtifact.getExtension(),
+                                               baseArtifact.getVersion());
+            } else {
+                artifact = baseArtifact;
+            }
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid artifact coordinates: {}", coordinates, e);
+            return Optional.empty();
+        }
+
+        var artifactRequest = new ArtifactRequest();
+        artifactRequest.setArtifact(artifact);
+        artifactRequest.setRepositories(repositories);
+
+        try {
+            logger.info("Resolving artifact: {}", artifact);
+            ArtifactResult artifactResult = system.resolveArtifact(session, artifactRequest);
+            Path filePath = artifactResult.getArtifact().getFile().toPath();
+            logger.info("Resolved artifact {} to {}", artifact, filePath);
+            return Optional.of(filePath);
+        } catch (ArtifactResolutionException e) {
+            if (e.getResults().stream().anyMatch(ArtifactResult::isMissing)) {
+                logger.info("Artifact not found: {}", artifact);
+            } else {
+                logger.warn("Could not resolve artifact: {}", artifact, e);
+            }
+            return Optional.empty();
+        }
+    }
+
+    private static class LoggingTransferListener extends AbstractTransferListener
+    {
+        @Override
+        public void transferInitiated(TransferEvent event) {
+            var resource = event.getResource();
+            logger.info("Downloading {}{}", resource.getRepositoryUrl(), resource.getResourceName());
+        }
+
+        @Override
+        public void transferSucceeded(TransferEvent event) {
+            var resource = event.getResource();
+            logger.info("Download complete for {}{}", resource.getRepositoryUrl(), resource.getResourceName());
+        }
+
+        @Override
+        public void transferFailed(TransferEvent event) {
+            var resource = event.getResource();
+            logger.warn("Download failed for {}{}", resource.getRepositoryUrl(), resource.getResourceName(), event.getException());
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,17 +54,4 @@ subprojects {
         }
     }
 
-    dependencies {
-        // Java Decompiler
-        "implementation"("com.jetbrains.intellij.java:java-decompiler-engine:243.25659.59")
-
-        // Maven Resolver for dependency import
-        "implementation"("org.apache.maven:maven-embedder:3.9.6")
-        "implementation"("org.apache.maven.resolver:maven-resolver-api:1.9.20")
-        "implementation"("org.apache.maven.resolver:maven-resolver-spi:1.9.20")
-        "implementation"("org.apache.maven.resolver:maven-resolver-util:1.9.20")
-        "implementation"("org.apache.maven.resolver:maven-resolver-impl:1.9.20")
-        "implementation"("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.20")
-        "implementation"("org.apache.maven.resolver:maven-resolver-transport-http:1.9.20")
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,8 @@ tasks.register("printVersion") {
 }
 
 subprojects {
+    apply(plugin = "java-library")
+
     repositories {
         mavenCentral()
         // Additional repositories for dependencies
@@ -50,5 +52,19 @@ subprojects {
         maven {
             url = uri("https://www.jetbrains.com/intellij-repository/releases")
         }
+    }
+
+    dependencies {
+        // Java Decompiler
+        "implementation"("com.jetbrains.intellij.java:java-decompiler-engine:243.25659.59")
+
+        // Maven Resolver for dependency import
+        "implementation"("org.apache.maven:maven-embedder:3.9.6")
+        "implementation"("org.apache.maven.resolver:maven-resolver-api:1.9.20")
+        "implementation"("org.apache.maven.resolver:maven-resolver-spi:1.9.20")
+        "implementation"("org.apache.maven.resolver:maven-resolver-util:1.9.20")
+        "implementation"("org.apache.maven.resolver:maven-resolver-impl:1.9.20")
+        "implementation"("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.20")
+        "implementation"("org.apache.maven.resolver:maven-resolver-transport-http:1.9.20")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ flatlaf = "3.6"
 flexmark = "0.64.8"
 treesitter = "0.25.3"
 picocli = "4.7.7"
+maven-embedder = "3.9.6"
+maven-resolver = "1.9.20"
 
 [libraries]
 # Scala
@@ -94,6 +96,15 @@ treesitter-typescript = "io.github.bonede:tree-sitter-typescript:0.21.1"
 # Decompiler
 java-decompiler = "com.jetbrains.intellij.java:java-decompiler-engine:243.25659.59"
 
+# Maven Resolver for dependency import
+maven-embedder = { module = "org.apache.maven:maven-embedder", version.ref = "maven-embedder" }
+maven-resolver-api = { module = "org.apache.maven.resolver:maven-resolver-api", version.ref = "maven-resolver" }
+maven-resolver-spi = { module = "org.apache.maven.resolver:maven-resolver-spi", version.ref = "maven-resolver" }
+maven-resolver-util = { module = "org.apache.maven.resolver:maven-resolver-util", version.ref = "maven-resolver" }
+maven-resolver-impl = { module = "org.apache.maven.resolver:maven-resolver-impl", version.ref = "maven-resolver" }
+maven-resolver-connector-basic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref = "maven-resolver" }
+maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref = "maven-resolver" }
+
 [bundles]
 joern = ["joern-x2cpg", "joern-c2cpg", "joern-javasrc2cpg", "joern-pysrc2cpg", "joern-cli", "joern-semanticcpg"]
 logging = ["slf4j-api", "log4j-slf4j2-impl"]
@@ -104,6 +115,7 @@ ui = ["flatlaf", "rsyntaxtextarea", "autocomplete", "jgoodies-forms"]
 markdown = ["flexmark-core", "flexmark-html2md", "mustache"]
 git = ["jgit-core", "jgit-ssh", "bouncycastle"]
 treesitter = ["treesitter-core", "treesitter-csharp", "treesitter-go", "treesitter-javascript", "treesitter-php", "treesitter-python", "treesitter-rust", "treesitter-typescript"]
+maven-resolver = ["maven-embedder", "maven-resolver-api", "maven-resolver-spi", "maven-resolver-util", "maven-resolver-impl", "maven-resolver-connector-basic", "maven-resolver-transport-http"]
 
 [plugins]
 errorprone = { id = "net.ltgt.errorprone", version = "3.1.0" }


### PR DESCRIPTION
This adds first-class support for importing original source code when a dependency’s *-sources.jar* is available and falls back to Fernflower decompilation only when necessary.

Key points
──────────
* build.gradle.kts – adds Maven Resolver dependencies required at runtime
* MavenArtifactFetcher – lightweight façade around Eclipse Aether • resolves <groupId>:<artifactId>:<version>[:classifier] to a local file • logs transfer progress and failures
* Decompiler • extracts Maven coordinates from pom.properties • tries sibling *-sources.jar* in same directory • otherwise uses MavenArtifactFetcher to pull sources from Central • cleans up temp dirs; prompts before overwriting existing dependency dir
* Thorough logging of every branch (download, unpack, decompile)

House-keeping
─────────────
* Second branch / PR because the original PR ran into merge conflicts with recent changes on `main`; rebased and resolved here for a clean history. Now utilizes Gradle instead of sbt. 