### PR TITLE
`LspAnalyzer`: Enable Field Support on `getUses`

### DIFF
--- a/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/UsagesProvider.java
+++ b/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/UsagesProvider.java
@@ -5,5 +5,11 @@ import java.util.List;
 /** Implemented by analyzers that can readily provide some kind of points-to analysis. */
 public interface UsagesProvider extends CapabilityProvider {
 
+    /**
+     * Provides a list of code units that use the code unit matching the given full name.
+     *
+     * @param fqName the full name of the code unit to determine usages for.
+     * @return code units using the matching code unit, if any.
+     */
     List<CodeUnit> getUses(String fqName);
 }

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspAnalyzerHelper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspAnalyzerHelper.java
@@ -35,7 +35,8 @@ public final class LspAnalyzerHelper {
     public static final Set<SymbolKind> MODULE_KINDS =
             Set.of(SymbolKind.Module, SymbolKind.Namespace, SymbolKind.Package);
 
-    public static final Set<SymbolKind> FIELD_KINDS = Set.of(SymbolKind.Field, SymbolKind.Variable);
+    public static final Set<SymbolKind> FIELD_KINDS =
+            Set.of(SymbolKind.Field, SymbolKind.Variable, SymbolKind.Constant);
 
     @NotNull
     public static CodeUnitType codeUnitForSymbolKind(@NotNull SymbolKind symbolKind) {

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
@@ -201,7 +201,7 @@ public abstract class LspLanguageClient implements LanguageClient {
     public CompletableFuture<Void> waitForDiagnosticsToSettle() {
         try {
             // We need to give diagnostics a moment to start
-            Thread.sleep(250);
+            Thread.sleep(500);
         } catch (InterruptedException e) {
             logger.warn("Interrupted while waiting for diagnostics to settle");
         }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -449,7 +449,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
                                                         contextManager.submitBackgroundTask(
                                                                 "Capture Usages",
                                                                 () -> contextManager.usageForIdentifier(
-                                                                        codeUnit.identifier()));
+                                                                        codeUnit.fqName()));
                                                     });
                                                 } else {
                                                     usageItem.setToolTipText(

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JdtAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JdtAnalyzerTest.java
@@ -427,7 +427,6 @@ public class JdtAnalyzerTest {
     }
 
     @Test
-    @Disabled("JDT LSP does not index field symbols")
     public void getUsesFieldExistingTest() {
         final var symbol = "D.field1"; // fully qualified field name
         final var usages = analyzer.getUses(symbol);
@@ -437,11 +436,18 @@ public class JdtAnalyzerTest {
     }
 
     @Test
-    @Disabled("JDT LSP does not index field symbols")
     public void getUsesFieldNonexistentTest() {
         final var symbol = "D.notAField";
         final var ex = assertThrows(IllegalArgumentException.class, () -> analyzer.getUses(symbol));
         assertTrue(ex.getMessage().contains("not found"));
+    }
+
+    @Test
+    public void getUsesFieldFromUseETest() {
+        final var symbol = "UseE.e";
+        final var usages = analyzer.getUses(symbol);
+        final var refs = usages.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
+        assertEquals(Set.of("UseE.moreM", "UseE.moreF"), refs);
     }
 
     @Test


### PR DESCRIPTION
* `LspAnalyzer` attempts to find the "container" and descend into members if no `fqName` hit returns any results.
* Including constants as "field-likes" as these are what static fields are classified as.
* Usages on PreviewTextPanel now give `fqName`.