### PR TITLE
enh/GUI: enable “Drop All” while viewing earlier history (#541)

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -87,8 +87,8 @@ public class WorkspacePanel extends JPanel {
         public List<Action> getActions(WorkspacePanel panel) {
             var actions = new ArrayList<Action>();
 
-            // Only add drop all action if workspace is editable and we're on the last history item
-            if (panel.workspaceCurrentlyEditable && panel.isOnLatestContext()) {
+            // Only add drop all action if workspace is editable
+            if (panel.workspaceCurrentlyEditable) {
                 actions.add(WorkspaceAction.DROP_ALL.createAction(panel));
             }
 
@@ -1796,6 +1796,7 @@ public class WorkspacePanel extends JPanel {
                 return;
             }
             contextManager.dropAll();
+            contextManager.setSelectedContext(contextManager.topContext());
         } else {
             for (var frag : selectedFragments) {
                 if (frag.getType() == ContextFragment.FragmentType.HISTORY) {
@@ -2079,7 +2080,6 @@ public class WorkspacePanel extends JPanel {
 
     private void refreshMenuState() {
         var editable = workspaceCurrentlyEditable;
-        var onLastHistoryItem = isOnLatestContext();
 
         for (var component : tablePopupMenu.getComponents()) {
             if (component instanceof JMenuItem mi) {
@@ -2087,10 +2087,10 @@ public class WorkspacePanel extends JPanel {
                 boolean dropAll = DROP_ALL_ACTION_CMD.equals(mi.getActionCommand());
 
                 if (dropAll) {
-                    // "Drop All" is only visible and enabled when workspace is editable and on last history item
-                    mi.setVisible(editable && onLastHistoryItem);
-                    mi.setEnabled(editable && onLastHistoryItem);
-                    mi.setToolTipText(editable && onLastHistoryItem ? null : READ_ONLY_TIP);
+                    // "Drop All" is always available
+                    mi.setVisible(true);
+                    mi.setEnabled(true);
+                    mi.setToolTipText(null);
                 } else if (copyAll) {
                     // "Copy All" is always enabled and visible
                     mi.setEnabled(true);
@@ -2107,7 +2107,7 @@ public class WorkspacePanel extends JPanel {
 
         // Also update the global drop all menu item
         if (dropAllMenuItem != null) {
-            dropAllMenuItem.setEnabled(editable && onLastHistoryItem);
+            dropAllMenuItem.setEnabled(true);
         }
     }
 }


### PR DESCRIPTION
Problem
-------
The “Drop All” action was only available when the Workspace was displaying the **latest** context.
If the user scrolled back in the History tab the Workspace became read-only (`workspaceCurrentlyEditable == false`) and all UI surfaces (menu bar, workspace right-click) hid or disabled the action. Issue #541 asks that “Drop All” be callable from *any* history entry and that the resulting empty context be selected automatically.

Solution
--------
* Remove the `isOnLatestContext()` / `workspaceCurrentlyEditable` guards for `WorkspaceAction.DROP_ALL` in the three popup-scenario builders (`NoSelection`, `SingleFragment`, `MultiFragment`).
* In `refreshMenuState()` stop tying the Drop-All menu item’s visibility/enabled state to `workspaceCurrentlyEditable`; it is now always visible and enabled (streaming/blocked state is still handled elsewhere).
* Keep the global menu-bar item in sync by always enabling it.
* After `contextManager.dropAll()` completes, explicitly set the selected context to `topContext()` so the History tab highlights the new empty entry when the action is invoked from a read-only view.

Behaviour
---------
• “Drop All” is offered in the menu bar and every workspace popup
  regardless of whether the latest or a past context is selected.
• Invoking it collapses the history to a single empty entry and that
  entry is immediately highlighted.
• Existing editability rules, streaming safeguards, and other menu
  items are untouched.