### PR TITLE
fix: make ContextManager non-async close function join

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1296,7 +1296,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
     @Override
     public void close() {
         // we're not in a hurry when calling close(), this indicates a single window shutting down
-        closeAsync(5_000);
+        closeAsync(5_000).join();
     }
 
     public CompletableFuture<Void> closeAsync(long awaitMillis) {


### PR DESCRIPTION
This is fixing an issue during shutdown where CM.close is called with the assumption that it was synchronous, but it returned immediately, causing the app to exit before the close was cleanly executed.