### PR TITLE
Removed `isCpg` Checks

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1743,7 +1743,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
 
     /** Ensure style guide exists, generating if needed */
     private void ensureStyleGuide() {
-        if (!project.getStyleGuide().isEmpty() || !analyzerWrapper.isCpg()) {
+        if (!project.getStyleGuide().isEmpty()) {
             return;
         }
 

--- a/app/src/main/java/io/github/jbellis/brokk/IProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/IProject.java
@@ -110,7 +110,7 @@ public interface IProject extends AutoCloseable {
         throw new UnsupportedOperationException();
     }
 
-    default CpgRefresh getAnalyzerRefresh() {
+    default AnalyzerRefresh getAnalyzerRefresh() {
         throw new UnsupportedOperationException();
     }
 
@@ -118,7 +118,7 @@ public interface IProject extends AutoCloseable {
         throw new UnsupportedOperationException();
     }
 
-    default void setAnalyzerRefresh(CpgRefresh cpgRefresh) {}
+    default void setAnalyzerRefresh(AnalyzerRefresh cpgRefresh) {}
 
     default boolean isDataShareAllowed() {
         return false;
@@ -293,7 +293,7 @@ public interface IProject extends AutoCloseable {
         throw new UnsupportedOperationException();
     }
 
-    enum CpgRefresh {
+    enum AnalyzerRefresh {
         AUTO,
         ON_RESTART,
         MANUAL,

--- a/app/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -738,18 +738,18 @@ public final class MainProject extends AbstractProject {
     }
 
     @Override
-    public CpgRefresh getAnalyzerRefresh() {
+    public AnalyzerRefresh getAnalyzerRefresh() {
         String value = projectProps.getProperty("code_intelligence_refresh");
-        if (value == null) return CpgRefresh.UNSET;
+        if (value == null) return AnalyzerRefresh.UNSET;
         try {
-            return CpgRefresh.valueOf(value.toUpperCase(Locale.ROOT));
+            return AnalyzerRefresh.valueOf(value.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            return CpgRefresh.UNSET;
+            return AnalyzerRefresh.UNSET;
         }
     }
 
     @Override
-    public void setAnalyzerRefresh(CpgRefresh value) {
+    public void setAnalyzerRefresh(AnalyzerRefresh value) {
         projectProps.setProperty("code_intelligence_refresh", value.name());
         saveProjectProperties();
     }

--- a/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
@@ -128,12 +128,12 @@ public final class WorktreeProject extends AbstractProject {
     }
 
     @Override
-    public CpgRefresh getAnalyzerRefresh() {
+    public AnalyzerRefresh getAnalyzerRefresh() {
         return parent.getAnalyzerRefresh();
     }
 
     @Override
-    public void setAnalyzerRefresh(CpgRefresh value) {
+    public void setAnalyzerRefresh(AnalyzerRefresh value) {
         parent.setAnalyzerRefresh(value);
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/agents/ArchitectAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/ArchitectAgent.java
@@ -884,9 +884,7 @@ public class ArchitectAgent {
         messages.addAll(precomputedWorkspaceMessages);
 
         // Add auto-context as a separate message/ack pair
-        var topClassesRaw = contextManager.getAnalyzerWrapper().isCpg()
-                ? contextManager.liveContext().buildAutoContext(10).text()
-                : "";
+        var topClassesRaw = contextManager.liveContext().buildAutoContext(10).text();
         if (!topClassesRaw.isBlank()) {
             var topClassesText =
                     """

--- a/app/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/ContextAgent.java
@@ -323,16 +323,15 @@ public class ContextAgent {
         Map<CodeUnit, String> rawSummaries;
         var ctx = cm.liveContext();
 
-        if (isCodeInWorkspace(ctx)
-                && !deepScan
-                && cm.getAnalyzerWrapper().isCpg()
-                && cm.getAnalyzerWrapper().isReady()) {
-            // If the workspace isn't empty, use pagerank candidates for Quick context
+        if (isCodeInWorkspace(ctx) && !deepScan && cm.getAnalyzerWrapper().isReady()) {
+            // If the workspace isn't empty, use Git distance candidates for Quick context
             var ac = cm.liveContext().buildAutoContext(50);
             // fetchSkeletons() is private in SkeletonFragment. We need to use its sources() or text().
             // For now, let's get the target FQNs and then fetch summaries for them.
             List<String> targetFqns = ac.getTargetIdentifiers();
-            debug("Non-empty workspace; using pagerank candidates (target FQNs: {})", String.join(",", targetFqns));
+            debug(
+                    "Non-empty workspace; using Git-based distance candidates (target FQNs: {})",
+                    String.join(",", targetFqns));
 
             // Create a temporary map for rawSummaries from these targetFqns
             Map<CodeUnit, String> tempSummaries = new HashMap<>();

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/ArchitectOptionsDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/ArchitectOptionsDialog.java
@@ -7,7 +7,10 @@ import io.github.jbellis.brokk.GitHubAuth;
 import io.github.jbellis.brokk.IProject;
 import io.github.jbellis.brokk.Service;
 import io.github.jbellis.brokk.agents.ArchitectAgent;
+import io.github.jbellis.brokk.analyzer.CallGraphProvider;
+import io.github.jbellis.brokk.analyzer.IAnalyzer;
 import io.github.jbellis.brokk.analyzer.Language;
+import io.github.jbellis.brokk.analyzer.UsagesProvider;
 import io.github.jbellis.brokk.git.GitRepo;
 import io.github.jbellis.brokk.gui.Chrome;
 import io.github.jbellis.brokk.gui.SwingUtil;
@@ -38,9 +41,13 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A modal dialog to configure the tools available to the Architect agent. */
 public class ArchitectOptionsDialog {
+
+    private static final Logger log = LoggerFactory.getLogger(ArchitectOptionsDialog.class);
 
     private static boolean isCodeIntelConfigured(IProject project) {
         var langs = project.getAnalyzerLanguages();
@@ -62,7 +69,17 @@ public class ArchitectOptionsDialog {
 
         SwingUtil.runOnEdt(() -> {
             var project = chrome.getProject();
-            var isCpg = contextManager.getAnalyzerWrapper().isCpg();
+
+            var tmpBool = false;
+            try {
+                IAnalyzer currentAnalyzer = contextManager.getAnalyzerWrapper().get();
+                tmpBool = currentAnalyzer.as(UsagesProvider.class).isPresent()
+                        && currentAnalyzer.as(CallGraphProvider.class).isPresent();
+            } catch (InterruptedException e) {
+                log.warn("Interrupted while determining analyzer capabilities.");
+            }
+            final var supportsInterproceduralAnalysis = tmpBool;
+
             boolean codeIntelConfigured = isCodeIntelConfigured(project);
 
             var currentOptions = project.getArchitectOptions();
@@ -136,11 +153,11 @@ public class ArchitectOptionsDialog {
                     "Code Intelligence Tools",
                     "Allow direct querying of code structure (e.g., find usages, call graphs)");
             analyzerCb.setSelected(currentOptions.includeAnalyzerTools() && codeIntelConfigured);
-            analyzerCb.setEnabled(isCpg && codeIntelConfigured);
+            analyzerCb.setEnabled(supportsInterproceduralAnalysis && codeIntelConfigured);
             if (!codeIntelConfigured) {
                 analyzerCb.setToolTipText(
                         "Code Intelligence is not configured. Please configure languages in Project Settings.");
-            } else if (!isCpg) {
+            } else if (!supportsInterproceduralAnalysis) {
                 analyzerCb.setToolTipText("Code Intelligence tools for %s are not yet available"
                         .formatted(project.getAnalyzerLanguages()));
             }
@@ -288,7 +305,7 @@ public class ArchitectOptionsDialog {
                         selectedCode,
                         contextCb.isSelected(),
                         validationCb.isSelected(),
-                        isCpg && codeIntelConfigured && analyzerCb.isSelected(),
+                        supportsInterproceduralAnalysis && codeIntelConfigured && analyzerCb.isSelected(),
                         workspaceCb.isSelected(),
                         codeCb.isSelected(),
                         searchCb.isSelected(),

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/MultiFileSelectionDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/MultiFileSelectionDialog.java
@@ -122,7 +122,7 @@ public class MultiFileSelectionDialog extends JDialog {
         }
 
         // --- Create Classes Tab (if requested) ---
-        if (modes.contains(SelectionMode.CLASSES) && analyzerWrapper.isCpg()) {
+        if (modes.contains(SelectionMode.CLASSES)) {
             tabbedPane.addTab("Classes", createClassSelectionPanel());
         }
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
@@ -50,8 +50,8 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
     private final SettingsDialog parentDialog;
 
     // UI Components managed by this panel
-    private JComboBox<MainProject.CpgRefresh> cpgRefreshComboBox = new JComboBox<>(new MainProject.CpgRefresh[] {
-        IProject.CpgRefresh.AUTO, IProject.CpgRefresh.ON_RESTART, IProject.CpgRefresh.MANUAL
+    private JComboBox<IProject.AnalyzerRefresh> cpgRefreshComboBox = new JComboBox<>(new IProject.AnalyzerRefresh[] {
+        IProject.AnalyzerRefresh.AUTO, IProject.AnalyzerRefresh.ON_RESTART, IProject.AnalyzerRefresh.MANUAL
     });
     private JTextField buildCleanCommandField = new JTextField();
     private JTextField allTestsCommandField = new JTextField();
@@ -1259,7 +1259,7 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
 
         var currentRefresh = project.getAnalyzerRefresh();
         cpgRefreshComboBox.setSelectedItem(
-                currentRefresh == IProject.CpgRefresh.UNSET ? IProject.CpgRefresh.AUTO : currentRefresh);
+                currentRefresh == IProject.AnalyzerRefresh.UNSET ? IProject.AnalyzerRefresh.AUTO : currentRefresh);
 
         // Primary language
         populatePrimaryLanguageComboBox();
@@ -1351,7 +1351,7 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
             logger.debug("Applied Run Command Timeout: {} seconds", timeout);
         }
 
-        var selectedRefresh = (MainProject.CpgRefresh) cpgRefreshComboBox.getSelectedItem();
+        var selectedRefresh = (IProject.AnalyzerRefresh) cpgRefreshComboBox.getSelectedItem();
         if (selectedRefresh != project.getAnalyzerRefresh()) {
             project.setAnalyzerRefresh(selectedRefresh);
             logger.debug("Applied Code Intelligence Refresh: {}", selectedRefresh);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitWorktreeTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitWorktreeTab.java
@@ -1004,30 +1004,30 @@ public class GitWorktreeTab extends JPanel {
         logger.debug("Adding worktree for branch '{}' at path {}", branchForWorktree, newWorktreePath);
         gitRepo.addWorktree(branchForWorktree, newWorktreePath);
 
-        // Copy (prefer hard-link) existing language CPG caches to the new worktree
+        // Copy (prefer hard-link) existing language storage caches to the new worktree
         var enabledLanguages = parentProject.getAnalyzerLanguages();
         for (var lang : enabledLanguages) {
-            if (!lang.isCpg()) {
-                continue;
-            }
-            var srcCpg = lang.getCpgPath(parentProject);
-            if (!Files.exists(srcCpg)) {
+            var sourceCache = lang.getStoragePath(parentProject);
+            if (!Files.exists(sourceCache)) {
                 continue;
             }
             try {
-                var relative = parentProject.getRoot().relativize(srcCpg);
-                var destCpg = newWorktreePath.resolve(relative);
-                Files.createDirectories(destCpg.getParent());
+                var relative = parentProject.getRoot().relativize(sourceCache);
+                var destCache = newWorktreePath.resolve(relative);
+                Files.createDirectories(destCache.getParent());
                 try {
-                    Files.createLink(destCpg, srcCpg); // Try hard-link first
-                    logger.debug("Hard-linked CPG cache from {} to {}", srcCpg, destCpg);
+                    Files.createLink(destCache, sourceCache); // Try hard-link first
+                    logger.debug("Hard-linked analyzer storage cache from {} to {}", sourceCache, destCache);
                 } catch (UnsupportedOperationException | IOException linkEx) {
-                    Files.copy(srcCpg, destCpg, StandardCopyOption.REPLACE_EXISTING);
-                    logger.debug("Copied CPG cache from {} to {}", srcCpg, destCpg);
+                    Files.copy(sourceCache, destCache, StandardCopyOption.REPLACE_EXISTING);
+                    logger.debug("Copied analyzer storage cache from {} to {}", sourceCache, destCache);
                 }
             } catch (IOException copyEx) {
                 logger.warn(
-                        "Failed to replicate CPG cache for language {}: {}", lang.name(), copyEx.getMessage(), copyEx);
+                        "Failed to replicate analyzer storage cache for language {}: {}",
+                        lang.name(),
+                        copyEx.getMessage(),
+                        copyEx);
             }
         }
 


### PR DESCRIPTION
Removed and refactored logic around `isCpg` cache. CpgCache and storage checks are refactored as a general-purpose cache.

Regarding `CpgCache`, do we kick this down the line until we have persistent storage? Seems it's functionality will be unused as long as nothing writes to the storage path.