### PR TITLE
fix: Rollback of files show the robot icon

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -578,7 +578,9 @@ public class HistoryOutputPanel extends JPanel {
             // Add rows for each context in history
             for (var ctx : contextManager.getContextHistoryList()) {
                 // Add icon for AI responses, null for user actions
-                Icon iconEmoji = (ctx.getParsedOutput() != null) ? SwingUtil.uiIcon("Brokk.ai-robot") : null;
+                boolean hasAiMessages = ctx.getParsedOutput() != null && ctx.getParsedOutput().messages().stream()
+                        .anyMatch(chatMessage -> chatMessage.type() == ChatMessageType.AI);
+                Icon iconEmoji = hasAiMessages ? SwingUtil.uiIcon("Brokk.ai-robot") : null;
                 historyModel.addRow(new Object[]{
                         iconEmoji,
                         ctx.getAction(),


### PR DESCRIPTION
Fixed by removing the robot icon for all entries containing output without ai messages. That means that `Welcome to Brokk` and similar now don't have it, I guess that's fine?
<img width="234" height="298" alt="image" src="https://github.com/user-attachments/assets/524a2b24-1e15-4a34-9c68-1a2818b23c10" />
