### PR TITLE
fix reasoning treatment in Messages.getText

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/util/Messages.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/Messages.java
@@ -51,7 +51,14 @@ public class Messages {
     public static String getText(ChatMessage message) {
         return switch (message) {
             case SystemMessage sm -> sm.text();
-            case AiMessage am -> am.text() == null ? "" : am.text();
+            case AiMessage am -> {
+                var text = am.text();
+                if (text != null && !text.isBlank()) {
+                    yield text;
+                }
+                var reasoning = am.reasoningContent();
+                yield reasoning == null ? "" : reasoning;
+            }
             case UserMessage um ->
                 um.contents().stream()
                         .filter(c -> c instanceof TextContent)


### PR DESCRIPTION
Closes #860:
- ~~Removed reasoning content from `Messages.getText`.~~ Return text if present, otherwise return reasoning.
- Added both in `getRepr`: if there is reasoning, we add `Reasoning:` and `Text:` headers, otherwise we keep the old behavior with text content without header (with optional tool calls).