### PR TITLE
`BRK_NO_LSP` Replaces JavaAnalyzer with JavaTreeSitterAnalyzer

### DIFF
--- a/app/src/main/development.md
+++ b/app/src/main/development.md
@@ -310,3 +310,47 @@ To explore available Look and Feel icons for UI development:
 - Console list: `./gradlew run --args="io.github.jbellis.brokk.gui.SwingIconUtil"`
 
 Use `SwingUtil.uiIcon("IconName")` to safely load icons with automatic fallbacks.
+
+## Environment Variables
+
+### BRK_NO_LSP
+
+Controls whether the Java Language Server (JDT LSP) is started. When disabled, the app runs in TSA-only mode (TreeSitter
+analyzers only) which improves startup time and reduces memory usage, but advanced Java analysis (call graph, usages, 
+linting via JDT) will not be available.
+
+- Name: BRK_NO_LSP
+- Type: Boolean (case-insensitive)
+- Recognized truthy values: 1, true, t, yes, y, on
+- Recognized falsy values: 0, false, f, no, n, off
+- Empty string: treated as true (disables LSP)
+- Unrecognized values: defaults to true (disables LSP) and logs a warning
+- Unset: treated as false (LSP enabled)
+
+Notes:
+- Parsing is case-insensitive and uses Locale.ROOT.
+- When disabled, a message is logged and the JDT LSP is not started.
+- Methods relying on JDT capabilities degrade gracefully and return empty/no-op results.
+
+Examples:
+```bash
+# Disable LSP (preferred explicit)
+export BRK_NO_LSP=true
+
+# Disable LSP (any of these are equivalent)
+export BRK_NO_LSP=1
+export BRK_NO_LSP=YES
+export BRK_NO_LSP=on
+
+# Enable LSP explicitly
+export BRK_NO_LSP=false
+export BRK_NO_LSP=0
+export BRK_NO_LSP=off
+
+# Unset => LSP enabled (default)
+unset BRK_NO_LSP
+
+# Empty or invalid => LSP disabled (with warning on invalid)
+export BRK_NO_LSP=""
+export BRK_NO_LSP="maybe"  # logs warning, disables LSP
+```

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaAnalyzer.java
@@ -71,7 +71,7 @@ public class JavaAnalyzer extends JavaTreeSitterAnalyzer
     @Override
     public Map<String, List<CallSite>> getCallgraphFrom(String methodName, int depth) {
         if (jdtAnalyzer != null) {
-            return jdtAnalyzer.getCallgraphTo(methodName, depth);
+            return jdtAnalyzer.getCallgraphFrom(methodName, depth);
         } else {
             return Collections.emptyMap();
         }


### PR DESCRIPTION
* If enabled, the analysis only relies on TreeSitter-based analysis. By Language returning the TreeSitterAnalyzer, the correct components related to usages and call graph availability are disabled from the UI and prompts.
* Fixed bug in JavaAnalyzer.getCallgraphFrom
* Documented variable under development.md