### PR TITLE
Fix: Disabled dependencies not persisted; refresh file cache after save

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -943,8 +943,11 @@ public final class MainProject extends AbstractProject {
     public Set<ProjectFile> getLiveDependencies() {
         var allDeps = getAllOnDiskDependencies();
         var liveDepsNames = mainWorkspaceProps.getProperty(LIVE_DEPENDENCIES_KEY);
-        if (liveDepsNames == null || liveDepsNames.isBlank()) {
+        if (liveDepsNames == null) {
             return allDeps;
+        }
+        if (liveDepsNames.isBlank()) {
+            return Set.of();
         }
 
         var liveNamesSet = Arrays.stream(liveDepsNames.split(","))

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/ManageDependenciesDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/ManageDependenciesDialog.java
@@ -247,6 +247,10 @@ public class ManageDependenciesDialog extends JDialog {
         }
         chrome.getProject().saveLiveDependencies(newLiveDependencyTopLevelDirs);
 
+        // Invalidate caches so getAllFiles() reflects the new dependency selection immediately
+        chrome.getProject().invalidateAllFiles();
+        chrome.getProject().getMainProject().invalidateAllFiles();
+
         var newFiles = chrome.getProject().getAllFiles();
 
         var addedFiles = new HashSet<>(newFiles);


### PR DESCRIPTION
fixes #772

- Problem: Unchecking dependencies in Manage Dependencies isn’t remembered and analyzer doesn’t reflect changes.
- Root causes: MainProject.getLiveDependencies treated blank as “all enabled”; getAllFiles() cache wasn’t invalidated.
- Solution: Interpret null as “all” (first run) and blank as “none.” After saving in ManageDependenciesDialog, invalidate project and main-project file caches before computing diffs.
- Result: Selections persist and analyzer/UI update immediately.