### PR TITLE
Disable GPG Signing if Enabled in Config

### DIFF
--- a/app/src/test/java/io/github/jbellis/brokk/GitProjectStateRestorerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/GitProjectStateRestorerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,7 +31,7 @@ public class GitProjectStateRestorerTest {
             var dummyFile = tempDir.resolve("dummy.txt");
             Files.writeString(dummyFile, "dummy");
             r.add(List.of(new ProjectFile(tempDir, Path.of("dummy.txt"))));
-            r.getGit().commit().setMessage("Initial commit").call();
+            r.getGit().commit().setSign(false).setMessage("Initial commit").call();
         }
 
         project = new MainProject(tempDir);
@@ -52,12 +51,12 @@ public class GitProjectStateRestorerTest {
 
         Files.writeString(file, "version 1");
         repo.add(List.of(projectFile));
-        var commit1 = repo.getGit().commit().setMessage("Initial commit").call();
+        var commit1 = repo.getGit().commit().setSign(false).setMessage("Initial commit").call();
         var commit1Id = commit1.getId().getName();
 
         Files.writeString(file, "version 2");
         repo.add(List.of(projectFile));
-        var commit2 = repo.getGit().commit().setMessage("Second commit").call();
+        var commit2 = repo.getGit().commit().setSign(false).setMessage("Second commit").call();
         var commit2Id = commit2.getId().getName();
 
         // now we are at commit 2. create a state for commit 1

--- a/app/src/test/java/io/github/jbellis/brokk/git/GitRepoMergeConflictTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/git/GitRepoMergeConflictTest.java
@@ -1,16 +1,14 @@
 package io.github.jbellis.brokk.git;
 
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,7 +38,7 @@ public class GitRepoMergeConflictTest {
         Path initialFile = tempDir.resolve("initial.txt");
         Files.writeString(initialFile, "initial content\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("initial.txt").call();
-        git.commit().setMessage("Initial commit").call();
+        git.commit().setMessage("Initial commit").setSign(false).call();
     }
 
     @AfterEach
@@ -55,7 +53,7 @@ public class GitRepoMergeConflictTest {
         Path file1 = tempDir.resolve("file1.txt");
         Files.writeString(file1, "branch1 content\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("file1.txt").call();
-        git.commit().setMessage("Add file1").call();
+        git.commit().setMessage("Add file1").setSign(false).call();
         
         // Create branch2 with non-conflicting changes
         git.checkout().setName("master").call();
@@ -63,7 +61,7 @@ public class GitRepoMergeConflictTest {
         Path file2 = tempDir.resolve("file2.txt");
         Files.writeString(file2, "branch2 content\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("file2.txt").call();
-        git.commit().setMessage("Add file2").call();
+        git.commit().setMessage("Add file2").setSign(false).call();
         
         // Test merge conflict check - should be null (no conflicts)
         String result = gitRepo.checkMergeConflicts("branch1", "branch2", GitRepo.MergeMode.MERGE_COMMIT);
@@ -77,14 +75,14 @@ public class GitRepoMergeConflictTest {
         Path sharedFile = tempDir.resolve("shared.txt");
         Files.writeString(sharedFile, "branch1 version\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("shared.txt").call();
-        git.commit().setMessage("Branch1 changes shared file").call();
+        git.commit().setMessage("Branch1 changes shared file").setSign(false).call();
         
         // Create branch2 with conflicting changes to same file
         git.checkout().setName("master").call();
         git.checkout().setCreateBranch(true).setName("branch2").call();
         Files.writeString(sharedFile, "branch2 version\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("shared.txt").call();
-        git.commit().setMessage("Branch2 changes shared file").call();
+        git.commit().setMessage("Branch2 changes shared file").setSign(false).call();
         
         // Test merge conflict check - should detect conflicts
         String result = gitRepo.checkMergeConflicts("branch1", "branch2", GitRepo.MergeMode.MERGE_COMMIT);
@@ -100,7 +98,7 @@ public class GitRepoMergeConflictTest {
         Path file1 = tempDir.resolve("file1.txt");
         Files.writeString(file1, "branch1 content\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("file1.txt").call();
-        git.commit().setMessage("Add file1").call();
+        git.commit().setMessage("Add file1").setSign(false).call();
         
         // Create branch2 with non-conflicting changes
         git.checkout().setName("master").call();
@@ -108,7 +106,7 @@ public class GitRepoMergeConflictTest {
         Path file2 = tempDir.resolve("file2.txt");
         Files.writeString(file2, "branch2 content\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("file2.txt").call();
-        git.commit().setMessage("Add file2").call();
+        git.commit().setMessage("Add file2").setSign(false).call();
         
         // Test squash merge conflict check - should be null (no conflicts)
         String result = gitRepo.checkMergeConflicts("branch1", "branch2", GitRepo.MergeMode.SQUASH_COMMIT);
@@ -122,14 +120,14 @@ public class GitRepoMergeConflictTest {
         Path sharedFile = tempDir.resolve("shared.txt");
         Files.writeString(sharedFile, "branch1 version\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("shared.txt").call();
-        git.commit().setMessage("Branch1 changes shared file").call();
+        git.commit().setMessage("Branch1 changes shared file").setSign(false).call();
         
         // Create branch2 with conflicting changes to same file
         git.checkout().setName("master").call();
         git.checkout().setCreateBranch(true).setName("branch2").call();
         Files.writeString(sharedFile, "branch2 version\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("shared.txt").call();
-        git.commit().setMessage("Branch2 changes shared file").call();
+        git.commit().setMessage("Branch2 changes shared file").setSign(false).call();
         
         // Test squash merge conflict check - should detect conflicts
         String result = gitRepo.checkMergeConflicts("branch1", "branch2", GitRepo.MergeMode.SQUASH_COMMIT);
@@ -145,7 +143,7 @@ public class GitRepoMergeConflictTest {
         Path file1 = tempDir.resolve("file1.txt");
         Files.writeString(file1, "branch1 content\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("file1.txt").call();
-        git.commit().setMessage("Add file1").call();
+        git.commit().setMessage("Add file1").setSign(false).call();
         
         // Create branch2 with non-conflicting changes
         git.checkout().setName("master").call();
@@ -153,7 +151,7 @@ public class GitRepoMergeConflictTest {
         Path file2 = tempDir.resolve("file2.txt");
         Files.writeString(file2, "branch2 content\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("file2.txt").call();
-        git.commit().setMessage("Add file2").call();
+        git.commit().setMessage("Add file2").setSign(false).call();
         
         // Test rebase conflict check - should be null (no conflicts)
         String result = gitRepo.checkMergeConflicts("branch1", "branch2", GitRepo.MergeMode.REBASE_MERGE);
@@ -167,14 +165,14 @@ public class GitRepoMergeConflictTest {
         Path sharedFile = tempDir.resolve("shared.txt");
         Files.writeString(sharedFile, "branch1 version\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("shared.txt").call();
-        git.commit().setMessage("Branch1 changes shared file").call();
+        git.commit().setMessage("Branch1 changes shared file").setSign(false).call();
         
         // Create branch2 with conflicting changes to same file
         git.checkout().setName("master").call();
         git.checkout().setCreateBranch(true).setName("branch2").call();
         Files.writeString(sharedFile, "branch2 version\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("shared.txt").call();
-        git.commit().setMessage("Branch2 changes shared file").call();
+        git.commit().setMessage("Branch2 changes shared file").setSign(false).call();
         
         // Test rebase conflict check - should detect conflicts
         String result = gitRepo.checkMergeConflicts("branch1", "branch2", GitRepo.MergeMode.REBASE_MERGE);
@@ -190,13 +188,13 @@ public class GitRepoMergeConflictTest {
         Path sharedFile = tempDir.resolve("shared.txt");
         Files.writeString(sharedFile, "branch1 version\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("shared.txt").call();
-        git.commit().setMessage("Branch1 changes").call();
+        git.commit().setMessage("Branch1 changes").setSign(false).call();
         
         git.checkout().setName("master").call();
         git.checkout().setCreateBranch(true).setName("branch2").call();
         Files.writeString(sharedFile, "branch2 version\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("shared.txt").call();
-        git.commit().setMessage("Branch2 changes").call();
+        git.commit().setMessage("Branch2 changes").setSign(false).call();
         
         // Store original branch
         String originalBranch = gitRepo.getCurrentBranch();
@@ -223,7 +221,7 @@ public class GitRepoMergeConflictTest {
         Path file1 = tempDir.resolve("feature.txt");
         Files.writeString(file1, "feature content\n", StandardCharsets.UTF_8);
         git.add().addFilepattern("feature.txt").call();
-        git.commit().setMessage("Add feature").call();
+        git.commit().setMessage("Add feature").setSign(false).call();
         
         // Test merge conflict check for fast-forward case
         String result = gitRepo.checkMergeConflicts("feature", "master", GitRepo.MergeMode.MERGE_COMMIT);

--- a/app/src/test/java/io/github/jbellis/brokk/git/GitRepoRemoteMergeTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/git/GitRepoRemoteMergeTest.java
@@ -3,7 +3,6 @@ package io.github.jbellis.brokk.git;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.MergeResult;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.RefSpec;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,10 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -50,6 +48,7 @@ public class GitRepoRemoteMergeTest {
         // Configure user for commits
         localGit.getRepository().getConfig().setString("user", null, "name", "Test User");
         localGit.getRepository().getConfig().setString("user", null, "email", "test@example.com");
+        localGit.getRepository().getConfig().setBoolean("commit", null, "gpgsign", false);
         localGit.getRepository().getConfig().save();
 
         // Create initial commit
@@ -116,7 +115,7 @@ public class GitRepoRemoteMergeTest {
         Path masterFile = tempDir.resolve("master.txt");
         Files.writeString(masterFile, "master content\n", StandardCharsets.UTF_8);
         localGit.add().addFilepattern("master.txt").call();
-        localGit.commit().setMessage("Add master file").call();
+        localGit.commit().setMessage("Add master file").setSign(false).call();
 
         // Fetch remote changes
         localGit.fetch().call();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,6 +80,7 @@ jsoup = "org.jsoup:jsoup:1.19.1"
 
 # Git
 jgit-core = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
+jgit-gpg = { module = "org.eclipse.jgit:org.eclipse.jgit.gpg.bc", version.ref = "jgit" }
 jgit-ssh = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "jgit" }
 bouncycastle = "org.bouncycastle:bcprov-jdk18on:1.80"
 
@@ -114,7 +115,7 @@ junit-runtime = ["junit-platform-engine", "junit-platform-launcher", "junit-plat
 scalatest = ["scalatest-core", "scalatest-junit4", "scalatest-junit5"]
 ui = ["flatlaf", "rsyntaxtextarea", "autocomplete", "jgoodies-forms"]
 markdown = ["flexmark-core", "flexmark-html2md", "mustache"]
-git = ["jgit-core", "jgit-ssh", "bouncycastle"]
+git = ["jgit-core", "jgit-gpg", "jgit-ssh", "bouncycastle"]
 treesitter = ["treesitter-core", "treesitter-java", "treesitter-csharp", "treesitter-go", "treesitter-javascript", "treesitter-php", "treesitter-python", "treesitter-rust", "treesitter-typescript"]
 maven-resolver = ["maven-embedder", "maven-resolver-api", "maven-resolver-spi", "maven-resolver-util", "maven-resolver-impl", "maven-resolver-connector-basic", "maven-resolver-transport-http"]
 


### PR DESCRIPTION
Fixes the issue where commits cannot be made via Git since GPG signing is currently unsupported. As someone who has GPG signing enabled globally, this is fairly important, and also currently fails my Brokk test suite.

Fixing the bug by simply letting unsigned commits is one thing, but supporting GPG signing is a much larger effort, so this is not attempted here. There is a placeholder for keeping the passphrase, but this is what we will need from the user in order to sign commits.

See https://github.com/BrokkAi/brokk/issues/98