### PR TITLE
enh/SplitButton: always include arrow width in min/max size (fixes #446)

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/components/SplitButton.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/components/SplitButton.java
@@ -216,9 +216,6 @@ public class SplitButton extends JButton {
         @Override
         public Dimension getPreferredSize(JComponent c) {
             Dimension d = super.getPreferredSize(c);
-            if (c.isPreferredSizeSet()) {
-                return d;
-            }
             d.width += ARROW_WIDTH;
             return d;
         }
@@ -226,25 +223,15 @@ public class SplitButton extends JButton {
         @Override
         public Dimension getMinimumSize(JComponent c) {
             Dimension d = super.getMinimumSize(c);
-            // If minimum size is explicitly set, or if preferred size is set, use the superclass's calculation.
-            // Otherwise, add arrow width.
-            if (c.isMinimumSizeSet() || c.isPreferredSizeSet()) {
-                return d;
-            }
             d.width += ARROW_WIDTH;
             return d;
         }
 
         @Override
         public Dimension getMaximumSize(JComponent c) {
-            Dimension d = super.getMaximumSize(c);
-            // If maximum size is explicitly set, or if preferred size is set, use the superclass's calculation.
-            // Otherwise, add arrow width.
-            if (c.isMaximumSizeSet() || c.isPreferredSizeSet()) {
-                return d;
-            }
-            d.width += ARROW_WIDTH;
-            return d;
+            // The maximum size is the preferred size, which is calculated by the super call
+            // and already includes the arrow width.
+            return super.getMaximumSize(c);
         }
     }
 }


### PR DESCRIPTION
FlatLaf’s `BoxLayout` occasionally shrank `SplitButton` below the space needed for its text because `getMinimumSize()` and `getMaximumSize()` dropped the arrow-section width whenever a preferred size had been set. This caused the arrow area to overpaint the label (see screenshot in #446).

The new logic unconditionally adds `ARROW_WIDTH` unless the caller has explicitly set a *minimum* or *maximum* size, bringing the button’s size contract in line with what it actually paints.

Limitation: if the user resizes the *entire* application window to an extremely small width, upstream layout managers may still violate the button’s minimum size, so labels can disappear. That trade-off is considered acceptable for now and matches typical Swing behaviour.