### PR TITLE
Fix Unaligned Empty Analyzer Settings

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
@@ -643,10 +643,22 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
                         projectRoot,
                         chrome.getContextManager().getIo());
                 analyzerSettingsPanels.add(panel);
+
                 final var languageLabel = new JLabel(language.name());
                 languageLabel.setHorizontalAlignment(SwingConstants.LEFT);
+                // Ensure the label aligns to the left in a BoxLayout container
+                languageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+                languageLabel.setBorder(BorderFactory.createEmptyBorder(6, 0, 4, 0));
                 container.add(languageLabel);
+
+                // Ensure the analyzer panel aligns left and can expand horizontally
+                panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+                var pref = panel.getPreferredSize();
+                panel.setMaximumSize(new Dimension(Integer.MAX_VALUE, Math.max(pref.height, 24)));
                 container.add(panel);
+
+                // Small spacing between analyzers for readability
+                container.add(Box.createVerticalStrut(8));
             });
 
             final JScrollPane scrollPane = new JScrollPane(container);


### PR DESCRIPTION
For analyzers without configurable settings, sets the message with proper alignment
<img width="622" height="599" alt="Screenshot 2025-09-16 at 12 14 44" src="https://github.com/user-attachments/assets/b88a86d2-9b39-47a3-b8a4-85c7dd4e365b" />
