### PR TITLE
Use LSP To Lint Code Before Attempting to Build

### DIFF
--- a/analyzer-api/build.gradle.kts
+++ b/analyzer-api/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
     compileOnly(libs.checker.qual)
     compileOnly(libs.jetbrains.annotations)
 
+    // Console and logging
+    implementation(libs.bundles.logging)
+
     // For JSON serialization interfaces (used by CodeUnit)
     runtimeOnly(libs.jackson.databind)
     api(libs.jackson.annotations)

--- a/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/IAnalyzer.java
+++ b/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/IAnalyzer.java
@@ -280,4 +280,16 @@ public interface IAnalyzer {
 
     /** Container for a function’s location and current source text. */
     record FunctionLocation(ProjectFile file, int startLine, int endLine, String code) {}
+
+    /**
+     * Lint the specified files and return any diagnostics found. This method should trigger analysis of the files and
+     * collect any compiler/linter errors, warnings, or other diagnostics.
+     *
+     * @param files the files to lint
+     * @return a LintResult containing any diagnostics found
+     */
+    default LintResult lintFiles(List<ProjectFile> files) {
+        // Default implementation returns no diagnostics
+        return new LintResult(List.of());
+    }
 }

--- a/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/LintResult.java
+++ b/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/LintResult.java
@@ -1,0 +1,36 @@
+package io.github.jbellis.brokk.analyzer;
+
+import java.util.List;
+import java.util.Set;
+
+/** Result of linting files, containing any diagnostic messages found. */
+public record LintResult(List<LintDiagnostic> diagnostics) {
+
+    /** Returns true if there are any ERROR level diagnostics. */
+    public boolean hasErrors() {
+        return diagnostics.stream().anyMatch(d -> d.severity() == LintDiagnostic.Severity.ERROR);
+    }
+
+    /** Returns only the ERROR level diagnostics. */
+    public List<LintDiagnostic> getErrors() {
+        return diagnostics.stream()
+                .filter(d -> d.severity() == LintDiagnostic.Severity.ERROR)
+                .toList();
+    }
+
+    /** Returns diagnostics for specific files. */
+    public List<LintDiagnostic> getDiagnosticsForFiles(Set<ProjectFile> files) {
+        var filePaths = files.stream().map(ProjectFile::toString).collect(java.util.stream.Collectors.toSet());
+        return diagnostics.stream().filter(d -> filePaths.contains(d.file())).toList();
+    }
+
+    /** Individual diagnostic message from linting. */
+    public record LintDiagnostic(String file, int line, int column, Severity severity, String message, String code) {
+        public enum Severity {
+            ERROR,
+            WARNING,
+            INFO,
+            HINT
+        }
+    }
+}

--- a/app/src/main/java/io/github/jbellis/brokk/TaskResult.java
+++ b/app/src/main/java/io/github/jbellis/brokk/TaskResult.java
@@ -65,6 +65,8 @@ public record TaskResult(
         APPLY_ERROR,
         /** Build errors occurred and were not improving after retries. */
         BUILD_ERROR,
+        /** Lint errors occurred and were not improving after retries. */
+        LINT_ERROR,
         /** The LLM attempted to edit a read-only file. */
         READ_ONLY_EDIT,
         /** Unable to write new file contents */

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaAnalyzer.java
@@ -103,6 +103,15 @@ public class JavaAnalyzer extends JavaTreeSitterAnalyzer implements HasDelayedCa
         }
     }
 
+    @Override
+    public LintResult lintFiles(List<ProjectFile> files) {
+        if (jdtAnalyzer != null) {
+            return jdtAnalyzer.lintFiles(files);
+        } else {
+            return super.lintFiles(files);
+        }
+    }
+
     public Path getProjectRoot() {
         return this.getProject().getRoot();
     }

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JdtAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JdtAnalyzer.java
@@ -287,6 +287,8 @@ public class JdtAnalyzer implements LspAnalyzer, CanCommunicate {
 
         // Clear existing diagnostics for these files
         languageClient.clearDiagnosticsForFiles(files);
+        // Update files
+        this.update(new HashSet<>(files));
 
         // Trigger analysis by refreshing the workspace
         // This will cause the LSP server to re-analyze the files and generate diagnostics

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JdtAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JdtAnalyzer.java
@@ -5,6 +5,7 @@ import io.github.jbellis.brokk.IProject;
 import io.github.jbellis.brokk.analyzer.lsp.LspAnalyzer;
 import io.github.jbellis.brokk.analyzer.lsp.LspAnalyzerHelper;
 import io.github.jbellis.brokk.analyzer.lsp.LspServer;
+import io.github.jbellis.brokk.analyzer.lsp.jdt.JdtLanguageClient;
 import io.github.jbellis.brokk.analyzer.lsp.jdt.JdtProjectHelper;
 import io.github.jbellis.brokk.analyzer.lsp.jdt.JdtSkeletonHelper;
 import io.github.jbellis.brokk.analyzer.lsp.jdt.SharedJdtLspServer;
@@ -31,23 +32,30 @@ public class JdtAnalyzer implements LspAnalyzer, CanCommunicate {
      * @throws IOException if the server cannot be started.
      */
     public JdtAnalyzer(IProject project) throws IOException {
-        this.projectRoot = project.getRoot().toAbsolutePath().normalize();
+        Path projectRoot = project.getRoot().toAbsolutePath().normalize();
+        try {
+            // Follow symlinks to "canonical" path if possible
+            projectRoot = project.getRoot().toAbsolutePath().normalize().toRealPath();
+        } catch (IOException e) {
+            logger.warn("Unable to resolve real path for {}", projectRoot);
+        }
+        this.projectRoot = projectRoot;
+
         if (!this.projectRoot.toFile().exists()) {
-            throw new FileNotFoundException("Project directory does not exist: " + projectRoot);
+            throw new FileNotFoundException("Project directory does not exist: " + this.projectRoot);
         } else {
             try {
                 useEclipseBuildFiles = JdtProjectHelper.ensureProjectConfiguration(this.projectRoot);
             } catch (Exception e) {
                 logger.warn(
                         "Error validating and creating project build files for: {}. Attempting to continue.",
-                        projectRoot,
+                        this.projectRoot,
                         e);
             }
             this.workspace = this.projectRoot.toUri().toString();
             this.sharedServer = SharedJdtLspServer.getInstance();
             this.sharedServer.registerClient(
                     this.projectRoot, project.getExcludedDirectories(), getInitializationOptions(), getLanguage());
-            this.sharedServer.refreshWorkspace().join();
             try {
                 // Indexing generally completes within a couple of seconds, but larger projects need grace
                 final var maybeWorkspaceReadyLatch = this.getWorkspaceReadyLatch(this.workspace);
@@ -92,6 +100,7 @@ public class JdtAnalyzer implements LspAnalyzer, CanCommunicate {
         final var references = new HashMap<String, Object>();
         final var configuration = new HashMap<String, Object>();
         final var imporT = new HashMap<String, Object>();
+        final var autobuild = new HashMap<String, Object>();
 
         server.put("launchMode", "Hybrid");
         // Include method declarations from source files in symbol search.
@@ -106,12 +115,14 @@ public class JdtAnalyzer implements LspAnalyzer, CanCommunicate {
             imporT.put("maven", Map.of("enabled", true, "wrapper", Map.of("enabled", true)));
             imporT.put("gradle", Map.of("enabled", true, "wrapper", Map.of("enabled", true)));
         }
+        autobuild.put("enabled", true);
 
         javaOptions.put("server", server);
         javaOptions.put("symbols", symbols);
         javaOptions.put("references", references);
         javaOptions.put("configuration", configuration);
         javaOptions.put("import", imporT);
+        javaOptions.put("autobuild", autobuild);
 
         options.put("java", javaOptions);
         return options;
@@ -259,6 +270,42 @@ public class JdtAnalyzer implements LspAnalyzer, CanCommunicate {
         } else {
             return false;
         }
+    }
+
+    @Override
+    public LintResult lintFiles(List<ProjectFile> files) {
+        if (files.isEmpty()) {
+            return new LintResult(List.of());
+        }
+
+        // Get the language client to access diagnostics
+        var languageClient = (JdtLanguageClient) sharedServer.getLanguageClient();
+        if (languageClient == null) {
+            logger.warn("JDT language client not available for linting");
+            return new LintResult(List.of());
+        }
+
+        // Clear existing diagnostics for these files
+        languageClient.clearDiagnosticsForFiles(files);
+
+        // Trigger analysis by refreshing the workspace
+        // This will cause the LSP server to re-analyze the files and generate diagnostics
+        try {
+            sharedServer.refreshWorkspace(getWorkspace()).join();
+        } catch (Exception e) {
+            logger.warn("Error refreshing workspace for linting", e);
+            return new LintResult(List.of());
+        }
+
+        try {
+            languageClient.waitForDiagnosticsToSettle().join();
+        } catch (Exception e) {
+            logger.warn("Error waiting for diagnostics to settle, continuing", e);
+        }
+
+        // Collect diagnostics for the specified files
+        var diagnostics = languageClient.getDiagnosticsForFiles(files);
+        return new LintResult(diagnostics);
     }
 
     @Override

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspAnalyzer.java
@@ -133,7 +133,7 @@ public interface LspAnalyzer extends IAnalyzer, AutoCloseable {
 
     @Override
     default @NotNull IAnalyzer update() {
-        getServer().refreshWorkspace().join();
+        getServer().refreshWorkspace(getWorkspace()).join();
         return this;
     }
 
@@ -675,7 +675,7 @@ public interface LspAnalyzer extends IAnalyzer, AutoCloseable {
      */
     default Optional<String> getAnonymousName(Location lambdaLocation) {
         final Path filePath = Paths.get(URI.create(lambdaLocation.getUri()));
-        logger.debug("Determining name for anonymous structure at {}", lambdaLocation);
+        logger.trace("Determining name for anonymous structure at {}", lambdaLocation);
         return LspAnalyzerHelper.getSymbolsInFile(getServer(), filePath)
                 .thenApply(eithers -> eithers.stream()
                         .flatMap(either -> {

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
@@ -33,7 +33,7 @@ public abstract class LspLanguageClient implements LanguageClient {
 
     private final int MAX_DIAGNOSTICS_PER_FILE = 500;
     protected final int ERROR_LOG_LINE_LIMIT = 4;
-    private final int DIAGNOSTIC_SETTLE_INTERVAL = 500;
+    private final int DIAGNOSTIC_SETTLE_INTERVAL = 1000;
 
     private @Nullable IConsoleIO io;
     private final Set<String> accumulatedErrors = new HashSet<>();
@@ -188,13 +188,14 @@ public abstract class LspLanguageClient implements LanguageClient {
     public List<LintResult.LintDiagnostic> getDiagnosticsForFiles(List<ProjectFile> files) {
         return files.stream()
                 .map(ProjectFile::absPath)
+                .map(this::safeResolvePath)
                 .map(Path::toString)
                 .flatMap(filePath -> fileDiagnostics.getOrDefault(filePath, List.of()).stream())
                 .toList();
     }
 
     /**
-     * Returns a CompletableFuture that completes when diagnostics have stopped coming in for at least 500ms. If
+     * Returns a CompletableFuture that completes when diagnostics have stopped coming in for at least 1 second. If
      * diagnostics are already settled, returns a completed future.
      */
     public CompletableFuture<Void> waitForDiagnosticsToSettle() {

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
@@ -1,0 +1,243 @@
+package io.github.jbellis.brokk.analyzer.lsp;
+
+import io.github.jbellis.brokk.IConsoleIO;
+import io.github.jbellis.brokk.analyzer.LintResult;
+import io.github.jbellis.brokk.analyzer.ProjectFile;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class LspLanguageClient implements LanguageClient {
+
+    protected final Logger logger = LoggerFactory.getLogger(LspLanguageClient.class);
+
+    protected final String language;
+    private final CountDownLatch serverReadyLatch;
+    protected final Map<String, CountDownLatch> workspaceReadyLatchMap;
+
+    private final int MAX_DIAGNOSTICS_PER_FILE = 500;
+    protected final int ERROR_LOG_LINE_LIMIT = 4;
+    private final int DIAGNOSTIC_SETTLE_INTERVAL = 500;
+
+    private @Nullable IConsoleIO io;
+    private final Set<String> accumulatedErrors = new HashSet<>();
+    protected final Map<String, List<LintResult.LintDiagnostic>> fileDiagnostics = new ConcurrentHashMap<>();
+    private final AtomicLong lastDiagnosticTime = new AtomicLong(0);
+    private final ScheduledExecutorService diagnosticsSettleExecutor;
+    private volatile @Nullable ScheduledFuture<?> settleTask;
+    private volatile @Nullable CompletableFuture<Void> settleFuture;
+
+    protected LspLanguageClient(
+            String language, CountDownLatch serverReadyLatch, Map<String, CountDownLatch> workspaceReadyLatchMap) {
+        this.language = language;
+        this.serverReadyLatch = serverReadyLatch;
+        this.workspaceReadyLatchMap = workspaceReadyLatchMap;
+        this.diagnosticsSettleExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            var thread = new Thread(r, "diagnostics-settle-" + language);
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    protected CountDownLatch getServerReadyLatch() {
+        return serverReadyLatch;
+    }
+
+    /**
+     * Sets the IO to report client-facing diagnostics with.
+     *
+     * @param io the IO object to use.
+     */
+    public void setIo(@Nullable IConsoleIO io) {
+        this.io = io;
+        if (!accumulatedErrors.isEmpty()) {
+            final var accumulatedMessage = String.join(System.lineSeparator(), accumulatedErrors);
+            alertUser(accumulatedMessage);
+            accumulatedErrors.clear();
+        }
+    }
+
+    protected void alertUser(String message) {
+        if (io != null) {
+            io.systemOutput(message);
+        } else {
+            accumulatedErrors.add(message);
+        }
+    }
+
+    @Override
+    public void telemetryEvent(Object object) {}
+
+    @Override
+    public void showMessage(MessageParams messageParams) {
+        logger.info("[LSP-SERVER-SHOW-MESSAGE] {}", messageParams);
+    }
+
+    @JsonNotification("language/eventNotification")
+    public void languageEvent(Object params) {
+        logger.info("Language Event {}", params);
+    }
+
+    @Override
+    @Nullable
+    public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams r) {
+        return null;
+    }
+
+    @JsonNotification("language/status")
+    public void languageStatus(LspStatus message) {
+        final var kind = message.type();
+        final var msg = message.message();
+        logger.debug("[LSP-SERVER-STATUS] {}: {}", kind, msg);
+    }
+
+    @Override
+    public CompletableFuture<Void> registerCapability(RegistrationParams params) {
+        // Acknowledge the server's request and return a completed future.
+        // This satisfies the protocol and prevents an exception.
+        logger.trace("Server requested to register capabilities: {}", params.getRegistrations());
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /** Clears diagnostics for the specified files. */
+    public void clearDiagnosticsForFiles(List<ProjectFile> files) {
+        files.stream().map(ProjectFile::absPath).map(Path::toString).forEach(fileDiagnostics::remove);
+    }
+
+    @Override
+    public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+        if (diagnostics.getDiagnostics().isEmpty()) return;
+
+        // Update last diagnostic time
+        lastDiagnosticTime.set(System.currentTimeMillis());
+        scheduleSettleCheck();
+
+        String uri = diagnostics.getUri();
+        String filePath = uriToFilePath(uri);
+
+        List<LintResult.LintDiagnostic> lintDiagnostics = diagnostics.getDiagnostics().stream()
+                .map(diagnostic -> new LintResult.LintDiagnostic(
+                        filePath,
+                        diagnostic.getRange().getStart().getLine() + 1, // LSP is 0-based, we want 1-based
+                        diagnostic.getRange().getStart().getCharacter() + 1,
+                        mapSeverity(diagnostic.getSeverity()),
+                        diagnostic.getMessage(),
+                        diagnostic.getCode() != null ? diagnostic.getCode().getLeft() : ""))
+                .toList();
+
+        // Store diagnostics, limiting size to prevent memory issues
+        fileDiagnostics.compute(filePath, (key, existing) -> {
+            var combined = new ArrayList<LintResult.LintDiagnostic>();
+            if (existing != null) {
+                combined.addAll(existing);
+            }
+            combined.addAll(lintDiagnostics);
+
+            // Keep only the most recent diagnostics if we exceed the limit
+            if (combined.size() > MAX_DIAGNOSTICS_PER_FILE) {
+                return combined.subList(combined.size() - MAX_DIAGNOSTICS_PER_FILE, combined.size());
+            }
+            return combined;
+        });
+
+        diagnostics.getDiagnostics().forEach(diagnostic -> {
+            // Errors might be useful to understand if certain symbols are not resolved properly
+            logger.trace("[LSP-SERVER-DIAGNOSTICS] [{}] {}", diagnostic.getSeverity(), diagnostic.getMessage());
+        });
+    }
+
+    protected String uriToFilePath(String uri) {
+        try {
+            return Paths.get(URI.create(uri)).toRealPath().toString();
+        } catch (Exception e) {
+            logger.warn("Failed to convert URI to file path: {}", uri, e);
+            return uri;
+        }
+    }
+
+    /** Gets diagnostics for the specified files. */
+    public List<LintResult.LintDiagnostic> getDiagnosticsForFiles(List<ProjectFile> files) {
+        return files.stream()
+                .map(ProjectFile::absPath)
+                .map(Path::toString)
+                .flatMap(filePath -> fileDiagnostics.getOrDefault(filePath, List.of()).stream())
+                .toList();
+    }
+
+    /**
+     * Returns a CompletableFuture that completes when diagnostics have stopped coming in for at least 500ms. If
+     * diagnostics are already settled, returns a completed future.
+     */
+    public CompletableFuture<Void> waitForDiagnosticsToSettle() {
+        try {
+            // We need to give diagnostics a moment to start
+            Thread.sleep(250);
+        } catch (InterruptedException e) {
+            logger.warn("Interrupted while waiting for diagnostics to settle");
+        }
+
+        var now = System.currentTimeMillis();
+        var lastDiagnostic = lastDiagnosticTime.get();
+
+        // If no diagnostics have been received yet, or they're already settled
+        if (lastDiagnostic == 0 || (now - lastDiagnostic) >= DIAGNOSTIC_SETTLE_INTERVAL) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        // Create or return existing settle future
+        if (settleFuture == null || settleFuture.isDone()) {
+            settleFuture = new CompletableFuture<>();
+        }
+
+        return settleFuture;
+    }
+
+    private void scheduleSettleCheck() {
+        // Cancel existing task if any
+        var currentTask = settleTask;
+        if (currentTask != null) {
+            currentTask.cancel(false);
+        }
+
+        // Schedule new task to check if diagnostics have settled
+        settleTask = diagnosticsSettleExecutor.schedule(
+                () -> {
+                    var now = System.currentTimeMillis();
+                    var lastDiagnostic = lastDiagnosticTime.get();
+
+                    if ((now - lastDiagnostic) >= DIAGNOSTIC_SETTLE_INTERVAL) {
+                        // Diagnostics have settled
+                        var future = settleFuture;
+                        if (future != null && !future.isDone()) {
+                            future.complete(null);
+                        }
+                    }
+                },
+                DIAGNOSTIC_SETTLE_INTERVAL,
+                TimeUnit.MILLISECONDS);
+    }
+
+    protected LintResult.LintDiagnostic.Severity mapSeverity(DiagnosticSeverity severity) {
+        return switch (severity) {
+            case Error -> LintResult.LintDiagnostic.Severity.ERROR;
+            case Warning -> LintResult.LintDiagnostic.Severity.WARNING;
+            case Information -> LintResult.LintDiagnostic.Severity.INFO;
+            case Hint -> LintResult.LintDiagnostic.Severity.HINT;
+        };
+    }
+}

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
@@ -3,6 +3,7 @@ package io.github.jbellis.brokk.analyzer.lsp;
 import io.github.jbellis.brokk.IConsoleIO;
 import io.github.jbellis.brokk.analyzer.LintResult;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -116,7 +117,20 @@ public abstract class LspLanguageClient implements LanguageClient {
 
     /** Clears diagnostics for the specified files. */
     public void clearDiagnosticsForFiles(List<ProjectFile> files) {
-        files.stream().map(ProjectFile::absPath).map(Path::toString).forEach(fileDiagnostics::remove);
+        files.stream()
+                .map(ProjectFile::absPath)
+                .map(this::safeResolvePath)
+                .map(Path::toString)
+                .forEach(fileDiagnostics::remove);
+    }
+
+    protected Path safeResolvePath(Path path) {
+        try {
+            return path.toRealPath();
+        } catch (IOException e) {
+            logger.error("Cannot resolve path {}", path, e);
+        }
+        return path;
     }
 
     @Override

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/jdt/JdtProjectHelper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/jdt/JdtProjectHelper.java
@@ -18,15 +18,17 @@ public final class JdtProjectHelper {
      * attempts to generate a temporary Eclipse one.
      *
      * @param projectPath the absolute project location.
-     * @return true if the project contains a build tool's configuration file supported by JDT, false if otherwise.
+     * @return true if the project contains a Eclipse configuration files, false if otherwise.
      */
     public static boolean ensureProjectConfiguration(Path projectPath) throws IOException {
         // If a JDT supported build file already exists, we're good.
-        if (Files.exists(projectPath.resolve(".project"))
-                || Files.exists(projectPath.resolve("pom.xml"))
-                || Files.exists(projectPath.resolve("build.gradle"))
-                || Files.exists(projectPath.resolve("build.gradle.kts"))) {
+        if (Files.exists(projectPath.resolve(".project"))) {
             return true;
+        } else if (Files.exists(projectPath.resolve("pom.xml"))
+                || Files.exists(projectPath.resolve("build.gradle"))
+                || Files.exists(projectPath.resolve("build.gradle.kts"))
+                || Files.exists(projectPath.resolve("build.xml"))) {
+            return false;
         }
 
         logger.debug("No standard build file found. Generating default Eclipse configuration.");

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/jdt/SharedJdtLspServer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/jdt/SharedJdtLspServer.java
@@ -3,6 +3,7 @@ package io.github.jbellis.brokk.analyzer.lsp.jdt;
 import com.google.common.base.Splitter;
 import io.github.jbellis.brokk.IConsoleIO;
 import io.github.jbellis.brokk.analyzer.lsp.LspFileUtilities;
+import io.github.jbellis.brokk.analyzer.lsp.LspLanguageClient;
 import io.github.jbellis.brokk.analyzer.lsp.LspServer;
 import io.github.jbellis.brokk.analyzer.lsp.SupportedLspServer;
 import io.github.jbellis.brokk.gui.dialogs.analyzer.JavaAnalyzerSettingsPanel;
@@ -90,9 +91,14 @@ public final class SharedJdtLspServer extends LspServer {
     }
 
     @Override
-    protected LanguageClient getLanguageClient(
+    protected LspLanguageClient getLanguageClient(
             String language, CountDownLatch serverReadyLatch, Map<String, CountDownLatch> workspaceReadyLatchMap) {
         this.languageClient = new JdtLanguageClient(language, serverReadyLatch, workspaceReadyLatchMap);
+        return this.languageClient;
+    }
+
+    /** Returns the current language client, or null if not initialized. */
+    public @Nullable LanguageClient getLanguageClient() {
         return this.languageClient;
     }
 

--- a/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
@@ -3,81 +3,17 @@ package io.github.jbellis.brokk;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.github.jbellis.brokk.analyzer.CodeUnit;
-import io.github.jbellis.brokk.analyzer.IAnalyzer;
-import io.github.jbellis.brokk.analyzer.ProjectFile;
+import io.github.jbellis.brokk.testutil.MockAnalyzer;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class CompletionsTest {
     @TempDir
     Path tempDir;
-
-    private static class MockAnalyzer implements IAnalyzer {
-        private final ProjectFile mockFile;
-        private final List<CodeUnit> allClasses;
-        private final Map<String, List<CodeUnit>> methodsMap;
-
-        MockAnalyzer(Path rootDir) {
-            this.mockFile = new ProjectFile(rootDir, "MockFile.java");
-            this.allClasses = List.of(
-                    CodeUnit.cls(mockFile, "a.b", "Do"),
-                    CodeUnit.cls(mockFile, "a.b", "Do$Re"),
-                    CodeUnit.cls(mockFile, "a.b", "Do$Re$Sub"), // nested inside Re
-                    CodeUnit.cls(mockFile, "x.y", "Zz"),
-                    CodeUnit.cls(mockFile, "w.u", "Zz"),
-                    CodeUnit.cls(mockFile, "test", "CamelClass"));
-            this.methodsMap = Map.ofEntries(
-                    Map.entry(
-                            "a.b.Do",
-                            List.of(CodeUnit.fn(mockFile, "a.b", "Do.foo"), CodeUnit.fn(mockFile, "a.b", "Do.bar"))),
-                    Map.entry("a.b.Do$Re", List.of(CodeUnit.fn(mockFile, "a.b", "Do$Re.baz"))),
-                    Map.entry("a.b.Do$Re$Sub", List.of(CodeUnit.fn(mockFile, "a.b", "Do$Re$Sub.qux"))),
-                    Map.entry("x.y.Zz", List.of()),
-                    Map.entry("w.u.Zz", List.of()),
-                    Map.entry("test.CamelClass", List.of(CodeUnit.fn(mockFile, "test", "CamelClass.someMethod"))));
-        }
-
-        @Override
-        public List<CodeUnit> getAllDeclarations() {
-            return allClasses;
-        }
-
-        @Override
-        public List<CodeUnit> getMembersInClass(String fqClass) {
-            return methodsMap.getOrDefault(fqClass, List.of());
-        }
-
-        @Override
-        public List<CodeUnit> searchDefinitions(String pattern) {
-            if (".*".equals(pattern)) {
-                return Stream.concat(
-                                allClasses.stream(),
-                                methodsMap.values().stream().flatMap(List::stream))
-                        .toList();
-            }
-
-            var regex = "^(?i)" + pattern + "$";
-
-            // Find matching classes
-            var matchingClasses =
-                    allClasses.stream().filter(cu -> cu.fqName().matches(regex)).toList();
-
-            // Find matching methods
-            var matchingMethods = methodsMap.entrySet().stream()
-                    .flatMap(entry -> entry.getValue().stream())
-                    .filter(cu -> cu.fqName().matches(regex))
-                    .toList();
-
-            return Stream.concat(matchingClasses.stream(), matchingMethods.stream())
-                    .toList();
-        }
-    }
 
     // Helper to extract values for easy assertion
     private static Set<String> toValues(List<CodeUnit> candidates) {

--- a/app/src/test/java/io/github/jbellis/brokk/agents/CodeAgentTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/agents/CodeAgentTest.java
@@ -10,6 +10,7 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import io.github.jbellis.brokk.*;
+import io.github.jbellis.brokk.analyzer.LintResult;
 import io.github.jbellis.brokk.prompts.EditBlockParser;
 import io.github.jbellis.brokk.testutil.TestConsoleIO;
 import io.github.jbellis.brokk.testutil.TestContextManager;
@@ -92,7 +93,8 @@ class CodeAgentTest {
                 new ArrayList<>(pendingBlocks), // Modifiable copy
                 0, // consecutiveParseFailures
                 0, // consecutiveApplyFailures
-                0, // consecutiveBuildFailures (new)
+                0, // consecutiveBuildFailures
+                0, // consecutiveLintFailures
                 blocksAppliedWithoutBuild,
                 "", // lastBuildError
                 new HashSet<>(), // changedFiles
@@ -345,7 +347,8 @@ class CodeAgentTest {
                         List.of(), // pending blocks are empty
                         retryStep.loopContext().editState().consecutiveParseFailures(),
                         retryStep.loopContext().editState().consecutiveApplyFailures(),
-                        retryStep.loopContext().editState().consecutiveBuildFailures(), // new
+                        retryStep.loopContext().editState().consecutiveBuildFailures(),
+                        retryStep.loopContext().editState().consecutiveLintFailures(),
                         1, // Simulate one new fix was applied to pass the guard in verifyPhase
                         retryStep.loopContext().editState().lastBuildError(),
                         retryStep.loopContext().editState().changedFiles(),
@@ -455,5 +458,117 @@ class CodeAgentTest {
         assertTrue(
                 continueStep.loopContext().editState().changedFiles().contains(file),
                 "changedFiles should include the edited file");
+    }
+
+    // L-3: Linting check - single lint error causes retry
+    @Test
+    void testVerifyPhase_lintErrorCausesRetry() throws IOException {
+        var file = contextManager.toFile("Test.java");
+        file.write("public class Test { }");
+        contextManager.addEditableFile(file);
+
+        // Configure mock analyzer to return lint errors
+        var lintDiagnostic = new LintResult.LintDiagnostic(
+                file.toString(), 1, 10, LintResult.LintDiagnostic.Severity.ERROR, "Missing semicolon", "CS001");
+        contextManager.getMockAnalyzer().setLintBehavior(files -> new LintResult(List.of(lintDiagnostic)));
+
+        // one block was applied to trigger verify phase
+        var loopContext = createLoopContext("goal", List.of(), new UserMessage("req"), List.of(), 1);
+        loopContext.editState().changedFiles().add(file);
+
+        var result = codeAgent.verifyPhase(loopContext, null);
+
+        assertInstanceOf(CodeAgent.Step.Retry.class, result);
+        var retryStep = (CodeAgent.Step.Retry) result;
+        assertEquals(1, retryStep.loopContext().editState().consecutiveLintFailures());
+
+        String retryMessage =
+                Messages.getText(retryStep.loopContext().conversationState().nextRequest());
+        assertTrue(retryMessage.contains("Linting found 1 error(s)"));
+        assertTrue(retryMessage.contains("Missing semicolon"));
+        assertTrue(retryMessage.contains(file.toString() + ":1:10"));
+    }
+
+    // L-4: Linting check - MAX_LINT_FAILURES reached
+    @Test
+    void testVerifyPhase_maxLintFailuresReached() throws IOException {
+        var file = contextManager.toFile("Test.java");
+        file.write("public class Test { }");
+        contextManager.addEditableFile(file);
+
+        // Configure mock analyzer to always return lint errors
+        var lintDiagnostic = new LintResult.LintDiagnostic(
+                file.toString(), 1, 10, LintResult.LintDiagnostic.Severity.ERROR, "Syntax error", "CS001");
+        contextManager.getMockAnalyzer().setLintBehavior(files -> new LintResult(List.of(lintDiagnostic)));
+
+        // Start with consecutive lint failures already at MAX_LINT_FAILURES - 1
+        var loopContext = createLoopContext("goal", List.of(), new UserMessage("req"), List.of(), 1);
+        var es = loopContext.editState();
+        var esWithFailures = new CodeAgent.EditState(
+                es.pendingBlocks(),
+                es.consecutiveParseFailures(),
+                es.consecutiveApplyFailures(),
+                es.consecutiveBuildFailures(),
+                CodeAgent.MAX_LINT_FAILURES - 1, // Just below the limit
+                es.blocksAppliedWithoutBuild(),
+                es.lastBuildError(),
+                es.changedFiles(),
+                es.originalFileContents());
+        var lcWithFailures =
+                new CodeAgent.LoopContext(loopContext.conversationState(), esWithFailures, loopContext.userGoal());
+        lcWithFailures.editState().changedFiles().add(file);
+
+        var result = codeAgent.verifyPhase(lcWithFailures, null);
+
+        assertInstanceOf(CodeAgent.Step.Fatal.class, result);
+        var fatalStep = (CodeAgent.Step.Fatal) result;
+        assertEquals(TaskResult.StopReason.BUILD_ERROR, fatalStep.stopDetails().reason());
+        assertTrue(fatalStep.stopDetails().explanation().contains("Unable to fix lint errors"));
+    }
+
+    // L-5: Linting check - success resets consecutive failures on build failure
+    @Test
+    void testVerifyPhase_lintSuccessResetsFailuresOnBuildFailure() throws IOException {
+        var file = contextManager.toFile("Test.java");
+        file.write("public class Test { }");
+        contextManager.addEditableFile(file);
+
+        // Configure mock analyzer to return no lint errors
+        contextManager.getMockAnalyzer().setLintBehavior(files -> new LintResult(List.of()));
+
+        // Configure build to fail
+        var bd = new BuildAgent.BuildDetails("echo build", "echo testAll", "echo test {{files}}", Set.of());
+        contextManager.getProject().setBuildDetails(bd);
+        contextManager.getProject().setCodeAgentTestScope(IProject.CodeAgentTestScope.ALL);
+        Environment.shellCommandRunnerFactory = (cmd, root) -> (outputConsumer, timeout) -> {
+            throw new Environment.FailureException("Build failed", "Some build error");
+        };
+
+        // Start with one prior lint failure
+        var loopContext = createLoopContext("goal", List.of(), new UserMessage("req"), List.of(), 1);
+        var es = loopContext.editState();
+        var esWithFailures = new CodeAgent.EditState(
+                es.pendingBlocks(),
+                es.consecutiveParseFailures(),
+                es.consecutiveApplyFailures(),
+                es.consecutiveBuildFailures(),
+                1, // one prior failure
+                es.blocksAppliedWithoutBuild(),
+                es.lastBuildError(),
+                es.changedFiles(),
+                es.originalFileContents());
+        var lcWithFailures =
+                new CodeAgent.LoopContext(loopContext.conversationState(), esWithFailures, loopContext.userGoal());
+        lcWithFailures.editState().changedFiles().add(file);
+
+        // This call should succeed linting, then fail the build, and return a Retry step
+        var result = codeAgent.verifyPhase(lcWithFailures, null);
+        assertInstanceOf(CodeAgent.Step.Retry.class, result);
+        var retryStep = (CodeAgent.Step.Retry) result;
+
+        // verify that consecutiveLintFailures is reset to 0
+        assertEquals(0, retryStep.loopContext().editState().consecutiveLintFailures());
+        // and that consecutiveBuildFailures is incremented
+        assertEquals(1, retryStep.loopContext().editState().consecutiveBuildFailures());
     }
 }

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/linting/JdtAnalyzerLintingTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/linting/JdtAnalyzerLintingTest.java
@@ -38,6 +38,7 @@ class JdtAnalyzerLintingTest {
 
     @BeforeEach
     void setUp() throws IOException {
+        tempDir = tempDir.toRealPath();
         Path testFile = tempDir.resolve("ErrorTest.java");
         Files.writeString(
                 testFile,

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/linting/JdtAnalyzerLintingTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/linting/JdtAnalyzerLintingTest.java
@@ -1,0 +1,136 @@
+package io.github.jbellis.brokk.analyzer.linting;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.wildfly.common.Assert.assertTrue;
+
+import io.github.jbellis.brokk.IProject;
+import io.github.jbellis.brokk.analyzer.JdtAnalyzer;
+import io.github.jbellis.brokk.analyzer.LintResult;
+import io.github.jbellis.brokk.analyzer.ProjectFile;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class JdtAnalyzerLintingTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Nullable
+    private static JdtAnalyzer analyzer = null;
+
+    private static IProject testProject;
+
+    private static final Logger logger = LoggerFactory.getLogger(JdtAnalyzerLintingTest.class);
+
+    @BeforeEach
+    void setUp() throws IOException {
+        Path testFile = tempDir.resolve("ErrorTest.java");
+        Files.writeString(
+                testFile,
+                """
+                        public class ErrorTest {
+                            private UndefinedType field; // Error: undefined type
+
+                            public void methodWithErrors() {
+                                nonExistentMethod(); // Error: undefined method
+                                int unused = 5; // Warning: unused variable
+                            }
+
+                            public void validMethod() {
+                                System.out.println("This is valid");
+                            }
+
+                        }
+                        """);
+
+        Path validFile = tempDir.resolve("ValidTest.java");
+        Files.writeString(
+                validFile,
+                """
+                        public class ValidTest {
+
+                            public void validMethod() {
+                                System.out.println("This is completely valid");
+                            }
+
+                        }
+                        """);
+
+        testProject = new IProject() {
+
+            @Override
+            public Path getRoot() {
+                return tempDir.toAbsolutePath();
+            }
+
+            @Override
+            public Set<ProjectFile> getAllFiles() {
+                var files = tempDir.toFile().listFiles();
+                if (files == null) {
+                    return Collections.emptySet();
+                }
+                return Arrays.stream(files)
+                        .map(file -> new ProjectFile(tempDir, file.toPath()))
+                        .collect(Collectors.toSet());
+            }
+        };
+        logger.debug("Setting up analyzer with test code from {}", testProject.getRoot());
+        analyzer = new JdtAnalyzer(testProject);
+    }
+
+    @AfterAll
+    public static void teardown() throws IOException {
+        if (analyzer != null) {
+            analyzer.close();
+        }
+
+        try {
+            testProject.close();
+        } catch (Exception e) {
+            logger.error("Exception encountered while closing the test project", e);
+        }
+    }
+
+    @Test
+    void testLintFilesWithoutErrors() {
+        assertNotNull(analyzer, "Analyzer should be initialized");
+        // Create a Java file with syntax error
+        Path javaFile = tempDir.resolve("ValidTest.java");
+        ProjectFile projectFile =
+                new ProjectFile(tempDir, javaFile.getFileName().toString());
+
+        // Test linting
+        LintResult results = analyzer.lintFiles(List.of(projectFile));
+        assertFalse(results.hasErrors());
+    }
+
+    @Test
+    void testLintFilesWithErrors() {
+        assertNotNull(analyzer, "Analyzer should be initialized");
+        // Create a Java file with syntax error
+        Path javaFile = tempDir.resolve("ErrorTest.java");
+        ProjectFile projectFile =
+                new ProjectFile(tempDir, javaFile.getFileName().toString());
+
+        // Test linting
+        LintResult results = analyzer.lintFiles(List.of(projectFile));
+        assertTrue(results.hasErrors());
+
+        final var errors = results.getErrors();
+        assertFalse(errors.isEmpty());
+    }
+}

--- a/app/src/test/java/io/github/jbellis/brokk/testutil/MockAnalyzer.java
+++ b/app/src/test/java/io/github/jbellis/brokk/testutil/MockAnalyzer.java
@@ -1,0 +1,121 @@
+package io.github.jbellis.brokk.testutil;
+
+import io.github.jbellis.brokk.analyzer.CodeUnit;
+import io.github.jbellis.brokk.analyzer.IAnalyzer;
+import io.github.jbellis.brokk.analyzer.LintResult;
+import io.github.jbellis.brokk.analyzer.ProjectFile;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Mock analyzer implementation for testing that provides minimal functionality to support fragment freezing and linting
+ * without requiring a full CPG.
+ */
+public class MockAnalyzer implements IAnalyzer {
+    private final ProjectFile mockFile;
+    private final List<CodeUnit> allClasses;
+    private final Map<String, List<CodeUnit>> methodsMap;
+    private Function<List<ProjectFile>, LintResult> lintBehavior = files -> new LintResult(List.of());
+
+    public MockAnalyzer(Path rootDir) {
+        this.mockFile = new ProjectFile(rootDir, "MockFile.java");
+        this.allClasses = List.of(
+                CodeUnit.cls(mockFile, "a.b", "Do"),
+                CodeUnit.cls(mockFile, "a.b", "Do$Re"),
+                CodeUnit.cls(mockFile, "a.b", "Do$Re$Sub"), // nested inside Re
+                CodeUnit.cls(mockFile, "x.y", "Zz"),
+                CodeUnit.cls(mockFile, "w.u", "Zz"),
+                CodeUnit.cls(mockFile, "test", "CamelClass"));
+        this.methodsMap = Map.ofEntries(
+                Map.entry(
+                        "a.b.Do",
+                        List.of(CodeUnit.fn(mockFile, "a.b", "Do.foo"), CodeUnit.fn(mockFile, "a.b", "Do.bar"))),
+                Map.entry("a.b.Do$Re", List.of(CodeUnit.fn(mockFile, "a.b", "Do$Re.baz"))),
+                Map.entry("a.b.Do$Re$Sub", List.of(CodeUnit.fn(mockFile, "a.b", "Do$Re$Sub.qux"))),
+                Map.entry("x.y.Zz", List.of()),
+                Map.entry("w.u.Zz", List.of()),
+                Map.entry("test.CamelClass", List.of(CodeUnit.fn(mockFile, "test", "CamelClass.someMethod"))));
+    }
+
+    public void setLintBehavior(Function<List<ProjectFile>, LintResult> behavior) {
+        this.lintBehavior = behavior;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public boolean isCpg() {
+        return false; // This will cause dynamic fragments to return placeholder text
+    }
+
+    @Override
+    public List<CodeUnit> getUses(String fqName) {
+        return List.of(); // Return empty list for test purposes
+    }
+
+    @Override
+    public List<CodeUnit> getAllDeclarations() {
+        return allClasses;
+    }
+
+    @Override
+    public List<CodeUnit> getMembersInClass(String fqClass) {
+        return methodsMap.getOrDefault(fqClass, List.of());
+    }
+
+    @Override
+    public List<CodeUnit> searchDefinitions(String pattern) {
+        if (".*".equals(pattern)) {
+            return Stream.concat(
+                            allClasses.stream(), methodsMap.values().stream().flatMap(List::stream))
+                    .toList();
+        }
+
+        var regex = "^(?i)" + pattern + "$";
+
+        // Find matching classes
+        var matchingClasses =
+                allClasses.stream().filter(cu -> cu.fqName().matches(regex)).toList();
+
+        // Find matching methods
+        var matchingMethods = methodsMap.entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream())
+                .filter(cu -> cu.fqName().matches(regex))
+                .toList();
+
+        return Stream.concat(matchingClasses.stream(), matchingMethods.stream()).toList();
+    }
+
+    @Override
+    public Optional<CodeUnit> getDefinition(String fqName) {
+        return Optional.empty(); // Return empty for test purposes
+    }
+
+    @Override
+    public Set<CodeUnit> getDeclarationsInFile(ProjectFile file) {
+        return Set.of(); // Return empty set for test purposes
+    }
+
+    @Override
+    public Optional<String> getSkeleton(String fqName) {
+        return Optional.empty(); // Return empty for test purposes
+    }
+
+    @Override
+    public Map<CodeUnit, String> getSkeletons(ProjectFile file) {
+        return Map.of(); // Return empty map for test purposes
+    }
+
+    @Override
+    public LintResult lintFiles(List<ProjectFile> files) {
+        return lintBehavior.apply(files);
+    }
+}

--- a/app/src/test/java/io/github/jbellis/brokk/testutil/TestContextManager.java
+++ b/app/src/test/java/io/github/jbellis/brokk/testutil/TestContextManager.java
@@ -16,7 +16,7 @@ import java.util.Set;
 
 public final class TestContextManager implements IContextManager {
     private final TestProject project;
-    private final IAnalyzer mockAnalyzer;
+    private final MockAnalyzer mockAnalyzer;
     private final InMemoryRepo inMemoryRepo;
     private final Set<ProjectFile> editableFiles = new HashSet<>();
     private final Set<ProjectFile> readonlyFiles = new HashSet<>();
@@ -26,7 +26,7 @@ public final class TestContextManager implements IContextManager {
 
     public TestContextManager(Path projectRoot, IConsoleIO consoleIO) {
         this.project = new TestProject(projectRoot, Language.JAVA);
-        this.mockAnalyzer = new MockAnalyzer();
+        this.mockAnalyzer = new MockAnalyzer(projectRoot);
         this.inMemoryRepo = new InMemoryRepo();
         this.consoleIO = consoleIO;
         this.stubService = new StubService(this.project);
@@ -61,6 +61,10 @@ public final class TestContextManager implements IContextManager {
     public void addReadonlyFile(ProjectFile file) {
         this.readonlyFiles.add(file);
         this.editableFiles.remove(file); // Cannot be both
+    }
+
+    public MockAnalyzer getMockAnalyzer() {
+        return mockAnalyzer;
     }
 
     @Override
@@ -106,48 +110,5 @@ public final class TestContextManager implements IContextManager {
     @Override
     public EditBlockParser getParserForWorkspace() {
         return EditBlockParser.getParserFor("");
-    }
-
-    /**
-     * Mock analyzer implementation for testing that provides minimal functionality to support fragment freezing without
-     * requiring a full CPG.
-     */
-    private static class MockAnalyzer implements IAnalyzer {
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
-
-        @Override
-        public boolean isCpg() {
-            return false; // This will cause dynamic fragments to return placeholder text
-        }
-
-        @Override
-        public java.util.List<io.github.jbellis.brokk.analyzer.CodeUnit> getUses(String fqName) {
-            return java.util.List.of(); // Return empty list for test purposes
-        }
-
-        @Override
-        public java.util.Optional<io.github.jbellis.brokk.analyzer.CodeUnit> getDefinition(String fqName) {
-            return java.util.Optional.empty(); // Return empty for test purposes
-        }
-
-        @Override
-        public java.util.Set<io.github.jbellis.brokk.analyzer.CodeUnit> getDeclarationsInFile(
-                io.github.jbellis.brokk.analyzer.ProjectFile file) {
-            return java.util.Set.of(); // Return empty set for test purposes
-        }
-
-        @Override
-        public java.util.Optional<String> getSkeleton(String fqName) {
-            return java.util.Optional.empty(); // Return empty for test purposes
-        }
-
-        @Override
-        public java.util.Map<io.github.jbellis.brokk.analyzer.CodeUnit, String> getSkeletons(
-                io.github.jbellis.brokk.analyzer.ProjectFile file) {
-            return java.util.Map.of(); // Return empty map for test purposes
-        }
     }
 }


### PR DESCRIPTION
* Created `IAnalyzer#lintFiles` API 
* If the result is non-empty, this is given to the CodeAgent to address before attempting to build
* Made various modifications to the LSP/JDT code in order to capture and refresh diagnostics when CodeAgent requires this

<img width="774" height="336" alt="Screenshot 2025-08-25 at 17 01 10" src="https://github.com/user-attachments/assets/b81d4b5b-39f0-455d-bc5c-f8fce41fc59c" />
