### PR TITLE
Improved scrolling in code blocks

### DIFF
--- a/frontend-mop/src/components/CopyablePre.svelte
+++ b/frontend-mop/src/components/CopyablePre.svelte
@@ -7,6 +7,32 @@
   let preElem: HTMLElement;
   let copyTimeout: number | null = null;
 
+  function handleWheel(event: WheelEvent) {
+    // Only intervene if the pre element doesn't need to scroll vertically
+    const { scrollTop, scrollHeight, clientHeight } = preElem;
+    const canScrollDown = scrollTop < scrollHeight - clientHeight;
+    const canScrollUp = scrollTop > 0;
+
+    const isScrollingDown = event.deltaY > 0;
+    const isScrollingUp = event.deltaY < 0;
+
+    // If we can't scroll vertically in the intended direction, pass to parent
+    if ((isScrollingDown && !canScrollDown) || (isScrollingUp && !canScrollUp)) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      // Find scrollable parent (more generic than .chat-container)
+      let parent = preElem.parentElement;
+      while (parent && parent.scrollHeight <= parent.clientHeight) {
+        parent = parent.parentElement;
+      }
+
+      if (parent) {
+        parent.scrollBy(0, event.deltaY);
+      }
+    }
+  }
+
   async function copyToClipboard() {
     const text = preElem?.innerText ?? '';
     if (!text) {
@@ -70,7 +96,7 @@
       {copied ? 'Copied to clipboard' : ''}
     </span>
   </div>
-  <pre bind:this={preElem} {...rest}>{@render children?.()}</pre>
+  <pre bind:this={preElem} on:wheel={handleWheel} {...rest}>{@render children?.()}</pre>
 </div>
 
 <style>


### PR DESCRIPTION
Fixes #809 

* Problem:
  Code blocks with overflow: auto were capturing all wheel events, preventing users from scrolling the parent chat container when the code block had no scrollable content or when scrolling reached the top/bottom boundaries. 

This created a frustrating UX where scrolling would "get stuck" on code blocks.

* Root Cause

  The browser's default behavior for elements with overflow: auto is to consume wheel events regardless of whether the element can actually  scroll in the intended direction. This prevents the events from bubbling up to scrollable parent containers.

* Solution

  Added an wheel event handler that:

  1. Checks scroll boundaries - Determines if the code block can scroll in the intended direction (up/down)
  2. Selective event handling - Only prevents default behavior when the code block has reached its scroll limits
  3. Parent delegation - Finds the nearest scrollable parent and forwards scroll events when the code block can't handle them
  4. Preserves native scrolling - Allows normal scrolling within code blocks that have scrollable content