### PR TITLE
Check Analyser Capabilities Before Offering Capture Option

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/MultiAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/MultiAnalyzer.java
@@ -232,4 +232,9 @@ public class MultiAnalyzer
         // TODO -- unused right now
         throw new UnsupportedOperationException();
     }
+
+    /** @return a copy of the delegates of this analyzer. */
+    public Map<Language, IAnalyzer> getDelegates() {
+        return Collections.unmodifiableMap(delegates);
+    }
 }


### PR DESCRIPTION
Checks if the analyser for the current file supports capturing usages/source code before enabling the option. If disabled, offers a tooltip to explain why feature is missing.
<img width="612" height="609" alt="Screenshot 2025-08-27 at 13 49 40" src="https://github.com/user-attachments/assets/2d964437-a8d5-4cd4-a8c7-f863a658de97" />
