### PR TITLE
Fix JavaAnalyzer Logic on Update

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaAnalyzer.java
@@ -89,19 +89,17 @@ public class JavaAnalyzer extends JavaTreeSitterAnalyzer
     @Override
     public IAnalyzer update(Set<ProjectFile> changedFiles) {
         if (jdtAnalyzer != null) {
-            return jdtAnalyzer.update(changedFiles);
-        } else {
-            return super.update(changedFiles);
+            jdtAnalyzer.update(changedFiles);
         }
+        return super.update(changedFiles);
     }
 
     @Override
     public IAnalyzer update() {
         if (jdtAnalyzer != null) {
-            return jdtAnalyzer.update();
-        } else {
-            return super.update();
+            jdtAnalyzer.update();
         }
+        return super.update();
     }
 
     @Override

--- a/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -28,8 +28,8 @@ import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.gpg.bc.internal.BouncyCastleGpgSignerFactory;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ProgressMonitor;
-import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.*;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
@@ -900,7 +900,7 @@ public class GitRepo implements Closeable, IGitRepo {
                 }
 
                 // Resolve HEAD and target branch; if either cannot be resolved, fall through to full checkout
-                var headId = repository.resolve("HEAD");       // may be null in an empty repo
+                var headId = repository.resolve("HEAD"); // may be null in an empty repo
                 var targetId = repository.resolve(branchName); // null if branch doesn't exist
 
                 if (headId != null && targetId != null) {

--- a/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -28,7 +28,6 @@ import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.gpg.bc.internal.BouncyCastleGpgSignerFactory;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ProgressMonitor;
-import org.eclipse.jgit.lib.RefUpdate;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.*;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
@@ -889,52 +888,6 @@ public class GitRepo implements Closeable, IGitRepo {
     /** Checkout a specific branch */
     @Override
     public void checkout(String branchName) throws GitAPIException {
-        // Attempt lightweight checkout optimization only for local branches
-        if (isLocalBranch(branchName)) {
-            try {
-                // If we're already on this branch, nothing to do
-                var currentBranch = repository.getBranch(); // may throw IOException
-                if (branchName.equals(currentBranch)) {
-                    logger.debug("Already on branch '{}'; skipping checkout.", branchName);
-                    return;
-                }
-
-                // Resolve HEAD and target branch; if either cannot be resolved, fall through to full checkout
-                var headId = repository.resolve("HEAD"); // may be null in an empty repo
-                var targetId = repository.resolve(branchName); // null if branch doesn't exist
-
-                if (headId != null && targetId != null) {
-                    try (var revWalk = new RevWalk(repository)) {
-                        var headCommit = revWalk.parseCommit(headId);
-                        var targetCommit = revWalk.parseCommit(targetId);
-
-                        // Compare tree IDs for identity
-                        var headTreeId = headCommit.getTree().getId();
-                        var targetTreeId = targetCommit.getTree().getId();
-
-                        if (headTreeId.equals(targetTreeId)) {
-                            logger.debug(
-                                    "Performing lightweight checkout to '{}' (identical trees): updating HEAD only",
-                                    branchName);
-                            var result = repository.updateRef("HEAD").link("refs/heads/" + branchName);
-                            if (result == RefUpdate.Result.IO_FAILURE || result == RefUpdate.Result.LOCK_FAILURE) {
-                                throw new IOException("RefUpdate.link failed with result: " + result);
-                            }
-                            invalidateCaches();
-                            return;
-                        }
-                    }
-                }
-            } catch (IOException e) {
-                logger.warn(
-                        "Lightweight checkout optimization failed for '{}': {}. Falling back to full checkout.",
-                        branchName,
-                        e.getMessage());
-                // fall through to full checkout
-            }
-        }
-
-        // Fallback: perform a full checkout
         git.checkout().setName(branchName).call();
         invalidateCaches();
     }


### PR DESCRIPTION
Found that JavaAnalyzer would only call update for one of the analysers, causing weird behaviour:

* The return value of `update` is the analyser itself, thus if the return value of the JdtAnalyzer is used, the JavaAnalyzer "disappears" during the update and the current analyser becomes the JdtAnalyzer
* If only one analyser updates, then only one analyser has the current state.

This fixes both issues, and confirms what I've observed in the `update` being a bit buggy for some reason (though I attributed this to some `isCpg` checks).