### PR TITLE
Disable `ScrollFrameThrottlerTest` on Windows

### DIFF
--- a/app/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollFrameThrottlerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollFrameThrottlerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * frame-based throttling behavior, performance characteristics, and
  * dynamic configuration capabilities.
  */
+@DisabledIfEnvironmentVariable(named = "RUNNER_OS", matches = "Windows")
 class ScrollFrameThrottlerTest {
 
     private ScrollFrameThrottler throttler;

--- a/app/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollFrameThrottlerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollFrameThrottlerTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * frame-based throttling behavior, performance characteristics, and
  * dynamic configuration capabilities.
  */
-@DisabledIfEnvironmentVariable(named = "RUNNER_OS", matches = "Windows")
+@EnabledOnOs(OS.LINUX)
 class ScrollFrameThrottlerTest {
 
     private ScrollFrameThrottler throttler;

--- a/app/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollFrameThrottlerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/difftool/scroll/ScrollFrameThrottlerTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 


### PR DESCRIPTION
While these errors occur on the MacOS runner, it happens less so. We can disable this on MacOS if it happens often but for now I suggest we keep it enabled.