### PR TITLE
Clear Search State Before New one

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/search/MarkdownSearchableComponent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/search/MarkdownSearchableComponent.java
@@ -71,12 +71,22 @@ public class MarkdownSearchableComponent implements SearchableComponent {
     @Override
     public void highlightAll(String searchText, boolean caseSensitive) {
         var q = searchText.trim();
-        if (q.isEmpty()) {
-            clearHighlights();
-            callback.onSearchComplete(0, 0);
+
+        // Skip if neither query nor case-sensitivity actually changed
+        if (!hasSearchChanged(q, caseSensitive)) {
             return;
         }
+
+        // Empty query -> just clear and exit (clearHighlights triggers callback)
+        if (q.isEmpty()) {
+            clearHighlights();
+            return;
+        }
+
+        // Notify listeners and prepare web view for a fresh search
         callback.onSearchStart();
+        panel.clearSearch();
+
         currentQuery = q;
         currentCaseSensitive = caseSensitive;
         panel.setSearch(q, caseSensitive);


### PR DESCRIPTION
The fix explicitly clears the previous search state before starting a new one, which prevents the search component from getting stuck on old results as the user types. This also avoids re-running identical searches for better performance.

Resolves #335