### PR TITLE
feat: Add file preview positioning and centering

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/TreeSitterAnalyzer.java
@@ -786,6 +786,27 @@ public abstract class TreeSitterAnalyzer
                 + 1;
     }
 
+    /**
+     * Gets the starting line number (0-based) for the given CodeUnit for UI positioning purposes. Returns the original
+     * code definition line (not expanded with comments) for better navigation.
+     *
+     * @param codeUnit The CodeUnit to get the line number for
+     * @return The 0-based starting line number of the actual definition, or -1 if not found
+     */
+    public int getStartLineForCodeUnit(CodeUnit codeUnit) {
+        return withReadLock(() -> {
+            var ranges = sourceRanges.get(codeUnit);
+            if (ranges == null || ranges.isEmpty()) {
+                return -1;
+            }
+
+            // Use the first range's startLine (0-based from TreeSitter)
+            // For classes and functions, this gives us the actual definition line
+            var range = ranges.getFirst();
+            return range.startLine();
+        });
+    }
+
     /* ---------- abstract hooks ---------- */
 
     /** Creates a new TSLanguage instance for the specific language. Called by ThreadLocal initializer. */


### PR DESCRIPTION
- Intent: we can open preview windows from MOP with the cursor at the location the code starts. the PR will also try to reuse preview windows rather than opening a new one everytime

- Key implementation ideas:
  - TreeSitterAnalyzer#getStartLineForCodeUnit returns the first sourceRange.startLine guarded by the analyzer read-lock.
  - Chrome tracks activePreviewWindows in a ConcurrentHashMap, generates stable keys, reuses/upgrades existing JFrames
  - PreviewTextPanel exposes setCaretPosition and setCaretPositionAndCenter and stores its scroll pane to enable viewport centering.
  - ContextMenuBuilder attempts to cast/analyze MultiAnalyzer delegates to obtain startLine, with fallbacks and logging.