### PR TITLE
feat: Filter empty file creations in diffs to avoid parser errors

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -483,6 +483,7 @@ public class GitRepo implements Closeable, IGitRepo {
                 return Stream.of(staged, unstaged).filter(s -> !s.isEmpty()).collect(Collectors.joining("\n"));
             } catch (NoHeadException e) {
                 // Handle empty repository case - return empty diff for repositories with no commits
+                logger.debug("NoHeadException caught - empty repository, returning empty diff");
                 return "";
             }
         } catch (IOException e) {
@@ -512,6 +513,7 @@ public class GitRepo implements Closeable, IGitRepo {
         trackedPaths.addAll(status.getMissing());
 
         if (trackedPaths.isEmpty()) {
+            logger.debug("No tracked changes found, returning empty diff");
             return "";
         }
 

--- a/app/src/main/java/io/github/jbellis/brokk/git/GitWorkflowService.java
+++ b/app/src/main/java/io/github/jbellis/brokk/git/GitWorkflowService.java
@@ -75,6 +75,8 @@ public final class GitWorkflowService {
      * throw RuntimeException if diffing fails or InterruptedException occurs.
      */
     public String suggestCommitMessage(List<ProjectFile> files) {
+        logger.debug("Suggesting commit message for {} files", files.size());
+
         String diff;
         try {
             diff = files.isEmpty() ? repo.diff() : repo.diffFiles(files);
@@ -84,11 +86,13 @@ public final class GitWorkflowService {
         }
 
         if (diff.isBlank()) {
+            logger.debug("Empty diff - no commit message to suggest");
             return "";
         }
 
         var messages = CommitPrompts.instance.collectMessages(contextManager.getProject(), diff);
         if (messages.isEmpty()) {
+            logger.debug("No commit message generated - diff preprocessing returned empty result");
             return "";
         }
 


### PR DESCRIPTION
- Intent: make commit-message generation more robust. Fixes #795

- Root Cause

  Git generates diffs for empty file creations with:
  - Standard file headers (diff --git, ---, +++)
  - Index line with empty blob hash (index 0000000..e69de29)
  - No @@ hunk headers (since there's no content)

  The UnifiedDiffReader expects hunk headers after file headers, causing parse failures on these legitimate but empty diffs.

  Solution

  Added filterEmptyFileCreations() method in CommitPrompts.java that:
  1. Pre-processes diffs before UnifiedDiffReader parsing
  2. Detects empty file sections by looking for e69de29 hash (SHA1 of empty content) combined with absence of hunk headers
  3. Filters out problematic sections while preserving legitimate new files with content
  4. Maintains two-stage workflow support where files are created empty then populated with content
