### PR TITLE
enh: Add "Delete File" option in file tree

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/context/ContextHistory.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/ContextHistory.java
@@ -6,6 +6,7 @@ import io.github.jbellis.brokk.AbstractProject;
 import io.github.jbellis.brokk.IConsoleIO;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -286,9 +287,15 @@ public class ContextHistory {
         getEntryInfo(popped.id()).ifPresent(info -> {
             var filesToDelete =
                     info.deletedFiles().stream().map(DeletedFile::file).toList();
-            if (!filesToDelete.isEmpty() && project.hasGit()) {
+            if (!filesToDelete.isEmpty()) {
                 try {
-                    project.getRepo().forceRemoveFiles(filesToDelete);
+                    if (project.hasGit()) {
+                        project.getRepo().forceRemoveFiles(filesToDelete);
+                    } else {
+                        for (var file : filesToDelete) {
+                            Files.deleteIfExists(file.absPath());
+                        }
+                    }
                     io.systemOutput("Deleted files as part of redo: "
                             + String.join(
                                     ", ",

--- a/app/src/main/java/io/github/jbellis/brokk/context/DtoMapper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/DtoMapper.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -499,5 +500,35 @@ public class DtoMapper {
         ProjectFile source = new ProjectFile(Path.of(pfd.repoRoot()), Path.of(pfd.relPath()));
         var kind = io.github.jbellis.brokk.analyzer.CodeUnitType.valueOf(dto.kind());
         return new CodeUnit(source, kind, dto.packageName(), dto.shortName());
+    }
+
+    /* ───────────── entryInfos mapping ───────────── */
+
+    public static Map<String, EntryInfoDto> toEntryInfosDto(
+            Map<UUID, ContextHistory.ContextHistoryEntryInfo> entryInfos) {
+        return entryInfos.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> e.getKey().toString(),
+                        e -> new EntryInfoDto(e.getValue().deletedFiles().stream()
+                                .map(DtoMapper::toDeletedFileDto)
+                                .toList())));
+    }
+
+    public static Map<String, ContextHistory.ContextHistoryEntryInfo> fromEntryInfosDto(
+            Map<String, EntryInfoDto> dtoMap) {
+        return dtoMap.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> new ContextHistory.ContextHistoryEntryInfo(e.getValue().deletedFiles().stream()
+                                .map(DtoMapper::fromDeletedFileDto)
+                                .toList())));
+    }
+
+    private static DeletedFileDto toDeletedFileDto(ContextHistory.DeletedFile df) {
+        return new DeletedFileDto(toProjectFileDto(df.file()), df.content(), df.wasTracked());
+    }
+
+    private static ContextHistory.DeletedFile fromDeletedFileDto(DeletedFileDto dto) {
+        return new ContextHistory.DeletedFile(fromProjectFileDto(dto.file()), dto.content(), dto.wasTracked());
     }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/context/FragmentDtos.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/FragmentDtos.java
@@ -240,6 +240,16 @@ public class FragmentDtos {
         }
     }
 
+    /** DTO representing a deleted file entry within a history entry. */
+    public record DeletedFileDto(ProjectFileDto file, String content, boolean wasTracked) {}
+
+    /** DTO representing entry info (currently only deleted files). */
+    public record EntryInfoDto(List<DeletedFileDto> deletedFiles) {
+        public EntryInfoDto {
+            deletedFiles = List.copyOf(deletedFiles);
+        }
+    }
+
     /** DTO for holding all unique fragments in a session history. Used as the top-level object for fragments.json. */
     public record AllFragmentsDto(
             int version, // Version of the fragment DTO structure

--- a/app/src/main/java/io/github/jbellis/brokk/gui/GitCommitTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/GitCommitTab.java
@@ -589,7 +589,7 @@ public class GitCommitTab extends JPanel {
                         .map(f -> {
                             var ppf = (ContextFragment.ProjectPathFragment) f;
                             try {
-                                return new ContextHistory.DeletedFile(ppf.file(), ppf.text());
+                                return new ContextHistory.DeletedFile(ppf.file(), ppf.text(), true);
                             } catch (java.io.UncheckedIOException e) {
                                 logger.error("Could not read content for new file being rolled back: " + ppf.file(), e);
                                 return null;

--- a/app/src/main/java/io/github/jbellis/brokk/util/HistoryIo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/HistoryIo.java
@@ -110,8 +110,10 @@ public final class HistoryIo {
                         rawGitStateDtos = objectMapper.readValue(zis.readAllBytes(), typeRef);
                     }
                     case ENTRY_INFOS_FILENAME -> {
-                        var typeRef = new TypeReference<Map<String, ContextHistory.ContextHistoryEntryInfo>>() {};
-                        entryInfoDtos = objectMapper.readValue(zis.readAllBytes(), typeRef);
+                        byte[] bytes = zis.readAllBytes();
+                        var typeRefNew = new TypeReference<Map<String, EntryInfoDto>>() {};
+                        Map<String, EntryInfoDto> dtoMap = objectMapper.readValue(bytes, typeRefNew);
+                        entryInfoDtos = DtoMapper.fromEntryInfosDto(dtoMap);
                     }
                     default -> {
                         if (entry.getName().startsWith(IMAGES_DIR_PREFIX) && !entry.isDirectory()) {
@@ -307,9 +309,8 @@ public final class HistoryIo {
         byte[] entryInfosBytes = null;
         var entryInfos = ch.getEntryInfos();
         if (!entryInfos.isEmpty()) {
-            var entryInfosToStringKeys = new HashMap<String, ContextHistory.ContextHistoryEntryInfo>();
-            entryInfos.forEach((key, value) -> entryInfosToStringKeys.put(key.toString(), value));
-            entryInfosBytes = objectMapper.writeValueAsBytes(entryInfosToStringKeys);
+            var entryInfosDto = DtoMapper.toEntryInfosDto(entryInfos);
+            entryInfosBytes = objectMapper.writeValueAsBytes(entryInfosDto);
         }
 
         byte[] resetEdgesBytes = null;


### PR DESCRIPTION
Closes #415:
- Operation is added to context history and can be undone/redone.
- Deleted tracked files are also git-removed, untracked ones are just deleted. The same behavior for redo.
- Deleted tracked files are git-added on undo, deleted untracked ones are just restored.