### PR TITLE
Feat: Adds "Capture" button to MOP, captures text, summarizes, and adds UI feedback

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1065,6 +1065,18 @@ public class ContextManager implements IContextManager, AutoCloseable {
     }
 
     /**
+     * Handles capturing text, e.g. from a code block in the MOP.
+     * Submits a task to summarize the text and adds a PasteTextFragment to the context.
+     *
+     * @param text The text to capture.
+     */
+    public void addPastedTextFragment(String text) {
+        Future<String> descriptionFuture = submitSummarizePastedText(text);
+        var fragment = new ContextFragment.PasteTextFragment(this, text, descriptionFuture);
+        addVirtualFragment(fragment);
+    }
+
+    /**
      * Adds a specific PathFragment (like GitHistoryFragment) to the read-only part of the live context.
      *
      * @param fragment The PathFragment to add.

--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1065,8 +1065,8 @@ public class ContextManager implements IContextManager, AutoCloseable {
     }
 
     /**
-     * Handles capturing text, e.g. from a code block in the MOP.
-     * Submits a task to summarize the text and adds a PasteTextFragment to the context.
+     * Handles capturing text, e.g. from a code block in the MOP. Submits a task to summarize the text and adds a
+     * PasteTextFragment to the context.
      *
      * @param text The text to capture.
      */

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -1978,13 +1978,7 @@ public class WorkspacePanel extends JPanel {
             }
 
             // Add as string fragment (possibly converted from HTML)
-            Future<String> summaryFuture = contextManager.submitSummarizePastedText(content);
-            String finalContent = content;
-            contextManager.pushContext(ctx -> {
-                var fragment = new ContextFragment.PasteTextFragment(
-                        contextManager, finalContent, summaryFuture); // Pass contextManager
-                return ctx.addVirtualFragment(fragment);
-            });
+            contextManager.addPastedTextFragment(content);
 
             // Inform the user about what happened
             if (stacktrace == null) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
@@ -5,6 +5,7 @@ import static org.checkerframework.checker.nullness.util.NullnessUtil.castNonNul
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
+import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.IContextManager;
 import io.github.jbellis.brokk.TaskEntry;
 import io.github.jbellis.brokk.context.ContextFragment;
@@ -37,7 +38,7 @@ public class MarkdownOutputPanel extends JPanel implements ThemeAware, Scrollabl
     private boolean blockClearAndReset = false;
     private final List<Runnable> textChangeListeners = new ArrayList<>();
     private final List<ChatMessage> messages = new ArrayList<>();
-    private @Nullable IContextManager currentContextManager;
+    private @Nullable ContextManager currentContextManager;
 
     @Override
     public boolean getScrollableTracksViewportHeight() {
@@ -249,7 +250,7 @@ public class MarkdownOutputPanel extends JPanel implements ThemeAware, Scrollabl
         webHost.removeSearchStateListener(l);
     }
 
-    public void withContextForLookups(@Nullable IContextManager contextManager, @Nullable Chrome chrome) {
+    public void withContextForLookups(@Nullable ContextManager contextManager, @Nullable Chrome chrome) {
         // Unregister from previous context manager if it exists
         if (currentContextManager != null) {
             currentContextManager.removeAnalyzerCallback(this);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/mop/webview/MOPBridge.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/mop/webview/MOPBridge.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.message.ChatMessageType;
-import io.github.jbellis.brokk.IContextManager;
+import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.gui.Chrome;
 import io.github.jbellis.brokk.gui.mop.SymbolLookupService;
 import java.io.UncheckedIOException;
@@ -37,7 +37,7 @@ public final class MOPBridge {
     private final AtomicInteger epoch = new AtomicInteger();
     private final Map<Integer, CompletableFuture<Void>> awaiting = new ConcurrentHashMap<>();
     private final LinkedBlockingQueue<BrokkEvent> eventQueue = new LinkedBlockingQueue<>();
-    private volatile @Nullable IContextManager contextManager;
+    private volatile @Nullable ContextManager contextManager;
     private volatile @Nullable Chrome chrome;
     private volatile @Nullable java.awt.Component hostComponent;
 
@@ -261,7 +261,7 @@ public final class MOPBridge {
         }
     }
 
-    public void setContextManager(@Nullable IContextManager contextManager) {
+    public void setContextManager(@Nullable ContextManager contextManager) {
         this.contextManager = contextManager;
     }
 
@@ -380,6 +380,13 @@ public final class MOPBridge {
                 }
             }
         });
+    }
+
+    public void captureText(String text) {
+        var cm = contextManager;
+        if (cm != null) {
+            cm.addPastedTextFragment(text);
+        }
     }
 
     public String getContextCacheId() {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/mop/webview/MOPWebViewHost.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/mop/webview/MOPWebViewHost.java
@@ -3,7 +3,7 @@ package io.github.jbellis.brokk.gui.mop.webview;
 import static java.util.Objects.requireNonNull;
 
 import dev.langchain4j.data.message.ChatMessageType;
-import io.github.jbellis.brokk.IContextManager;
+import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.util.Environment;
 import java.awt.*;
 import java.util.List;
@@ -33,7 +33,7 @@ public final class MOPWebViewHost extends JPanel {
     private final java.util.List<HostCommand> pendingCommands = new CopyOnWriteArrayList<>();
     private final List<Consumer<MOPBridge.SearchState>> searchListeners = new CopyOnWriteArrayList<>();
     private volatile boolean darkTheme = true; // Default to dark theme
-    private volatile @Nullable IContextManager contextManager;
+    private volatile @Nullable ContextManager contextManager;
     private volatile @Nullable io.github.jbellis.brokk.gui.Chrome chrome;
 
     // Bridge readiness tracking
@@ -496,7 +496,7 @@ public final class MOPWebViewHost extends JPanel {
         flushBufferedCommands();
     }
 
-    public void setContextManager(@Nullable IContextManager contextManager) {
+    public void setContextManager(@Nullable ContextManager contextManager) {
         this.contextManager = contextManager;
         var bridge = bridgeRef.get();
         if (bridge != null) {

--- a/frontend-mop/src/components/CopyablePre.svelte
+++ b/frontend-mop/src/components/CopyablePre.svelte
@@ -4,8 +4,10 @@
 
   // Reactive state in Svelte 5 (Runes)
   let copied = $state(false);
+  let captured = $state(false);
   let preElem: HTMLElement;
   let copyTimeout: number | null = null;
+  let captureTimeout: number | null = null;
 
   async function copyToClipboard() {
     const text = preElem?.innerText ?? '';
@@ -39,6 +41,21 @@
     }
   }
 
+  function captureToWorkspace() {
+    const text = preElem?.innerText ?? '';
+    if (!text) {
+      return;
+    }
+
+    const javaBridge = window.javaBridge;
+    if (javaBridge.captureText) {
+      javaBridge.captureText(text);
+      setCapturedTransient();
+    } else {
+      console.warn('`window.brokk.captureText` is not available');
+    }
+  }
+
   function setCopiedTransient() {
     copied = true;
     if (copyTimeout !== null) {
@@ -47,6 +64,17 @@
     copyTimeout = window.setTimeout(() => {
       copied = false;
       copyTimeout = null;
+    }, 1200);
+  }
+
+  function setCapturedTransient() {
+    captured = true;
+    if (captureTimeout !== null) {
+      clearTimeout(captureTimeout);
+    }
+    captureTimeout = window.setTimeout(() => {
+      captured = false;
+      captureTimeout = null;
     }, 1200);
   }
 </script>
@@ -59,6 +87,16 @@
     <button
       type="button"
       class="copy-btn"
+      class:captured={captured}
+      on:click={captureToWorkspace}
+      aria-label={captured ? 'Captured!' : 'Capture code to workspace'}
+      title={captured ? 'Captured!' : 'Capture code to workspace'}
+    >
+      <Icon icon={captured ? 'mdi:check' : 'mdi:camera-plus-outline'} />
+    </button>
+    <button
+      type="button"
+      class="copy-btn"
       class:copied={copied}
       on:click={copyToClipboard}
       aria-label={copied ? 'Copied!' : 'Copy code to clipboard'}
@@ -67,7 +105,7 @@
       <Icon icon={copied ? 'mdi:check' : 'mdi:content-copy'} />
     </button>
     <span class="sr-only" aria-live="polite" role="status">
-      {copied ? 'Copied to clipboard' : ''}
+      {copied ? 'Copied to clipboard' : captured ? 'Captured to workspace' : ''}
     </span>
   </div>
   <pre bind:this={preElem} {...rest}>{@render children?.()}</pre>
@@ -122,7 +160,8 @@
   }
 
   /* Visual hint on success */
-  .copy-btn.copied {
+  .copy-btn.copied,
+  .copy-btn.captured {
     color: var(--git-status-added);
     opacity: 1;
   }

--- a/frontend-mop/src/global.d.ts
+++ b/frontend-mop/src/global.d.ts
@@ -30,6 +30,7 @@ declare global {
       jsLog: (level: string, message: string) => void;
       searchStateChanged: (total: number, current: number) => void;
       onSymbolClick: (symbolName: string, symbolExists: boolean, symbolFqn: string | null, x: number, y: number) => void;
+      captureText:(text: string) => void;
       lookupSymbolsAsync?: (symbolNamesJson: string, seq: number | null, contextId: string) => void;
     };
   }


### PR DESCRIPTION
fixes #173

- Intent: allow users to capture code/text blocks from the MOP view into the workspace as a virtual pasted-text fragment, with an asynchronous summarization task attached and immediate UI feedback.

- Behaviour changes:
  - Adds a "Capture" button to code blocks in the MOP frontend. Clicking it calls the Java bridge and shows transient "Captured" feedback.
  - Captured text is submitted to the ContextManager which creates a PasteTextFragment and schedules background summarization.
  - WorkspacePanel no longer duplicates summary submission; it delegates to ContextManager.addPastedTextFragment.
  - Accessibility: ARIA/role/status updated to announce capture events.

- Key implementation notes:
  - New ContextManager.addPastedTextFragment(text) submits the summarization Future and adds a ContextFragment.PasteTextFragment via addVirtualFragment.
  - MOPBridge and MOPWebViewHost now accept a concrete ContextManager (instead of IContextManager) to call the new API; MOPBridge.captureText forwards captures to the context manager.
  - Frontend: CopyablePre.svelte adds capture UI/state and calls window.javaBridge.captureText; global.d.ts exposes captureText on the bridge.
  
  
<img width="1392" height="366" alt="image" src="https://github.com/user-attachments/assets/7d9c0760-75c2-4efe-bad6-7988f34a546d" />
