### PR TITLE
Fixes text detection, noted on reading a PR for reviews

### DIFF
--- a/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/BrokkFile.java
+++ b/analyzer-api/src/main/java/io/github/jbellis/brokk/analyzer/BrokkFile.java
@@ -23,10 +23,14 @@ public interface BrokkFile extends Comparable<BrokkFile> {
     @JsonIgnore
     default boolean isText() {
         try {
-            return Files.isRegularFile(absPath())
-                    && FileExtensions.IMAGE_EXTENSIONS.stream().noneMatch(ext -> FileExtensions.matches(absPath(), ext))
-                    && (FileExtensions.TEXT_EXTENSIONS.stream().anyMatch(ext -> FileExtensions.matches(absPath(), ext))
-                            || Files.size(absPath()) < 128 * 1024);
+            var path = absPath();
+            var isNotImage =
+                    FileExtensions.IMAGE_EXTENSIONS.stream().noneMatch(ext -> FileExtensions.matches(path, ext));
+            var hasTextExtension =
+                    FileExtensions.TEXT_EXTENSIONS.stream().anyMatch(ext -> FileExtensions.matches(path, ext));
+            var isSmallFile = Files.exists(path) && Files.isRegularFile(path) && Files.size(path) < 128 * 1024;
+
+            return isNotImage && (hasTextExtension || isSmallFile);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
@@ -616,7 +616,13 @@ public interface ContextFragment {
         @Override
         public Image image() throws UncheckedIOException {
             try {
-                return javax.imageio.ImageIO.read(file.absPath().toFile());
+                Image result = javax.imageio.ImageIO.read(file.absPath().toFile());
+                if (result == null) {
+                    // ImageIO.read() returns null if no registered ImageReader can read the file
+                    // This can happen for unsupported formats, corrupted files, or non-image files
+                    throw new UncheckedIOException(new IOException("Unable to read image file: " + file.absPath()));
+                }
+                return result;
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
@@ -971,7 +977,8 @@ public interface ContextFragment {
         private final Image image;
 
         // Helper to get image bytes, might throw UncheckedIOException
-        private static byte[] imageToBytes(Image image) {
+        @Nullable
+        private static byte[] imageToBytes(@Nullable Image image) {
             try {
                 // Assuming FrozenFragment.imageToBytes will be made public
                 return FrozenFragment.imageToBytes(image);
@@ -1025,6 +1032,7 @@ public interface ContextFragment {
             return image;
         }
 
+        @Nullable
         public byte[] imageBytes() {
             return imageToBytes(image);
         }

--- a/app/src/main/java/io/github/jbellis/brokk/util/HistoryIo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/HistoryIo.java
@@ -386,6 +386,10 @@ public final class HistoryIo {
                 for (var aif : pastedImageFragments) {
                     try {
                         byte[] imageBytes = aif.imageBytes();
+                        if (imageBytes == null) {
+                            logger.warn("Skipping image fragment {} because imageBytes is null", aif.id());
+                            continue;
+                        }
                         ZipEntry entry = new ZipEntry(IMAGES_DIR_PREFIX + aif.id() + ".png"); // Assumes PNG
                         entry.setMethod(ZipEntry.STORED);
                         entry.setSize(imageBytes.length);


### PR DESCRIPTION
- Intent: fix incorrect text detection for files that exist in Git but not on disk, make image handling more robust (avoid NPEs/unhandled null images), and add tests covering these cases.

Fixes #933 

- Behaviour changes:
  - BrokkFile.isText(): no longer calls Files.size on non-existent/non-regular paths; classifies a path as text if it’s not an image and either has a known text extension or is a small regular file (<128KB).
  - ContextFragment.image(): treats ImageIO.read() returning null as an error (throws UncheckedIOException).
  - FrozenFragment: logs image read failures, tolerates null image bytes, and imageToBytes now accepts/null-checks null images.
  - HistoryIo: skips images with null bytes and logs a warning instead of failing.
