### PR TITLE
Minimize Side Tabs on Click

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -87,6 +87,10 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     @Nullable
     private Component lastRelevantFocusOwner = null;
 
+    // Debouncing for tab toggle to prevent duplicate events
+    private long lastTabToggleTime = 0;
+    private static final long TAB_TOGGLE_DEBOUNCE_MS = 200;
+
     // Swing components:
     final JFrame frame;
     private JLabel backgroundStatusLabel;
@@ -214,13 +218,25 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         leftTabbedPanel.setTabComponentAt(projectTabIdx, projectTabLabel);
         projectTabLabel.addMouseListener(new MouseAdapter() {
             @Override
-            public void mouseClicked(MouseEvent e) {
-                leftTabbedPanel.setSelectedIndex(projectTabIdx);
-            }
-
-            @Override
             public void mousePressed(MouseEvent e) {
-                leftTabbedPanel.setSelectedIndex(projectTabIdx);
+                long currentTime = System.currentTimeMillis();
+                if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
+                    return; // Ignore rapid successive clicks
+                }
+                lastTabToggleTime = currentTime;
+
+                if (leftTabbedPanel.getSelectedIndex() == projectTabIdx) {
+                    // Tab already selected, minimize the panel but keep tabs visible
+                    leftTabbedPanel.setSelectedIndex(-1);
+                    bottomSplitPane.setDividerLocation(40);
+                } else {
+                    leftTabbedPanel.setSelectedIndex(projectTabIdx);
+                    // Restore panel if it was minimized
+                    if (bottomSplitPane.getDividerLocation() < 50) {
+                        int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
+                        bottomSplitPane.setDividerLocation(preferred);
+                    }
+                }
             }
         });
 
@@ -238,12 +254,46 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             gitTabLabel.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mouseClicked(MouseEvent e) {
-                    leftTabbedPanel.setSelectedIndex(gitTabIdx);
+                    long currentTime = System.currentTimeMillis();
+                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
+                        return; // Ignore rapid successive clicks
+                    }
+                    lastTabToggleTime = currentTime;
+
+                    if (leftTabbedPanel.getSelectedIndex() == gitTabIdx) {
+                        // Tab already selected, minimize the panel but keep tabs visible
+                        leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerLocation(40);
+                    } else {
+                        leftTabbedPanel.setSelectedIndex(gitTabIdx);
+                        // Restore panel if it was minimized
+                        if (bottomSplitPane.getDividerLocation() < 50) {
+                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
+                            bottomSplitPane.setDividerLocation(preferred);
+                        }
+                    }
                 }
 
                 @Override
                 public void mousePressed(MouseEvent e) {
-                    leftTabbedPanel.setSelectedIndex(gitTabIdx);
+                    long currentTime = System.currentTimeMillis();
+                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
+                        return; // Ignore rapid successive clicks
+                    }
+                    lastTabToggleTime = currentTime;
+
+                    if (leftTabbedPanel.getSelectedIndex() == gitTabIdx) {
+                        // Tab already selected, minimize the panel but keep tabs visible
+                        leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerLocation(40);
+                    } else {
+                        leftTabbedPanel.setSelectedIndex(gitTabIdx);
+                        // Restore panel if it was minimized
+                        if (bottomSplitPane.getDividerLocation() < 50) {
+                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
+                            bottomSplitPane.setDividerLocation(preferred);
+                        }
+                    }
                 }
             });
             gitPanel.updateRepo();
@@ -263,12 +313,46 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             prLabel.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mouseClicked(MouseEvent e) {
-                    leftTabbedPanel.setSelectedIndex(prIdx);
+                    long currentTime = System.currentTimeMillis();
+                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
+                        return; // Ignore rapid successive clicks
+                    }
+                    lastTabToggleTime = currentTime;
+
+                    if (leftTabbedPanel.getSelectedIndex() == prIdx) {
+                        // Tab already selected, minimize the panel but keep tabs visible
+                        leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerLocation(40);
+                    } else {
+                        leftTabbedPanel.setSelectedIndex(prIdx);
+                        // Restore panel if it was minimized
+                        if (bottomSplitPane.getDividerLocation() < 50) {
+                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
+                            bottomSplitPane.setDividerLocation(preferred);
+                        }
+                    }
                 }
 
                 @Override
                 public void mousePressed(MouseEvent e) {
-                    leftTabbedPanel.setSelectedIndex(prIdx);
+                    long currentTime = System.currentTimeMillis();
+                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
+                        return; // Ignore rapid successive clicks
+                    }
+                    lastTabToggleTime = currentTime;
+
+                    if (leftTabbedPanel.getSelectedIndex() == prIdx) {
+                        // Tab already selected, minimize the panel but keep tabs visible
+                        leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerLocation(40);
+                    } else {
+                        leftTabbedPanel.setSelectedIndex(prIdx);
+                        // Restore panel if it was minimized
+                        if (bottomSplitPane.getDividerLocation() < 50) {
+                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
+                            bottomSplitPane.setDividerLocation(preferred);
+                        }
+                    }
                 }
             });
         }
@@ -285,12 +369,46 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             issLabel.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mouseClicked(MouseEvent e) {
-                    leftTabbedPanel.setSelectedIndex(issIdx);
+                    long currentTime = System.currentTimeMillis();
+                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
+                        return; // Ignore rapid successive clicks
+                    }
+                    lastTabToggleTime = currentTime;
+
+                    if (leftTabbedPanel.getSelectedIndex() == issIdx) {
+                        // Tab already selected, minimize the panel but keep tabs visible
+                        leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerLocation(40);
+                    } else {
+                        leftTabbedPanel.setSelectedIndex(issIdx);
+                        // Restore panel if it was minimized
+                        if (bottomSplitPane.getDividerLocation() < 50) {
+                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
+                            bottomSplitPane.setDividerLocation(preferred);
+                        }
+                    }
                 }
 
                 @Override
                 public void mousePressed(MouseEvent e) {
-                    leftTabbedPanel.setSelectedIndex(issIdx);
+                    long currentTime = System.currentTimeMillis();
+                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
+                        return; // Ignore rapid successive clicks
+                    }
+                    lastTabToggleTime = currentTime;
+
+                    if (leftTabbedPanel.getSelectedIndex() == issIdx) {
+                        // Tab already selected, minimize the panel but keep tabs visible
+                        leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerLocation(40);
+                    } else {
+                        leftTabbedPanel.setSelectedIndex(issIdx);
+                        // Restore panel if it was minimized
+                        if (bottomSplitPane.getDividerLocation() < 50) {
+                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
+                            bottomSplitPane.setDividerLocation(preferred);
+                        }
+                    }
                 }
             });
         }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -89,7 +89,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
 
     // Debouncing for tab toggle to prevent duplicate events
     private long lastTabToggleTime = 0;
-    private static final long TAB_TOGGLE_DEBOUNCE_MS = 100;
+    private static final long TAB_TOGGLE_DEBOUNCE_MS = 150;
 
     // Store original divider size for hiding/showing divider
     private int originalBottomDividerSize;
@@ -1493,10 +1493,16 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             int bottomHorizPos = project.getHorizontalSplitPosition();
             if (bottomHorizPos > 0) {
                 bottomSplitPane.setDividerLocation(bottomHorizPos);
+                // Check if restored position indicates minimized state
+                if (bottomHorizPos < 50) {
+                    bottomSplitPane.setDividerSize(0);
+                    leftTabbedPanel.setSelectedIndex(-1);
+                }
             } else {
                 int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                 bottomSplitPane.setDividerLocation(preferred);
             }
+
             bottomSplitPane.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, e -> {
                 if (bottomSplitPane.isShowing()) {
                     var newPos = bottomSplitPane.getDividerLocation();

--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -91,6 +91,33 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     private long lastTabToggleTime = 0;
     private static final long TAB_TOGGLE_DEBOUNCE_MS = 150;
 
+    /**
+     * Handles tab toggle behavior - minimizes panel if tab is already selected, otherwise selects the tab and restores
+     * panel if it was minimized.
+     */
+    private void handleTabToggle(int tabIndex) {
+        long currentTime = System.currentTimeMillis();
+        if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
+            return; // Ignore rapid successive clicks
+        }
+        lastTabToggleTime = currentTime;
+
+        if (leftTabbedPanel.getSelectedIndex() == tabIndex) {
+            // Tab already selected, minimize the panel but keep tabs visible
+            leftTabbedPanel.setSelectedIndex(-1);
+            bottomSplitPane.setDividerSize(0);
+            bottomSplitPane.setDividerLocation(40);
+        } else {
+            leftTabbedPanel.setSelectedIndex(tabIndex);
+            // Restore panel if it was minimized
+            if (bottomSplitPane.getDividerLocation() < 50) {
+                bottomSplitPane.setDividerSize(originalBottomDividerSize);
+                int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
+                bottomSplitPane.setDividerLocation(preferred);
+            }
+        }
+    }
+
     // Store original divider size for hiding/showing divider
     private int originalBottomDividerSize;
 
@@ -222,26 +249,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         projectTabLabel.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
-                long currentTime = System.currentTimeMillis();
-                if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
-                    return; // Ignore rapid successive clicks
-                }
-                lastTabToggleTime = currentTime;
-
-                if (leftTabbedPanel.getSelectedIndex() == projectTabIdx) {
-                    // Tab already selected, minimize the panel but keep tabs visible
-                    leftTabbedPanel.setSelectedIndex(-1);
-                    bottomSplitPane.setDividerSize(0);
-                    bottomSplitPane.setDividerLocation(40);
-                } else {
-                    leftTabbedPanel.setSelectedIndex(projectTabIdx);
-                    // Restore panel if it was minimized
-                    if (bottomSplitPane.getDividerLocation() < 50) {
-                        bottomSplitPane.setDividerSize(originalBottomDividerSize);
-                        int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
-                        bottomSplitPane.setDividerLocation(preferred);
-                    }
-                }
+                handleTabToggle(projectTabIdx);
             }
         });
 
@@ -259,26 +267,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             gitTabLabel.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mousePressed(MouseEvent e) {
-                    long currentTime = System.currentTimeMillis();
-                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
-                        return; // Ignore rapid successive clicks
-                    }
-                    lastTabToggleTime = currentTime;
-
-                    if (leftTabbedPanel.getSelectedIndex() == gitTabIdx) {
-                        // Tab already selected, minimize the panel but keep tabs visible
-                        leftTabbedPanel.setSelectedIndex(-1);
-                        bottomSplitPane.setDividerSize(0);
-                        bottomSplitPane.setDividerLocation(40);
-                    } else {
-                        leftTabbedPanel.setSelectedIndex(gitTabIdx);
-                        // Restore panel if it was minimized
-                        if (bottomSplitPane.getDividerLocation() < 50) {
-                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
-                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
-                            bottomSplitPane.setDividerLocation(preferred);
-                        }
-                    }
+                    handleTabToggle(gitTabIdx);
                 }
             });
             gitPanel.updateRepo();
@@ -298,26 +287,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             prLabel.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mousePressed(MouseEvent e) {
-                    long currentTime = System.currentTimeMillis();
-                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
-                        return; // Ignore rapid successive clicks
-                    }
-                    lastTabToggleTime = currentTime;
-
-                    if (leftTabbedPanel.getSelectedIndex() == prIdx) {
-                        // Tab already selected, minimize the panel but keep tabs visible
-                        leftTabbedPanel.setSelectedIndex(-1);
-                        bottomSplitPane.setDividerSize(0);
-                        bottomSplitPane.setDividerLocation(40);
-                    } else {
-                        leftTabbedPanel.setSelectedIndex(prIdx);
-                        // Restore panel if it was minimized
-                        if (bottomSplitPane.getDividerLocation() < 50) {
-                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
-                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
-                            bottomSplitPane.setDividerLocation(preferred);
-                        }
-                    }
+                    handleTabToggle(prIdx);
                 }
             });
         }
@@ -334,26 +304,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             issLabel.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mousePressed(MouseEvent e) {
-                    long currentTime = System.currentTimeMillis();
-                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
-                        return; // Ignore rapid successive clicks
-                    }
-                    lastTabToggleTime = currentTime;
-
-                    if (leftTabbedPanel.getSelectedIndex() == issIdx) {
-                        // Tab already selected, minimize the panel but keep tabs visible
-                        leftTabbedPanel.setSelectedIndex(-1);
-                        bottomSplitPane.setDividerSize(0);
-                        bottomSplitPane.setDividerLocation(40);
-                    } else {
-                        leftTabbedPanel.setSelectedIndex(issIdx);
-                        // Restore panel if it was minimized
-                        if (bottomSplitPane.getDividerLocation() < 50) {
-                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
-                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
-                            bottomSplitPane.setDividerLocation(preferred);
-                        }
-                    }
+                    handleTabToggle(issIdx);
                 }
             });
         }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -258,30 +258,6 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             leftTabbedPanel.setTabComponentAt(gitTabIdx, gitTabLabel);
             gitTabLabel.addMouseListener(new MouseAdapter() {
                 @Override
-                public void mouseClicked(MouseEvent e) {
-                    long currentTime = System.currentTimeMillis();
-                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
-                        return; // Ignore rapid successive clicks
-                    }
-                    lastTabToggleTime = currentTime;
-
-                    if (leftTabbedPanel.getSelectedIndex() == gitTabIdx) {
-                        // Tab already selected, minimize the panel but keep tabs visible
-                        leftTabbedPanel.setSelectedIndex(-1);
-                        bottomSplitPane.setDividerSize(0);
-                        bottomSplitPane.setDividerLocation(40);
-                    } else {
-                        leftTabbedPanel.setSelectedIndex(gitTabIdx);
-                        // Restore panel if it was minimized
-                        if (bottomSplitPane.getDividerLocation() < 50) {
-                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
-                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
-                            bottomSplitPane.setDividerLocation(preferred);
-                        }
-                    }
-                }
-
-                @Override
                 public void mousePressed(MouseEvent e) {
                     long currentTime = System.currentTimeMillis();
                     if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
@@ -321,30 +297,6 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             leftTabbedPanel.setTabComponentAt(prIdx, prLabel);
             prLabel.addMouseListener(new MouseAdapter() {
                 @Override
-                public void mouseClicked(MouseEvent e) {
-                    long currentTime = System.currentTimeMillis();
-                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
-                        return; // Ignore rapid successive clicks
-                    }
-                    lastTabToggleTime = currentTime;
-
-                    if (leftTabbedPanel.getSelectedIndex() == prIdx) {
-                        // Tab already selected, minimize the panel but keep tabs visible
-                        leftTabbedPanel.setSelectedIndex(-1);
-                        bottomSplitPane.setDividerSize(0);
-                        bottomSplitPane.setDividerLocation(40);
-                    } else {
-                        leftTabbedPanel.setSelectedIndex(prIdx);
-                        // Restore panel if it was minimized
-                        if (bottomSplitPane.getDividerLocation() < 50) {
-                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
-                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
-                            bottomSplitPane.setDividerLocation(preferred);
-                        }
-                    }
-                }
-
-                @Override
                 public void mousePressed(MouseEvent e) {
                     long currentTime = System.currentTimeMillis();
                     if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
@@ -380,30 +332,6 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             var issLabel = createSquareTabLabel(issIcon, "Issues");
             leftTabbedPanel.setTabComponentAt(issIdx, issLabel);
             issLabel.addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseClicked(MouseEvent e) {
-                    long currentTime = System.currentTimeMillis();
-                    if (currentTime - lastTabToggleTime < TAB_TOGGLE_DEBOUNCE_MS) {
-                        return; // Ignore rapid successive clicks
-                    }
-                    lastTabToggleTime = currentTime;
-
-                    if (leftTabbedPanel.getSelectedIndex() == issIdx) {
-                        // Tab already selected, minimize the panel but keep tabs visible
-                        leftTabbedPanel.setSelectedIndex(-1);
-                        bottomSplitPane.setDividerSize(0);
-                        bottomSplitPane.setDividerLocation(40);
-                    } else {
-                        leftTabbedPanel.setSelectedIndex(issIdx);
-                        // Restore panel if it was minimized
-                        if (bottomSplitPane.getDividerLocation() < 50) {
-                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
-                            int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
-                            bottomSplitPane.setDividerLocation(preferred);
-                        }
-                    }
-                }
-
                 @Override
                 public void mousePressed(MouseEvent e) {
                     long currentTime = System.currentTimeMillis();
@@ -819,11 +747,6 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             var label = createSquareTabLabel(icon, "Issues");
             leftTabbedPanel.setTabComponentAt(tabIdx, label);
             label.addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseClicked(MouseEvent e) {
-                    leftTabbedPanel.setSelectedIndex(tabIdx);
-                }
-
                 @Override
                 public void mousePressed(MouseEvent e) {
                     leftTabbedPanel.setSelectedIndex(tabIdx);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -89,7 +89,10 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
 
     // Debouncing for tab toggle to prevent duplicate events
     private long lastTabToggleTime = 0;
-    private static final long TAB_TOGGLE_DEBOUNCE_MS = 200;
+    private static final long TAB_TOGGLE_DEBOUNCE_MS = 100;
+
+    // Store original divider size for hiding/showing divider
+    private int originalBottomDividerSize;
 
     // Swing components:
     final JFrame frame;
@@ -228,11 +231,13 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                 if (leftTabbedPanel.getSelectedIndex() == projectTabIdx) {
                     // Tab already selected, minimize the panel but keep tabs visible
                     leftTabbedPanel.setSelectedIndex(-1);
+                    bottomSplitPane.setDividerSize(0);
                     bottomSplitPane.setDividerLocation(40);
                 } else {
                     leftTabbedPanel.setSelectedIndex(projectTabIdx);
                     // Restore panel if it was minimized
                     if (bottomSplitPane.getDividerLocation() < 50) {
+                        bottomSplitPane.setDividerSize(originalBottomDividerSize);
                         int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                         bottomSplitPane.setDividerLocation(preferred);
                     }
@@ -263,11 +268,13 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                     if (leftTabbedPanel.getSelectedIndex() == gitTabIdx) {
                         // Tab already selected, minimize the panel but keep tabs visible
                         leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerSize(0);
                         bottomSplitPane.setDividerLocation(40);
                     } else {
                         leftTabbedPanel.setSelectedIndex(gitTabIdx);
                         // Restore panel if it was minimized
                         if (bottomSplitPane.getDividerLocation() < 50) {
+                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
                             int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                             bottomSplitPane.setDividerLocation(preferred);
                         }
@@ -285,11 +292,13 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                     if (leftTabbedPanel.getSelectedIndex() == gitTabIdx) {
                         // Tab already selected, minimize the panel but keep tabs visible
                         leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerSize(0);
                         bottomSplitPane.setDividerLocation(40);
                     } else {
                         leftTabbedPanel.setSelectedIndex(gitTabIdx);
                         // Restore panel if it was minimized
                         if (bottomSplitPane.getDividerLocation() < 50) {
+                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
                             int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                             bottomSplitPane.setDividerLocation(preferred);
                         }
@@ -322,11 +331,13 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                     if (leftTabbedPanel.getSelectedIndex() == prIdx) {
                         // Tab already selected, minimize the panel but keep tabs visible
                         leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerSize(0);
                         bottomSplitPane.setDividerLocation(40);
                     } else {
                         leftTabbedPanel.setSelectedIndex(prIdx);
                         // Restore panel if it was minimized
                         if (bottomSplitPane.getDividerLocation() < 50) {
+                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
                             int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                             bottomSplitPane.setDividerLocation(preferred);
                         }
@@ -344,11 +355,13 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                     if (leftTabbedPanel.getSelectedIndex() == prIdx) {
                         // Tab already selected, minimize the panel but keep tabs visible
                         leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerSize(0);
                         bottomSplitPane.setDividerLocation(40);
                     } else {
                         leftTabbedPanel.setSelectedIndex(prIdx);
                         // Restore panel if it was minimized
                         if (bottomSplitPane.getDividerLocation() < 50) {
+                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
                             int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                             bottomSplitPane.setDividerLocation(preferred);
                         }
@@ -378,11 +391,13 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                     if (leftTabbedPanel.getSelectedIndex() == issIdx) {
                         // Tab already selected, minimize the panel but keep tabs visible
                         leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerSize(0);
                         bottomSplitPane.setDividerLocation(40);
                     } else {
                         leftTabbedPanel.setSelectedIndex(issIdx);
                         // Restore panel if it was minimized
                         if (bottomSplitPane.getDividerLocation() < 50) {
+                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
                             int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                             bottomSplitPane.setDividerLocation(preferred);
                         }
@@ -400,11 +415,13 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                     if (leftTabbedPanel.getSelectedIndex() == issIdx) {
                         // Tab already selected, minimize the panel but keep tabs visible
                         leftTabbedPanel.setSelectedIndex(-1);
+                        bottomSplitPane.setDividerSize(0);
                         bottomSplitPane.setDividerLocation(40);
                     } else {
                         leftTabbedPanel.setSelectedIndex(issIdx);
                         // Restore panel if it was minimized
                         if (bottomSplitPane.getDividerLocation() < 50) {
+                            bottomSplitPane.setDividerSize(originalBottomDividerSize);
                             int preferred = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                             bottomSplitPane.setDividerLocation(preferred);
                         }
@@ -450,6 +467,9 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         bottomSplitPane.setResizeWeight(0.0);
         int initialDividerLocation = computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
         bottomSplitPane.setDividerLocation(initialDividerLocation);
+
+        // Store original divider size
+        originalBottomDividerSize = bottomSplitPane.getDividerSize();
 
         bottomPanel.add(bottomSplitPane, BorderLayout.CENTER);
 


### PR DESCRIPTION
Similar to what one can do in VSCode and IntelliJ, clicking on a side tab icon that is already open would minimize the side tab. This is also "remembered" when re-opening the IDE as the tab width would be 0 on startup and detected accordingly as "minimised".

https://github.com/user-attachments/assets/69991396-e1eb-46a1-bf0a-af1c1eb1d72e

