### PR TITLE
Disables WebView's context menu using `setContextMenuEnabled(false)` for custom control

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/mop/webview/MOPWebViewHost.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/mop/webview/MOPWebViewHost.java
@@ -61,6 +61,7 @@ public final class MOPWebViewHost extends JPanel {
 
         Platform.runLater(() -> {
             var view = new WebView();
+            view.setContextMenuEnabled(false);
             webViewRef.set(view); // Store reference for later theme updates
             var scene = new Scene(view);
             requireNonNull(fxPanel).setScene(scene);


### PR DESCRIPTION
fixes #619

- Intent: disable the built-in JavaFX/WebKit right-click context menu for the embedded MOP WebView so the app can control or suppress context interactions (e.g., provide a custom menu or prevent copy/paste/web actions).
- Behaviour change: the WebView will no longer show the default browser-like context menu on right-click. This reduces unexpected UI from the web engine and avoids exposing web-specific actions to users.
- Implementation: immediately after creating the WebView on the JavaFX thread (Platform.runLater), call view.setContextMenuEnabled(false). The reference storing and Scene setup are unchanged, so existing theme updates and scene wiring continue to work.