### PR TITLE
Enhanced Git file history: accurate paths, rename tracking

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/GitHistoryTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/GitHistoryTab.java
@@ -43,8 +43,6 @@ public class GitHistoryTab extends JPanel {
         return file.toString();
     }
 
-    /* -----------------------  UI construction  ----------------------- */
-
     private void buildHistoryTabUI()
     {
         fileHistoryModel = new DefaultTableModel(
@@ -64,8 +62,6 @@ public class GitHistoryTab extends JPanel {
             fileHistoryTable.getColumnModel().getColumn(col).setMaxWidth(0);
             fileHistoryTable.getColumnModel().getColumn(col).setWidth(0);
         }
-
-        /* -------- context menu -------- */
 
         var menu                  = new JPopupMenu();
         chrome.themeManager.registerPopupMenu(menu);
@@ -121,7 +117,7 @@ public class GitHistoryTab extends JPanel {
             }
         });
 
-        /* double-click → show diff */
+        /* double-click => show diff */
         fileHistoryTable.addMouseListener(new java.awt.event.MouseAdapter() {
             @Override public void mouseClicked(java.awt.event.MouseEvent e) {
                 if (e.getClickCount() != 2) return;
@@ -134,8 +130,6 @@ public class GitHistoryTab extends JPanel {
                 GitUiUtil.showFileHistoryDiff(contextManager, chrome, commitId, histFile);
             }
         });
-
-        /* ----- context-menu actions ----- */
 
         captureDiffItem.addActionListener(e -> {
             int row = fileHistoryTable.getSelectedRow();
@@ -183,8 +177,6 @@ public class GitHistoryTab extends JPanel {
 
         add(new JScrollPane(fileHistoryTable), BorderLayout.CENTER);
     }
-
-    /* -----------------------  data loading  ----------------------- */
 
     private void loadFileHistory()
     {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/GitHistoryTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/GitHistoryTab.java
@@ -19,17 +19,22 @@ public class GitHistoryTab extends JPanel {
 
     private final Chrome chrome;
     private final ContextManager contextManager;
-    private final GitPanel gitPanel; // Parent panel to call back for Log tab interaction
+    private final GitPanel gitPanel;
     private final ProjectFile file;
+
     private JTable fileHistoryTable;
     private DefaultTableModel fileHistoryModel;
 
-    public GitHistoryTab(Chrome chrome, ContextManager contextManager, GitPanel gitPanel, ProjectFile file) {
+    public GitHistoryTab(Chrome chrome,
+                         ContextManager contextManager,
+                         GitPanel gitPanel,
+                         ProjectFile file)
+    {
         super(new BorderLayout());
-        this.chrome = chrome;
-        this.contextManager = contextManager;
-        this.gitPanel = gitPanel;
-        this.file = file;
+        this.chrome          = chrome;
+        this.contextManager  = contextManager;
+        this.gitPanel        = gitPanel;
+        this.file            = file;
         buildHistoryTabUI();
         loadFileHistory();
     }
@@ -38,194 +43,193 @@ public class GitHistoryTab extends JPanel {
         return file.toString();
     }
 
+    /* -----------------------  UI construction  ----------------------- */
+
     private void buildHistoryTabUI()
     {
         fileHistoryModel = new DefaultTableModel(
-                new Object[]{"Message", "Author", "Date", "ID"}, 0
-        ) {
-            @Override public boolean isCellEditable(int row, int column) { return false; }
-            @Override public Class<?> getColumnClass(int columnIndex) { return String.class; }
+                new Object[]{"Message", "Author", "Date", "ID", "Path"}, 0)
+        {
+            @Override public boolean isCellEditable(int r, int c) { return false; }
+            @Override public Class<?> getColumnClass(int c) { return String.class; }
         };
 
         fileHistoryTable = new JTable(fileHistoryModel);
         fileHistoryTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         fileHistoryTable.setRowHeight(18);
 
-        // Hide the ID column
-        fileHistoryTable.getColumnModel().getColumn(3).setMinWidth(0);
-        fileHistoryTable.getColumnModel().getColumn(3).setMaxWidth(0);
-        fileHistoryTable.getColumnModel().getColumn(3).setWidth(0);
+        // Hide the “ID” and “Path” columns
+        for (int col : new int[]{3, 4}) {
+            fileHistoryTable.getColumnModel().getColumn(col).setMinWidth(0);
+            fileHistoryTable.getColumnModel().getColumn(col).setMaxWidth(0);
+            fileHistoryTable.getColumnModel().getColumn(col).setWidth(0);
+        }
 
-        // Context menu
-        JPopupMenu historyContextMenu = new JPopupMenu();
-        chrome.themeManager.registerPopupMenu(historyContextMenu);
+        /* -------- context menu -------- */
 
-        JMenuItem addToContextItem       = new JMenuItem("Capture Diff");
-        JMenuItem compareWithLocalItem   = new JMenuItem("Compare with Local");
-        JMenuItem viewFileAtRevisionItem = new JMenuItem("View File at Revision");
-        JMenuItem viewDiffItem           = new JMenuItem("View Diff");
-        JMenuItem viewInLogItem          = new JMenuItem("View in Log");
-        JMenuItem editFileItem           = new JMenuItem("Edit File");
+        var menu                  = new JPopupMenu();
+        chrome.themeManager.registerPopupMenu(menu);
 
-        historyContextMenu.add(addToContextItem);
-        historyContextMenu.add(editFileItem);
-        historyContextMenu.addSeparator();
-        historyContextMenu.add(viewInLogItem);
-        historyContextMenu.addSeparator();
-        historyContextMenu.add(viewFileAtRevisionItem);
-        historyContextMenu.add(viewDiffItem);
-        historyContextMenu.add(compareWithLocalItem);
+        var captureDiffItem       = new JMenuItem("Capture Diff");
+        var compareWithLocalItem  = new JMenuItem("Compare with Local");
+        var viewFileAtRevItem     = new JMenuItem("View File at Revision");
+        var viewDiffItem          = new JMenuItem("View Diff");
+        var viewInLogItem         = new JMenuItem("View in Log");
+        var editFileItem          = new JMenuItem("Edit File");
 
-        // Right-click => select row
-        historyContextMenu.addPopupMenuListener(new javax.swing.event.PopupMenuListener() {
-            @Override
-            public void popupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent e) {
+        menu.add(captureDiffItem);
+        menu.add(editFileItem);
+        menu.addSeparator();
+        menu.add(viewInLogItem);
+        menu.addSeparator();
+        menu.add(viewFileAtRevItem);
+        menu.add(viewDiffItem);
+        menu.add(compareWithLocalItem);
+
+        /* right-click selects row */
+        menu.addPopupMenuListener(new javax.swing.event.PopupMenuListener() {
+            @Override public void popupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent e) {
                 SwingUtilities.invokeLater(() -> {
-                    Point point = MouseInfo.getPointerInfo().getLocation();
-                    SwingUtilities.convertPointFromScreen(point, fileHistoryTable);
-                    int row = fileHistoryTable.rowAtPoint(point);
-                    if (row >= 0) {
-                        fileHistoryTable.setRowSelectionInterval(row, row);
-                    }
+                    var p = MouseInfo.getPointerInfo().getLocation();
+                    SwingUtilities.convertPointFromScreen(p, fileHistoryTable);
+                    int row = fileHistoryTable.rowAtPoint(p);
+                    if (row >= 0) fileHistoryTable.setRowSelectionInterval(row, row);
                 });
             }
             @Override public void popupMenuWillBecomeInvisible(javax.swing.event.PopupMenuEvent e) {}
             @Override public void popupMenuCanceled(javax.swing.event.PopupMenuEvent e) {}
         });
 
-        fileHistoryTable.setComponentPopupMenu(historyContextMenu);
+        fileHistoryTable.setComponentPopupMenu(menu);
 
-        // Enable/disable items based on selection
+        /* enable / disable menu items */
         fileHistoryTable.getSelectionModel().addListSelectionListener(e -> {
-            if (!e.getValueIsAdjusting()) {
-                int selectedRowCount = fileHistoryTable.getSelectedRowCount();
-                boolean singleSelected = selectedRowCount == 1;
+            if (e.getValueIsAdjusting()) return;
+            boolean single = fileHistoryTable.getSelectedRowCount() == 1;
 
-                addToContextItem.setEnabled(singleSelected);
-                compareWithLocalItem.setEnabled(singleSelected);
-                viewFileAtRevisionItem.setEnabled(singleSelected);
-                viewDiffItem.setEnabled(singleSelected);
-                viewInLogItem.setEnabled(singleSelected);
+            captureDiffItem.setEnabled(single);
+            compareWithLocalItem.setEnabled(single);
+            viewFileAtRevItem.setEnabled(single);
+            viewDiffItem.setEnabled(single);
+            viewInLogItem.setEnabled(single);
 
-                // Edit File => only if not already in context
-                if (singleSelected) {
-                    var selectedFile = contextManager.toFile(getFilePath());
-                    editFileItem.setEnabled(!contextManager.getEditableFiles().contains(selectedFile));
-                } else {
-                    editFileItem.setEnabled(false);
-                }
+            if (single) {
+                var selFile = contextManager.toFile(getFilePath());
+                editFileItem.setEnabled(!contextManager.getEditableFiles().contains(selFile));
+            } else {
+                editFileItem.setEnabled(false);
             }
         });
 
-        // Double-click => show diff
+        /* double-click → show diff */
         fileHistoryTable.addMouseListener(new java.awt.event.MouseAdapter() {
-            @Override
-            public void mouseClicked(java.awt.event.MouseEvent e) {
-                if (e.getClickCount() == 2) {
-                    int row = fileHistoryTable.rowAtPoint(e.getPoint());
-                    if (row >= 0) {
-                        fileHistoryTable.setRowSelectionInterval(row, row);
-                        String commitId = (String) fileHistoryModel.getValueAt(row, 3);
-                        GitUiUtil.showFileHistoryDiff(contextManager, chrome, commitId, file);
-                    }
-                }
+            @Override public void mouseClicked(java.awt.event.MouseEvent e) {
+                if (e.getClickCount() != 2) return;
+                int row = fileHistoryTable.rowAtPoint(e.getPoint());
+                if (row < 0) return;
+
+                fileHistoryTable.setRowSelectionInterval(row, row);
+                var commitId = (String) fileHistoryModel.getValueAt(row, 3);
+                var histFile = (ProjectFile) fileHistoryModel.getValueAt(row, 4);
+                GitUiUtil.showFileHistoryDiff(contextManager, chrome, commitId, histFile);
             }
         });
 
-        // Menu actions:
-        addToContextItem.addActionListener(e -> {
+        /* ----- context-menu actions ----- */
+
+        captureDiffItem.addActionListener(e -> {
             int row = fileHistoryTable.getSelectedRow();
-            if (row >= 0) {
-                String commitId = (String) fileHistoryModel.getValueAt(row, 3);
-                GitUiUtil.addFileChangeToContext(contextManager, chrome, commitId, file);
-            }
+            if (row < 0) return;
+            var commitId = (String) fileHistoryModel.getValueAt(row, 3);
+            var histFile = (ProjectFile) fileHistoryModel.getValueAt(row, 4);
+            GitUiUtil.addFileChangeToContext(contextManager, chrome, commitId, histFile);
         });
 
-        viewFileAtRevisionItem.addActionListener(e -> {
+        viewFileAtRevItem.addActionListener(e -> {
             int row = fileHistoryTable.getSelectedRow();
-            if (row >= 0) {
-                String commitId = (String) fileHistoryTable.getValueAt(row, 3);
-                GitUiUtil.viewFileAtRevision(contextManager, chrome, commitId, getFilePath());
-            }
+            if (row < 0) return;
+            var commitId = (String) fileHistoryTable.getValueAt(row, 3);
+            var histFile = (ProjectFile) fileHistoryTable.getValueAt(row, 4);
+            GitUiUtil.viewFileAtRevision(contextManager, chrome, commitId, histFile.toString());
         });
 
         viewDiffItem.addActionListener(e -> {
             int row = fileHistoryTable.getSelectedRow();
-            if (row >= 0) {
-                String commitId = (String) fileHistoryTable.getValueAt(row, 3);
-                GitUiUtil.showFileHistoryDiff(contextManager, chrome, commitId, file);
-            }
+            if (row < 0) return;
+            var commitId = (String) fileHistoryTable.getValueAt(row, 3);
+            var histFile = (ProjectFile) fileHistoryTable.getValueAt(row, 4);
+            GitUiUtil.showFileHistoryDiff(contextManager, chrome, commitId, histFile);
         });
 
         compareWithLocalItem.addActionListener(e -> {
             int row = fileHistoryTable.getSelectedRow();
-            if (row >= 0) {
-                String commitId = (String) fileHistoryTable.getValueAt(row, 3);
-                // Compare commit -> local
-                GitUiUtil.showDiffVsLocal(contextManager, chrome,
-                                          commitId, getFilePath(), /*useParent=*/ false);
-            }
+            if (row < 0) return;
+            var commitId = (String) fileHistoryTable.getValueAt(row, 3);
+            var histFile = (ProjectFile) fileHistoryTable.getValueAt(row, 4);
+            GitUiUtil.showDiffVsLocal(contextManager, chrome,
+                                      commitId, histFile.toString(), false);
         });
 
         viewInLogItem.addActionListener(e -> {
             int row = fileHistoryTable.getSelectedRow();
             if (row >= 0) {
-                String commitId = (String) fileHistoryTable.getValueAt(row, 3);
+                var commitId = (String) fileHistoryTable.getValueAt(row, 3);
                 gitPanel.showCommitInLogTab(commitId);
             }
         });
 
         editFileItem.addActionListener(e ->
-                                               GitUiUtil.editFile(contextManager, getFilePath())
-        );
+                GitUiUtil.editFile(contextManager, getFilePath()));
 
         add(new JScrollPane(fileHistoryTable), BorderLayout.CENTER);
     }
 
+    /* -----------------------  data loading  ----------------------- */
 
-    private void loadFileHistory() {
+    private void loadFileHistory()
+    {
         contextManager.submitBackgroundTask("Loading file history: " + file, () -> {
             try {
-                var repo = getRepo();
-                var history = repo.getFileHistory(file);
+                var history = getRepo().getFileHistoryWithPaths(file);
                 SwingUtilities.invokeLater(() -> {
                     fileHistoryModel.setRowCount(0);
                     if (history.isEmpty()) {
-                        fileHistoryModel.addRow(new Object[]{"No history found", "", "", ""});
+                        fileHistoryModel.addRow(
+                                new Object[]{"No history found", "", "", "", ""});
                         return;
                     }
 
-                    var today = java.time.LocalDate.now(java.time.ZoneId.systemDefault());
-                    for (var commit : history) {
-                        var formattedDate = GitUiUtil.formatRelativeDate(commit.date(), today);
+                    var today = java.time.LocalDate.now(
+                            java.time.ZoneId.systemDefault());
+
+                    for (var entry : history) {
+                        var date = GitUiUtil.formatRelativeDate(
+                                entry.commit().date(), today);
                         fileHistoryModel.addRow(new Object[]{
-                                commit.message(),
-                                commit.author(),
-                                formattedDate,
-                                commit.id()
+                                entry.commit().message(),
+                                entry.commit().author(),
+                                date,
+                                entry.commit().id(),
+                                entry.path()
                         });
                     }
 
-                    // Now that data is loaded, adjust column widths
-                    TableUtils.fitColumnWidth(fileHistoryTable, 1); // author column
-                    TableUtils.fitColumnWidth(fileHistoryTable, 2); // date column
+                    TableUtils.fitColumnWidth(fileHistoryTable, 1);
+                    TableUtils.fitColumnWidth(fileHistoryTable, 2);
                 });
-            } catch (Exception e) {
-                logger.error("Error loading file history for: {}", file, e);
+            } catch (Exception ex) {
+                logger.error("Error loading file history for: {}", file, ex);
                 SwingUtilities.invokeLater(() -> {
                     fileHistoryModel.setRowCount(0);
                     fileHistoryModel.addRow(new Object[]{
-                            "Error loading history: " + e.getMessage(), "", "", ""
-                    });
+                            "Error loading history: " + ex.getMessage(),
+                            "", "", "", ""});
                 });
             }
             return null;
         });
     }
 
-    /**
-     * Returns the current GitRepo from ContextManager.
-     */
     private GitRepo getRepo() {
         return (GitRepo) contextManager.getProject().getRepo();
     }

--- a/app/src/test/java/io/github/jbellis/brokk/git/GitRepoFileHistoryTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/git/GitRepoFileHistoryTest.java
@@ -1,0 +1,252 @@
+package io.github.jbellis.brokk.git;
+
+import io.github.jbellis.brokk.analyzer.ProjectFile;
+import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for GitRepo file history with rename following functionality.
+ */
+public class GitRepoFileHistoryTest {
+    private Path projectRoot;
+    private GitRepo repo;
+    private Git git;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        projectRoot = tempDir.resolve("testRepo");
+        Files.createDirectories(projectRoot);
+
+        git = Git.init().setDirectory(projectRoot.toFile()).call();
+
+        // Create initial commit with a file
+        var initialFile = projectRoot.resolve("original.txt");
+        Files.writeString(initialFile, "Initial content");
+        git.add().addFilepattern("original.txt").call();
+        git.commit()
+           .setMessage("Initial commit")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        repo = new GitRepo(projectRoot);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        GitTestCleanupUtil.cleanupGitResources(repo);
+        if (git != null) {
+            git.close();
+        }
+    }
+
+    @Test
+    void testSimpleRename() throws Exception {
+        // Modify and rename file
+        var originalFile = projectRoot.resolve("original.txt");
+        Files.writeString(originalFile, "Modified content");
+        git.add().addFilepattern("original.txt").call();
+        git.commit()
+           .setMessage("Modify file")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        // Rename the file using git mv to ensure rename detection
+        git.rm().addFilepattern("original.txt").call();
+        var renamedFile = projectRoot.resolve("renamed.txt");
+        Files.writeString(renamedFile, "Modified content");
+        git.add().addFilepattern("renamed.txt").call();
+        git.commit()
+           .setMessage("Rename file")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        // Test getFileHistoryWithPaths
+        var currentFile = new ProjectFile(projectRoot, "renamed.txt");
+        var history = repo.getFileHistoryWithPaths(currentFile);
+
+        assertEquals(3, history.size(), "Should have 3 commits in history");
+
+        // Most recent commit should use current name
+        assertEquals("renamed.txt", history.get(0).path().toString());
+        assertEquals("Rename file", history.get(0).commit().message());
+
+        // Middle commit should use original name (before rename)
+        assertEquals("original.txt", history.get(1).path().toString());
+        assertEquals("Modify file", history.get(1).commit().message());
+
+        // Initial commit should use original name
+        assertEquals("original.txt", history.get(2).path().toString());
+        assertEquals("Initial commit", history.get(2).commit().message());
+    }
+
+    @Test
+    void testMultipleRenames() throws Exception {
+        // Create chain of renames: original.txt -> middle.txt -> final.txt
+        var originalFile = projectRoot.resolve("original.txt");
+
+        // First rename: original.txt -> middle.txt
+        git.rm().addFilepattern("original.txt").call();
+        var middleFile = projectRoot.resolve("middle.txt");
+        Files.writeString(middleFile, "Initial content");
+        git.add().addFilepattern("middle.txt").call();
+        git.commit()
+           .setMessage("First rename")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        // Second rename: middle.txt -> final.txt
+        git.rm().addFilepattern("middle.txt").call();
+        var finalFile = projectRoot.resolve("final.txt");
+        Files.writeString(finalFile, "Initial content");
+        git.add().addFilepattern("final.txt").call();
+        git.commit()
+           .setMessage("Second rename")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        var currentFile = new ProjectFile(projectRoot, "final.txt");
+        var history = repo.getFileHistoryWithPaths(currentFile);
+
+        assertEquals(3, history.size(), "Should have 3 commits in history");
+
+        // Most recent: final.txt
+        assertEquals("final.txt", history.get(0).path().toString());
+        assertEquals("Second rename", history.get(0).commit().message());
+
+        // Middle: middle.txt
+        assertEquals("middle.txt", history.get(1).path().toString());
+        assertEquals("First rename", history.get(1).commit().message());
+
+        // Oldest: original.txt
+        assertEquals("original.txt", history.get(2).path().toString());
+        assertEquals("Initial commit", history.get(2).commit().message());
+    }
+
+    @Test
+    void testRenameWithTwoParents() throws Exception {
+        // First modify the original file to create some history
+        var originalFile = projectRoot.resolve("original.txt");
+        Files.writeString(originalFile, "Modified content");
+        git.add().addFilepattern("original.txt").call();
+        git.commit()
+           .setMessage("Modify original file")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        // Then rename it
+        git.rm().addFilepattern("original.txt").call();
+        var renamedFile = projectRoot.resolve("renamed.txt");
+        Files.writeString(renamedFile, "Modified content");
+        git.add().addFilepattern("renamed.txt").call();
+        git.commit()
+           .setMessage("Rename file")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        var currentFile = new ProjectFile(projectRoot, "renamed.txt");
+        var history = repo.getFileHistoryWithPaths(currentFile);
+
+        assertEquals(3, history.size(), "Should have 3 commits in history");
+
+        // Verify the rename was detected and paths are correct
+        assertEquals("renamed.txt", history.get(0).path().toString());
+        assertEquals("Rename file", history.get(0).commit().message());
+
+        assertEquals("original.txt", history.get(1).path().toString());
+        assertEquals("Modify original file", history.get(1).commit().message());
+
+        assertEquals("original.txt", history.get(2).path().toString());
+        assertEquals("Initial commit", history.get(2).commit().message());
+    }
+
+    @Test
+    void testNoRenameScenario() throws Exception {
+        // Just modify file without renaming
+        var file = projectRoot.resolve("original.txt");
+        Files.writeString(file, "Modified content");
+        git.add().addFilepattern("original.txt").call();
+        git.commit()
+           .setMessage("Modify file")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        var currentFile = new ProjectFile(projectRoot, "original.txt");
+        var history = repo.getFileHistoryWithPaths(currentFile);
+
+        assertEquals(2, history.size(), "Should have 2 commits in history");
+
+        // All entries should have same path since no rename occurred
+        for (var entry : history) {
+            assertEquals("original.txt", entry.path().toString(),
+                        "All entries should have original path");
+        }
+    }
+
+    @Test
+    void testRootCommitHandling() throws Exception {
+        // Test with just the initial commit (no parents)
+        var currentFile = new ProjectFile(projectRoot, "original.txt");
+        var history = repo.getFileHistoryWithPaths(currentFile);
+
+        assertEquals(1, history.size(), "Should have 1 commit in history");
+        assertEquals("original.txt", history.get(0).path().toString());
+        assertEquals("Initial commit", history.get(0).commit().message());
+    }
+
+    @Test
+    void testNonExistentFile() throws Exception {
+        var nonExistentFile = new ProjectFile(projectRoot, "nonexistent.txt");
+        var history = repo.getFileHistoryWithPaths(nonExistentFile);
+
+        assertTrue(history.isEmpty(), "History should be empty for non-existent file");
+    }
+
+    @Test
+    void testFileWithSubdirectoryRename() throws Exception {
+        // Create subdirectory and move file there
+        var subDir = projectRoot.resolve("subdir");
+        Files.createDirectories(subDir);
+
+        git.rm().addFilepattern("original.txt").call();
+        var movedFile = subDir.resolve("moved.txt");
+        Files.writeString(movedFile, "Initial content");
+        git.add().addFilepattern("subdir/moved.txt").call();
+        git.commit()
+           .setMessage("Move to subdirectory")
+           .setAuthor("Test User", "test@example.com")
+           .setSign(false)
+           .call();
+
+        var currentFile = new ProjectFile(projectRoot, "subdir/moved.txt");
+        var history = repo.getFileHistoryWithPaths(currentFile);
+
+        assertEquals(2, history.size(), "Should have 2 commits in history");
+
+        // Most recent should be in subdirectory
+        assertEquals("subdir/moved.txt", history.get(0).path().toString());
+        assertEquals("Move to subdirectory", history.get(0).commit().message());
+
+        // Original should be at root
+        assertEquals("original.txt", history.get(1).path().toString());
+        assertEquals("Initial commit", history.get(1).commit().message());
+    }
+}

--- a/app/src/test/java/io/github/jbellis/brokk/git/GitRepoFileHistoryTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/git/GitRepoFileHistoryTest.java
@@ -81,15 +81,15 @@ public class GitRepoFileHistoryTest {
         assertEquals(3, history.size(), "Should have 3 commits in history");
 
         // Most recent commit should use current name
-        assertEquals("renamed.txt", history.get(0).path().toString());
+        assertEquals(Path.of("renamed.txt"), history.get(0).path().getRelPath());
         assertEquals("Rename file", history.get(0).commit().message());
 
         // Middle commit should use original name (before rename)
-        assertEquals("original.txt", history.get(1).path().toString());
+        assertEquals(Path.of("original.txt"), history.get(1).path().getRelPath());
         assertEquals("Modify file", history.get(1).commit().message());
 
         // Initial commit should use original name
-        assertEquals("original.txt", history.get(2).path().toString());
+        assertEquals(Path.of("original.txt"), history.get(2).path().getRelPath());
         assertEquals("Initial commit", history.get(2).commit().message());
     }
 
@@ -126,15 +126,15 @@ public class GitRepoFileHistoryTest {
         assertEquals(3, history.size(), "Should have 3 commits in history");
 
         // Most recent: final.txt
-        assertEquals("final.txt", history.get(0).path().toString());
+        assertEquals(Path.of("final.txt"), history.get(0).path().getRelPath());
         assertEquals("Second rename", history.get(0).commit().message());
 
         // Middle: middle.txt
-        assertEquals("middle.txt", history.get(1).path().toString());
+        assertEquals(Path.of("middle.txt"), history.get(1).path().getRelPath());
         assertEquals("First rename", history.get(1).commit().message());
 
         // Oldest: original.txt
-        assertEquals("original.txt", history.get(2).path().toString());
+        assertEquals(Path.of("original.txt"), history.get(2).path().getRelPath());
         assertEquals("Initial commit", history.get(2).commit().message());
     }
 
@@ -167,13 +167,13 @@ public class GitRepoFileHistoryTest {
         assertEquals(3, history.size(), "Should have 3 commits in history");
 
         // Verify the rename was detected and paths are correct
-        assertEquals("renamed.txt", history.get(0).path().toString());
+        assertEquals(Path.of("renamed.txt"), history.get(0).path().getRelPath());
         assertEquals("Rename file", history.get(0).commit().message());
 
-        assertEquals("original.txt", history.get(1).path().toString());
+        assertEquals(Path.of("original.txt"), history.get(1).path().getRelPath());
         assertEquals("Modify original file", history.get(1).commit().message());
 
-        assertEquals("original.txt", history.get(2).path().toString());
+        assertEquals(Path.of("original.txt"), history.get(2).path().getRelPath());
         assertEquals("Initial commit", history.get(2).commit().message());
     }
 
@@ -196,7 +196,7 @@ public class GitRepoFileHistoryTest {
 
         // All entries should have same path since no rename occurred
         for (var entry : history) {
-            assertEquals("original.txt", entry.path().toString(),
+            assertEquals(Path.of("original.txt"), entry.path().getRelPath(),
                         "All entries should have original path");
         }
     }
@@ -208,7 +208,7 @@ public class GitRepoFileHistoryTest {
         var history = repo.getFileHistoryWithPaths(currentFile);
 
         assertEquals(1, history.size(), "Should have 1 commit in history");
-        assertEquals("original.txt", history.get(0).path().toString());
+        assertEquals(Path.of("original.txt"), history.get(0).path().getRelPath());
         assertEquals("Initial commit", history.get(0).commit().message());
     }
 
@@ -242,11 +242,11 @@ public class GitRepoFileHistoryTest {
         assertEquals(2, history.size(), "Should have 2 commits in history");
 
         // Most recent should be in subdirectory
-        assertEquals("subdir/moved.txt", history.get(0).path().toString());
+        assertEquals(Path.of("subdir", "moved.txt"), history.get(0).path().getRelPath());
         assertEquals("Move to subdirectory", history.get(0).commit().message());
 
         // Original should be at root
-        assertEquals("original.txt", history.get(1).path().toString());
+        assertEquals(Path.of("original.txt"), history.get(1).path().getRelPath());
         assertEquals("Initial commit", history.get(1).commit().message());
     }
 }


### PR DESCRIPTION
### Pull Request Description

**Intent:**  
This PR enhances the Git integration to accurately track and display file history across renames, improving the GUI's ability to show the correct file paths for each commit. This helps users navigate file changes more effectively, especially in scenarios involving file renames.

Fixes #552 

**Behavior Changes:**  
- The `GitRepo` class now includes a new method, `getFileHistoryWithPaths`, which returns commit history along with the file's path at each commit, following renames backwards.  
- In `GitHistoryTab`, the history table incorporates per-commit paths (stored but hidden), and context menu actions (e.g., viewing diffs or editing) use these paths, ensuring actions reference the correct historical file location.

**Key Implementation Ideas:**  
- Leverages JGit's DiffFormatter with rename detection to scan commit parents and update file paths dynamically.  
- Iterates through commits in reverse order, checking for renames and building a list of `FileHistoryEntry` records.  
- Updates the GUI's table model and event listeners to handle the new path data without altering the visible UI layout.  

<img width="1051" height="383" alt="screenshot-Brokk Userscquiroz brokkworktreesbrokkwt2-2025-07-29-20-26-43" src="https://github.com/user-attachments/assets/1fb157c7-111d-4b60-8b9a-3ae4147a9e56" />
