### PR TITLE
feat: Node dependency display and storage improvements: "name@version" format, safe folder names

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/NodeJsDependencyHelper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/NodeJsDependencyHelper.java
@@ -100,7 +100,7 @@ public final class NodeJsDependencyHelper {
 
             var display = meta.name.isEmpty()
                     ? dir.getFileName().toString()
-                    : (meta.version.isEmpty() ? meta.name : meta.name + " " + meta.version);
+                    : (meta.version.isEmpty() ? meta.name : meta.name + "@" + meta.version);
 
             long files = countNodeFiles(dir);
             var kind = pickKind(meta.name, deps, devDeps, peerDeps);
@@ -129,11 +129,15 @@ public final class NodeJsDependencyHelper {
             return false;
         }
 
+        var meta = readPackageJson(sourceRoot.resolve("package.json"));
+        var folderName = (meta != null && !meta.name.isEmpty())
+                ? toSafeFolderName(meta.name, meta.version)
+                : pkg.displayName().replace("/", "__");
         var targetRoot = chrome.getProject()
                 .getRoot()
                 .resolve(AbstractProject.BROKK_DIR)
                 .resolve(AbstractProject.DEPENDENCIES_DIR)
-                .resolve(pkg.displayName());
+                .resolve(folderName);
 
         final var currentListener = lifecycle;
         if (currentListener != null) {
@@ -270,6 +274,32 @@ public final class NodeJsDependencyHelper {
     }
 
     // ---- helpers ----
+
+    private static String toSafeFolderName(String name, String version) {
+        var base = version.isEmpty() ? name : name + "@" + version;
+        return base.replace("/", "__");
+    }
+
+    /**
+     * Reads a package.json located inside the given directory.
+     *
+     * @param packageDir directory that may contain a package.json
+     * @return NodePackage metadata if present and parsable; null otherwise
+     */
+    public static @Nullable NodePackage readPackageJsonFromDir(Path packageDir) {
+        return readPackageJson(packageDir.resolve("package.json"));
+    }
+
+    /**
+     * Builds a human-friendly display name ("name version") from NodePackage metadata.
+     * If version is empty, returns just the name. Returns empty string if name is empty.
+     */
+    public static String displayNameFrom(NodePackage pkg) {
+        var name = pkg.name;
+        var version = pkg.version;
+        if (name.isEmpty()) return "";
+        return version.isEmpty() ? name : name + "@" + version;
+    }
 
     private static @Nullable NodePackage readPackageJson(Path pkgJsonPath) {
         try {

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/NodeJsDependencyHelper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/NodeJsDependencyHelper.java
@@ -291,8 +291,8 @@ public final class NodeJsDependencyHelper {
     }
 
     /**
-     * Builds a human-friendly display name ("name version") from NodePackage metadata.
-     * If version is empty, returns just the name. Returns empty string if name is empty.
+     * Builds a human-friendly display name ("name version") from NodePackage metadata. If version is empty, returns
+     * just the name. Returns empty string if name is empty.
      */
     public static String displayNameFrom(NodePackage pkg) {
         var name = pkg.name;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
@@ -3,8 +3,8 @@ package io.github.jbellis.brokk.gui.dependencies;
 import static java.util.Objects.requireNonNull;
 
 import io.github.jbellis.brokk.IProject;
-import io.github.jbellis.brokk.analyzer.ProjectFile;
 import io.github.jbellis.brokk.analyzer.NodeJsDependencyHelper;
+import io.github.jbellis.brokk.analyzer.ProjectFile;
 import io.github.jbellis.brokk.gui.BorderUtils;
 import io.github.jbellis.brokk.gui.Chrome;
 import io.github.jbellis.brokk.gui.Constants;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.github.jbellis.brokk.IProject;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
+import io.github.jbellis.brokk.analyzer.NodeJsDependencyHelper;
 import io.github.jbellis.brokk.gui.BorderUtils;
 import io.github.jbellis.brokk.gui.Chrome;
 import io.github.jbellis.brokk.gui.Constants;
@@ -325,10 +326,14 @@ public final class DependenciesPanel extends JPanel {
         Set<IProject.Dependency> liveDeps = new HashSet<>(project.getLiveDependencies());
 
         for (var dep : allDeps) {
-            String name = dep.getRelPath().getFileName().toString();
-            dependencyProjectFileMap.put(name, dep);
+            String folderName = dep.getRelPath().getFileName().toString();
+            var pkg = NodeJsDependencyHelper.readPackageJsonFromDir(dep.absPath());
+            String displayName = (pkg != null) ? NodeJsDependencyHelper.displayNameFrom(pkg) : folderName;
+            if (displayName == null || displayName.isEmpty()) displayName = folderName;
+
+            dependencyProjectFileMap.put(displayName, dep);
             boolean isLive = liveDeps.stream().anyMatch(d -> d.root().equals(dep));
-            tableModel.addRow(new Object[] {isLive, name, 0L});
+            tableModel.addRow(new Object[] {isLive, displayName, 0L});
         }
         isProgrammaticChange = false;
 


### PR DESCRIPTION
fixes #1002 

Fixes npm scoped dependencies being collapsed under a single @scope entry in the Dependencies table.
Ensures the UI shows the original package name with version using the common format name@version (e.g., @angular/material@19.2.5).
Stores imported Node packages under a flat, sanitized folder name where “/” is replaced with “__” (e.g., @angular__material@19.2.5) to avoid nested directories.

<img width="948" height="639" alt="image" src="https://github.com/user-attachments/assets/3ac66e76-be40-4534-a2eb-465939a18569" />


## What changed

Import: Target folder name is derived from package.json’s name and version as name@version, replacing “/” with “__”.
Display: Dependencies table now reads package.json from each imported folder and uses name@version for the display name. Falls back to the folder name if package.json is missing/unreadable.


## Why

Previously, scoped packages imported into nested directories (e.g., .brokk/dependencies/@angular/material), causing the Dependencies table to show only the top-level @angular folder.
After sanitizing folder names, the UI was showing the sanitized folder name (e.g., @angular__material), which is incorrect for display.


## Impact and compatibility

Existing imported Node packages will display correctly if they contain a package.json.
Non-Node dependencies (local directories, repos without package.json) continue to show their folder name.