### PR TITLE
feat: Open settings dialog for custom model configuration

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class SettingsGlobalPanel extends JPanel implements ThemeAware {
     private static final Logger logger = LogManager.getLogger(SettingsGlobalPanel.class);
-    public static final String MODELS_TAB_TITLE = "Default Models"; // Used for targeting this tab
+    public static final String MODELS_TAB_TITLE = "Favorite Models"; // Used for targeting this tab
 
     private final Chrome chrome;
     private final SettingsDialog parentDialog; // To access project for data retention refresh
@@ -70,7 +70,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware {
 
         // Quick Models Tab
         var quickModelsPanel = createQuickModelsPanel();
-        globalSubTabbedPane.addTab("Favorite Models", null, quickModelsPanel, "Define model aliases (shortcuts)");
+        globalSubTabbedPane.addTab(MODELS_TAB_TITLE, null, quickModelsPanel, "Define model aliases (shortcuts)");
 
         // GitHub Tab (conditionally added)
         var project = chrome.getProject();


### PR DESCRIPTION
- Intent: replace the small inline "configure custom model" dialog with the full Settings dialog's Favorite Models tab, and automatically pick up any favorite model the user creates there. Fixes #825

- Behaviour changes:
  - Clicking "custom/configure" now opens the global Settings dialog on the Favorite Models tab instead of showing an ad-hoc modal UI.
  - After the Settings dialog closes, the selector reloads favorites; if a new favorite was added it is selected automatically, otherwise the prior selection is restored.
