### PR TITLE
fix: new test files not recognized as such

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/agents/BuildAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/BuildAgent.java
@@ -381,9 +381,9 @@ public class BuildAgent {
                 .collect(Collectors.toSet());
 
         // Check if any of the identified project test files are present in the current workspace set
-        var projectTestFiles = cm.getTestFiles();
-        var workspaceTestFiles =
-                projectTestFiles.stream().filter(workspaceFiles::contains).toList();
+        var workspaceTestFiles = workspaceFiles.stream()
+                .filter(ContextManager::isTestFile)
+                .toList();
 
         // Decide which command to use
         if (workspaceTestFiles.isEmpty()) {


### PR DESCRIPTION
Fixed the case where the new test file was not run automatically after edits.

Could not reproduce:
> 2. Right click on file, Run Tests. Vanilla build runs again.
Maybe it happens in some situations where analyzer might [not return ](https://github.com/BrokkAi/brokk/blob/e10ab8dd34e19b851e26fb5dc55183945662b3f0/app/src/main/java/io/github/jbellis/brokk/agents/BuildAgent.java#L459) code units for test classes or is [empty](https://github.com/BrokkAi/brokk/blob/e10ab8dd34e19b851e26fb5dc55183945662b3f0/app/src/main/java/io/github/jbellis/brokk/agents/BuildAgent.java#L445) (probably @DavidBakerEffendi or @cmanto might also want to take a look at this case).