### PR TITLE
Redesign of File Badge Click Handling

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/TableUtils.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/TableUtils.java
@@ -341,7 +341,7 @@ public final class TableUtils {
 
     /** Component to display and interact with a list of file references. */
     public static class FileReferenceList extends JPanel {
-        private final List<FileReferenceData> fileReferences = new ArrayList<>();
+        protected final List<FileReferenceData> fileReferences = new ArrayList<>();
         private boolean selected = false;
 
         private static final int BADGE_ARC_WIDTH = 10;
@@ -496,6 +496,7 @@ public final class TableUtils {
             // Add each file reference as a label
             for (FileReferenceData file : this.fileReferences) {
                 JLabel fileLabel = createBadgeLabel(file.getFileName());
+                file.setBadgeLabel(fileLabel);
                 fileLabel.setOpaque(false);
 
                 // Set tooltip to show the full path
@@ -618,6 +619,10 @@ public final class TableUtils {
             @Nullable
             private final ProjectFile projectFile; // Optional, if available
 
+            // Transient UI element representing this reference when rendered
+            @Nullable
+            private transient JLabel badgeLabel;
+
             public FileReferenceData(String fileName, String fullPath, @Nullable ProjectFile projectFile) {
                 this.fileName = fileName;
                 this.fullPath = fullPath;
@@ -636,6 +641,17 @@ public final class TableUtils {
             @Nullable
             public ProjectFile getRepoFile() {
                 return projectFile;
+            }
+
+            /** Returns the JLabel badge associated with this reference, if any. */
+            @Nullable
+            public JLabel getBadgeLabel() {
+                return badgeLabel;
+            }
+
+            /** Associates a JLabel badge with this reference. */
+            public void setBadgeLabel(@Nullable JLabel badgeLabel) {
+                this.badgeLabel = badgeLabel;
             }
 
             @Override
@@ -664,69 +680,71 @@ public final class TableUtils {
      * @param row The row index
      * @param column The column index containing the file references
      * @param table The table containing the badges
-     * @param visibleReferences The list of visible file references
      * @return The FileReferenceData under the point, or null if none
      */
     @Nullable
     public static TableUtils.FileReferenceList.FileReferenceData findClickedReference(
-            Point pointInTableCoords,
-            int row,
-            int column,
-            JTable table,
-            List<TableUtils.FileReferenceList.FileReferenceData> visibleReferences) {
-        // Convert to cell-local coordinates
+            Point pointInTableCoords, int row, int column, JTable table) {
+
+        // Retrieve the renderer component for the clicked cell
+        Component cellComponent = table.prepareRenderer(table.getCellRenderer(row, column), row, column);
+        if (!(cellComponent instanceof Container container)) {
+            return null;
+        }
+
+        // Search for a FileReferenceList inside the renderer hierarchy
+        FileReferenceList fileReferenceList = findFileReferenceList(container);
+        if (fileReferenceList == null) {
+            return null;
+        }
+
+        // Compute the cell rectangle (needed for size/layout adjustments)
         Rectangle cellRect = table.getCellRect(row, column, false);
-        int xInCell = pointInTableCoords.x - cellRect.x;
-        int yInCell = pointInTableCoords.y - cellRect.y;
-        if (xInCell < 0 || yInCell < 0) return null;
 
-        // For WorkspacePanel's new layout where badges are below description text,
-        // we need to account for the description text height
-        if (column == WorkspacePanel.DESCRIPTION_COLUMN) { // Description column with badges below
-            // Estimate description text height (single line)
-            var baseFont = table.getFont();
-            var descriptionHeight = table.getFontMetrics(baseFont).getHeight() + 3; // +3 for vertical strut
+        // Ensure the renderer hierarchy is laid out so child components have valid bounds.
+        // Without this, components may report (0,0) size which breaks hit detection.
+        container.setBounds(0, 0, cellRect.width, cellRect.height);
+        container.doLayout();
+        fileReferenceList.doLayout();
 
-            // Check if click is in the badge area (below description)
-            if (yInCell < descriptionHeight) {
-                return null; // Click was in description area, not badges
-            }
+        // Translate the click into the FileReferenceList’s coordinate space
+        Point pointInCell = new Point(pointInTableCoords.x - cellRect.x, pointInTableCoords.y - cellRect.y);
+        Point pointInList = SwingUtilities.convertPoint(cellComponent, pointInCell, fileReferenceList);
 
-            // Adjust Y coordinate to be relative to badge area
-            yInCell -= descriptionHeight;
+        // Identify the child component that was clicked
+        Component clickedComponent = fileReferenceList.getComponentAt(pointInList);
+        if (!(clickedComponent instanceof JLabel clickedLabel)) {
+            return null;
         }
 
-        // Badge layout parameters – keep in sync with FileReferenceList
-        final int hgap = 4; // FlowLayout hgap in FileReferenceList
+        // Map the clicked JLabel back to its FileReferenceData
+        List<FileReferenceList.FileReferenceData> refs =
+                (fileReferenceList instanceof FileReferenceList.AdaptiveFileReferenceList afl)
+                        ? afl.getVisibleFiles()
+                        : fileReferenceList.fileReferences;
 
-        // Get the actual renderer component to use its font metrics
-        Component renderer = table.prepareRenderer(table.getCellRenderer(row, column), row, column);
-
-        // Font used inside the badges (85 % of component font size)
-        Font componentFont = renderer.getFont();
-        if (componentFont == null) {
-            componentFont = table.getFont(); // Fallback to table font
-        }
-        var badgeFont = componentFont.deriveFont(Font.PLAIN, componentFont.getSize() * 0.85f);
-        var fm = renderer.getFontMetrics(badgeFont);
-
-        int currentX = 0;
-        // Calculate insets based on BORDER_THICKNESS and text padding (matching createBadgeLabel)
-        int borderStrokeInset = (int) Math.ceil(FileReferenceList.BORDER_THICKNESS);
-        int textPaddingHorizontal = 6; // As defined in createBadgeLabel's EmptyBorder logic
-        int totalInsetsPerSide = borderStrokeInset + textPaddingHorizontal;
-
-        for (var ref : visibleReferences) {
-            int textWidth = fm.stringWidth(ref.getFileName());
-            // Label width is text width + total left inset + total right inset
-            int labelWidth = textWidth + (2 * totalInsetsPerSide);
-            if (xInCell >= currentX && xInCell <= currentX + labelWidth) {
+        for (var ref : refs) {
+            if (ref.getBadgeLabel() == clickedLabel) {
                 return ref;
             }
-            currentX += labelWidth + hgap;
         }
-        // Note: This method only checks visible file badges, not the overflow badge
-        // Overflow badge detection is handled by the caller checking for null result
+        return null;
+    }
+
+    /** Recursively searches a component hierarchy for a FileReferenceList instance. */
+    @Nullable
+    private static FileReferenceList findFileReferenceList(Container container) {
+        for (Component comp : container.getComponents()) {
+            if (comp instanceof FileReferenceList frl) {
+                return frl;
+            }
+            if (comp instanceof Container child) {
+                FileReferenceList nested = findFileReferenceList(child);
+                if (nested != null) {
+                    return nested;
+                }
+            }
+        }
         return null;
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/TableUtils.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/TableUtils.java
@@ -741,6 +741,10 @@ public final class TableUtils {
     /** Recursively searches a component hierarchy for a FileReferenceList instance. */
     @Nullable
     static FileReferenceList findFileReferenceList(Container container) {
+        // If the container itself *is* a FileReferenceList (or subclass), return it
+        if (container instanceof FileReferenceList frlSelf) {
+            return frlSelf;
+        }
         for (Component comp : container.getComponents()) {
             if (comp instanceof FileReferenceList frl) {
                 return frl;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -763,11 +763,7 @@ public class WorkspacePanel extends JPanel {
                                     && !descriptionData.fileReferences().isEmpty()) {
                                 // Check if the click actually hit a badge (not just anywhere in the cell)
                                 var clickedRef = TableUtils.findClickedReference(
-                                        e.getPoint(),
-                                        row,
-                                        DESCRIPTION_COLUMN,
-                                        contextTable,
-                                        descriptionData.fileReferences());
+                                        e.getPoint(), row, DESCRIPTION_COLUMN, contextTable);
 
                                 if (clickedRef != null) {
                                     // Use ContextMenuUtils directly now that we have the proper data structure
@@ -1404,7 +1400,7 @@ public class WorkspacePanel extends JPanel {
                     if (yInCell > cellRect.height / 2) {
                         // Try to find which specific badge was clicked
                         TableUtils.FileReferenceList.FileReferenceData clickedFileRef =
-                                TableUtils.findClickedReference(e.getPoint(), row, col, contextTable, fileReferences);
+                                TableUtils.findClickedReference(e.getPoint(), row, col, contextTable);
 
                         if (clickedFileRef != null && clickedFileRef.getRepoFile() != null) {
                             return new FileBadge(clickedFileRef);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
@@ -130,7 +130,7 @@ public final class ContextMenuUtils {
         // Check what kind of mouse event we're handling
         if (e.isPopupTrigger()) {
             // Right-click (context menu)
-            var targetRef = TableUtils.findClickedReference(p, row, columnIndex, table, visibleFiles);
+            var targetRef = TableUtils.findClickedReference(p, row, columnIndex, table);
 
             // Right-click on overflow badge?
             if (targetRef == null && hasOverflow) {
@@ -147,7 +147,7 @@ public final class ContextMenuUtils {
             e.consume(); // Prevent further listeners from acting on this event
         } else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 1) {
             // Left-click
-            var targetRef = TableUtils.findClickedReference(p, row, columnIndex, table, visibleFiles);
+            var targetRef = TableUtils.findClickedReference(p, row, columnIndex, table);
             logger.debug(
                     "Left-click on file badges - targetRef={}, hasOverflow={}, visibleFiles={}, totalFiles={}",
                     targetRef != null ? targetRef.getFileName() : "null",

--- a/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
@@ -158,8 +158,7 @@ public final class ContextMenuUtils {
             // If no visible badge was clicked, check if it was an overflow badge click
             if (targetRef == null && hasOverflow) {
                 // Check if the click is actually on the overflow badge area
-                boolean isOverflowClick =
-                        TableUtils.isClickOnOverflowBadge(p, row, columnIndex, table, visibleFiles, hasOverflow);
+                boolean isOverflowClick = TableUtils.isClickOnOverflowBadge(p, row, columnIndex, table);
                 logger.debug("Overflow badge click check - isOverflowClick={}", isOverflowClick);
                 if (isOverflowClick) {
                     // Show the overflow popup with only the hidden files


### PR DESCRIPTION
The original onclick detection attempts to calculate if the click hit a JLabel badge based on assumptions about row/col/font size/etc. and was prone to breaking whenever the layout changed. 

This change pairs the file reference data with the JLabel so that the location is always "live" when a click event comes through. This click event is then compared to all JLabel locations that are known to be in the selected column.

This also removed the click handling on mouse exit as this would firing two events for every click which may be attributed to jitter.

TODO: Increase cell height when badge overflows to next line