### PR TITLE
Normalize `$` Class Separators as `.`

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/AnalyzerUtil.java
+++ b/app/src/main/java/io/github/jbellis/brokk/AnalyzerUtil.java
@@ -35,6 +35,8 @@ public class AnalyzerUtil {
                                 .computeIfAbsent(classname, k -> new ArrayList<>())
                                 .add(source.get());
                         sources.add(cu);
+                    } else {
+                        logger.warn("Unable to obtain source code for method use by {}", cu.fqName());
                     }
                 }
                 if (!groupedMethods.isEmpty()) {

--- a/app/src/main/java/io/github/jbellis/brokk/FuzzyMatcher.java
+++ b/app/src/main/java/io/github/jbellis/brokk/FuzzyMatcher.java
@@ -1045,20 +1045,20 @@ public class FuzzyMatcher {
             if (!Character.isLowerCase(c)) {
                 return false;
             }
-            if (c == '$' || c == '.' || isWordSeparator(c)) {
+            if (isWordSeparator(c)) {
                 return false;
             }
         }
         return true;
     }
 
-    /** Checks whether the final matched fragment ends right before a '$' in the name. */
+    /** Checks whether the final matched fragment ends right before a '.' in the name. */
     private static boolean endsBeforeDollar(String name, FList<TextRange> fragments) {
         var last = fragments.getLast();
         if (last == null) {
             return false;
         }
         int end = last.getEndOffset();
-        return end < name.length() && name.charAt(end) == '$';
+        return end < name.length() && name.charAt(end) == '.';
     }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzer.java
@@ -69,12 +69,7 @@ public class JavaTreeSitterAnalyzer extends TreeSitterAnalyzer {
     @Override
     protected CodeUnit createCodeUnit(
             ProjectFile file, String captureName, String simpleName, String packageName, String classChain) {
-        final char delimiter =
-                Optional.ofNullable(JAVA_SYNTAX_PROFILE.captureConfiguration().get(captureName)).stream()
-                                .anyMatch(x -> x.equals(SkeletonType.CLASS_LIKE))
-                        ? '$'
-                        : '.';
-        final String fqName = classChain.isEmpty() ? simpleName : classChain + delimiter + simpleName;
+        final String fqName = classChain.isEmpty() ? simpleName : classChain + "." + simpleName;
 
         var skeletonType = getSkeletonTypeForCapture(captureName);
         var type =

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzer.java
@@ -142,9 +142,10 @@ public final class TypescriptAnalyzer extends TreeSitterAnalyzer {
         String finalShortName;
         SkeletonType skeletonType = getSkeletonTypeForCapture(captureName);
 
+        final String shortName = classChain.isEmpty() ? simpleName : classChain + "." + simpleName;
         switch (skeletonType) {
             case CLASS_LIKE -> {
-                finalShortName = classChain.isEmpty() ? simpleName : classChain + "$" + simpleName;
+                finalShortName = shortName;
                 return CodeUnit.cls(file, packageName, finalShortName);
             }
             case FUNCTION_LIKE -> {
@@ -157,7 +158,7 @@ public final class TypescriptAnalyzer extends TreeSitterAnalyzer {
                     // simpleName might be "anonymous_arrow_function" if #set! "default_name" was used and no var name
                     // found
                 }
-                finalShortName = classChain.isEmpty() ? simpleName : classChain + "." + simpleName;
+                finalShortName = shortName;
                 return CodeUnit.fn(file, packageName, finalShortName);
             }
             case FIELD_LIKE -> {

--- a/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
@@ -43,7 +43,7 @@ public class CompletionsTest {
         // Input "re" -> user wants to find "a.b.Do$Re" by partial name "Re"
         var completions = Completions.completeSymbols("re", mock, CodeUnit.NameType.IDENTIFIER);
         var values = toValues(completions);
-        assertEquals(Set.of("a.b.Do$Re"), values);
+        assertEquals(Set.of("a.b.Do.Re"), values);
     }
 
     @Test
@@ -53,8 +53,8 @@ public class CompletionsTest {
         var values = toValues(completions);
 
         assertEquals(2, values.size());
-        assertTrue(values.contains("a.b.Do$Re"));
-        assertTrue(values.contains("a.b.Do$Re$Sub"));
+        assertTrue(values.contains("a.b.Do.Re"));
+        assertTrue(values.contains("a.b.Do.Re.Sub"));
     }
 
     @Test
@@ -84,8 +84,8 @@ public class CompletionsTest {
         assertEquals(3, completions.size());
         var shortValues = toShortValues(completions);
         assertTrue(shortValues.contains("Do"));
-        assertTrue(shortValues.contains("Do$Re"));
-        assertTrue(shortValues.contains("Do$Re$Sub"));
+        assertTrue(shortValues.contains("Do.Re"));
+        assertTrue(shortValues.contains("Do.Re.Sub"));
     }
 
     @Test

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerSearchTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerSearchTest.java
@@ -149,9 +149,9 @@ public class JavaTreeSitterAnalyzerSearchTest {
         assertFalse(innerSymbols.isEmpty(), "Should find nested classes containing 'Inner'");
 
         var innerFqNames = innerSymbols.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
-        assertTrue(innerFqNames.contains("A$AInner"), "Should find nested class 'A.AInner'");
+        assertTrue(innerFqNames.contains("A.AInner"), "Should find nested class 'A.AInner'");
         assertTrue(
-                innerFqNames.contains("A$AInner$AInnerInner"),
+                innerFqNames.contains("A.AInner.AInnerInner"),
                 "Should find deeply nested class 'A.AInner.AInnerInner'");
     }
 
@@ -251,17 +251,11 @@ public class JavaTreeSitterAnalyzerSearchTest {
 
     @Test
     public void testAutocomplete_DotDollarEquivalence_NestedClasses() {
-        // Query using dot-separated nested path; stored nested FQNs use '$' separators
+        // Query using dot-separated nested path; stored nested FQNs use '.' separators
         var dotQuery = analyzer.autocompleteDefinitions("A.AInner.AInnerInner");
         var dotNames = dotQuery.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
         assertTrue(
-                dotNames.contains("A$AInner$AInnerInner"),
-                "Dot-hierarchy query should match nested class FQN with $ separators");
-
-        // Query using dollar-separated nested path should also match
-        var dollarQuery = analyzer.autocompleteDefinitions("A$AInner$AInnerInner");
-        var dollarNames = dollarQuery.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
-        assertTrue(
-                dollarNames.contains("A$AInner$AInnerInner"), "Dollar-hierarchy query should match nested class FQN");
+                dotNames.contains("A.AInner.AInnerInner"),
+                "Dot-hierarchy query should match nested class FQN with '.' separators");
     }
 }

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
@@ -75,7 +75,7 @@ public class JavaTreeSitterAnalyzerTest {
 
     @Test
     public void extractMethodSourceNested() {
-        final var sourceOpt = analyzer.getMethodSource("A$AInner$AInnerInner.method7", true);
+        final var sourceOpt = analyzer.getMethodSource("A.AInner.AInnerInner.method7", true);
         assertTrue(sourceOpt.isPresent());
         final var source = sourceOpt.get().trim().stripIndent();
 
@@ -122,7 +122,7 @@ public class JavaTreeSitterAnalyzerTest {
 
     @Test
     public void getClassSourceNestedTest() {
-        final var sourceOpt = analyzer.getClassSource("A$AInner", true);
+        final var sourceOpt = analyzer.getClassSource("A.AInner", true);
         assertTrue(sourceOpt.isPresent());
         final var source = sourceOpt.get().stripIndent();
         // Verify the source contains inner class definition
@@ -143,7 +143,7 @@ public class JavaTreeSitterAnalyzerTest {
 
     @Test
     public void getClassSourceTwiceNestedTest() {
-        final var sourceOpt = analyzer.getClassSource("A$AInner$AInnerInner", true);
+        final var sourceOpt = analyzer.getClassSource("A.AInner.AInnerInner", true);
         assertTrue(sourceOpt.isPresent());
         final var source = sourceOpt.get().stripIndent();
         // Verify the source contains inner class definition
@@ -162,7 +162,7 @@ public class JavaTreeSitterAnalyzerTest {
 
     @Test
     public void getClassSourceNotFoundTest() {
-        assertThrows(SymbolNotFoundException.class, () -> analyzer.getClassSource("A$NonExistent", true));
+        assertThrows(SymbolNotFoundException.class, () -> analyzer.getClassSource("A.NonExistent", true));
     }
 
     @Test
@@ -253,23 +253,23 @@ public class JavaTreeSitterAnalyzerTest {
                 .toList();
         final var expected = List.of(
                 "A",
-                "A$AInner",
-                "A$AInner$AInnerInner",
-                "A$AInnerStatic",
+                "A.AInner",
+                "A.AInner.AInnerInner",
+                "A.AInnerStatic",
                 "AnnotatedClass",
-                "AnnotatedClass$InnerHelper",
+                "AnnotatedClass.InnerHelper",
                 "AnonymousUsage",
-                "AnonymousUsage$NestedClass",
+                "AnonymousUsage.NestedClass",
                 "B",
                 "BaseClass",
                 "C",
-                "C$Foo",
+                "C.Foo",
                 "CamelClass",
                 "CustomAnnotation",
                 "CyclicMethods",
                 "D",
-                "D$DSub",
-                "D$DSubStatic",
+                "D.DSub",
+                "D.DSubStatic",
                 "E",
                 "F",
                 "Interface",
@@ -293,8 +293,8 @@ public class JavaTreeSitterAnalyzerTest {
         final var expected = Set.of(
                 // Classes
                 CodeUnit.cls(file, "", "D"),
-                CodeUnit.cls(file, "", "D$DSub"),
-                CodeUnit.cls(file, "", "D$DSubStatic"),
+                CodeUnit.cls(file, "", "D.DSub"),
+                CodeUnit.cls(file, "", "D.DSubStatic"),
                 // Methods
                 CodeUnit.fn(file, "", "D.methodD1"),
                 CodeUnit.fn(file, "", "D.methodD2"),
@@ -364,8 +364,8 @@ public class JavaTreeSitterAnalyzerTest {
                         CodeUnit.field(file, "", "D.field1"),
                         CodeUnit.field(file, "", "D.field2"),
                         // Classes
-                        CodeUnit.cls(file, "", "D$DSubStatic"),
-                        CodeUnit.cls(file, "", "D$DSub"))
+                        CodeUnit.cls(file, "", "D.DSubStatic"),
+                        CodeUnit.cls(file, "", "D.DSub"))
                 .sorted()
                 .toList();
         assertEquals(expected, members);
@@ -384,8 +384,8 @@ public class JavaTreeSitterAnalyzerTest {
 
         final var expected = Stream.of(
                         // Classes
-                        CodeUnit.cls(file, "", "D$DSub"),
-                        CodeUnit.cls(file, "", "D$DSubStatic"),
+                        CodeUnit.cls(file, "", "D.DSub"),
+                        CodeUnit.cls(file, "", "D.DSubStatic"),
                         // Methods
                         CodeUnit.fn(file, "", "D.methodD1"),
                         CodeUnit.fn(file, "", "D.methodD2"),
@@ -447,9 +447,9 @@ public class JavaTreeSitterAnalyzerTest {
         // method with anon class (just digits)
         assertEquals("package.Class.method", analyzer.nearestMethodName("package.Class.method$1"));
         // method in nested class
-        assertEquals("package.A$AInner.method", analyzer.nearestMethodName("package.A$AInner.method"));
+        assertEquals("package.A.AInner.method", analyzer.nearestMethodName("package.A.AInner.method"));
         // method with lambda in nested class
-        assertEquals("package.A$AInner.method", analyzer.nearestMethodName("package.A$AInner.method$anon$1"));
+        assertEquals("package.A.AInner.method", analyzer.nearestMethodName("package.A.AInner.method$anon$1"));
     }
 
     @Test
@@ -531,8 +531,8 @@ public class JavaTreeSitterAnalyzerTest {
 
     @Test
     public void getClassSourceWithInnerClassJavadocsTest() {
-        final var sourceOpt = analyzer.getClassSource("AnnotatedClass$InnerHelper", true);
-        assertTrue(sourceOpt.isPresent(), "Should find AnnotatedClass$InnerHelper");
+        final var sourceOpt = analyzer.getClassSource("AnnotatedClass.InnerHelper", true);
+        assertTrue(sourceOpt.isPresent(), "Should find AnnotatedClass.InnerHelper");
         final var source = sourceOpt.get();
 
         // Verify inner class Javadocs are captured

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/PythonAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/PythonAnalyzerTest.java
@@ -253,7 +253,7 @@ public final class PythonAnalyzerTest {
                 "Constructor source should include method definition");
 
         // Test nested class method (use correct FQN format)
-        Optional<String> innerMethodSource = analyzer.getMethodSource("OuterClass$InnerClass.inner_method", true);
+        Optional<String> innerMethodSource = analyzer.getMethodSource("OuterClass.InnerClass.inner_method", true);
         assertTrue(innerMethodSource.isPresent(), "inner_method should be found");
 
         String normalizedInnerMethodSource = normalize.apply(innerMethodSource.get());

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzerTest.java
@@ -450,10 +450,10 @@ public class TypescriptAnalyzerTest {
         assertTrue(declarations.contains(doWorkFunc), "ThirdPartyLib.doWork should be captured as a function member");
 
         // Verify ambient namespace interface member
-        CodeUnit libOptionsInterface = CodeUnit.cls(advancedTsFile, "", "ThirdPartyLib$LibOptions");
+        CodeUnit libOptionsInterface = CodeUnit.cls(advancedTsFile, "", "ThirdPartyLib.LibOptions");
         assertTrue(
                 declarations.contains(libOptionsInterface),
-                "ThirdPartyLib$LibOptions should be captured as an interface member");
+                "ThirdPartyLib.LibOptions should be captured as an interface member");
 
         // Verify no duplicate captures for ambient declarations
         long dollarVarCount =
@@ -693,7 +693,7 @@ public class TypescriptAnalyzerTest {
                 declarations.contains(doWorkFunc),
                 "Function inside ambient namespace should be captured as separate CodeUnit");
 
-        CodeUnit libOptionsInterface = CodeUnit.cls(advancedTsFile, "", "ThirdPartyLib$LibOptions");
+        CodeUnit libOptionsInterface = CodeUnit.cls(advancedTsFile, "", "ThirdPartyLib.LibOptions");
         assertTrue(
                 declarations.contains(libOptionsInterface),
                 "Interface inside ambient namespace should be captured as separate CodeUnit");

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/TypescriptAnalyzerTest.java
@@ -246,7 +246,7 @@ public class TypescriptAnalyzerTest {
                 normalize.apply(skeletons.get(topLevelGenericAlias)));
 
         // Check a nested item via getSkeleton
-        Optional<String> innerClassSkel = analyzer.getSkeleton("MyModule$InnerClass");
+        Optional<String> innerClassSkel = analyzer.getSkeleton("MyModule.InnerClass");
         assertTrue(innerClassSkel.isPresent());
         // When getting skeleton for a nested CU, it should be part of the parent's reconstruction.
         // The current `getSkeleton` will reconstruct from the top-level parent of that CU.
@@ -270,9 +270,9 @@ public class TypescriptAnalyzerTest {
 
         Set<CodeUnit> declarations = analyzer.getDeclarationsInFile(moduleTsFile);
         // TODO: capture nested modules
-        assertTrue(declarations.contains(CodeUnit.cls(moduleTsFile, "", "MyModule$NestedNamespace$DeeperClass")));
+        assertTrue(declarations.contains(CodeUnit.cls(moduleTsFile, "", "MyModule.NestedNamespace.DeeperClass")));
         assertTrue(declarations.contains(CodeUnit.field(moduleTsFile, "", "MyModule.InnerTypeAlias")));
-        assertTrue(declarations.contains(CodeUnit.field(moduleTsFile, "", "MyModule$NestedNamespace.DeepType")));
+        assertTrue(declarations.contains(CodeUnit.field(moduleTsFile, "", "MyModule.NestedNamespace.DeepType")));
         assertTrue(declarations.contains(topLevelGenericAlias));
     }
 

--- a/app/src/test/java/io/github/jbellis/brokk/testutil/MockAnalyzer.java
+++ b/app/src/test/java/io/github/jbellis/brokk/testutil/MockAnalyzer.java
@@ -24,8 +24,8 @@ public class MockAnalyzer implements IAnalyzer, UsagesProvider, SkeletonProvider
         this.mockFile = new ProjectFile(rootDir, "MockFile.java");
         this.allClasses = List.of(
                 CodeUnit.cls(mockFile, "a.b", "Do"),
-                CodeUnit.cls(mockFile, "a.b", "Do$Re"),
-                CodeUnit.cls(mockFile, "a.b", "Do$Re$Sub"), // nested inside Re
+                CodeUnit.cls(mockFile, "a.b", "Do.Re"),
+                CodeUnit.cls(mockFile, "a.b", "Do.Re.Sub"), // nested inside Re
                 CodeUnit.cls(mockFile, "x.y", "Zz"),
                 CodeUnit.cls(mockFile, "w.u", "Zz"),
                 CodeUnit.cls(mockFile, "test", "CamelClass"),
@@ -34,8 +34,8 @@ public class MockAnalyzer implements IAnalyzer, UsagesProvider, SkeletonProvider
                 Map.entry(
                         "a.b.Do",
                         List.of(CodeUnit.fn(mockFile, "a.b", "Do.foo"), CodeUnit.fn(mockFile, "a.b", "Do.bar"))),
-                Map.entry("a.b.Do$Re", List.of(CodeUnit.fn(mockFile, "a.b", "Do$Re.baz"))),
-                Map.entry("a.b.Do$Re$Sub", List.of(CodeUnit.fn(mockFile, "a.b", "Do$Re$Sub.qux"))),
+                Map.entry("a.b.Do.Re", List.of(CodeUnit.fn(mockFile, "a.b", "Do.Re.baz"))),
+                Map.entry("a.b.Do.Re.Sub", List.of(CodeUnit.fn(mockFile, "a.b", "Do.Re.Sub.qux"))),
                 Map.entry("x.y.Zz", List.of()),
                 Map.entry("w.u.Zz", List.of()),
                 Map.entry("test.CamelClass", List.of(CodeUnit.fn(mockFile, "test", "CamelClass.someMethod"))));


### PR DESCRIPTION
A problem with using the `$` separators is that JDT does not use them. It is easy to map from TreeSitter names that have dollar signs, but not the other way around due to loss of precision in the name.

This may mean that any `fqNames` from JDT referring to nested classes cannot be resolved in TreeSitter-based analysers.

This PR ensures TreeSitter analyzers use `.` separators for inner classes to be consistent with JDT's naming scheme. This simplifies a few checks elsewhere too.