### PR TITLE
Make BlitzForge* call BuildAgent outside the EDT

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/agents/BuildAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/BuildAgent.java
@@ -9,6 +9,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.*;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import io.github.jbellis.brokk.AnalyzerUtil;
+import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.IContextManager;
 import io.github.jbellis.brokk.IProject;
 import io.github.jbellis.brokk.Llm;
@@ -31,6 +32,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -365,6 +367,18 @@ public class BuildAgent {
         }
 
         return getBuildLintCommand(cm, details, workspaceTestFiles);
+    }
+
+    /**
+     * Runs {@link #determineVerificationCommand(IContextManager)} on the
+     * {@link ContextManager} background pool and delivers the result asynchronously.
+     *
+     * @return a {@link CompletableFuture} that completes on the background thread.
+     */
+    public static CompletableFuture<@Nullable String> determineVerificationCommandAsync(ContextManager cm)
+    {
+        return cm.submitBackgroundTask("Determine build verification command",
+                                       () -> determineVerificationCommand(cm));
     }
 
     public static String getBuildLintCommand(IContextManager cm, BuildDetails details, Collection<ProjectFile> workspaceTestFiles) {


### PR DESCRIPTION
### Pull Request Description

**Intent:**  
This PR improves GUI responsiveness in the BlitzForge application by running potentially blocking operations, like determining and executing build verification commands, asynchronously to prevent UI freezes.

**Behavior Changes:**  
- Verification command checks in BlitzForgeDialog and BlitzForgeProgressDialog now run in the background using CompletableFuture, avoiding delays on the Event Dispatch Thread (EDT).  
- Post-processing logic dynamically enables/disables UI elements based on async results, ensuring the "Build First" checkbox reflects build availability without blocking user interactions.

**Key Implementation Ideas:**  
- Added a new async method in BuildAgent (`determineVerificationCommandAsync`) to offload work to a background thread.  
- Utilized Java's CompletableFuture for asynchronous execution and SwingUtilities.invokeLater to safely update the UI from background tasks, keeping the application responsive. (102 words)
- Avoids an exception when opening BuildAgent from the EDT
Fixes #522 