### PR TITLE
fix: Refresh sessions drop-down in all open worktree windows

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/Brokk.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Brokk.java
@@ -953,6 +953,10 @@ public class Brokk {
         return openProjectWindows;
     }
 
+    public static List<Chrome> getWorktreeChromes(IProject mainProject) {
+        return mainToWorktreeChromes.getOrDefault(mainProject, List.of());
+    }
+
     /**
      * Gracefully exit the application: - request each open project's ContextManager to close with a timeout - wait for
      * all closes to complete - then terminate the JVM

--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -336,9 +336,8 @@ public class ContextManager implements IContextManager, AutoCloseable {
                             "Skipped moving currently active session {} due to unreadable history; user may move or delete it manually.",
                             currentSessionId);
                 }
-                if (moved > 0 && io instanceof Chrome chrome) {
-                    SwingUtilities.invokeLater(
-                            () -> chrome.getHistoryOutputPanel().updateSessionComboBox());
+                if (moved > 0 && io instanceof Chrome) {
+                    mainProject.sessionsListChanged();
                 }
             });
         }
@@ -1963,11 +1962,9 @@ public class ContextManager implements IContextManager, AutoCloseable {
         if (currentSession.isPresent()
                 && DEFAULT_SESSION_NAME.equals(currentSession.get().name())) {
             renameSessionAsync(currentSessionId, actionFuture).thenRun(() -> {
-                SwingUtilities.invokeLater(() -> {
-                    if (io instanceof Chrome chrome) {
-                        chrome.getHistoryOutputPanel().updateSessionComboBox();
-                    }
-                });
+                if (io instanceof Chrome) {
+                    project.getMainProject().sessionsListChanged();
+                }
             });
         }
 

--- a/app/src/main/java/io/github/jbellis/brokk/IProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/IProject.java
@@ -281,6 +281,10 @@ public interface IProject extends AutoCloseable {
         throw new UnsupportedOperationException();
     }
 
+    default void sessionsListChanged() {
+        throw new UnsupportedOperationException();
+    }
+
     default Set<String> getExcludedDirectories() {
         return Set.of();
     }

--- a/app/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -7,6 +7,7 @@ import io.github.jbellis.brokk.agents.BuildAgent;
 import io.github.jbellis.brokk.analyzer.Language;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
 import io.github.jbellis.brokk.git.GitRepo;
+import io.github.jbellis.brokk.gui.Chrome;
 import io.github.jbellis.brokk.issues.IssueProviderType;
 import io.github.jbellis.brokk.util.AtomicWrites;
 import io.github.jbellis.brokk.util.Environment;
@@ -31,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import javax.swing.SwingUtilities;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jgit.errors.ConfigInvalidException;
@@ -1593,5 +1595,21 @@ public final class MainProject extends AbstractProject {
     @Override
     public SessionManager getSessionManager() {
         return sessionManager;
+    }
+
+    @Override
+    public void sessionsListChanged() {
+        var mainChrome = Brokk.findOpenProjectWindow(getRoot());
+        var worktreeChromes = Brokk.getWorktreeChromes(this);
+
+        var allChromes = new ArrayList<Chrome>();
+        if (mainChrome != null) {
+            allChromes.add(mainChrome);
+        }
+        allChromes.addAll(worktreeChromes);
+
+        for (var chrome : allChromes) {
+            SwingUtilities.invokeLater(() -> chrome.getHistoryOutputPanel().updateSessionComboBox());
+        }
     }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
@@ -222,4 +222,9 @@ public final class WorktreeProject extends AbstractProject {
     public SessionManager getSessionManager() {
         return parent.getSessionManager();
     }
+
+    @Override
+    public void sessionsListChanged() {
+        parent.sessionsListChanged();
+    }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -236,7 +236,7 @@ public class HistoryOutputPanel extends JPanel {
         newSessionButton.addActionListener(e -> {
             contextManager
                     .createSessionAsync(ContextManager.DEFAULT_SESSION_NAME)
-                    .thenRun(() -> SwingUtilities.invokeLater(this::updateSessionComboBox));
+                    .thenRun(() -> contextManager.getProject().getMainProject().sessionsListChanged());
         });
         // Split-arrow menu → session with copied workspace
         newSessionButton.setMenuSupplier(() -> {
@@ -245,7 +245,8 @@ public class HistoryOutputPanel extends JPanel {
             copyWorkspaceItem.addActionListener(ev -> {
                 contextManager
                         .createSessionFromContextAsync(contextManager.topContext(), ContextManager.DEFAULT_SESSION_NAME)
-                        .thenRun(() -> SwingUtilities.invokeLater(this::updateSessionComboBox));
+                        .thenRun(() ->
+                                contextManager.getProject().getMainProject().sessionsListChanged());
             });
             popup.add(copyWorkspaceItem);
             return popup;
@@ -257,19 +258,19 @@ public class HistoryOutputPanel extends JPanel {
             var popup = new JPopupMenu();
 
             var renameItem = new JMenuItem("Rename Current Session");
-            renameItem.addActionListener(ev -> SessionsDialog.renameCurrentSession(
-                    HistoryOutputPanel.this, chrome, contextManager, HistoryOutputPanel.this));
+            renameItem.addActionListener(
+                    ev -> SessionsDialog.renameCurrentSession(HistoryOutputPanel.this, chrome, contextManager));
             popup.add(renameItem);
 
             var deleteItem = new JMenuItem("Delete Current Session");
-            deleteItem.addActionListener(ev -> SessionsDialog.deleteCurrentSession(
-                    HistoryOutputPanel.this, chrome, contextManager, HistoryOutputPanel.this));
+            deleteItem.addActionListener(
+                    ev -> SessionsDialog.deleteCurrentSession(HistoryOutputPanel.this, chrome, contextManager));
             popup.add(deleteItem);
 
             return popup;
         });
         manageSessionsButton.addActionListener(e -> {
-            var dialog = new SessionsDialog(HistoryOutputPanel.this, chrome, contextManager);
+            var dialog = new SessionsDialog(chrome, contextManager);
             dialog.setVisible(true);
         });
 
@@ -581,7 +582,7 @@ public class HistoryOutputPanel extends JPanel {
             }
 
             // Update session combo box after table update
-            updateSessionComboBox();
+            contextManager.getProject().getMainProject().sessionsListChanged();
             var resetEdges = contextManager.getContextHistory().getResetEdges();
             arrowLayerUI.setResetEdges(resetEdges);
         });

--- a/app/src/main/java/io/github/jbellis/brokk/gui/MenuBar.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/MenuBar.java
@@ -233,8 +233,7 @@ public class MenuBar {
         newSessionItem.addActionListener(e -> runWithRefocus(chrome, () -> {
             chrome.getContextManager()
                     .createSessionAsync(ContextManager.DEFAULT_SESSION_NAME)
-                    .thenRun(() -> SwingUtilities.invokeLater(
-                            () -> chrome.getHistoryOutputPanel().updateSessionComboBox()));
+                    .thenRun(() -> chrome.getProject().getMainProject().sessionsListChanged());
         }));
         contextMenu.add(newSessionItem);
 
@@ -245,8 +244,7 @@ public class MenuBar {
             chrome.getContextManager()
                     .createSessionFromContextAsync(
                             chrome.getContextManager().topContext(), ContextManager.DEFAULT_SESSION_NAME)
-                    .thenRun(() -> SwingUtilities.invokeLater(
-                            () -> chrome.getHistoryOutputPanel().updateSessionComboBox()));
+                    .thenRun(() -> chrome.getProject().getMainProject().sessionsListChanged());
         }));
         contextMenu.add(newSessionCopyWorkspaceItem);
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SessionsDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SessionsDialog.java
@@ -4,6 +4,7 @@ import static io.github.jbellis.brokk.SessionManager.SessionInfo;
 
 import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.ContextManager;
+import io.github.jbellis.brokk.SessionRegistry;
 import io.github.jbellis.brokk.context.Context;
 import io.github.jbellis.brokk.context.ContextHistory;
 import io.github.jbellis.brokk.difftool.utils.ColorUtil;
@@ -11,7 +12,6 @@ import io.github.jbellis.brokk.difftool.utils.Colors;
 import io.github.jbellis.brokk.gui.ActivityTableRenderers;
 import io.github.jbellis.brokk.gui.Chrome;
 import io.github.jbellis.brokk.gui.GitUiUtil;
-import io.github.jbellis.brokk.gui.HistoryOutputPanel;
 import io.github.jbellis.brokk.gui.WorkspacePanel;
 import io.github.jbellis.brokk.gui.mop.MarkdownOutputPanel;
 import io.github.jbellis.brokk.gui.util.Icons;
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import javax.swing.*;
 import javax.swing.plaf.LayerUI;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -41,7 +42,6 @@ import org.jetbrains.annotations.Nullable;
 
 /** Modal dialog for managing sessions with Activity log, Workspace panel, and MOP preview */
 public class SessionsDialog extends JDialog {
-    private final HistoryOutputPanel historyOutputPanel;
     private final Chrome chrome;
     private final ContextManager contextManager;
 
@@ -61,9 +61,8 @@ public class SessionsDialog extends JDialog {
     private JScrollPane markdownScrollPane;
     private @Nullable Context selectedActivityContext;
 
-    public SessionsDialog(HistoryOutputPanel historyOutputPanel, Chrome chrome, ContextManager contextManager) {
+    public SessionsDialog(Chrome chrome, ContextManager contextManager) {
         super(chrome.getFrame(), "Manage Sessions", true);
-        this.historyOutputPanel = historyOutputPanel;
         this.chrome = chrome;
         this.contextManager = contextManager;
 
@@ -431,12 +430,11 @@ public class SessionsDialog extends JDialog {
 
             JMenuItem setActiveItem = new JMenuItem("Set as Active");
             setActiveItem.setEnabled(!sessionInfo.id().equals(contextManager.getCurrentSessionId()));
-            setActiveItem.addActionListener(ev -> contextManager
-                    .switchSessionAsync(sessionInfo.id())
-                    .thenRun(() -> SwingUtilities.invokeLater(() -> {
-                        refreshSessionsTable();
-                        historyOutputPanel.updateSessionComboBox();
-                    })));
+            setActiveItem.addActionListener(
+                    ev -> contextManager.switchSessionAsync(sessionInfo.id()).thenRun(() -> {
+                        SwingUtilities.invokeLater(this::refreshSessionsTable);
+                        contextManager.getProject().getMainProject().sessionsListChanged();
+                    }));
             popup.add(setActiveItem);
             popup.addSeparator();
 
@@ -455,16 +453,29 @@ public class SessionsDialog extends JDialog {
                     JOptionPane.YES_NO_OPTION,
                     JOptionPane.WARNING_MESSAGE);
             if (confirm == JOptionPane.YES_OPTION) {
+                var activeSessions = selectedSessions.stream()
+                        .filter(s -> SessionRegistry.isSessionActiveElsewhere(
+                                contextManager.getProject().getRoot(), s.id()))
+                        .toList();
+
+                if (!activeSessions.isEmpty()) {
+                    var sessionNames =
+                            activeSessions.stream().map(SessionInfo::name).collect(Collectors.joining(", "));
+                    chrome.toolError(
+                            "Cannot delete sessions active in other worktrees: " + sessionNames, "Sessions in use");
+                    return;
+                }
+
                 var futures = new java.util.ArrayList<java.util.concurrent.CompletableFuture<?>>();
                 for (var s : selectedSessions) {
                     futures.add(contextManager.deleteSessionAsync(s.id()));
                 }
                 java.util.concurrent.CompletableFuture.allOf(
                                 futures.toArray(new java.util.concurrent.CompletableFuture[0]))
-                        .thenRun(() -> SwingUtilities.invokeLater(() -> {
-                            refreshSessionsTable();
-                            historyOutputPanel.updateSessionComboBox();
-                        }));
+                        .thenRun(() -> {
+                            SwingUtilities.invokeLater(this::refreshSessionsTable);
+                            contextManager.getProject().getMainProject().sessionsListChanged();
+                        });
             }
         });
         popup.add(deleteItem);
@@ -477,10 +488,10 @@ public class SessionsDialog extends JDialog {
                 futures.add(contextManager.copySessionAsync(s.id(), s.name()));
             }
             java.util.concurrent.CompletableFuture.allOf(futures.toArray(new java.util.concurrent.CompletableFuture[0]))
-                    .thenRun(() -> SwingUtilities.invokeLater(() -> {
-                        refreshSessionsTable();
-                        historyOutputPanel.updateSessionComboBox();
-                    }));
+                    .thenRun(() -> {
+                        SwingUtilities.invokeLater(this::refreshSessionsTable);
+                        contextManager.getProject().getMainProject().sessionsListChanged();
+                    });
         });
         popup.add(dupItem);
 
@@ -496,10 +507,10 @@ public class SessionsDialog extends JDialog {
         if (newName != null && !newName.trim().isBlank()) {
             contextManager
                     .renameSessionAsync(sessionInfo.id(), CompletableFuture.completedFuture(newName.trim()))
-                    .thenRun(() -> SwingUtilities.invokeLater(() -> {
-                        refreshSessionsTable();
-                        historyOutputPanel.updateSessionComboBox();
-                    }));
+                    .thenRun(() -> {
+                        SwingUtilities.invokeLater(this::refreshSessionsTable);
+                        contextManager.getProject().getMainProject().sessionsListChanged();
+                    });
         }
     }
 
@@ -661,8 +672,7 @@ public class SessionsDialog extends JDialog {
     }
 
     // ---------- Static helpers for other UI components ----------
-    public static void renameCurrentSession(
-            Component parent, Chrome chrome, ContextManager contextManager, HistoryOutputPanel historyOutputPanel) {
+    public static void renameCurrentSession(Component parent, Chrome chrome, ContextManager contextManager) {
         var sessionManager = contextManager.getProject().getSessionManager();
         var currentId = contextManager.getCurrentSessionId();
         var maybeInfo = sessionManager.listSessions().stream()
@@ -679,12 +689,11 @@ public class SessionsDialog extends JDialog {
             contextManager
                     .renameSessionAsync(
                             info.id(), java.util.concurrent.CompletableFuture.completedFuture(newName.trim()))
-                    .thenRun(() -> SwingUtilities.invokeLater(historyOutputPanel::updateSessionComboBox));
+                    .thenRun(() -> contextManager.getProject().getMainProject().sessionsListChanged());
         }
     }
 
-    public static void deleteCurrentSession(
-            Component parent, Chrome chrome, ContextManager contextManager, HistoryOutputPanel historyOutputPanel) {
+    public static void deleteCurrentSession(Component parent, Chrome chrome, ContextManager contextManager) {
         var sessionManager = contextManager.getProject().getSessionManager();
         var currentId = contextManager.getCurrentSessionId();
         var maybeInfo = sessionManager.listSessions().stream()
@@ -704,7 +713,7 @@ public class SessionsDialog extends JDialog {
         if (confirm == JOptionPane.YES_OPTION) {
             contextManager
                     .deleteSessionAsync(info.id())
-                    .thenRun(() -> SwingUtilities.invokeLater(historyOutputPanel::updateSessionComboBox));
+                    .thenRun(() -> contextManager.getProject().getMainProject().sessionsListChanged());
         }
     }
 }


### PR DESCRIPTION
Closes #707:
- Refresh session list in all worktree windows.
- Prevent deletion of sessions that are active in worktrees.