### PR TITLE
`searchFilenames`: Normalize Paths in Pattern Compilation

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/tools/SearchTools.java
+++ b/app/src/main/java/io/github/jbellis/brokk/tools/SearchTools.java
@@ -160,7 +160,8 @@ public class SearchTools {
                 Pattern regex = Pattern.compile(pat);
                 predicates.add(s -> regex.matcher(s).find());
             } catch (PatternSyntaxException ex) {
-                predicates.add(s -> s.contains(pat));
+                // Fallback: simple substring match, but normalize to forward slashes
+                predicates.add(s -> s.contains(pat.replace('\\', '/')));
             }
         }
         return predicates;

--- a/app/src/test/java/io/github/jbellis/brokk/tools/SearchToolsTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/tools/SearchToolsTest.java
@@ -6,6 +6,7 @@ import io.github.jbellis.brokk.IContextManager;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
 import io.github.jbellis.brokk.git.GitRepo;
 import java.lang.reflect.Proxy;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.AfterEach;
@@ -134,5 +135,36 @@ public class SearchToolsTest {
 
         // 4. Ensure the file name appears in the output
         assertTrue(result.contains("filename_[[-test.txt"), "Result should reference the test filename");
+    }
+
+    @Test
+    void testSearchFilenames_withSubdirectories() throws Exception {
+        // 1. Create a file with a subdirectory path
+        Path subDir = projectRoot.resolve("frontend-mop").resolve("src");
+        Files.createDirectories(subDir);
+        Path filePath = subDir.resolve("MOP.svelte");
+        Files.writeString(filePath, "dummy content");
+
+        // 2. Add to mock project file list.
+        String relativePathNix = "frontend-mop/src/MOP.svelte";
+        mockProjectFiles.add(new ProjectFile(projectRoot, relativePathNix));
+
+        // 3. Test cases
+        // A. Full path with forward slashes
+        String resultNix = searchTools.searchFilenames(java.util.List.of(relativePathNix), "test nix path");
+        assertTrue(resultNix.contains(relativePathNix), "Should find file with forward-slash path");
+
+        // B. File name only
+        String resultName = searchTools.searchFilenames(java.util.List.of("MOP.svelte"), "test file name");
+        assertTrue(resultName.contains(relativePathNix), "Should find file with file name only");
+
+        // C. Partial path
+        String resultPartial = searchTools.searchFilenames(java.util.List.of("src/MOP"), "test partial path");
+        assertTrue(resultPartial.contains(relativePathNix), "Should find file with partial path");
+
+        // D. Full path with backslashes (Windows-style)
+        String relativePathWin = "frontend-mop\\src\\MOP.svelte";
+        String resultWin = searchTools.searchFilenames(java.util.List.of(relativePathWin), "test windows path");
+        assertTrue(resultWin.contains(relativePathNix), "Should find file with back-slash path pattern");
     }
 }


### PR DESCRIPTION
Should resolve #726.  The unit tests ensure the reported file can be found, but I essentially made no change besides ensuring no sketchy `\\` slip in. 

As an additional test, I asked the architect mode to find the file with the given path, and add it to my workspace which it was able to do. 

<img width="715" height="109" alt="Screenshot 2025-08-21 at 17 03 30" src="https://github.com/user-attachments/assets/79d0dfba-dc8e-4d70-852a-60242c3f9576" />
