### PR TITLE
fix: AssertionError on worktree with copying session

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1964,7 +1964,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         var sessionManager = project.getSessionManager();
         var newSessionInfo = sessionManager.newSession(newSessionName);
         updateActiveSession(newSessionInfo.id());
-        var ctx = newContextFrom(sourceFrozenContext);
+        var ctx = Context.unfreeze(newContextFrom(sourceFrozenContext));
         // the intent is that we save a history to the new session that initializeCurrentSessionAndHistory will pull in
         // later
         var ch = new ContextHistory(ctx);


### PR DESCRIPTION
Closes #633.

It seems that `createSessionFromContextAsync` relies on GUI to be set up (sets the current context history, notifies listeners, etc), while `createSessionWithoutGui` synchronously creates the session that is later to be picked up in the initialization as the active session. So fixed by just unfreezing the context in `createSessionWithoutGui` too, to make it work without any refactoring for now.