### PR TITLE
refactor: fix race conditions with liveContext in ContextManager

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/context/ContextHistory.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/ContextHistory.java
@@ -34,21 +34,31 @@ public class ContextHistory {
     private final Deque<Context> history = new ArrayDeque<>();
     private final Deque<Context> redo   = new ArrayDeque<>();
     private final List<ResetEdge> resetEdges = new ArrayList<>();
+    private Context liveContext;
 
     /** UI-selection; never {@code null} once an initial context is set. */
     private @Nullable Context selected;
 
-    public ContextHistory(Context initialContext) {
-        history.add(initialContext.freeze());
+    public ContextHistory(Context liveContext) {
+        var fr = liveContext.freezeAndCleanup();
+        this.liveContext = fr.liveContext();
+        var frozen = fr.frozenContext();
+        history.add(frozen);
+        selected = frozen;
     }
 
     public ContextHistory(List<Context> contexts) {
         this(contexts, List.of());
     }
 
-    public ContextHistory(List<Context> contexts, List<ResetEdge> resetEdges) {
-        history.addAll(contexts);
+    public ContextHistory(List<Context> frozenContexts, List<ResetEdge> resetEdges) {
+        if (frozenContexts.isEmpty()) {
+            throw new IllegalArgumentException("Cannot initialize ContextHistory from empty list of contexts");
+        }
+        history.addAll(frozenContexts);
         this.resetEdges.addAll(resetEdges);
+        this.liveContext = Context.unfreeze(castNonNull(history.peekLast()));
+        selected = history.peekLast();
     }
 
     /* ───────────────────────── public API ─────────────────────────── */
@@ -61,6 +71,10 @@ public class ContextHistory {
     /** Latest context or {@code null} when uninitialised. */
     public synchronized Context topContext() {
         return castNonNull(history.peekLast());
+    }
+
+    public synchronized Context getLiveContext() {
+        return liveContext;
     }
 
     public synchronized boolean hasUndoStates() { return history.size() > 1; }
@@ -92,15 +106,28 @@ public class ContextHistory {
         return false;
     }
 
-    /** Initialise with a single frozen context. */
-    public synchronized void setInitialContext(Context frozenInitial) {
-        assert !frozenInitial.containsDynamicFragments();
-        history.clear();
-        redo.clear();
-        resetEdges.clear();
-        history.add(frozenInitial);
-        selected = frozenInitial;
-        logger.debug("Initial context set: {}", frozenInitial);
+
+    /**
+     * Applies the given function to the live context, freezes the result, and pushes it to the history.
+     *
+     * @param contextGenerator a function to apply to the live context
+     * @return the new live context
+     */
+    public synchronized Context push(java.util.function.Function<Context, Context> contextGenerator) {
+        var updatedLiveContext = contextGenerator.apply(this.liveContext);
+        if (this.liveContext.equals(updatedLiveContext)) {
+            return this.liveContext;
+        }
+
+        var fr = updatedLiveContext.freezeAndCleanup();
+        this.liveContext = fr.liveContext();
+        addFrozenContextAndClearRedo(fr.frozenContext());
+        return this.liveContext;
+    }
+
+    public synchronized void pushLiveAndFrozen(Context live, Context frozen) {
+        this.liveContext = live;
+        addFrozenContextAndClearRedo(frozen);
     }
 
     /** Push {@code frozen} and clear redo stack. */
@@ -113,16 +140,17 @@ public class ContextHistory {
     }
 
     /**
-     * Replaces the most recent context in history with the provided frozen context.
+     * Replaces the most recent context in history with the provided live and frozen contexts.
      * This is useful for coalescing rapid changes into a single history entry.
      */
-    public synchronized void replaceTopContext(Context newFrozenContext) {
-        assert !newFrozenContext.containsDynamicFragments();
+    public synchronized void replaceTop(Context newLive, Context newFrozen) {
+        assert !newFrozen.containsDynamicFragments();
         assert !history.isEmpty() : "Cannot replace top context in empty history";
         history.removeLast();
-        history.addLast(newFrozenContext);
+        history.addLast(newFrozen);
         redo.clear();
-        selected = newFrozenContext;
+        selected = newFrozen;
+        liveContext = newLive;
     }
 
     /* ─────────────── undo / redo  ────────────── */
@@ -143,7 +171,9 @@ public class ContextHistory {
             resetEdges.removeIf(edge -> edge.targetId().equals(popped.id()));
             redo.addLast(popped);
         }
-        applyFrozenContextToWorkspace(history.peekLast(), io);
+        var newTop = history.peekLast();
+        applyFrozenContextToWorkspace(newTop, io);
+        liveContext = Context.unfreeze(castNonNull(newTop));
         selected = topContext();
         return UndoResult.success(toUndo);
     }
@@ -168,6 +198,7 @@ public class ContextHistory {
         var popped = redo.removeLast();
         history.addLast(popped);
         truncateHistory();
+        liveContext = Context.unfreeze(castNonNull(popped));
         selected = topContext();
         applyFrozenContextToWorkspace(history.peekLast(), io);
         return true;

--- a/app/src/test/java/io/github/jbellis/brokk/context/ContextSerializationTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/context/ContextSerializationTest.java
@@ -457,7 +457,6 @@ public class ContextSerializationTest {
     @Test
     void testActionPersistenceAcrossSerializationRoundTrip() throws Exception {
         var context1 = new Context(mockContextManager, "Initial context");
-        var history = new ContextHistory(context1);
         
         // Create context with a completed action
         var projectFile = new ProjectFile(tempDir, "test.java");
@@ -466,7 +465,7 @@ public class ContextSerializationTest {
         var fragment = new ContextFragment.ProjectPathFragment(projectFile, mockContextManager);
         
         var updatedContext1 = context1.addEditableFiles(List.of(fragment));
-        history.setInitialContext(updatedContext1.freeze()); // Freeze context
+        var history = new ContextHistory(updatedContext1);
         
         // Create context with a slow-resolving action (simulates async operation)
         var slowFuture = CompletableFuture.supplyAsync(() -> {
@@ -543,7 +542,6 @@ public class ContextSerializationTest {
         Files.writeString(dummyFile.absPath(), "Dummy file content for session history test.");
         
         // Populate originalHistory
-        originalHistory.setInitialContext(initialContext.freeze());
         
         ContextFragment.StringFragment sf = new ContextFragment.StringFragment(mockContextManager, "Test string fragment content", "TestSF", SyntaxConstants.SYNTAX_STYLE_NONE);
         ContextFragment.ProjectPathFragment pf = new ContextFragment.ProjectPathFragment(dummyFile, mockContextManager);
@@ -596,7 +594,6 @@ public class ContextSerializationTest {
     @Test
     void testFragmentInterningDuringDeserialization() throws IOException {
         var context1 = new Context(mockContextManager, "Context 1");
-        var history = new ContextHistory(context1);
         var projectFile = new ProjectFile(tempDir, "shared.txt");
         Files.writeString(projectFile.absPath(), "shared content");
 
@@ -615,7 +612,7 @@ public class ContextSerializationTest {
         var updatedContext1 = context1
                 .addEditableFiles(List.of(liveProjectPathFragment))
                 .addVirtualFragment(liveStringFragment);
-        history.setInitialContext(updatedContext1.freeze());
+        var history = new ContextHistory(updatedContext1);
 
         // Context 2 also uses the same live instances
         var context2 = new Context(mockContextManager, "Context 2")
@@ -676,11 +673,10 @@ public class ContextSerializationTest {
         String sharedTaskFragmentId = sharedTaskFragment.id();
 
         var ctxWithTask1 = new Context(mockContextManager, "CtxTask1");
-        var origHistoryWithTask = new ContextHistory(ctxWithTask1);
         var taskEntry = new TaskEntry(1, sharedTaskFragment, null);
 
         var updatedCtxWithTask1 = ctxWithTask1.addHistoryEntry(taskEntry, sharedTaskFragment, CompletableFuture.completedFuture("action1"));
-        origHistoryWithTask.setInitialContext(updatedCtxWithTask1.freeze());
+        var origHistoryWithTask = new ContextHistory(updatedCtxWithTask1);
 
         var ctxWithTask2 = new Context(mockContextManager, "CtxTask2")
                 .addHistoryEntry(taskEntry, sharedTaskFragment, CompletableFuture.completedFuture("action2"));
@@ -820,7 +816,6 @@ public class ContextSerializationTest {
         // Create some history content
         Context context = new Context(mockContextManager, "Test content");
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
         sessionManager.saveHistory(originalHistory, originalId);
         
         SessionInfo copiedSessionInfo = sessionManager.copySession(originalId, "Copied Session");
@@ -871,7 +866,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test GitFileFragment")
                 .addReadonlyFiles(List.of(fragment));
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_gitfile_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -898,7 +892,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test ExternalPathFragment")
                 .addReadonlyFiles(List.of(fragment));
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_externalpath_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -928,7 +921,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test ImageFileFragment")
                 .addReadonlyFiles(List.of(fragment));
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_imagefile_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -971,7 +963,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test SearchFragment")
                 .addVirtualFragment(fragment);
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_search_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -996,7 +987,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test SkeletonFragment")
                 .addVirtualFragment(fragment);
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_skeleton_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -1028,7 +1018,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test UsageFragment")
                 .addVirtualFragment(fragment);
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_usage_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -1058,7 +1047,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test CallGraphFragment")
                 .addVirtualFragment(fragment);
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_callgraph_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -1095,7 +1083,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test HistoryFragment")
                 .addVirtualFragment(fragment);
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_history_frag_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -1117,7 +1104,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test PasteTextFragment")
                 .addVirtualFragment(fragment);
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_pastetext_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -1146,7 +1132,6 @@ public class ContextSerializationTest {
         var context = new Context(mockContextManager, "Test StacktraceFragment")
                 .addVirtualFragment(fragment);
         ContextHistory originalHistory = new ContextHistory(context);
-        originalHistory.setInitialContext(context.freeze());
 
         Path zipFile = tempDir.resolve("test_stacktrace_history.zip");
         HistoryIo.writeZip(originalHistory, zipFile);
@@ -1167,7 +1152,6 @@ public class ContextSerializationTest {
     @Test
     void testVirtualFragmentDeduplicationAfterSerialization() throws Exception {
         var context = new Context(mockContextManager, "Test Deduplication");
-        ContextHistory originalHistory = new ContextHistory(context);
 
         // Add virtual fragments, some with duplicate text content
         // The IDs will be 3, 4, 5, 6, 7 based on current setup
@@ -1183,7 +1167,7 @@ public class ContextSerializationTest {
         context = context.addVirtualFragment(vf4_duplicate_of_vf2);
         context = context.addVirtualFragment(vf5_duplicate_of_vf1);
 
-        originalHistory.setInitialContext(context.freeze());
+        ContextHistory originalHistory = new ContextHistory(context);
 
         // Serialize and deserialize
         Path zipFile = tempDir.resolve("deduplication_test_history.zip");


### PR DESCRIPTION
- Moved `liveContext` to `ContextHistory`.
- Using a new `ContextHistory` instance instead of mutating existing one when changing sessions.

We should also probably revisit the logic related to `pushContext` in `ContextManager` to confirm that no race conditions exist there, but it will be a bit easier to follow up and improve that now too if needed.