### PR TITLE
feat: history entries in MOP shows edit metrics and line count

### DIFF
--- a/frontend-mop/src/components/EditBlock.svelte
+++ b/frontend-mop/src/components/EditBlock.svelte
@@ -57,10 +57,6 @@
 
 <style>
     .edit-block-wrapper {
-        --diff-add: #28a745;
-        --diff-del: #dc3545;
-        --diff-add-bg: rgba(40, 167, 69, 0.1);
-        --diff-del-bg: rgba(220, 53, 69, 0.1);
         border: 1px solid var(--message-border-custom);
         border-radius: 8px;
         margin: 1em 0;

--- a/frontend-mop/src/styles/global.scss
+++ b/frontend-mop/src/styles/global.scss
@@ -29,11 +29,23 @@ body {
 .theme-dark {
   --scrollbar-thumb: #666;
   --scrollbar-thumb-hover: #7b8286;
+
+  /* Global diff color tokens */
+  --diff-add: #28a745;
+  --diff-del: #dc3545;
+  --diff-add-bg: rgba(40, 167, 69, 0.1);
+  --diff-del-bg: rgba(220, 53, 69, 0.1);
 }
 
 .theme-light {
   --scrollbar-thumb: #b7b7b7;
   --scrollbar-thumb-hover: #8c8c8c;
+
+  /* Global diff color tokens */
+  --diff-add: #28a745;
+  --diff-del: #dc3545;
+  --diff-add-bg: rgba(40, 167, 69, 0.1);
+  --diff-del-bg: rgba(220, 53, 69, 0.1);
 }
 
 * {

--- a/frontend-mop/src/worker/shared.d.ts
+++ b/frontend-mop/src/worker/shared.d.ts
@@ -78,3 +78,13 @@ export interface EditBlockProperties {
     headerOk: boolean;
     isGitDiff?: boolean;
 }
+
+/* Augment unist.Data so tree.data is strongly typed for our rehype pipeline */
+import 'unist';
+
+declare module 'unist' {
+  interface Data {
+    diffSummary?: { adds: number; dels: number };
+    detectedDiffLangs?: Set<string>;
+  }
+}


### PR DESCRIPTION
- Intent: surface edit/diff metrics in thread headers (collapsed history entries) and centralize diff color tokens for theming. Also propagate per-bubble diff summaries from the rehype pipeline so the UI can aggregate them for the edit metrics.

---

Now the history works like that:

1. In the main MOP you see the tasks in the history collapsed at the top
a. you see the edits, message count and lines for each task
b. the copy + capture button (below the main MOP) is scoped to the current task and ignoring the history tasks
2. If you open the history entry (from the workspace; i.e. with double-click), you see
a. the whole history in one node (expanded by default)
b. collapsing shows the all edits, message count and lines for the whole history (from all tasks) => [around 600 LOCs ~ 664 LOC shown in the workspace table]
c. context-menu copy => copies the whole history

<img width="1607" height="1174" alt="image" src="https://github.com/user-attachments/assets/49877b9c-4bcd-482d-9f1a-cc68b2ef5fd4" />


---

- Behaviour changes:
  - Thread headers now show total +adds and -dels for the whole thread (when present), a message count label, and total lines across all bubbles.
  - Diff color tokens moved from a local component to global theme variables so colors work consistently across themes.
  - Rehype edit-diff plugin now records a compact diffSummary (adds/dels) on tree.data for each parsed bubble.

- Key implementation details:
  - ThreadBlock computes threadTotals via reduce over bubbles reading bubble.hast.data.diffSummary, computes totalLinesAll from markdown line splits, and conditionally renders the edits in the header with small CSS tweaks.
  - Global SCSS now defines --diff-add/--diff-del/--diff-*-bg for both light and dark themes; removed duplicate local tokens.
  - rehype-edit-diff accumulates totalAdds/totalDels and writes tree.data.diffSummary, and uses tree.data ??= {} consistently.
  - added TypeScript augmentation for unist.Data to type diffSummary and detectedDiffLangs.