### PR TITLE
Safer project lookup and fix ClassCastExcpetion

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/IProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/IProject.java
@@ -71,6 +71,10 @@ public interface IProject extends AutoCloseable {
         return this;
     }
 
+    default MainProject getMainProject() {
+        throw new UnsupportedOperationException();
+    }
+
     default boolean hasGit() {
         return false;
     }

--- a/app/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -274,6 +274,11 @@ public final class MainProject extends AbstractProject {
     }
 
     @Override
+    public MainProject getMainProject() {
+        return this;
+    }
+
+    @Override
     public Path getMasterRootPathForConfig() {
         return this.masterRootPathForConfig;
     }

--- a/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
@@ -23,6 +23,11 @@ public final class WorktreeProject extends AbstractProject {
     }
 
     @Override
+    public MainProject getMainProject() {
+        return parent;
+    }
+
+    @Override
     public Path getMasterRootPathForConfig() {
         return parent.getMasterRootPathForConfig();
     }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/GitWorktreeTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/GitWorktreeTab.java
@@ -480,7 +480,7 @@ public class GitWorktreeTab extends JPanel {
             boolean okPressed) {}
 
     private void addWorktree() {
-        MainProject project = (MainProject) contextManager.getProject();
+        MainProject project = contextManager.getProject().getMainProject();
         IGitRepo repo = project.getRepo(); // This repo instance is effectively final for the lambda
 
         contextManager.submitContextTask("Preparing to add worktree...", () -> {
@@ -776,7 +776,7 @@ public class GitWorktreeTab extends JPanel {
             return;
         }
 
-        MainProject project = (MainProject) contextManager.getProject();
+        MainProject project = contextManager.getProject().getMainProject();
         IGitRepo repo = project.getRepo();
 
         if (!(repo instanceof GitRepo)) { // Should not happen if buttons are correctly disabled by buildUnsupportedUI

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -20,6 +20,7 @@ import io.github.jbellis.brokk.context.Context;
 import io.github.jbellis.brokk.context.ContextFragment;
 import io.github.jbellis.brokk.context.ContextFragment.TaskFragment;
 import io.github.jbellis.brokk.git.GitRepo;
+import io.github.jbellis.brokk.git.IGitRepo;
 import io.github.jbellis.brokk.gui.TableUtils.FileReferenceList.FileReferenceData;
 import io.github.jbellis.brokk.gui.components.OverlayPanel;
 import io.github.jbellis.brokk.gui.components.SplitButton;
@@ -1207,13 +1208,20 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                 Path newWorktreePath;
                 String actualBranchName;
 
-                IProject projectForWorktreeSetup = currentProject.getParent();
-                GitRepo mainGitRepo = (GitRepo) projectForWorktreeSetup.getRepo();
+                MainProject projectForWorktreeSetup = currentProject.getMainProject();
+                IGitRepo repo = projectForWorktreeSetup.getRepo();
+                if (!(repo instanceof GitRepo mainGitRepo)) {
+                    chrome.hideOutputSpinner();
+                    chrome.toolError(
+                            "Cannot create worktree: Main project repository does not support Git operations.");
+                    populateInstructionsArea(originalInstructions);
+                    return;
+                }
                 String sourceBranchForNew =
                         mainGitRepo.getCurrentBranch(); // New branch is created from current branch of main repo
 
                 var setupResult = GitWorktreeTab.setupNewGitWorktree(
-                        (MainProject) projectForWorktreeSetup,
+                        projectForWorktreeSetup,
                         mainGitRepo,
                         generatedBranchName,
                         true, // Always creating a new branch in this flow

--- a/app/src/main/java/io/github/jbellis/brokk/gui/MergeBranchDialogPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/MergeBranchDialogPanel.java
@@ -118,7 +118,7 @@ public class MergeBranchDialogPanel extends JDialog {
      */
     public MergeDialogResult showDialog(GitRepo gitRepo, ContextManager contextManager) {
         // Set up merge mode from last-used, and persist changes
-        var mainProject = (MainProject) contextManager.getProject().getParent();
+        var mainProject = contextManager.getProject().getMainProject();
         var lastMergeMode = mainProject.getLastMergeMode().orElse(GitRepo.MergeMode.MERGE_COMMIT);
         mergeModeComboBox.setSelectedItem(lastMergeMode);
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
@@ -1155,7 +1155,7 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
             runTestsInWorkspaceRadio.setSelected(true);
         }
 
-        buildTimeoutSpinner.setValue((int) ((MainProject) project).getRunCommandTimeoutSeconds());
+        buildTimeoutSpinner.setValue((int) project.getMainProject().getRunCommandTimeoutSeconds());
 
         var currentRefresh = project.getAnalyzerRefresh();
         cpgRefreshComboBox.setSelectedItem(
@@ -1235,7 +1235,7 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
             logger.debug("Applied Code Agent Test Scope: {}", selectedScope);
         }
 
-        var mainProject = (MainProject) project;
+        var mainProject = project.getMainProject();
         long timeout = ((Number) buildTimeoutSpinner.getValue()).longValue();
         if (timeout != mainProject.getRunCommandTimeoutSeconds()) {
             mainProject.setRunCommandTimeoutSeconds(timeout);


### PR DESCRIPTION
- Introduces a safe way to locate the owning MainProject from any IProject by adding IProject.getMainProject() (default throws), implemented in MainProject (returns this) and WorktreeProject (returns parent).
- Replaces multiple unsafe casts to (MainProject) with calls to getMainProject(), removing assumptions about project types in GitWorktreeTab, MergeBranchDialogPanel, SettingsProjectPanel, and others.

Fixes #675 