### PR TITLE
History Fetches Latest Items on Dropdown + Dynamic Truncation

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -569,18 +569,9 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         final var noHistory = "(No history items)";
 
         var project = chrome.getProject();
-        List<String> historyItems = project.loadTextHistory();
 
         var model = new DefaultComboBoxModel<>();
         model.addElement(placeholder);
-
-        if (historyItems.isEmpty()) {
-            model.addElement(noHistory);
-        } else {
-            for (String item : historyItems) {
-                model.addElement(item);
-            }
-        }
 
         var dropdown = new JComboBox<>(model);
         dropdown.setToolTipText("Select a previous instruction from history");
@@ -609,16 +600,40 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                     && !selected.equals(placeholder)
                     && !selected.equals(noHistory)) {
                 // This is a valid history item
-                commandInputOverlay.hideOverlay();
-                instructionsArea.setEnabled(true);
+                Objects.requireNonNull(commandInputOverlay).hideOverlay();
+                Objects.requireNonNull(instructionsArea).setEnabled(true);
 
                 instructionsArea.setText(historyItem);
-                commandInputUndoManager.discardAllEdits();
+                Objects.requireNonNull(commandInputUndoManager).discardAllEdits();
                 instructionsArea.requestFocusInWindow();
 
                 // Reset to placeholder
                 SwingUtilities.invokeLater(() -> dropdown.setSelectedItem(placeholder));
             }
+        });
+
+        dropdown.addPopupMenuListener(new PopupMenuListener() {
+            @Override
+            public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+                model.removeAllElements();
+                model.addElement(placeholder);
+                List<String> historyItems = project.loadTextHistory();
+
+                logger.trace("History items loaded: {}", historyItems.size());
+                if (historyItems.isEmpty()) {
+                    model.addElement(noHistory);
+                } else {
+                    for (var item : historyItems) {
+                        model.addElement(item);
+                    }
+                }
+            }
+
+            @Override
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {}
+
+            @Override
+            public void popupMenuCanceled(PopupMenuEvent e) {}
         });
 
         return dropdown;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -582,7 +582,30 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                     JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
                 super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof String historyItem) {
-                    setText(historyItem);
+                    // To prevent the dropdown from becoming excessively wide, we truncate the display text
+                    // to fit within the width of the JComboBox itself.
+                    String displayText = historyItem.replace('\n', ' ');
+                    int width = dropdown.getWidth();
+                    if (width > 20) {
+                        FontMetrics fm = getFontMetrics(getFont());
+                        if (fm.stringWidth(displayText) > width) {
+                            displayText = SwingUtilities.layoutCompoundLabel(
+                                    this,
+                                    fm,
+                                    displayText,
+                                    null,
+                                    SwingConstants.CENTER,
+                                    SwingConstants.LEFT,
+                                    SwingConstants.CENTER,
+                                    SwingConstants.LEFT,
+                                    new Rectangle(width, getHeight()),
+                                    new Rectangle(),
+                                    new Rectangle(),
+                                    0);
+                        }
+                    }
+
+                    setText(displayText);
                     setEnabled(true);
                     if (historyItem.equals(noHistory) || historyItem.equals(placeholder)) {
                         setToolTipText(null);


### PR DESCRIPTION
* Items are now fetched on drop-down click to ensure latest items are always available
* Truncation is re-introduced via dynamically obtaining the width of the combo box as the width reference (still no hardcoded variable)
* Latest items are on the top, but this was already the case.

<img width="1432" height="151" alt="Screenshot 2025-09-03 at 10 10 28" src="https://github.com/user-attachments/assets/0040f255-fd7f-4c1e-a4a7-0021fdb05b80" />
