### PR TITLE
Find Nearest Parent Method `fqName`

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1151,11 +1151,6 @@ public class ContextManager implements IContextManager, AutoCloseable {
         });
     }
 
-    /** usage for identifier */
-    public void usageForIdentifier(String identifier) {
-        usageForIdentifier(identifier, false);
-    }
-
     /** usage for identifier with control over including test files */
     public void usageForIdentifier(String identifier, boolean includeTestFiles) {
         var fragment = new ContextFragment.UsageFragment(this, identifier, includeTestFiles);

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzer.java
@@ -5,11 +5,14 @@ import static io.github.jbellis.brokk.analyzer.java.JavaTreeSitterNodeTypes.*;
 import io.github.jbellis.brokk.IProject;
 import java.util.*;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.treesitter.TSLanguage;
 import org.treesitter.TSNode;
 import org.treesitter.TreeSitterJava;
 
 public class JavaTreeSitterAnalyzer extends TreeSitterAnalyzer {
+
+    private final Pattern LAMBDA_REGEX = Pattern.compile("(\\$anon|\\$\\d+)");
 
     public JavaTreeSitterAnalyzer(IProject project) {
         super(project, Language.JAVA, project.getExcludedDirectories());
@@ -160,5 +163,17 @@ public class JavaTreeSitterAnalyzer extends TreeSitterAnalyzer {
     @Override
     protected String getLanguageSpecificCloser(CodeUnit cu) {
         return "}";
+    }
+
+    @Override
+    protected String nearestMethodName(String fqName) {
+        // Lambdas from LSP look something like `package.Class.Method$anon$357:32`, and we want `package.Class.Method`
+        var matcher = LAMBDA_REGEX.matcher(fqName);
+        if (matcher.find()) {
+            var match = matcher.group(1);
+            return fqName.substring(0, fqName.indexOf(match));
+        } else {
+            return fqName;
+        }
     }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/TreeSitterAnalyzer.java
@@ -384,7 +384,13 @@ public abstract class TreeSitterAnalyzer
     @Override
     public Optional<CodeUnit> getDefinition(String fqName) {
         return uniqueCodeUnitList().stream()
-                .filter(cu -> cu.fqName().equals(fqName))
+                .filter(cu -> {
+                    if (cu.isFunction()) {
+                        return cu.fqName().equals(nearestMethodName(fqName));
+                    } else {
+                        return cu.fqName().equals(fqName);
+                    }
+                })
                 .findFirst();
     }
 
@@ -630,6 +636,18 @@ public abstract class TreeSitterAnalyzer
             log.trace("getSkeleton: fqName='{}', found=false", fqName);
             return Optional.empty();
         });
+    }
+
+    /**
+     * Assuming the fqName is an entity nested within a method, or is a method itself, will return the fqName of the
+     * method. This is mostly useful with escaping lambdas to their parent method.
+     *
+     * @param fqName the fqName of a method.
+     * @return the surrounding method, or the given fqName otherwise.
+     */
+    protected String nearestMethodName(String fqName) {
+        // Should be overridden by the superclass
+        return fqName;
     }
 
     @Override

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -451,7 +451,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware {
                                                         contextManager.submitBackgroundTask(
                                                                 "Capture Usages",
                                                                 () -> contextManager.usageForIdentifier(
-                                                                        codeUnit.fqName()));
+                                                                        codeUnit.fqName(), true));
                                                     });
                                                 } else {
                                                     usageItem.setToolTipText(

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
@@ -433,4 +433,18 @@ public class JavaTreeSitterAnalyzerTest {
         assertTrue(classSkeletonStr.contains("formatMessage"));
         assertTrue(classSkeletonStr.contains("printVersion"));
     }
+
+    @Test
+    public void testNearestMethodName() {
+        // regular method
+        assertEquals("package.Class.method", analyzer.nearestMethodName("package.Class.method"));
+        // method with lambda/anon class
+        assertEquals("package.Class.method", analyzer.nearestMethodName("package.Class.method$anon$357:32"));
+        // method with anon class (just digits)
+        assertEquals("package.Class.method", analyzer.nearestMethodName("package.Class.method$1"));
+        // method in nested class
+        assertEquals("package.A$AInner.method", analyzer.nearestMethodName("package.A$AInner.method"));
+        // method with lambda in nested class
+        assertEquals("package.A$AInner.method", analyzer.nearestMethodName("package.A$AInner.method$anon$1"));
+    }
 }


### PR DESCRIPTION
* To solve the disconnect between JDT lambda methods and Java TS analyzer, the surrounding method name is used.
* Usages includes test files by default if usages are selected by PreviewTextPanel.

Relies on #984 to test