### PR TITLE
enh: update Llm timeouts for thinking models

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/Service.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Service.java
@@ -43,8 +43,9 @@ public class Service {
     public static float MINIMUM_PAID_BALANCE = 0.20f;
     public static float LOW_BALANCE_WARN_AT = 2.00f;
 
-    // TODO replace this when we consistently get thinking tokens
-    public static final int LLM_MAX_RESPONSE_TIME = 6 * 60;
+    public static final long FLEX_TOKEN_TIMEOUT_SECONDS = 15L * 60L; // 15 minutes
+    public static final long DEFAULT_FIRST_TOKEN_TIMEOUT_SECONDS = 2L * 60L; // 2 minutes
+    public static final long DEFAULT_NEXT_TOKEN_TIMEOUT_SECONDS = 60L; // 1 minute
 
     // Helper record to store model name and reasoning level for checking
     public record ModelConfig(String name, ReasoningLevel reasoning, ProcessingTier tier) {
@@ -767,7 +768,10 @@ public class Service {
                 .logResponses(true)
                 .strictJsonSchema(true)
                 .baseUrl(baseUrl)
-                .timeout(Duration.ofSeconds(LLM_MAX_RESPONSE_TIME));
+            .timeout(Duration.ofSeconds(
+                    config.tier == ProcessingTier.FLEX
+                            ? FLEX_TOKEN_TIMEOUT_SECONDS
+                            : Math.max(DEFAULT_FIRST_TOKEN_TIMEOUT_SECONDS, DEFAULT_NEXT_TOKEN_TIMEOUT_SECONDS)));
         if (config.tier != ProcessingTier.DEFAULT) {
             builder.serviceTier(config.tier.toString().toLowerCase(Locale.ROOT));
         }
@@ -965,6 +969,25 @@ public class Service {
 
         var supports = info.get("supports_vision");
         return supports instanceof Boolean boolVal && boolVal;
+    }
+
+    /** Returns the configured processing tier for the given model (defaults to DEFAULT). */
+    public static ProcessingTier getProcessingTier(StreamingChatModel model) {
+        if (model instanceof OpenAiStreamingChatModel om) {
+            var tier = om.defaultRequestParameters().serviceTier();
+            if (tier == null) {
+                return ProcessingTier.DEFAULT;
+            }
+            var normalized = tier.toLowerCase(Locale.ROOT);
+            if ("flex".equals(normalized)) {
+                return ProcessingTier.FLEX;
+            } else if ("priority".equals(normalized)) {
+                return ProcessingTier.PRIORITY;
+            } else {
+                return ProcessingTier.DEFAULT;
+            }
+        }
+        return ProcessingTier.DEFAULT;
     }
 
     /**

--- a/app/src/main/java/io/github/jbellis/brokk/Service.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Service.java
@@ -43,9 +43,9 @@ public class Service {
     public static float MINIMUM_PAID_BALANCE = 0.20f;
     public static float LOW_BALANCE_WARN_AT = 2.00f;
 
-    public static final long FLEX_TOKEN_TIMEOUT_SECONDS = 15L * 60L; // 15 minutes
+    public static final long FLEX_FIRST_TOKEN_TIMEOUT_SECONDS = 15L * 60L; // 15 minutes
     public static final long DEFAULT_FIRST_TOKEN_TIMEOUT_SECONDS = 2L * 60L; // 2 minutes
-    public static final long DEFAULT_NEXT_TOKEN_TIMEOUT_SECONDS = 60L; // 1 minute
+    public static final long NEXT_TOKEN_TIMEOUT_SECONDS = 60L; // 1 minute
 
     // Helper record to store model name and reasoning level for checking
     public record ModelConfig(String name, ReasoningLevel reasoning, ProcessingTier tier) {
@@ -768,10 +768,10 @@ public class Service {
                 .logResponses(true)
                 .strictJsonSchema(true)
                 .baseUrl(baseUrl)
-            .timeout(Duration.ofSeconds(
-                    config.tier == ProcessingTier.FLEX
-                            ? FLEX_TOKEN_TIMEOUT_SECONDS
-                            : Math.max(DEFAULT_FIRST_TOKEN_TIMEOUT_SECONDS, DEFAULT_NEXT_TOKEN_TIMEOUT_SECONDS)));
+                .timeout(Duration.ofSeconds(
+                        config.tier == ProcessingTier.FLEX
+                                ? FLEX_FIRST_TOKEN_TIMEOUT_SECONDS
+                                : Math.max(DEFAULT_FIRST_TOKEN_TIMEOUT_SECONDS, NEXT_TOKEN_TIMEOUT_SECONDS)));
         if (config.tier != ProcessingTier.DEFAULT) {
             builder.serviceTier(config.tier.toString().toLowerCase(Locale.ROOT));
         }


### PR DESCRIPTION
Updated timeouts (reset when we get either a thinking or output token):
- 2m for the first token
- 1m for every next token
- 15m for first and next token for `flex` service tier.

I did not change the [retry](https://github.com/BrokkAi/brokk/blob/f26d016d28517e932f60ad0ea41c4d53ce043d1b/app/src/main/java/io/github/jbellis/brokk/Llm.java#L74) logic with backoff time here, so when a timeout happens, we'd still retry.