### PR TITLE
fix(SearchAgent): Clarify prompt to prevent merged tool calls

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
@@ -316,7 +316,7 @@ public class SearchAgent {
             for follow-on code changes. If you already have enough to answer, use answerSearch. If we cannot answer,
             use abortSearch with a clear explanation.
 
-            You are encouraged to invoke multiple Workspace tools at once (add summaries, drop fragments, etc).
+            You can call multiple tools in a single turn. To do so, provide a list of separate tool calls, each with its own name and arguments (add summaries, drop fragments, etc).
             Do NOT invoke multiple answer/abort actions. Do NOT write code.
 
             %s


### PR DESCRIPTION
fixes #789 

Resolves an issue where the Search Agent would fail silently after the LLM merged multiple tool names into a single, invalid call (e.g., toolAtoolB).

The prompt ambiguously encouraged invoking tools "at once," which the LLM misinterpreted. This change clarifies the instruction, explicitly telling the model to provide a list of separate tool calls. This prevents malformed requests, ensures correct tool execution, and improves agent reliability when planning multiple actions in a single turn.