### PR TITLE
HiDPI support #

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/Brokk.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Brokk.java
@@ -76,6 +76,7 @@ public class Brokk {
     public static final CompletableFuture<@Nullable AbstractModel> embeddingModelFuture;
 
     public static final String ICON_RESOURCE = "/brokk-icon.png";
+    private static final SystemScaleProvider systemScaleProvider = new SystemScaleProviderImpl();
 
     // Helper record for argument parsing result
     private record ParsedArgs(boolean noProjectFlag, boolean noKeyFlag, @Nullable String projectPathArg) {}
@@ -118,6 +119,57 @@ public class Brokk {
     }
 
     private static void setupSystemPropertiesAndIcon() {
+
+        if (!Environment.isMacOs()) {
+            var existing = System.getProperty("sun.java2d.uiScale");
+            if (existing != null) {
+                logger.info("sun.java2d.uiScale already set to {}. Respecting user override.", existing);
+            } else {
+                // Apply saved UI preference first (takes precedence over detection)
+                String uiPref = MainProject.getUiScalePref();
+                boolean appliedPref = false;
+                if (!"auto".equalsIgnoreCase(uiPref)) {
+                    try {
+                        double custom = Double.parseDouble(uiPref);
+                        if (custom > 0.0) {
+                            double normalized = SystemScaleDetector.normalizeUiScaleToAllowed(custom);
+                            System.setProperty("sun.java2d.uiScale", Double.toString(normalized));
+                            logger.info("Applied user UI scale preference (normalized): {}", normalized);
+                            appliedPref = true;
+                        } else {
+                            logger.warn(
+                                    "Ignoring non-positive UI scale preference '{}'; falling back to detection.",
+                                    uiPref);
+                        }
+                    } catch (NumberFormatException nfe) {
+                        logger.warn("Invalid UI scale preference '{}'; falling back to detection.", uiPref);
+                    }
+                }
+
+                if (!appliedPref) {
+                    if (Environment.isLinux()) {
+                        var detected = SystemScaleDetector.detectLinuxUiScale(systemScaleProvider);
+                        if (detected != null && detected > 0.0) {
+                            System.setProperty("sun.java2d.uiScale", Double.toString(detected));
+                            logger.info("Applied sun.java2d.uiScale from environment: {}", detected);
+                        } else {
+                            logger.info("No reliable Linux UI scale detected; leaving sun.java2d.uiScale unset.");
+                        }
+                    } else if (Environment.isWindows()) {
+                        var detected = SystemScaleDetector.tryDetectScaleViaWindows(systemScaleProvider);
+                        if (detected != null && detected > 0.0) {
+                            var normalized = SystemScaleDetector.normalizeUiScaleToAllowed(detected);
+                            System.setProperty("sun.java2d.uiScale", Double.toString(normalized));
+                            logger.info("Applied sun.java2d.uiScale from environment: {}", normalized);
+                        } else {
+                            logger.info("No reliable Windows UI scale detected; leaving sun.java2d.uiScale unset.");
+                        }
+                    } else {
+                        logger.info("Unknown platform detected. Leaving sun.java2d.uiScale unset.");
+                    }
+                }
+            }
+        }
         System.setProperty("apple.laf.useScreenMenuBar", "true");
         if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac")) {
             System.setProperty("apple.awt.application.name", "Brokk");

--- a/app/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -1013,6 +1013,29 @@ public final class MainProject extends AbstractProject {
         saveGlobalProperties(props);
     }
 
+    // UI Scale global preference
+    // Values:
+    //  - "auto" (default): detect from environment (kscreen-doctor/gsettings on Linux)
+    //  - numeric value (e.g., "1.25"), applied to sun.java2d.uiScale at startup, capped elsewhere to sane bounds
+    private static final String UI_SCALE_KEY = "uiScale";
+
+    public static String getUiScalePref() {
+        var props = loadGlobalProperties();
+        return props.getProperty(UI_SCALE_KEY, "auto");
+    }
+
+    public static void setUiScalePrefAuto() {
+        var props = loadGlobalProperties();
+        props.setProperty(UI_SCALE_KEY, "auto");
+        saveGlobalProperties(props);
+    }
+
+    public static void setUiScalePrefCustom(double scale) {
+        var props = loadGlobalProperties();
+        props.setProperty(UI_SCALE_KEY, Double.toString(scale));
+        saveGlobalProperties(props);
+    }
+
     public static String getBrokkKey() {
         var props = loadGlobalProperties();
         return props.getProperty("brokkApiKey", "");

--- a/app/src/main/java/io/github/jbellis/brokk/SystemScaleDetector.java
+++ b/app/src/main/java/io/github/jbellis/brokk/SystemScaleDetector.java
@@ -1,0 +1,157 @@
+package io.github.jbellis.brokk;
+
+import com.google.common.base.Splitter;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.Nullable;
+
+/** Extraction of HiDPI detection/parsing logic that is testable via injection of SystemScaleProvider. */
+public final class SystemScaleDetector {
+
+    private SystemScaleDetector() {}
+
+    public static @Nullable Double detectLinuxUiScale(SystemScaleProvider provider) {
+        var kde = tryDetectScaleViaKscreenDoctor(provider);
+        if (kde != null) {
+            return normalizeUiScaleToAllowed(kde);
+        }
+        var gnome = tryDetectScaleViaGsettings(provider);
+        if (gnome != null) {
+            return normalizeUiScaleToAllowed(gnome);
+        }
+        return null;
+    }
+
+    public static double normalizeUiScaleToAllowed(double v) {
+        int rounded = (int) Math.round(v);
+        if (rounded < 1) rounded = 1;
+        if (rounded > 5) rounded = 5;
+        return (double) rounded;
+    }
+
+    public static @Nullable Double tryDetectScaleViaKscreenDoctor(SystemScaleProvider provider) {
+        var lines = provider.runCommand("kscreen-doctor", "-o");
+        if (lines == null || lines.isEmpty()) {
+            return null;
+        }
+        Double firstScale = null;
+        Double currentScale = null;
+        boolean currentPrimary = false;
+
+        for (var raw : lines) {
+            var line = raw.trim();
+            if (line.startsWith("Output")) {
+                // New block: if previous block was primary and had a scale, prefer it
+                if (currentPrimary && currentScale != null) {
+                    return currentScale;
+                }
+                if (firstScale == null && currentScale != null) {
+                    firstScale = currentScale;
+                }
+                // reset for new block
+                currentScale = null;
+                currentPrimary = false;
+                continue;
+            }
+
+            if (line.regionMatches(true, 0, "Scale:", 0, "Scale:".length())) {
+                var val = line.substring("Scale:".length()).trim();
+                try {
+                    var tokens = Splitter.on(Pattern.compile("\\s+"))
+                            .omitEmptyStrings()
+                            .splitToList(val);
+                    if (!tokens.isEmpty()) {
+                        currentScale = Double.parseDouble(tokens.get(0));
+                    }
+                } catch (NumberFormatException nfe) {
+                    // ignore parse errors, keep behavior consistent with prior code
+                }
+                continue;
+            }
+
+            if (line.toLowerCase(Locale.ROOT).startsWith("primary:")) {
+                var val = line.substring("primary:".length()).trim().toLowerCase(Locale.ROOT);
+                currentPrimary = val.startsWith("yes") || val.startsWith("true");
+            }
+        }
+
+        // After loop, last block check
+        if (currentPrimary && currentScale != null) {
+            return currentScale;
+        }
+        if (firstScale != null) {
+            return firstScale;
+        }
+        return null;
+    }
+
+    public static @Nullable Double tryDetectScaleViaGsettings(SystemScaleProvider provider) {
+        var lines = provider.runCommand("gsettings", "get", "org.gnome.desktop.interface", "scaling-factor");
+        if (lines == null || lines.isEmpty()) {
+            return null;
+        }
+        var out = String.join(" ", lines).trim();
+        // Expected formats: "uint32 2" or "2"
+        String numberPart = out;
+        if (out.startsWith("uint32")) {
+            var parts = Splitter.on(Pattern.compile("\\s+")).omitEmptyStrings().splitToList(out);
+            if (parts.size() >= 2) {
+                numberPart = parts.get(1);
+            }
+        }
+        try {
+            int i = Integer.parseInt(numberPart);
+            if (i >= 1) {
+                return (double) i;
+            }
+        } catch (NumberFormatException nfe) {
+            // ignore, return null below
+        }
+        return null;
+    }
+
+    public static @Nullable Double tryDetectScaleViaWindows(SystemScaleProvider provider) {
+        // Try GraphicsConfiguration first (preferred)
+        var fromGc = provider.getGraphicsConfigScale();
+        if (fromGc != null) {
+            return fromGc;
+        }
+
+        // Fallback: Toolkit DPI (96 DPI == 1.0)
+        var toolkitDpi = provider.getToolkitDpi();
+        if (toolkitDpi != null && toolkitDpi > 0) {
+            return toolkitDpi / 96.0;
+        }
+
+        // Last resort: registry AppliedDPI
+        var lines =
+                provider.runCommand("reg", "query", "HKCU\\Control Panel\\Desktop\\WindowMetrics", "/v", "AppliedDPI");
+        if (lines == null || lines.isEmpty()) {
+            return null;
+        }
+        for (var raw : lines) {
+            var line = raw.trim();
+            if (line.toLowerCase(Locale.ROOT).contains("applieddpi")) {
+                var parts =
+                        Splitter.on(Pattern.compile("\\s+")).omitEmptyStrings().splitToList(line);
+                if (parts.size() >= 3) {
+                    var valStr = parts.get(parts.size() - 1);
+                    try {
+                        int appliedDpi;
+                        if (valStr.startsWith("0x")) {
+                            appliedDpi = Integer.parseInt(valStr.substring(2), 16);
+                        } else {
+                            appliedDpi = Integer.parseInt(valStr);
+                        }
+                        if (appliedDpi > 0) {
+                            return appliedDpi / 96.0;
+                        }
+                    } catch (NumberFormatException nfe) {
+                        // ignore parse errors
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/io/github/jbellis/brokk/SystemScaleProvider.java
+++ b/app/src/main/java/io/github/jbellis/brokk/SystemScaleProvider.java
@@ -1,0 +1,18 @@
+package io.github.jbellis.brokk;
+
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
+
+/* package-private */ interface SystemScaleProvider {
+    /** Return the scale derived from GraphicsConfiguration default transform (or null if unavailable). */
+    @Nullable
+    Double getGraphicsConfigScale();
+
+    /** Return toolkit DPI (Toolkit.getDefaultToolkit().getScreenResolution()) or null if unavailable. */
+    @Nullable
+    Integer getToolkitDpi();
+
+    /** Run an external command synchronously and return textual output as a list of lines, or null on timeout/error. */
+    @Nullable
+    List<String> runCommand(String... command);
+}

--- a/app/src/main/java/io/github/jbellis/brokk/SystemScaleProviderImpl.java
+++ b/app/src/main/java/io/github/jbellis/brokk/SystemScaleProviderImpl.java
@@ -1,0 +1,85 @@
+package io.github.jbellis.brokk;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Toolkit;
+import java.awt.geom.AffineTransform;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
+/* package-private */ final class SystemScaleProviderImpl implements SystemScaleProvider {
+    private static final Logger logger = LogManager.getLogger(SystemScaleProviderImpl.class);
+
+    @Override
+    public @Nullable Double getGraphicsConfigScale() {
+        try {
+            var ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+            var gd = ge.getDefaultScreenDevice();
+            if (gd != null) {
+                var gc = gd.getDefaultConfiguration();
+                if (gc != null) {
+                    AffineTransform tx = gc.getDefaultTransform();
+                    double scaleX = tx.getScaleX();
+                    double scaleY = tx.getScaleY();
+                    if (scaleX > 0.0 && Math.abs(scaleX - scaleY) < 1e-6) {
+                        logger.debug("GraphicsConfiguration-derived scale: {}", scaleX);
+                        return scaleX;
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            logger.debug("GraphicsConfiguration provider failed: {}", t.toString());
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable Integer getToolkitDpi() {
+        try {
+            int dpi = Toolkit.getDefaultToolkit().getScreenResolution();
+            return dpi > 0 ? Integer.valueOf(dpi) : null;
+        } catch (Throwable t) {
+            logger.debug("Toolkit DPI provider failed: {}", t.toString());
+            return null;
+        }
+    }
+
+    @Override
+    public @Nullable List<String> runCommand(String... command) {
+        try {
+            var pb = new ProcessBuilder(command);
+            pb.redirectErrorStream(true);
+            var proc = pb.start();
+            boolean finished = proc.waitFor(1, TimeUnit.SECONDS);
+            if (!finished) {
+                proc.destroyForcibly();
+                logger.warn("Command timed out: {}", String.join(" ", command));
+                return null;
+            }
+            var lines = new ArrayList<String>();
+            try (var is = proc.getInputStream();
+                    var isr = new InputStreamReader(is, UTF_8);
+                    var br = new BufferedReader(isr)) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    lines.add(line);
+                }
+            }
+            if (proc.exitValue() != 0) {
+                logger.debug("Command exited with non-zero status {}: {}", proc.exitValue(), String.join(" ", command));
+            }
+            return lines;
+        } catch (IOException | InterruptedException e) {
+            logger.debug("Failed running command '{}': {}", String.join(" ", command), e.toString());
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
@@ -28,6 +28,7 @@ public class SettingsDialog extends JDialog implements ThemeAware {
     private final JButton applyButton;
 
     private boolean proxySettingsChanged = false; // Track if proxy needs restart
+    private boolean uiScaleSettingsChanged = false; // Track if UI scale needs restart
 
     public SettingsDialog(Frame owner, Chrome chrome) {
         super(owner, "Settings", true);
@@ -128,13 +129,14 @@ public class SettingsDialog extends JDialog implements ThemeAware {
     }
 
     private void handleProxyRestartIfNeeded() {
-        if (proxySettingsChanged) {
+        if (proxySettingsChanged || uiScaleSettingsChanged) {
             JOptionPane.showMessageDialog(
                     this,
-                    "LLM Proxy settings have changed. Please restart Brokk to apply them.",
+                    "Some settings have changed (Proxy and/or UI Scale).\nPlease restart Brokk to apply them.",
                     "Restart Required",
                     JOptionPane.INFORMATION_MESSAGE);
-            proxySettingsChanged = false; // Reset flag
+            proxySettingsChanged = false;
+            uiScaleSettingsChanged = false;
         }
     }
 
@@ -159,6 +161,11 @@ public class SettingsDialog extends JDialog implements ThemeAware {
         globalSettingsPanel.applyTheme(guiTheme);
         projectSettingsPanel.applyTheme(guiTheme);
         setSize(previousSize);
+    }
+
+    // Called by SettingsGlobalPanel when UI scale preference changes
+    public void markRestartNeededForUiScale() {
+        this.uiScaleSettingsChanged = true;
     }
 
     public static SettingsDialog showSettingsDialog(Chrome chrome, String targetTabName) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -7,6 +7,7 @@ import io.github.jbellis.brokk.gui.Chrome;
 import io.github.jbellis.brokk.gui.GuiTheme;
 import io.github.jbellis.brokk.gui.ThemeAware;
 import io.github.jbellis.brokk.gui.components.BrowserLabel;
+import io.github.jbellis.brokk.util.Environment;
 import java.awt.*;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,6 +47,15 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware {
 
     @Nullable
     private JTextField gitHubTokenField; // Null if GitHub tab not shown
+
+    @Nullable
+    private JRadioButton uiScaleAutoRadio; // Hidden on macOS
+
+    @Nullable
+    private JRadioButton uiScaleCustomRadio; // Hidden on macOS
+
+    @Nullable
+    private JComboBox<String> uiScaleCombo; // Hidden on macOS
 
     private JTabbedPane globalSubTabbedPane = new JTabbedPane(JTabbedPane.TOP);
 
@@ -248,6 +258,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware {
         gbc.anchor = GridBagConstraints.WEST;
         int row = 0;
 
+        // Theme
         gbc.gridx = 0;
         gbc.gridy = row;
         gbc.weightx = 0.0;
@@ -271,6 +282,61 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware {
         gbc.gridy = row++;
         appearancePanel.add(darkThemeRadio, gbc);
 
+        // UI Scale controls (hidden on macOS)
+        if (!Environment.isMacOs()) {
+            gbc.insets = new Insets(10, 5, 2, 5); // spacing before next section
+            gbc.gridx = 0;
+            gbc.gridy = row;
+            gbc.weightx = 0.0;
+            gbc.fill = GridBagConstraints.NONE;
+            appearancePanel.add(new JLabel("UI Scale:"), gbc);
+
+            uiScaleAutoRadio = new JRadioButton("Auto (recommended)");
+            uiScaleCustomRadio = new JRadioButton("Custom:");
+            var scaleGroup = new ButtonGroup();
+            scaleGroup.add(uiScaleAutoRadio);
+            scaleGroup.add(uiScaleCustomRadio);
+
+            uiScaleCombo = new JComboBox<>();
+            final JComboBox<String> combo = uiScaleCombo;
+            var uiScaleModel = new DefaultComboBoxModel<String>();
+            uiScaleModel.addElement("1.0");
+            uiScaleModel.addElement("2.0");
+            uiScaleModel.addElement("3.0");
+            uiScaleModel.addElement("4.0");
+            uiScaleModel.addElement("5.0");
+            combo.setModel(uiScaleModel);
+            combo.setEnabled(false);
+
+            uiScaleAutoRadio.addActionListener(e -> combo.setEnabled(false));
+            uiScaleCustomRadio.addActionListener(e -> combo.setEnabled(true));
+
+            gbc.gridx = 1;
+            gbc.gridy = row++;
+            gbc.weightx = 1.0;
+            gbc.fill = GridBagConstraints.HORIZONTAL;
+            appearancePanel.add(uiScaleAutoRadio, gbc);
+
+            var customPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
+            customPanel.add(uiScaleCustomRadio);
+            customPanel.add(combo);
+
+            gbc.gridy = row++;
+            appearancePanel.add(customPanel, gbc);
+
+            var restartLabel = new JLabel("Restart required after changing UI scale");
+            restartLabel.setFont(restartLabel.getFont().deriveFont(Font.ITALIC));
+            gbc.gridy = row++;
+            gbc.insets = new Insets(0, 25, 2, 5);
+            appearancePanel.add(restartLabel, gbc);
+            gbc.insets = new Insets(2, 5, 2, 5);
+        } else {
+            uiScaleAutoRadio = null;
+            uiScaleCustomRadio = null;
+            uiScaleCombo = null;
+        }
+
+        // filler
         gbc.gridy = row;
         gbc.weighty = 1.0;
         gbc.fill = GridBagConstraints.VERTICAL;
@@ -398,6 +464,40 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware {
             lightThemeRadio.setSelected(true);
         }
 
+        // UI Scale (if present; hidden on macOS)
+        if (uiScaleAutoRadio != null && uiScaleCustomRadio != null && uiScaleCombo != null) {
+            String pref = MainProject.getUiScalePref();
+            if ("auto".equalsIgnoreCase(pref)) {
+                uiScaleAutoRadio.setSelected(true);
+                uiScaleCombo.setSelectedItem("1.0");
+                uiScaleCombo.setEnabled(false);
+            } else {
+                uiScaleCustomRadio.setSelected(true);
+                var model = (DefaultComboBoxModel<String>) uiScaleCombo.getModel();
+                String selected = pref;
+                boolean found = false;
+                for (int i = 0; i < model.getSize(); i++) {
+                    if (pref.equals(model.getElementAt(i))) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    try {
+                        double v = Double.parseDouble(pref);
+                        int nearest = (int) Math.round(v);
+                        if (nearest < 1) nearest = 1;
+                        if (nearest > 5) nearest = 5;
+                        selected = nearest + ".0";
+                    } catch (NumberFormatException ignore) {
+                        selected = "1.0";
+                    }
+                }
+                uiScaleCombo.setSelectedItem(selected);
+                uiScaleCombo.setEnabled(true);
+            }
+        }
+
         // Quick Models Tab
         quickModelsTableModel.setFavorites(MainProject.loadFavoriteModels());
 
@@ -460,6 +560,35 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware {
         if (!newTheme.equals(MainProject.getTheme())) {
             chrome.switchTheme(newIsDark);
             logger.debug("Applied Theme: {}", newTheme);
+        }
+
+        // UI Scale preference (if present; hidden on macOS)
+        if (uiScaleAutoRadio != null && uiScaleCustomRadio != null && uiScaleCombo != null) {
+            String before = MainProject.getUiScalePref();
+            if (uiScaleAutoRadio.isSelected()) {
+                if (!"auto".equalsIgnoreCase(before)) {
+                    MainProject.setUiScalePrefAuto();
+                    parentDialog.markRestartNeededForUiScale();
+                    logger.debug("Applied UI scale preference: auto");
+                }
+            } else {
+                String txt = String.valueOf(uiScaleCombo.getSelectedItem()).trim();
+                var allowed = java.util.Set.of("1.0", "2.0", "3.0", "4.0", "5.0");
+                if (!allowed.contains(txt)) {
+                    JOptionPane.showMessageDialog(
+                            this,
+                            "Select a scale from 1.0, 2.0, 3.0, 4.0, or 5.0.",
+                            "Invalid UI Scale",
+                            JOptionPane.ERROR_MESSAGE);
+                    return false;
+                }
+                if (!txt.equals(before)) {
+                    double v = Double.parseDouble(txt);
+                    MainProject.setUiScalePrefCustom(v);
+                    parentDialog.markRestartNeededForUiScale();
+                    logger.debug("Applied UI scale preference: {}", v);
+                }
+            }
         }
 
         // Quick Models Tab

--- a/app/src/test/java/io/github/jbellis/brokk/ScreenScaleDetectionTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/ScreenScaleDetectionTest.java
@@ -1,0 +1,170 @@
+package io.github.jbellis.brokk;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+class ScreenScaleDetectionTest {
+
+    static class FakeProvider implements SystemScaleProvider {
+        @Nullable
+        private Double graphicsScale = null;
+
+        @Nullable
+        private Integer toolkitDpi = null;
+
+        @Nullable
+        private List<String> lastCommandResult = null;
+
+        FakeProvider() {}
+
+        FakeProvider graphicsScale(@Nullable Double s) {
+            this.graphicsScale = s;
+            return this;
+        }
+
+        FakeProvider toolkitDpi(@Nullable Integer d) {
+            this.toolkitDpi = d;
+            return this;
+        }
+
+        FakeProvider commandResult(@Nullable List<String> out) {
+            this.lastCommandResult = out;
+            return this;
+        }
+
+        @Override
+        public @Nullable Double getGraphicsConfigScale() {
+            return graphicsScale;
+        }
+
+        @Override
+        public @Nullable Integer getToolkitDpi() {
+            return toolkitDpi;
+        }
+
+        @Override
+        public @Nullable List<String> runCommand(String... command) {
+            return lastCommandResult;
+        }
+    }
+
+    @Test
+    void tryDetectScaleViaKscreenDoctor_primaryPresent() {
+        var lines = Arrays.asList(
+                "Output: 0",
+                "  Connector: HDMI-A-1",
+                "  Scale: 1.0",
+                "Output: 1",
+                "  Connector: DP-1",
+                "  Primary: true",
+                "  Scale: 1.5");
+        var provider = new FakeProvider().commandResult(lines);
+
+        var raw = SystemScaleDetector.tryDetectScaleViaKscreenDoctor(provider);
+        assertNotNull(raw);
+        assertEquals(1.5, raw, 1e-9);
+
+        var normalized = SystemScaleDetector.detectLinuxUiScale(provider);
+        assertNotNull(normalized);
+        // 1.5 rounds to 2
+        assertEquals(2.0, normalized, 1e-9);
+    }
+
+    @Test
+    void tryDetectScaleViaKscreenDoctor_noPrimary_takeFirst() {
+        var lines = Arrays.asList(
+                "Output: 0", "  Connector: HDMI-A-1", "  Scale: 2.0", "Output: 1", "  Connector: DP-1", "  Scale: 1.0");
+        var provider = new FakeProvider().commandResult(lines);
+
+        var raw = SystemScaleDetector.tryDetectScaleViaKscreenDoctor(provider);
+        assertNotNull(raw);
+        assertEquals(2.0, raw, 1e-9);
+
+        var normalized = SystemScaleDetector.detectLinuxUiScale(provider);
+        assertEquals(2.0, normalized, 1e-9);
+    }
+
+    @Test
+    void tryDetectScaleViaKscreenDoctor_malformed_returnsNull() {
+        var lines = Arrays.asList(
+                "Output: 0",
+                "  Connector: HDMI-A-1",
+                "  SomeOtherLine: yes",
+                "Output: 1",
+                "  Connector: DP-1",
+                "  Primary: maybe");
+        var provider = new FakeProvider().commandResult(lines);
+
+        var raw = SystemScaleDetector.tryDetectScaleViaKscreenDoctor(provider);
+        assertNull(raw);
+    }
+
+    @Test
+    void tryDetectScaleViaGsettings_integerParsing() {
+        var provider = new FakeProvider().commandResult(Arrays.asList("2"));
+
+        var detected = SystemScaleDetector.tryDetectScaleViaGsettings(provider);
+        assertNotNull(detected);
+        assertEquals(2.0, detected, 1e-9);
+    }
+
+    @Test
+    void tryDetectScaleViaGsettings_uint32Prefix() {
+        var provider = new FakeProvider().commandResult(Arrays.asList("uint32 2"));
+
+        var detected = SystemScaleDetector.tryDetectScaleViaGsettings(provider);
+        assertNotNull(detected);
+        assertEquals(2.0, detected, 1e-9);
+    }
+
+    @Test
+    void tryDetectScaleViaGsettings_nonNumeric_returnsNull() {
+        var provider = new FakeProvider().commandResult(Arrays.asList("'some string'"));
+
+        var detected = SystemScaleDetector.tryDetectScaleViaGsettings(provider);
+        assertNull(detected);
+    }
+
+    @Test
+    void tryDetectScaleViaWindows_graphicsTransform() {
+        var provider = new FakeProvider().graphicsScale(1.25);
+
+        var detected = SystemScaleDetector.tryDetectScaleViaWindows(provider);
+        assertNotNull(detected);
+        assertEquals(1.25, detected, 1e-9);
+    }
+
+    @Test
+    void tryDetectScaleViaWindows_toolkitDpi() {
+        var provider = new FakeProvider().graphicsScale(null).toolkitDpi(144);
+
+        var detected = SystemScaleDetector.tryDetectScaleViaWindows(provider);
+        assertNotNull(detected);
+        assertEquals(1.5, detected, 1e-9);
+    }
+
+    @Test
+    void tryDetectScaleViaWindows_registryDecimalAndHex() {
+        var providerDecimal = new FakeProvider().commandResult(Arrays.asList("    AppliedDPI    REG_DWORD    96"));
+        var detectedDecimal = SystemScaleDetector.tryDetectScaleViaWindows(providerDecimal);
+        assertNotNull(detectedDecimal);
+        assertEquals(1.0, detectedDecimal, 1e-9);
+
+        var providerHex = new FakeProvider().commandResult(Arrays.asList("    AppliedDPI    REG_DWORD    0x60"));
+        var detectedHex = SystemScaleDetector.tryDetectScaleViaWindows(providerHex);
+        assertNotNull(detectedHex);
+        assertEquals(1.0, detectedHex, 1e-9);
+    }
+
+    @Test
+    void normalizeUiScaleToAllowed_edgeCases() {
+        assertEquals(2.0, SystemScaleDetector.normalizeUiScaleToAllowed(2.4), 1e-9);
+        assertEquals(5.0, SystemScaleDetector.normalizeUiScaleToAllowed(4.9), 1e-9);
+        assertEquals(1.0, SystemScaleDetector.normalizeUiScaleToAllowed(0.9), 1e-9);
+        assertEquals(3.0, SystemScaleDetector.normalizeUiScaleToAllowed(3.0), 1e-9);
+    }
+}


### PR DESCRIPTION
- added an entry in the appearance menu for setting custom UI scale
- auto detection of scale for Windows and Linux using OS specific tricks
- no scale detection or scale setting for MacOS as that tends to just work
- only allowing non-fractional scale 1.0, 2.0, 3.0, 4.0 and 5.0
- scale is using JRE based options
- can override auto detection on start with a -D flag