### PR TITLE
enh: Rollback changes on a new file should git rm -f it

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -824,7 +824,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
     }
 
     public boolean undoContext() {
-        UndoResult result = contextHistory.undo(1, io);
+        UndoResult result = contextHistory.undo(1, io, project);
         if (result.wasUndone()) {
             notifyContextListeners(topContext());
             project.getSessionManager().saveHistory(contextHistory, currentSessionId); // Save history of frozen contexts
@@ -839,7 +839,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      */
     public Future<?> undoContextUntilAsync(Context targetFrozenContext) {
         return submitUserTask("Undoing", () -> {
-            UndoResult result = contextHistory.undoUntil(targetFrozenContext, io);
+            UndoResult result = contextHistory.undoUntil(targetFrozenContext, io, project);
             if (result.wasUndone()) {
                 notifyContextListeners(topContext());
                 project.getSessionManager().saveHistory(contextHistory, currentSessionId);
@@ -855,7 +855,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      */
     public Future<?> redoContextAsync() {
         return submitUserTask("Redoing", () -> {
-            boolean wasRedone = contextHistory.redo(io);
+            boolean wasRedone = contextHistory.redo(io, project);
             if (wasRedone) {
                 notifyContextListeners(topContext());
                 project.getSessionManager().saveHistory(contextHistory, currentSessionId);

--- a/app/src/main/java/io/github/jbellis/brokk/SessionManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/SessionManager.java
@@ -212,7 +212,7 @@ public class SessionManager implements AutoCloseable
 
     public void saveHistory(ContextHistory ch, UUID sessionId) {
         // ContextHistory is mutable, take a copy before passing it to an async task
-        var contextHistory = new ContextHistory(ch.getHistory(), ch.getResetEdges(), ch.getGitStates());
+        var contextHistory = new ContextHistory(ch.getHistory(), ch.getResetEdges(), ch.getGitStates(), ch.getEntryInfos());
         SessionInfo infoToSave = null;
         SessionInfo currentInfo = sessionsCache.get(sessionId);
         if (currentInfo != null) {

--- a/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -359,6 +359,30 @@ public class GitRepo implements Closeable, IGitRepo {
     }
 
     /**
+     * Forcefully removes files from the working directory and the Git index.
+     * This is equivalent to deleting the files and then running `git rm`.
+     *
+     * @param files The list of files to remove.
+     * @throws GitAPIException if the Git command fails.
+     */
+    @Override
+    public synchronized void forceRemoveFiles(List<ProjectFile> files) throws GitAPIException {
+        try {
+            for (var file : files) {
+                Files.deleteIfExists(file.absPath());
+            }
+            var rmCommand = git.rm();
+            for (var file : files) {
+                rmCommand.addFilepattern(toRepoRelativePath(file));
+            }
+            rmCommand.call();
+            invalidateCaches();
+        } catch (IOException e) {
+            throw new GitWrappedIOException(e);
+        }
+    }
+
+    /**
      * Returns a list of RepoFile objects representing all tracked files in the repository.
      */
     @Override

--- a/app/src/main/java/io/github/jbellis/brokk/git/IGitRepo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/git/IGitRepo.java
@@ -83,6 +83,10 @@ public interface IGitRepo {
         throw new UnsupportedOperationException();
     }
 
+    default void forceRemoveFiles(List<ProjectFile> files) throws GitAPIException {
+        throw new UnsupportedOperationException();
+    }
+
     default List<WorktreeInfo> listWorktrees() throws GitAPIException {
         throw new UnsupportedOperationException();
     }

--- a/app/src/test/java/io/github/jbellis/brokk/git/GitRepoTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/git/GitRepoTest.java
@@ -1,19 +1,17 @@
 package io.github.jbellis.brokk.git;
 
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.diff.DiffEntry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import io.github.jbellis.brokk.git.CommitInfo;
 
 import io.github.jbellis.brokk.analyzer.ProjectFile;
 
@@ -976,7 +974,40 @@ public class GitRepoTest {
         assertTrue(result.startsWith("brokk_temp_rebase_feature_branch-name123_"),
                   "Should maintain valid branch name components: " + result);
     }
-    
+
+    @Test
+    void testForceRemoveFiles() throws Exception {
+        // 1. Create and commit a file
+        Path fileToRemove = projectRoot.resolve("file-to-remove.txt");
+        Files.writeString(fileToRemove, "This file will be removed.");
+        repo.getGit().add().addFilepattern("file-to-remove.txt").call();
+        repo.getGit().commit().setMessage("Add file for removal test").setSign(false).call();
+
+        // Verify it exists and is tracked
+        assertTrue(Files.exists(fileToRemove));
+        var trackedFilesBefore = repo.getTrackedFiles();
+        assertTrue(trackedFilesBefore.stream().anyMatch(pf -> pf.getFileName().equals("file-to-remove.txt")));
+
+        // 2. Call forceRemoveFiles
+        var projectFile = new ProjectFile(projectRoot, "file-to-remove.txt");
+        repo.forceRemoveFiles(List.of(projectFile));
+
+        // 3. Verify file is deleted from filesystem
+        assertFalse(Files.exists(fileToRemove), "File should be deleted from the filesystem.");
+
+        // 4. Verify the removal is staged and there are no unstaged changes
+        var stagedDiffs = repo.getGit().diff().setCached(true).call();
+        assertEquals(1, stagedDiffs.size());
+        var diff = stagedDiffs.get(0);
+        assertEquals(DiffEntry.ChangeType.DELETE, diff.getChangeType());
+        assertEquals("file-to-remove.txt", diff.getOldPath());
+
+        var unstagedStatus = repo.getGit().status().call();
+        assertTrue(unstagedStatus.getModified().isEmpty(), "No unstaged modifications");
+        assertTrue(unstagedStatus.getMissing().isEmpty(), "No missing files");
+        assertTrue(unstagedStatus.getUntracked().isEmpty(), "No untracked files");
+    }
+
     @Test
     void testCloneRepo_Shallow() throws Exception {
         // 1. Create an origin repository with a single commit


### PR DESCRIPTION
Introduced `ContextHistoryEntryInfo` that can be attached to an entry in ContextHistory and that can contain additional information about the entry (used it here to store the info about deleted files so that the deletion can be undone and redone).