### PR TITLE
Ignored-by-default Test Code Checkbox in Usage Dialog

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1091,9 +1091,14 @@ public class ContextManager implements IContextManager, AutoCloseable {
 
     /** usage for identifier */
     public void usageForIdentifier(String identifier) {
-        var fragment = new ContextFragment.UsageFragment(this, identifier);
+        usageForIdentifier(identifier, false);
+    }
+
+    /** usage for identifier with control over including test files */
+    public void usageForIdentifier(String identifier, boolean includeTestFiles) {
+        var fragment = new ContextFragment.UsageFragment(this, identifier, includeTestFiles);
         pushContext(currentLiveCtx -> currentLiveCtx.addVirtualFragment(fragment));
-        io.systemOutput("Added uses of " + identifier);
+        io.systemOutput("Added uses of " + identifier + (includeTestFiles ? " (including tests)" : ""));
     }
 
     public void sourceCodeForCodeUnit(CodeUnit codeUnit) {

--- a/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
@@ -1244,7 +1244,14 @@ public interface ContextFragment {
 
         @Override
         public Set<ProjectFile> files() {
-            return sources().stream().map(CodeUnit::source).collect(Collectors.toSet());
+            final var allSources = sources().stream().map(CodeUnit::source);
+            if (!includeTestFiles) {
+                return allSources
+                        .filter(source -> !ContextManager.isTestFile(source))
+                        .collect(Collectors.toSet());
+            } else {
+                return allSources.collect(Collectors.toSet());
+            }
         }
 
         @Override

--- a/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
@@ -5,6 +5,7 @@ import static org.checkerframework.checker.nullness.util.NullnessUtil.castNonNul
 
 import dev.langchain4j.data.message.ChatMessage;
 import io.github.jbellis.brokk.AnalyzerUtil;
+import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.IContextManager;
 import io.github.jbellis.brokk.IProject;
 import io.github.jbellis.brokk.TaskEntry;
@@ -1169,18 +1170,30 @@ public interface ContextFragment {
 
     class UsageFragment extends VirtualFragment { // Dynamic, uses nextId
         private final String targetIdentifier;
+        private final boolean includeTestFiles;
 
         public UsageFragment(IContextManager contextManager, String targetIdentifier) {
+            this(contextManager, targetIdentifier, false);
+        }
+
+        public UsageFragment(IContextManager contextManager, String targetIdentifier, boolean includeTestFiles) {
             super(contextManager); // Assigns dynamic numeric String ID
             assert !targetIdentifier.isBlank();
             this.targetIdentifier = targetIdentifier;
+            this.includeTestFiles = includeTestFiles;
         }
 
         // Constructor for DTOs/unfreezing where ID might be a numeric string or hash (if frozen)
         public UsageFragment(String existingId, IContextManager contextManager, String targetIdentifier) {
+            this(existingId, contextManager, targetIdentifier, false);
+        }
+
+        public UsageFragment(
+                String existingId, IContextManager contextManager, String targetIdentifier, boolean includeTestFiles) {
             super(existingId, contextManager); // Handles numeric ID parsing for nextId
             assert !targetIdentifier.isBlank();
             this.targetIdentifier = targetIdentifier;
+            this.includeTestFiles = includeTestFiles;
         }
 
         @Override
@@ -1194,6 +1207,11 @@ public interface ContextFragment {
             return analyzer.as(UsagesProvider.class)
                     .map(up -> {
                         List<CodeUnit> uses = up.getUses(targetIdentifier);
+                        if (!includeTestFiles) {
+                            uses = uses.stream()
+                                    .filter(cu -> !ContextManager.isTestFile(cu.source()))
+                                    .toList();
+                        }
                         var result = AnalyzerUtil.processUsages(analyzer, uses);
                         return result.code().isEmpty()
                                 ? "No relevant usages found for symbol: " + targetIdentifier
@@ -1213,6 +1231,11 @@ public interface ContextFragment {
             return analyzer.as(UsagesProvider.class)
                     .map(up -> {
                         List<CodeUnit> uses = up.getUses(targetIdentifier);
+                        if (!includeTestFiles) {
+                            uses = uses.stream()
+                                    .filter(cu -> !ContextManager.isTestFile(cu.source()))
+                                    .toList();
+                        }
                         var result = AnalyzerUtil.processUsages(analyzer, uses);
                         return result.sources();
                     })
@@ -1244,6 +1267,10 @@ public interface ContextFragment {
 
         public String targetIdentifier() {
             return targetIdentifier;
+        }
+
+        public boolean getIncludeTestFiles() {
+            return includeTestFiles;
         }
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -1603,9 +1603,11 @@ public class WorkspacePanel extends JPanel {
                     return;
                 }
 
-                String symbol = showSymbolSelectionDialog("Select Symbol", CodeUnitType.ALL);
-                if (symbol != null && !symbol.isBlank()) {
-                    contextManager.usageForIdentifier(symbol);
+                var selection = showSymbolSelectionDialog("Select Symbol", CodeUnitType.ALL);
+                if (selection != null
+                        && selection.symbol() != null
+                        && !selection.symbol().isBlank()) {
+                    contextManager.usageForIdentifier(selection.symbol(), selection.includeTestFiles());
                 } else {
                     chrome.systemOutput("No symbol selected.");
                 }
@@ -1683,7 +1685,8 @@ public class WorkspacePanel extends JPanel {
     }
 
     /** Show the symbol selection dialog with a type filter */
-    private @Nullable String showSymbolSelectionDialog(String title, Set<CodeUnitType> typeFilter) {
+    private @Nullable SymbolSelectionDialog.SymbolSelection showSymbolSelectionDialog(
+            String title, Set<CodeUnitType> typeFilter) {
         var analyzer = contextManager.getAnalyzerUninterrupted();
         var dialogRef = new AtomicReference<SymbolSelectionDialog>();
         SwingUtil.runOnEdt(() -> {
@@ -1694,10 +1697,7 @@ public class WorkspacePanel extends JPanel {
             dialogRef.set(dialog);
         });
         var dialog = castNonNull(dialogRef.get());
-        if (dialog.isConfirmed()) {
-            return dialog.getSelectedSymbol();
-        }
-        return null;
+        return dialog.isConfirmed() ? dialog.getSelection() : null;
     }
 
     /** Show the call graph dialog for configuring method and depth */

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SymbolSelectionDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SymbolSelectionDialog.java
@@ -14,9 +14,13 @@ public class SymbolSelectionDialog extends JDialog {
     private final SymbolSelectionPanel selectionPanel;
     private final JButton okButton;
     private final JButton cancelButton;
+    // Checkbox to include usages in test files
+    private final JCheckBox includeTestFilesCheckBox;
 
-    // The selected symbol
-    private @Nullable String selectedSymbol = null;
+    // The selected symbol and options
+    public record SymbolSelection(@Nullable String symbol, boolean includeTestFiles) {}
+
+    private @Nullable SymbolSelectionDialog.SymbolSelection symbolSelection = null;
 
     // Indicates if the user confirmed the selection
     private boolean confirmed = false;
@@ -30,6 +34,11 @@ public class SymbolSelectionDialog extends JDialog {
         // Create the symbol selection panel
         selectionPanel = new SymbolSelectionPanel(analyzer, typeFilter);
         mainPanel.add(selectionPanel, BorderLayout.NORTH);
+
+        // Include test files checkbox in center
+        includeTestFilesCheckBox = new JCheckBox("Include usages in test files");
+        includeTestFilesCheckBox.setSelected(false);
+        mainPanel.add(includeTestFilesCheckBox, BorderLayout.CENTER);
 
         // Buttons at the bottom
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
@@ -50,7 +59,7 @@ public class SymbolSelectionDialog extends JDialog {
                 .registerKeyboardAction(
                         e -> {
                             confirmed = false;
-                            selectedSymbol = null;
+                            symbolSelection = null;
                             dispose();
                         },
                         escapeKeyStroke,
@@ -70,11 +79,11 @@ public class SymbolSelectionDialog extends JDialog {
     /** When OK is pressed, get the symbol from the text input. */
     private void doOk() {
         confirmed = true;
-        selectedSymbol = null;
+        symbolSelection = null;
 
         String typed = selectionPanel.getSymbolText();
         if (!typed.isEmpty()) {
-            selectedSymbol = typed;
+            symbolSelection = new SymbolSelection(typed, includeTestFilesCheckBox.isSelected());
         }
         dispose();
     }
@@ -84,8 +93,8 @@ public class SymbolSelectionDialog extends JDialog {
         return confirmed;
     }
 
-    /** Return the selected symbol or null if none. */
-    public @Nullable String getSelectedSymbol() {
-        return selectedSymbol;
+    /** Returns the full selection, including the 'include test files' flag. */
+    public @Nullable SymbolSelectionDialog.SymbolSelection getSelection() {
+        return symbolSelection;
     }
 }


### PR DESCRIPTION
* Usages dialog includes an unchecked tickbox to include test code
* Modified selection dialog to use a record to contain selection information
* UsageFragment filters out test files on various getters based on the `includeTestFiles` field
* To test: Choose something widely used like `CodeUnit.fqName` to illustrate difference.