### PR TITLE
Model-aware Markdown reminders for GPT-5, implemented via CodePrompts methods

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/agents/ArchitectAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/ArchitectAgent.java
@@ -834,7 +834,8 @@ public class ArchitectAgent {
     {
         var messages = new ArrayList<ChatMessage>();
         // System message defines the agent's role and general instructions
-        messages.add(ArchitectPrompts.instance.systemMessage(contextManager, CodePrompts.ARCHITECT_REMINDER));
+        var reminder = CodePrompts.instance.architectReminder(contextManager.getService(), model);
+        messages.add(ArchitectPrompts.instance.systemMessage(contextManager, reminder));
         // Workspace contents are added directly
         messages.addAll(precomputedWorkspaceMessages);
 

--- a/app/src/main/java/io/github/jbellis/brokk/agents/CodeAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/CodeAgent.java
@@ -107,7 +107,7 @@ public class CodeAgent {
         // We'll collect the conversation as ChatMessages to store in context history.
         var taskMessages = new ArrayList<ChatMessage>();
         UserMessage nextRequest = CodePrompts.instance.codeRequest(userInput.trim(),
-                                                                   CodePrompts.reminderForModel(contextManager.getService(), model),
+                                                                   CodePrompts.instance.codeReminder(contextManager.getService(), model),
                                                                    parser,
                                                                    null);
 
@@ -247,7 +247,7 @@ public class CodeAgent {
         var parser = EditBlockConflictsParser.instance;
 
         UserMessage initialRequest = CodePrompts.instance.codeRequest(instructions,
-                                                                      CodePrompts.reminderForModel(contextManager.getService(), model),
+                                                                      CodePrompts.instance.codeReminder(contextManager.getService(), model),
                                                                       parser,
                                                                       file);
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -957,7 +957,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
     public static TaskResult executeAskCommand(IContextManager cm, StreamingChatModel model, String question) {
         List<ChatMessage> messages;
         try {
-            messages = CodePrompts.instance.collectAskMessages(cm, question);
+            messages = CodePrompts.instance.collectAskMessages(cm, question, model);
         } catch (InterruptedException e) {
             return new TaskResult(cm,
                                   "Ask: " + question,


### PR DESCRIPTION
- Intent: make system reminders model-aware and add special Markdown guidance for GPT-5-class models so assistants use Markdown where appropriate (inline code, code fences, lists, etc.).

- Behaviour changes: code and architect system messages now append a GPT-5-specific Markdown reminder when the selected model name starts with "gpt-5". Ask/“help me” prompts also include that guidance for GPT-5; for other models the reminders remain as before (ask returns empty).

- Key implementation:
  - Added GPT5_MARKDOWN_REMINDER constant and three instance methods on CodePrompts: codeReminder, architectReminder, askReminder. They inspect service.nameOf(model) to decide whether to append the extra guidance.
  - Replaced the old static reminderForModel with the new instance methods and updated call sites accordingly (ArchitectAgent, CodeAgent).
  - InstructionsPanel.collectAskMessages now accepts a model argument and passes it through to CodePrompts.
  - Existing workspace/history message flows are unchanged; only the system reminder text is adjusted per model.