### PR TITLE
macOS: Themed Title Bar

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/Brokk.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Brokk.java
@@ -3,7 +3,6 @@ package io.github.jbellis.brokk;
 import static java.util.Objects.requireNonNull;
 import static org.checkerframework.checker.nullness.util.NullnessUtil.castNonNull;
 
-import com.formdev.flatlaf.util.SystemInfo;
 import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.ModelSupport;
 import com.github.tjake.jlama.safetensors.DType;
@@ -104,12 +103,6 @@ public class Brokk {
 
         if (Boolean.getBoolean("brokk.devmode")) {
             RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
-        }
-
-        // https://www.formdev.com/flatlaf/window-decorations/
-        if (SystemInfo.isLinux) {
-            JFrame.setDefaultLookAndFeelDecorated(true);
-            JDialog.setDefaultLookAndFeelDecorated(true);
         }
 
         var iconUrl = Brokk.class.getResource(ICON_RESOURCE);

--- a/app/src/main/java/io/github/jbellis/brokk/Brokk.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Brokk.java
@@ -3,6 +3,7 @@ package io.github.jbellis.brokk;
 import static java.util.Objects.requireNonNull;
 import static org.checkerframework.checker.nullness.util.NullnessUtil.castNonNull;
 
+import com.formdev.flatlaf.util.SystemInfo;
 import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.ModelSupport;
 import com.github.tjake.jlama.safetensors.DType;
@@ -103,6 +104,12 @@ public class Brokk {
 
         if (Boolean.getBoolean("brokk.devmode")) {
             RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
+        }
+
+        // https://www.formdev.com/flatlaf/window-decorations/
+        if (SystemInfo.isLinux) {
+            JFrame.setDefaultLookAndFeelDecorated(true);
+            JDialog.setDefaultLookAndFeelDecorated(true);
         }
 
         var iconUrl = Brokk.class.getResource(ICON_RESOURCE);


### PR DESCRIPTION
Converts the generic "white" title bar on macOS to be themed by using the full height of the content window, and inserting a JLabel in order to obtain a fully themed window.

This does not affect dialogs, only JFrames.

#### Dark Theme
<img width="1416" height="919" alt="Screenshot 2025-08-28 at 13 33 02" src="https://github.com/user-attachments/assets/fc6a5aa9-8c2e-4a22-a94d-ce21326eba70" />
<img width="1416" height="919" alt="Screenshot 2025-08-28 at 13 33 11" src="https://github.com/user-attachments/assets/00311120-0828-45b5-b7d1-b979399f8309" />
<img width="1416" height="919" alt="Screenshot 2025-08-28 at 13 33 20" src="https://github.com/user-attachments/assets/e9ec0ef4-1675-44c8-a30d-64022e00751b" />
#### Light Mode
<img width="1416" height="919" alt="Screenshot 2025-08-28 at 13 35 04" src="https://github.com/user-attachments/assets/808105c9-5212-4461-a9bf-40a942c6b797" />
<img width="1416" height="919" alt="Screenshot 2025-08-28 at 13 34 59" src="https://github.com/user-attachments/assets/51bc8e25-ef7f-4868-8422-8ebea4889809" />