### PR TITLE
enh: Improve BuildAgent instructions and add quiet flags

### DIFF
--- a/.brokk/project.properties
+++ b/.brokk/project.properties
@@ -1,6 +1,6 @@
 #Brokk project configuration
-#Thu Jul 24 08:00:45 CEST 2025
-buildDetailsJson={"buildLintCommand"\:"./gradlew classes","testAllCommand"\:"./gradlew test","testSomeCommand"\:"./gradlew test{{\#classes}} --tests {{value}}{{/classes}}","excludedDirectories"\:[".gradle","/dist","/nbbuild","/nbproject/private",".vscode","/workspace","build","/nbdist","build-logic/.gradle","/.nb-gradle",".idea",".direnv"]}
+#Thu Jul 31 15:34:54 CLT 2025
+buildDetailsJson={"buildLintCommand"\:"./gradlew --quiet classes","testAllCommand"\:"./gradlew --quiet test","testSomeCommand"\:"./gradlew --quiet test{{\#classes}} --tests {{value}}{{/classes}}","excludedDirectories"\:[".gradle","project/.bloop",".vscode","bin",".bsp","/nbdist","build-logic/.gradle","project/project","cli/build",".bloop",".direnv","out","target","/dist","/nbbuild","/nbproject/private","/workspace","build","/.nb-gradle",".idea",".metals",".settings"]}
 codeAgentTestScope=WORKSPACE
 code_intelligence_language=JAVA
 code_intelligence_refresh=AUTO

--- a/app/src/main/java/io/github/jbellis/brokk/agents/BuildAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/BuildAgent.java
@@ -233,7 +233,7 @@ public class BuildAgent {
                                        Use the tools to examine build files (like `pom.xml`, `build.gradle`, etc.), configuration files, and linting files,
                                        as necessary, to determine the information needed by `reportBuildDetails`.
 
-                                       When selecting build or test commands, prefer flags or sub-commands that minimise console output (for example, Maven -q, Gradle --quiet, npm test --silent).
+                                       When selecting build or test commands, prefer flags or sub-commands that minimise console output (for example, Maven -q, Gradle --quiet, npm test --silent, sbt -error).
                                        Avoid verbose flags such as --info, --debug, or -X unless they are strictly required for correct operation.
 
                                        The lists are DecoratedCollection instances, so you get first/last/index/value fields.
@@ -241,8 +241,8 @@ public class BuildAgent {
 
                                        | Build tool        | One-liner a user could write
                                        | ----------------- | ------------------------------------------------------------------------
-                                       | **SBT**           | `sbt "testOnly{{#classes}} {{value}}{{/classes}}"`
-                                       | **Maven**         | `mvn -q test -Dtest={{#classes}}{{value}}{{^-last}},{{/-last}}{{/classes}}`
+                                       | **SBT**           | `sbt -error "testOnly{{#classes}} {{value}}{{/classes}}"`
+                                       | **Maven**         | `mvn --quiet test -Dtest={{#classes}}{{value}}{{^-last}},{{/-last}}{{/classes}}`
                                        | **Gradle**        | `gradle --quiet test{{#classes}} --tests {{value}}{{/classes}}`
                                        | **Go**            | `go test -run '{{#classes}}{{value}}{{^-last}} | {{/-last}}{{/classes}}`
                                        | **.NET CLI**      | `dotnet test --filter "{{#classes}}FullyQualifiedName\\~{{value}}{{^-last}} | {{/-last}}{{/classes}}"`


### PR DESCRIPTION
### Pull Request Description

**Intent:**  
This update refines the BuildAgent to prioritize a cleaner, more efficient local development experience by minimizing console output in build and test commands, and favoring project-specific wrapper scripts over global ones.
Fixes #551

**Behavior Changes:**  
- Build and test commands now include quiet flags (e.g., Maven's -q or Gradle's --quiet) to reduce verbosity, making output more manageable.  
- Commands prefer wrapper scripts like ./gradlew or ./mvnw if available, falling back to bare commands only when necessary.  

**Key Implementation Ideas:**  
- Updated the agent's prompt string to embed preferences for quiet modes and wrapper scripts, with revised examples in the command table.  


