### PR TITLE
Fix Duplicate Actions in File Preview

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -1158,8 +1158,9 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             // 4. Specific handling for Git-history snapshots
             if (workingFragment.getType() == ContextFragment.FragmentType.GIT_FILE) {
                 var ghf = (ContextFragment.GitFileFragment) workingFragment;
-                var previewPanel =
-                        new PreviewTextPanel(contextManager, null, ghf.text(), ghf.syntaxStyle(), themeManager, ghf);
+                // pass the actual ProjectFile so dynamic menu items can be built
+                var previewPanel = new PreviewTextPanel(
+                        contextManager, ghf.file(), ghf.text(), ghf.syntaxStyle(), themeManager, ghf);
                 showPreviewFrame(contextManager, title, previewPanel);
                 return;
             }
@@ -1205,9 +1206,14 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                 }
 
                 // Otherwise – fall back to showing the frozen snapshot.
+                ProjectFile srcFile = null;
+                if (workingFragment instanceof ContextFragment.PathFragment pfFrag
+                        && pfFrag.file() instanceof ProjectFile p) {
+                    srcFile = p; // supply the ProjectFile if we have one
+                }
                 var snapshotPanel = new PreviewTextPanel(
                         contextManager,
-                        null,
+                        srcFile,
                         workingFragment.text(),
                         workingFragment.syntaxStyle(),
                         themeManager,

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -332,16 +332,36 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
                         var lineText = getText(lineStartOffset, lineEndOffset - lineStartOffset);
 
                         if (lineText != null && !lineText.trim().isEmpty()) {
+                            var addedShortNames = new HashMap<String, CodeUnit>();
                             for (CodeUnit unit : codeUnits) {
                                 var identifier = unit.identifier();
                                 var p = Pattern.compile("\\b" + Pattern.quote(identifier) + "\\b");
                                 if (p.matcher(lineText).find()) {
-                                    var item = new JMenuItem("Capture usages of " + unit.shortName());
+                                    if (addedShortNames.containsKey(unit.shortName())) {
+                                        continue; // already have a menu item for this shortName
+                                    }
+                                    addedShortNames.put(unit.shortName(), unit);
+                                }
+                            }
+                            for (String shortName : addedShortNames.keySet()) {
+                                // Specific to some languages, the constructor is the name of the type and may come
+                                // up when clicking on the type. These both refer to the same usages, thus will be
+                                // duplicates.
+                                final var codeUnit = addedShortNames.get(shortName);
+                                // Check if another code unit shares this name and is a class
+                                final var isConstructor = codeUnit.isFunction()
+                                        && addedShortNames.values().stream()
+                                                .anyMatch(x -> !x.equals(codeUnit)
+                                                        && x.isClass()
+                                                        && shortName.endsWith(x.shortName()));
+
+                                if (!isConstructor) {
+                                    var item = new JMenuItem(
+                                            "<html>Capture usages of <code>" + shortName + "</code></html>");
                                     // Use a local variable for the action listener lambda
                                     item.addActionListener(action -> {
                                         contextManager.submitBackgroundTask(
-                                                "Capture Usages",
-                                                () -> contextManager.usageForIdentifier(unit.fqName()));
+                                                "Capture Usages", () -> contextManager.usageForIdentifier(shortName));
                                     });
                                     dynamicMenuItems.add(item); // Track for removal
                                 }


### PR DESCRIPTION
Tested on both `master` and `0.13`:
* Fixes issue where `file` in the popup was `null` during preview
* Prevents duplicate unit actions being populated
* In the case of `master`, where constructors share the name of the type`, special deduplication handling is added.
* (Optional) Made the shortname render within `<code>` blocks. If this is irritating to look at, it can easily be rolled back.
<img width="494" height="240" alt="Screenshot 2025-08-21 at 14 49 08" src="https://github.com/user-attachments/assets/1c440660-a0ac-4d4a-8244-b09731efdd3e" />

Note: Merging this into 0.13 as it fixes some bugs.

Related to https://github.com/BrokkAi/brokk/issues/686