### PR TITLE
fix(ci): trigger analyzer rebuild when languages change

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
@@ -1035,6 +1035,7 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
         if (!currentAnalyzerLanguagesForDialog.equals(project.getAnalyzerLanguages())) {
             project.setAnalyzerLanguages(currentAnalyzerLanguagesForDialog);
             logger.debug("Applied Code Intelligence Languages: {}", currentAnalyzerLanguagesForDialog);
+            chrome.getContextManager().requestRebuild();
         }
 
         // Data Retention Tab


### PR DESCRIPTION
Calling `requestRebuild()` right after saving the new language set ensures Code-Intelligence refreshes immediately, addressing #435.