### PR TITLE
Deduplicate LLM Recommendation

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
@@ -114,7 +114,7 @@ public class ContextAgent {
         static final LlmRecommendation EMPTY = new LlmRecommendation(List.of(), List.of(), "", null);
 
         public LlmRecommendation(List<ProjectFile> files, List<CodeUnit> classes, String reasoning) {
-            this(files, classes, reasoning, null);
+            this(files.stream().distinct().toList(), classes.stream().distinct().toList(), reasoning, null);
         }
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
@@ -629,7 +629,8 @@ public class ContextAgent {
                 logger.warn("Failed to retrieve chunk result", e);
             }
         }
-        return new LlmRecommendation(combinedFiles, Set.of(), combinedReasoning.toString().strip(), combinedUsage);
+        return new LlmRecommendation(
+                combinedFiles, Set.of(), combinedReasoning.toString().strip(), combinedUsage);
     }
 
     private LlmRecommendation askLlmDeepRecommendContext(


### PR DESCRIPTION
It was discovered that the LLM may suggest duplicate file paths. This may cause issues down the line. This fix deduplicates the suggested objects in the `LlmRecommendation` constructor.