### PR TITLE
Fix: Ask/Search/Scan respect model dropdown; SearchAgent uses injected model

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
@@ -423,7 +423,7 @@ public class SearchAgent {
     // =======================
 
     private void addInitialContextToWorkspace() throws InterruptedException {
-        var contextAgent = new ContextAgent(cm, cm.getSearchModel(), goal, true);
+        var contextAgent = new ContextAgent(cm, model, goal, true);
         io.llmOutput("\nPerforming initial project scan", ChatMessageType.CUSTOM);
 
         var recommendation = contextAgent.getRecommendations(true);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -659,8 +659,39 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
             SwingUtilities.invokeLater(
                     () -> SettingsDialog.showSettingsDialog(chrome, SettingsGlobalPanel.MODELS_TAB_TITLE));
         }
-        // In either case (Settings opened or Cancel pressed), the original action is aborted by returning from the
-        // caller.
+    // In either case (Settings opened or Cancel pressed), the original action is aborted by returning from the
+    // caller.
+    }
+
+    /**
+     * Centralized model selection from the dropdown with fallback and optional vision check.
+     * Returns null if selection fails or vision is required but unsupported.
+     */
+    private @Nullable StreamingChatModel selectDropdownModelOrShowError(String actionLabel, boolean requireVision) {
+        var cm = chrome.getContextManager();
+        var models = cm.getService();
+
+        Service.ModelConfig config;
+        try {
+            config = modelSelector.getModel();
+        } catch (IllegalStateException e) {
+            chrome.toolError("Please finish configuring your custom model or select a favorite first.");
+            return null;
+        }
+
+        var selectedModel = models.getModel(config);
+        if (selectedModel == null) {
+            chrome.toolError(
+                    "Selected model '" + config.name() + "' is not available with reasoning level " + config.reasoning());
+            selectedModel = castNonNull(models.getModel(Service.GPT_5_MINI));
+        }
+
+        if (requireVision && contextHasImages() && !models.supportsVision(selectedModel)) {
+            showVisionSupportErrorDialog(models.nameOf(selectedModel) + " (" + actionLabel + ")");
+            return null;
+        }
+
+        return selectedModel;
     }
 
     // --- Public API ---
@@ -1341,8 +1372,11 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
 
     // Public entry point for default Ask model
     public void runAskCommand(String input) {
-        var contextManager = chrome.getContextManager();
-        prepareAndRunAskCommand(contextManager.getSearchModel(), input);
+        final var modelToUse = selectDropdownModelOrShowError("Ask", true);
+        if (modelToUse == null) {
+            return;
+        }
+        prepareAndRunAskCommand(modelToUse, input);
     }
 
     // Core method to prepare and submit the Ask action
@@ -1353,12 +1387,6 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         }
 
         var contextManager = chrome.getContextManager();
-        var models = contextManager.getService();
-
-        if (contextHasImages() && !models.supportsVision(modelToUse)) {
-            showVisionSupportErrorDialog(models.nameOf(modelToUse) + " (Ask)");
-            return;
-        }
 
         chrome.getProject().addToInstructionsHistory(input, 20);
         clearCommandInput();
@@ -1393,13 +1421,9 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
             return;
         }
 
-        var contextManager = chrome.getContextManager();
-        var models = contextManager.getService();
-        var searchModel = contextManager.getSearchModel();
-
-        if (contextHasImages() && !models.supportsVision(searchModel)) {
-            showVisionSupportErrorDialog(models.nameOf(searchModel) + " (Search)");
-            return; // Abort if model doesn't support vision and context has images
+        final var modelToUse = selectDropdownModelOrShowError("Search", true);
+        if (modelToUse == null) {
+            return;
         }
 
         chrome.getProject().addToInstructionsHistory(input, 20);
@@ -1409,7 +1433,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                 ChatMessageType.CUSTOM);
         clearCommandInput();
         // Submit the action, calling the private execute method inside the lambda
-        submitAction(ACTION_SEARCH, input, () -> executeSearchCommand(searchModel, input));
+        submitAction(ACTION_SEARCH, input, () -> executeSearchCommand(modelToUse, input));
     }
 
     public void runRunCommand() {
@@ -1560,19 +1584,15 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
             return;
         }
 
-        var contextManager = chrome.getContextManager();
-        var models = contextManager.getService();
-        var searchModel = contextManager.getSearchModel();
-
-        if (contextHasImages() && !models.supportsVision(searchModel)) {
-            showVisionSupportErrorDialog(models.nameOf(searchModel) + " (Scan Project)");
+        final var modelToUse = selectDropdownModelOrShowError("Scan Project", true);
+        if (modelToUse == null) {
             return;
         }
 
         chrome.getProject().addToInstructionsHistory(goal, 20);
         clearCommandInput();
 
-        submitAction("Scan Project", goal, () -> executeScanProjectCommand(searchModel, goal));
+        submitAction("Scan Project", goal, () -> executeScanProjectCommand(modelToUse, goal));
     }
 
     private void executeScanProjectCommand(StreamingChatModel model, String goal) {


### PR DESCRIPTION
Problem: Ask, Search, and SearchAgent’s initial scan read the global Search model (props/cm.getSearchModel), ignoring the Instructions dropdown and often falling back to GPT‑5-mini.

Solution: Centralize UI model selection via selectDropdownModelOrShowError(action, requireVision). Wire Ask, Search, and Scan Project to use the dropdown model with vision support checks and explicit fallback/error messaging. In SearchAgent, pass the already-selected model to ContextAgent (use model instead of cm.getSearchModel). Remove redundant per-call vision checks and unused paths.