### PR TITLE
Separated Completion Task from Wrangling `searchDefinitions` to Dedicated `autocompleteDefinitions`

### DIFF
--- a/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/IAnalyzer.java
+++ b/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/IAnalyzer.java
@@ -93,7 +93,7 @@ public interface IAnalyzer {
 
     /**
      * Provides a search facility that is based on auto-complete logic based on (non-regex) user-input. By default, this
-     * hands over to {@link IAnalyzer#searchDefinitions(String)}.
+     * hands over to {@link IAnalyzer#searchDefinitions(String)} surrounded by wildcards.
      *
      * @param query the search query
      * @return a list of candidates where their fully qualified names may match the query.

--- a/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/IAnalyzer.java
+++ b/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/IAnalyzer.java
@@ -92,6 +92,17 @@ public interface IAnalyzer {
     }
 
     /**
+     * Provides a search facility that is based on auto-complete logic based on (non-regex) user-input. By default, this
+     * hands over to {@link IAnalyzer#searchDefinitions(String)}.
+     *
+     * @param query the search query
+     * @return a list of candidates where their fully qualified names may match the query.
+     */
+    default List<CodeUnit> autocompleteDefinitions(String query) {
+        return searchDefinitions(".*" + query + ".*");
+    }
+
+    /**
      * Implementation-specific search method called by the default searchDefinitions. Subclasses should implement this
      * method to provide their specific search logic.
      *

--- a/app/src/main/java/io/github/jbellis/brokk/Completions.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Completions.java
@@ -23,15 +23,15 @@ public class Completions {
         }
 
         // getAllDeclarations would not be correct here since it only lists top-level CodeUnits
-        List<CodeUnit> allDefs;
+        List<CodeUnit> candidates;
         try {
-            allDefs =
+            candidates =
                     analyzer.autocompleteDefinitions(query).stream().limit(5000).toList();
         } catch (Exception e) {
             // Handle analyzer exceptions (e.g., SchemaViolationException from JoernAnalyzer)
             logger.warn("Failed to search definitions for autocomplete: {}", e.getMessage());
             // Fall back to using top-level declarations only
-            allDefs = analyzer.getAllDeclarations();
+            candidates = analyzer.getAllDeclarations();
         }
 
         var matcher = new FuzzyMatcher(query);
@@ -40,7 +40,7 @@ public class Completions {
         // has a family resemblance to scoreShortAndLong but different enough that it doesn't fit
         record ScoredCU(CodeUnit cu, int score) { // Renamed local record to avoid conflict
         }
-        return allDefs.stream()
+        return candidates.stream()
                 .map(cu -> {
                     int score;
                     if (hierarchicalQuery) {

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/MultiAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/MultiAnalyzer.java
@@ -167,6 +167,15 @@ public class MultiAnalyzer
     }
 
     @Override
+    public List<CodeUnit> autocompleteDefinitions(String query) {
+        return delegates.values().stream()
+                .flatMap(analyzer -> analyzer.autocompleteDefinitions(query).stream())
+                .distinct()
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public Set<String> getSymbols(Set<CodeUnit> sources) {
         return delegates.values().stream()
                 .flatMap(analyzer -> {

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/TreeSitterAnalyzer.java
@@ -53,6 +53,19 @@ public abstract class TreeSitterAnalyzer
     protected static final Logger log = LoggerFactory.getLogger(TreeSitterAnalyzer.class);
     // Native library loading is assumed automatic by the io.github.bonede.tree_sitter library.
 
+    // Common separators across languages to denote hierarchy or member access.
+    // Includes: '.' (Java/others), '$' (Java nested classes), '::' (C++/C#/Ruby), '->' (PHP), etc.
+    private static final Set<String> COMMON_HIERARCHY_SEPARATORS = Set.of(".", "$", "::", "->");
+
+    private static boolean containsAnyHierarchySeparator(String s) {
+        for (String sep : COMMON_HIERARCHY_SEPARATORS) {
+            if (s.contains(sep)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /* ---------- instance state ---------- */
     private final ThreadLocal<TSLanguage> threadLocalLanguage = ThreadLocal.withInitial(this::createTSLanguage);
     private final ThreadLocal<TSQuery> query;
@@ -429,7 +442,7 @@ public abstract class TreeSitterAnalyzer
         // If the query looks like a simple non-hierarchical prefix (no dots/dollars, not a camel all-upper pattern),
         // leverage the NavigableSet view from the symbolIndex for an efficient prefix scan.
         boolean usePrefixOptimization =
-                !lowerCaseQuery.contains(".") && !lowerCaseQuery.contains("$") && !isAllUpper && query.length() >= 2;
+                !containsAnyHierarchySeparator(lowerCaseQuery) && !isAllUpper && query.length() >= 2;
 
         NavigableSet<String> keys = symbolIndex.navigableKeySet();
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -1876,7 +1876,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                 var symbols = Completions.completeSymbols(text, analyzer);
                 completions = symbols.stream()
                         .limit(50)
-                        .map(symbol -> (Completion) new ShorthandCompletion(this, symbol.identifier(), symbol.fqName()))
+                        .map(symbol -> (Completion) new ShorthandCompletion(this, symbol.shortName(), symbol.fqName()))
                         .toList();
             }
 

--- a/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
@@ -1,6 +1,7 @@
 package io.github.jbellis.brokk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.jbellis.brokk.analyzer.CodeUnit;
 import io.github.jbellis.brokk.testutil.MockAnalyzer;
@@ -51,12 +52,20 @@ public class CompletionsTest {
         var completions = Completions.completeSymbols("Re", mock);
         var values = toValues(completions);
 
-        assertEquals(Set.of("a.b.Do$Re", "a.b.Do$Re$Sub"), values);
+        assertEquals(2, values.size());
+        assertTrue(values.contains("a.b.Do$Re"));
+        assertTrue(values.contains("a.b.Do$Re$Sub"));
     }
 
     @Test
     public void testCamelCaseCompletion() {
-        var mock = new MockAnalyzer(tempDir);
+        var mock = new MockAnalyzer(tempDir) {
+            @Override
+            public List<CodeUnit> autocompleteDefinitions(String query) {
+                // give all for the sake of testing camel case fuzzy matching
+                return super.autocompleteDefinitions(".*");
+            }
+        };
         // Input "CC" -> should match "test.CamelClass" due to camel case matching
         var completions = Completions.completeSymbols("CC", mock);
         var values = toValues(completions);
@@ -72,6 +81,18 @@ public class CompletionsTest {
         var mock = new MockAnalyzer(tempDir);
 
         var completions = Completions.completeSymbols("Do", mock);
-        assertEquals(Set.of("Do", "Do$Re", "Do$Re$Sub"), toShortValues(completions));
+        assertEquals(3, completions.size());
+        var shortValues = toShortValues(completions);
+        assertTrue(shortValues.contains("Do"));
+        assertTrue(shortValues.contains("Do$Re"));
+        assertTrue(shortValues.contains("Do$Re$Sub"));
+    }
+
+    @Test
+    public void testArchCompletion() {
+        var mock = new MockAnalyzer(tempDir);
+        var completions = Completions.completeSymbols("arch", mock);
+        var values = toValues(completions);
+        assertEquals(Set.of("a.b.Architect"), values);
     }
 }

--- a/app/src/test/java/io/github/jbellis/brokk/testutil/MockAnalyzer.java
+++ b/app/src/test/java/io/github/jbellis/brokk/testutil/MockAnalyzer.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Mock analyzer implementation for testing that provides minimal functionality to support fragment freezing and linting
@@ -27,7 +28,8 @@ public class MockAnalyzer implements IAnalyzer, UsagesProvider, SkeletonProvider
                 CodeUnit.cls(mockFile, "a.b", "Do$Re$Sub"), // nested inside Re
                 CodeUnit.cls(mockFile, "x.y", "Zz"),
                 CodeUnit.cls(mockFile, "w.u", "Zz"),
-                CodeUnit.cls(mockFile, "test", "CamelClass"));
+                CodeUnit.cls(mockFile, "test", "CamelClass"),
+                CodeUnit.cls(mockFile, "a.b", "Architect"));
         this.methodsMap = Map.ofEntries(
                 Map.entry(
                         "a.b.Do",
@@ -64,7 +66,10 @@ public class MockAnalyzer implements IAnalyzer, UsagesProvider, SkeletonProvider
     }
 
     @Override
-    public List<CodeUnit> searchDefinitions(String pattern) {
+    public List<CodeUnit> searchDefinitions(@Nullable String pattern) {
+        if (pattern == null || pattern.isEmpty()) {
+            return List.of();
+        }
         if (".*".equals(pattern)) {
             return Stream.concat(
                             allClasses.stream(), methodsMap.values().stream().flatMap(List::stream))
@@ -83,7 +88,9 @@ public class MockAnalyzer implements IAnalyzer, UsagesProvider, SkeletonProvider
                 .filter(cu -> cu.fqName().matches(regex))
                 .toList();
 
-        return Stream.concat(matchingClasses.stream(), matchingMethods.stream()).toList();
+        return Stream.concat(matchingClasses.stream(), matchingMethods.stream())
+                .distinct()
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
Take 3 or 4 of trying to solve the auto-complete issue. This change focuses on `TreeSitterAnalyzer`. 

This approach tries something new, that is, using a navigable set structure to find initial auto-complete candidates. It involves introducing a new global data structure which is not ideal, but further makes the case for something like Chronicle map/ a database down the line.

This is backed by a skip list and provides us with `NavigableSet` methods like `tailSet` which are used if possible to speed up prefix-based queries. Other queries that are more camel-case or hierarchical leverage a more expensive, O(N), strategy.

Symbols are also cached to matching code units for fast lookups.

In terms of testing, this also tests against the `JavaAnalyzer` to get more of an integration test and view how the auto-complete performance is in practice.

Attempts to resolve
* https://github.com/BrokkAi/brokk/issues/742
* https://github.com/BrokkAi/brokk/issues/741
* https://github.com/BrokkAi/brokk/issues/799