### PR TITLE
Rolls back "getChildren" component of completions

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/Completions.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Completions.java
@@ -32,12 +32,24 @@ public class Completions {
 
         // Create matcher from the effective pattern (without trailing dot if present).
         var matcher = new FuzzyMatcher(pattern);
+        boolean hierarchicalQuery = pattern.indexOf('.') >= 0 || pattern.indexOf('$') >= 0;
 
         // has a family resemblance to scoreShortAndLong but different enough that it doesn't fit
         record ScoredCU(CodeUnit cu, int score) { // Renamed local record to avoid conflict
         }
         return allDefs.stream()
-                .map(cu -> new ScoredCU(cu, matcher.score(cu.fqName())))
+                .map(cu -> {
+                    int score;
+                    if (hierarchicalQuery) {
+                        score = matcher.score(cu.fqName());
+                    } else {
+                        var fqName = cu.fqName();
+                        var lastDot = fqName.lastIndexOf('.');
+                        var simpleName = lastDot < 0 ? fqName : fqName.substring(lastDot + 1);
+                        score = matcher.score(simpleName);
+                    }
+                    return new ScoredCU(cu, score);
+                })
                 .filter(sc -> sc.score() != Integer.MAX_VALUE)
                 .sorted(Comparator.<ScoredCU>comparingInt(ScoredCU::score)
                         .thenComparing(sc -> sc.cu().fqName()))
@@ -81,8 +93,8 @@ public class Completions {
             // 1) Quoted substring search (handles special chars safely)
             patterns.add(".*" + Pattern.quote(pattern) + ".*");
 
-            // 2) Split-char fuzzy pattern for short queries
-            if (pattern.length() < 5) {
+            // 2) Split-char fuzzy pattern for short queries with uppercase letters
+            if (pattern.length() < 5 && pattern.chars().anyMatch(Character::isUpperCase)) {
                 var sb = new StringBuilder(".*");
                 for (int i = 0; i < pattern.length(); i++) {
                     char ch = pattern.charAt(i);
@@ -103,17 +115,6 @@ public class Completions {
 
         var results =
                 analyzer.searchDefinitions(finalRegex).stream().limit(5000).toList();
-
-        // For trailing dot queries, include members of matching classes
-        if (trailingDot) {
-            String baseShort = pattern.substring(0, pattern.length() - 1);
-            var classes = results.stream()
-                    .filter(cu -> cu.identifier().equalsIgnoreCase(baseShort))
-                    .toList();
-            if (!classes.isEmpty()) {
-                return includeMembersForClasses(analyzer, classes);
-            }
-        }
 
         return results;
     }
@@ -250,23 +251,6 @@ public class Completions {
                 && Character.isLetter(s.charAt(0))
                 && s.charAt(1) == ':'
                 && (s.charAt(2) == '\\' || s.charAt(2) == '/');
-    }
-
-    // Given a list of class declarations, return a list containing the classes followed by their members.
-    private static List<CodeUnit> includeMembersForClasses(IAnalyzer analyzer, List<CodeUnit> classes) {
-        var builder = new java.util.ArrayList<CodeUnit>(classes.size() * 2);
-        builder.addAll(classes);
-        for (var cls : classes) {
-            try {
-                var members = analyzer.getMembersInClass(cls.fqName());
-                if (!members.isEmpty()) {
-                    builder.addAll(members);
-                }
-            } catch (Exception ignored) {
-                // ignore member lookup failures and continue
-            }
-        }
-        return java.util.List.copyOf(builder);
     }
 
     private record ScoredItem<T>(T source, int score, int tiebreakScore, boolean isShort) { // Renamed to avoid conflict

--- a/app/src/main/java/io/github/jbellis/brokk/FuzzyMatcher.java
+++ b/app/src/main/java/io/github/jbellis/brokk/FuzzyMatcher.java
@@ -191,10 +191,27 @@ public class FuzzyMatcher {
             return name.isEmpty() ? 0 : Integer.MAX_VALUE;
         }
 
+        if (patternHasTrailingDot) {
+            var endOffset = requireNonNull(fragments.getLast()).getEndOffset();
+            if (endOffset < name.length()) {
+                char nextChar = name.charAt(endOffset);
+                if (nextChar == '$') {
+                    // when user types '.', they are looking for members, not nested classes
+                    return Integer.MAX_VALUE;
+                }
+            }
+        }
+
         // Exclude matches that finish immediately before a '$' when the pattern is simple
         // (all-lowercase without separators). This prevents queries like "do" from matching
         // the outer part of "Do$Re".
         if (isSimpleLowercasePattern() && endsBeforeDollar(name, fragments)) {
+            return Integer.MAX_VALUE;
+        }
+
+        // Exclude matches that are a prefix of a component in the fqname, when the pattern is simple
+        // (no separators). This prevents queries like "Do" from matching "Do" in "a.b.Do.bar".
+        if (!patternHasTrailingDot && isSimplePattern() && endsBeforeDot(name, fragments)) {
             return Integer.MAX_VALUE;
         }
 
@@ -447,8 +464,11 @@ public class FuzzyMatcher {
         // Penalize any unmatched characters left at the end of the name,
         // but only when the entire match is a *single* contiguous fragment.
         // (Keeps adjacency-vs-gap tests working while still preferring exact matches.)
-        int unmatchedTail = name.length() - fragments.getLast().getEndOffset();
-        int unmatchedPenalty = fragments.size() == 1 ? unmatchedTail * 2 : 0;
+        int unmatchedTail = name.length() - requireNonNull(fragments.getLast()).getEndOffset();
+        int unmatchedPenalty = fragments.size() == 1
+                        && name.indexOf('.', requireNonNull(fragments.getLast()).getEndOffset()) == -1
+                ? unmatchedTail * 2
+                : 0;
 
         // Combine components into the final score (higher is better internally before inversion)
         // Realigned with MinusculeMatcherImpl.matchingDegree formula
@@ -1060,6 +1080,16 @@ public class FuzzyMatcher {
     // Additional helpers for nested-class filtering
     // ---------------------------------------------------------------------
 
+    /** Returns true if the pattern does not contain any hierarchy separators ('.' or '$'). */
+    private boolean isSimplePattern() {
+        for (char c : patternChars) {
+            if (c == '.' || c == '$') {
+                return false;
+            }
+        }
+        return patternChars.length > 0;
+    }
+
     /**
      * Returns true if the pattern is made exclusively of lowercase letters and contains no hierarchy or word-separator
      * characters.
@@ -1087,5 +1117,18 @@ public class FuzzyMatcher {
         }
         int end = last.getEndOffset();
         return end < name.length() && name.charAt(end) == '$';
+    }
+
+    /**
+     * Checks whether a '.' exists in the name at or after the end of the last matched fragment. This is used to filter
+     * out member matches for simple (non-hierarchical) patterns.
+     */
+    private static boolean endsBeforeDot(String name, FList<TextRange> fragments) {
+        var last = fragments.getLast();
+        if (last == null) {
+            return false;
+        }
+        int end = last.getEndOffset();
+        return name.indexOf('.', end) >= 0;
     }
 }

--- a/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
@@ -22,20 +22,21 @@ public class CompletionsTest {
     public void testUnqualifiedInput() {
         var mock = new MockAnalyzer(tempDir);
 
-        // Input "do" -> we want it to match "a.b.Do" and its methods
+        // Input "do" -> we want it to match "a.b.Do"
+        // Because "Do" simple name starts with 'D'
         var completions = Completions.completeSymbols("do", mock);
 
         var values = toValues(completions);
-        assertEquals(List.of("a.b.Do", "a.b.Do.bar", "a.b.Do.foo"), values);
+        assertEquals(List.of("a.b.Do"), values);
     }
 
     @Test
     public void testUnqualifiedRe() {
         var mock = new MockAnalyzer(tempDir);
-        // Input "re" -> user wants to find "a.b.Do$Re" and its methods
+        // Input "re" -> user wants to find "a.b.Do$Re" by partial name "Re"
         var completions = Completions.completeSymbols("re", mock);
         var values = toValues(completions);
-        assertEquals(List.of("a.b.Do$Re", "a.b.Do$Re.baz"), values);
+        assertEquals(List.of("a.b.Do$Re"), values);
     }
 
     @Test
@@ -44,7 +45,7 @@ public class CompletionsTest {
         var completions = Completions.completeSymbols("Re", mock);
         var values = toValues(completions);
 
-        assertEquals(List.of("a.b.Do$Re", "a.b.Do$Re$Sub", "a.b.Do$Re.baz", "a.b.Do$Re$Sub.qux"), values);
+        assertEquals(List.of("a.b.Do$Re", "a.b.Do$Re$Sub"), values);
     }
 
     @Test
@@ -53,11 +54,11 @@ public class CompletionsTest {
         // Input "CC" -> should match "test.CamelClass" and its methods due to camel case matching
         var completions = Completions.completeSymbols("CC", mock);
         var values = toValues(completions);
-        assertEquals(List.of("test.CamelClass", "test.CamelClass.someMethod"), values);
+        assertEquals(List.of("test.CamelClass"), values);
 
         completions = Completions.completeSymbols("cam", mock);
         values = toValues(completions);
-        assertEquals(List.of("test.CamelClass", "test.CamelClass.someMethod"), values);
+        assertEquals(List.of("test.CamelClass"), values);
     }
 
     @Test
@@ -65,16 +66,7 @@ public class CompletionsTest {
         var mock = new MockAnalyzer(tempDir);
 
         var completions = Completions.completeSymbols("Do", mock);
-        assertEquals(
-                List.of(
-                        "a.b.Do",
-                        "a.b.Do$Re",
-                        "a.b.Do.bar",
-                        "a.b.Do.foo",
-                        "a.b.Do$Re$Sub",
-                        "a.b.Do$Re.baz",
-                        "a.b.Do$Re$Sub.qux"),
-                toValues(completions));
+        assertEquals(List.of("a.b.Do", "a.b.Do$Re", "a.b.Do$Re$Sub"), toValues(completions));
     }
 
     @Test


### PR DESCRIPTION
Partially resolves https://github.com/BrokkAi/brokk/issues/700#issuecomment-3233242983

The edited test cases largely roll back the added "child" results and are passing. I am seeing completions coming up nicely again