### PR TITLE
File Preview Captures Exact Token

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspAnalyzerHelper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspAnalyzerHelper.java
@@ -521,7 +521,9 @@ public final class LspAnalyzerHelper {
                 symbol.getContainerName() == null || symbol.getContainerName().isEmpty()
                         ? symbol.getName()
                         : symbol.getContainerName() + "." + symbol.getName();
-        return symbol.getName().equals(simpleOrFullName) || symbolFullName.equals(simpleOrFullName);
+        return symbol.getName().equals(simpleOrFullName)
+                || symbolFullName.equals(simpleOrFullName)
+                || (simpleOrFullName.contains(".") && symbolFullName.endsWith(simpleOrFullName));
     }
 
     public static boolean simpleOrFullMatch(

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
+import org.fife.ui.rsyntaxtextarea.TokenTypes;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.jetbrains.annotations.Nullable;
 
@@ -329,39 +330,61 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
                         int lineNum = getLineOfOffset(offset);
                         int lineStartOffset = getLineStartOffset(lineNum);
                         int lineEndOffset = getLineEndOffset(lineNum);
-                        var lineText = getText(lineStartOffset, lineEndOffset - lineStartOffset);
+                        // Determine the identifier (token) that the mouse is currently over
+                        var token = getTokenListForLine(lineNum);
+                        String clickedIdentifier = null;
+                        while (token != null && token.getType() != TokenTypes.NULL) {
+                            int tokenStart = token.getOffset();
+                            int tokenEnd = tokenStart + token.length();
+                            if (offset >= tokenStart && offset < tokenEnd) {
+                                clickedIdentifier = token.getLexeme();
+                                break;
+                            }
+                            token = token.getNextToken();
+                        }
 
-                        if (lineText != null && !lineText.trim().isEmpty()) {
+                        // Fallback: use the entire line text when we cannot determine a single token
+                        if (clickedIdentifier == null) {
+                            clickedIdentifier = getText(lineStartOffset, lineEndOffset - lineStartOffset)
+                                    .trim();
+                        }
+
+                        if (!clickedIdentifier.isEmpty()) {
                             var addedShortNames = new HashMap<String, CodeUnit>();
                             for (CodeUnit unit : codeUnits) {
                                 var identifier = unit.identifier();
-                                var p = Pattern.compile("\\b" + Pattern.quote(identifier) + "\\b");
-                                if (p.matcher(lineText).find()) {
-                                    if (addedShortNames.containsKey(unit.shortName())) {
-                                        continue; // already have a menu item for this shortName
+
+                                if (identifier.endsWith(clickedIdentifier)) {
+                                    // Exact match with the clicked token
+                                    addedShortNames.putIfAbsent(clickedIdentifier, unit);
+                                } else {
+                                    // Fallback: does the clicked text contain this identifier as a whole word?
+                                    var p = Pattern.compile("\\b" + Pattern.quote(identifier) + "\\b");
+                                    if (p.matcher(clickedIdentifier).find()) {
+                                        addedShortNames.putIfAbsent(clickedIdentifier, unit);
                                     }
-                                    addedShortNames.put(unit.shortName(), unit);
                                 }
                             }
-                            for (String shortName : addedShortNames.keySet()) {
+
+                            for (String identifier : addedShortNames.keySet()) {
                                 // Specific to some languages, the constructor is the name of the type and may come
                                 // up when clicking on the type. These both refer to the same usages, thus will be
                                 // duplicates.
-                                final var codeUnit = addedShortNames.get(shortName);
+                                final var codeUnit = addedShortNames.get(identifier);
                                 // Check if another code unit shares this name and is a class
                                 final var isConstructor = codeUnit.isFunction()
                                         && addedShortNames.values().stream()
                                                 .anyMatch(x -> !x.equals(codeUnit)
                                                         && x.isClass()
-                                                        && shortName.endsWith(x.shortName()));
+                                                        && identifier.endsWith(x.shortName()));
 
                                 if (!isConstructor) {
                                     var item = new JMenuItem(
-                                            "<html>Capture usages of <code>" + shortName + "</code></html>");
+                                            "<html>Capture usages of <code>" + identifier + "</code></html>");
                                     // Use a local variable for the action listener lambda
                                     item.addActionListener(action -> {
                                         contextManager.submitBackgroundTask(
-                                                "Capture Usages", () -> contextManager.usageForIdentifier(shortName));
+                                                "Capture Usages", () -> contextManager.usageForIdentifier(identifier));
                                     });
                                     dynamicMenuItems.add(item); // Track for removal
                                 }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -39,6 +39,7 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
@@ -353,8 +354,13 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
                             var addedShortNames = new HashMap<String, CodeUnit>();
                             for (CodeUnit unit : codeUnits) {
                                 var identifier = unit.identifier();
+                                // in the case of nested classes, etc.
+                                var simpleIdentifier = Arrays.stream(identifier.split("[$.]"))
+                                        .toList()
+                                        .getLast();
 
-                                if (identifier.endsWith(clickedIdentifier)) {
+                                if (identifier.equals(clickedIdentifier)
+                                        || simpleIdentifier.equals(clickedIdentifier)) {
                                     // Exact match with the clicked token
                                     addedShortNames.putIfAbsent(clickedIdentifier, unit);
                                 } else {
@@ -384,13 +390,14 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
                                     // Use a local variable for the action listener lambda
                                     item.addActionListener(action -> {
                                         contextManager.submitBackgroundTask(
-                                                "Capture Usages", () -> contextManager.usageForIdentifier(identifier));
+                                                "Capture Usages",
+                                                () -> contextManager.usageForIdentifier(codeUnit.identifier()));
                                     });
                                     dynamicMenuItems.add(item); // Track for removal
                                 }
                             }
                         }
-                    } catch (javax.swing.text.BadLocationException ex) {
+                    } catch (BadLocationException ex) {
                         logger.warn(
                                 "Error getting line text for usage capture menu items based on offset {}", offset, ex);
                     }

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
@@ -193,6 +193,7 @@ public class JavaTreeSitterAnalyzerTest {
                   }
                   public static class AInnerStatic {
                   }
+                  void usesInnerClass()
                 }
                 """
                         .trim()

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JdtAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JdtAnalyzerTest.java
@@ -259,6 +259,7 @@ public class JdtAnalyzerTest {
                   public static class AInnerStatic {
                     public AInnerStatic() {...}
                   }
+                  public void usesInnerClass() {...}
                 }
                 """
                         .trim()
@@ -488,6 +489,15 @@ public class JdtAnalyzerTest {
         final var ex = assertThrows(IllegalArgumentException.class, () -> analyzer.getUses(symbol));
         assertTrue(ex.getMessage()
                 .contains("Symbol 'NoSuchClass' (resolved: 'NoSuchClass') not found as a method, field, or class"));
+    }
+
+    @Test
+    public void getUsesNestedClassTest() {
+        final var symbol = "A$AInner";
+        final var usages = analyzer.getUses(symbol);
+        assertEquals(
+                Set.of("A.usesInnerClass"),
+                usages.stream().map(CodeUnit::fqName).collect(Collectors.toSet()));
     }
 
     @Test

--- a/app/src/test/resources/testcode-java/A.java
+++ b/app/src/test/resources/testcode-java/A.java
@@ -45,4 +45,8 @@ public class A {
     }
 
     public static class AInnerStatic {}
+
+    public void usesInnerClass() {
+        System.out.println(new AInner());
+    }
 }


### PR DESCRIPTION
Modified `createPopupMenu` to capture the exact token where possible, or use the full line as fallback. This results in much more precise `CodeUnit` matches. If this token matches, it is used in the menu as the identifier. 

The reason why records and nested classes were not being populated is because their `shortName()` contained the parent class separated by the `$` symbol. This approach ensures we only consider the simple identifier as far as possible.

Examples
<img width="715" height="212" alt="Screenshot 2025-08-22 at 15 54 33" src="https://github.com/user-attachments/assets/e8ca8d22-007b-448d-8697-e95ff5321ee5" />
<img width="715" height="212" alt="Screenshot 2025-08-22 at 15 54 25" src="https://github.com/user-attachments/assets/0eaf4ed9-1d37-4b23-9009-1267e72c8ce3" />

Fixed bug where `no usages == definition not found` and an exception was thrown in JdtAnalyzer. 
