### PR TITLE
Fix: Deduplicate Files before Reading

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
@@ -1009,6 +1009,7 @@ public class ContextAgent {
 
     private Map<ProjectFile, String> readFileContents(Collection<ProjectFile> files) {
         return files.stream()
+                .distinct()
                 .parallel()
                 .map(file -> {
                     try {


### PR DESCRIPTION
If duplicate files are given to `ContextAgent.readFileContents` then the line `.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));` may throw an exception as it does not expect duplicate keys.