### PR TITLE
Show Placeholder Fragment in Workspace for Long Running Tasks

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1033,6 +1033,11 @@ public class ContextManager implements IContextManager, AutoCloseable {
         pushContext(currentLiveCtx -> currentLiveCtx.addVirtualFragment(fragment));
     }
 
+    /** Replaces a virtual fragment by id with a new fragment. No-op if id is not found. */
+    public void replaceVirtualFragment(String placeholderId, VirtualFragment actualFragment) {
+        pushContext(currentLiveCtx -> currentLiveCtx.replaceVirtualFragmentById(placeholderId, actualFragment));
+    }
+
     /**
      * Lazily creates and updates the special BuildFragment with the latest build results text. Does not push a history
      * entry for updates after creation. Triggers a workspace UI refresh.

--- a/app/src/main/java/io/github/jbellis/brokk/context/Context.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/Context.java
@@ -279,6 +279,23 @@ public class Context {
         return getWithFragments(editableFiles, readonlyFiles, newFragments, action);
     }
 
+    public Context replaceVirtualFragmentById(String fragmentId, ContextFragment.VirtualFragment newFragment) {
+        int index = -1;
+        for (int i = 0; i < virtualFragments.size(); i++) {
+            if (Objects.equals(virtualFragments.get(i).id(), fragmentId)) {
+                index = i;
+                break;
+            }
+        }
+        if (index < 0) {
+            return this; // no-op if not found
+        }
+        var newVirtuals = new ArrayList<ContextFragment.VirtualFragment>(virtualFragments);
+        newVirtuals.set(index, newFragment);
+        String action = "Updated " + newFragment.shortDescription();
+        return getWithFragments(editableFiles, readonlyFiles, newVirtuals, action);
+    }
+
     private Context getWithFragments(
             List<ContextFragment> newEditableFiles,
             List<ContextFragment> newReadonlyFiles,

--- a/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
@@ -50,7 +50,8 @@ public interface ContextFragment {
         PASTE_TEXT(false, true, false), // Content-hashed ID
         PASTE_IMAGE(false, true, false), // Content-hashed ID, isText=false for this virtual fragment
         STACKTRACE(false, true, false), // Content-hashed ID
-        BUILD_LOG(false, true, false); // Dynamic; updated by ContextManager with latest build results
+        BUILD_LOG(false, true, false), // Dynamic; updated by ContextManager with latest build results
+        PLACEHOLDER(false, true, false); // Dynamic; temporary loading indicator
 
         private final boolean isPath;
         private final boolean isVirtual;
@@ -1627,6 +1628,46 @@ public interface ContextFragment {
         @Override
         public String toString() {
             return "BuildFragment('%s')".formatted(description());
+        }
+    }
+
+    // Placeholder fragment used to indicate a task is in progress and will be replaced later.
+    class PlaceholderFragment extends VirtualFragment { // Dynamic, uses nextId
+        private final String message;
+
+        public PlaceholderFragment(IContextManager contextManager, String message) {
+            super(contextManager);
+            this.message = message;
+        }
+
+        @Override
+        public FragmentType getType() {
+            return FragmentType.PLACEHOLDER;
+        }
+
+        @Override
+        public String description() {
+            return message;
+        }
+
+        @Override
+        public String text() {
+            return "Loading: " + message;
+        }
+
+        @Override
+        public boolean isDynamic() {
+            return true;
+        }
+
+        @Override
+        public String syntaxStyle() {
+            return SyntaxConstants.SYNTAX_STYLE_NONE;
+        }
+
+        @Override
+        public String formatSummary() {
+            return "<fragment description=\"%s\" status=\"loading\" />".formatted(description());
         }
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/context/FrozenFragment.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/FrozenFragment.java
@@ -337,6 +337,7 @@ public final class FrozenFragment extends ContextFragment.VirtualFragment {
                     meta.put("depth", String.valueOf(cgf.getDepth()));
                     meta.put("isCalleeGraph", String.valueOf(cgf.isCalleeGraph()));
                 }
+                case PlaceholderFragment pf -> meta.put("message", pf.description());
                 default -> {
                     /* No type-specific meta beyond what's standard for hashing */
                 }
@@ -457,6 +458,13 @@ public final class FrozenFragment extends ContextFragment.VirtualFragment {
                 var depth = Integer.parseInt(depthStr);
                 var isCalleeGraph = Boolean.parseBoolean(isCalleeGraphStr);
                 yield new ContextFragment.CallGraphFragment(cm, methodName, depth, isCalleeGraph);
+            }
+            case "io.github.jbellis.brokk.context.ContextFragment$PlaceholderFragment" -> {
+                var message = meta.get("message");
+                if (message == null) {
+                    throw new IllegalArgumentException("Missing metadata for PlaceholderFragment");
+                }
+                yield new ContextFragment.PlaceholderFragment(cm, message);
             }
             case "io.github.jbellis.brokk.context.ContextFragment$BuildFragment" -> {
                 // Recreate a live BuildFragment with the captured build output.

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -1629,13 +1629,9 @@ public class WorkspacePanel extends JPanel {
         }
     }
 
-
-    /**
-     * Show the symbol selection dialog with a pre-fetched analyzer (must be called on the EDT).
-     */
+    /** Show the symbol selection dialog with a pre-fetched analyzer (must be called on the EDT). */
     private SymbolSelectionDialog.@Nullable SymbolSelection showSymbolSelectionDialogWithAnalyzer(IAnalyzer analyzer) {
-        assert SwingUtilities.isEventDispatchThread()
-                : "showSymbolSelectionDialogWithAnalyzer must be called from EDT";
+        assert SwingUtilities.isEventDispatchThread() : "showSymbolSelectionDialogWithAnalyzer must be called from EDT";
 
         logger.debug("Creating dialog with pre-fetched analyzer");
         var dialog = new SymbolSelectionDialog(chrome.getFrame(), analyzer, "Select Symbol", CodeUnitType.ALL);
@@ -1649,7 +1645,8 @@ public class WorkspacePanel extends JPanel {
 
     /** Shows the symbol selection dialog; fetch analyzer off-EDT first, then show dialog on EDT. */
     public void findSymbolUsageAsync() {
-        logger.debug("findSymbolUsageAsync called from thread: " + Thread.currentThread().getName());
+        logger.debug("findSymbolUsageAsync called from thread: "
+                + Thread.currentThread().getName());
         if (!isAnalyzerReady()) {
             logger.warn("Analyzer not ready, aborting");
             return;
@@ -1662,19 +1659,18 @@ public class WorkspacePanel extends JPanel {
                 var analyzer = contextManager.getAnalyzerUninterrupted();
 
                 if (analyzer.isEmpty()) {
-                            SwingUtilities.invokeLater(() -> {
-                                chrome.toolError("Code Intelligence is empty; nothing to add");
-                                logger.debug("Analyzer is empty");
-                            });
-                            return;
-                        }
+                    SwingUtilities.invokeLater(() -> {
+                        chrome.toolError("Code Intelligence is empty; nothing to add");
+                        logger.debug("Analyzer is empty");
+                    });
+                    return;
+                }
 
                 // Analyzer obtained, scheduling dialog on EDT
                 SwingUtilities.invokeLater(() -> {
                     try {
                         logger.debug("Starting dialog display on EDT with pre-fetched analyzer");
-                        var selection = showSymbolSelectionDialogWithAnalyzer(
-                                analyzer);
+                        var selection = showSymbolSelectionDialogWithAnalyzer(analyzer);
 
                         if (selection == null
                                 || selection.symbol() == null
@@ -1812,8 +1808,8 @@ public class WorkspacePanel extends JPanel {
             logger.debug("Background task started for symbol: {}", symbol);
             try {
                 // Update placeholder status while computing
-                var searchingPlaceholder = new ContextFragment.PlaceholderFragment(
-                        contextManager, "Finding uses of " + symbol);
+                var searchingPlaceholder =
+                        new ContextFragment.PlaceholderFragment(contextManager, "Finding uses of " + symbol);
                 contextManager.replaceVirtualFragment(initialPlaceholder.id(), searchingPlaceholder);
 
                 // Build the actual fragment and replace the placeholder when ready
@@ -1821,8 +1817,8 @@ public class WorkspacePanel extends JPanel {
                         new ContextFragment.UsageFragment(contextManager, symbol, selection.includeTestFiles());
                 contextManager.replaceVirtualFragment(searchingPlaceholder.id(), actualFragment);
 
-                chrome.systemOutput("Added uses of " + symbol
-                        + (selection.includeTestFiles() ? " (including tests)" : ""));
+                chrome.systemOutput(
+                        "Added uses of " + symbol + (selection.includeTestFiles() ? " (including tests)" : ""));
             } catch (CancellationException cex) {
                 chrome.systemOutput("Symbol selection canceled.");
                 var cancelled = new ContextFragment.StringFragment(
@@ -1834,7 +1830,6 @@ public class WorkspacePanel extends JPanel {
             }
         });
     }
-
 
     /**
      * Performed by the action buttons/menus in the context panel: "edit / read / copy / drop / summarize / paste" If

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -1644,7 +1644,7 @@ public class WorkspacePanel extends JPanel {
 
         // Create a placeholder immediately so the user gets instant feedback
         var initialPlaceholder =
-                new ContextFragment.PlaceholderFragment(contextManager, "Preparing symbol search...");
+                new ContextFragment.PlaceholderFragment(contextManager, "Searching for symbol usages...");
         contextManager.addVirtualFragment(initialPlaceholder);
         chrome.systemOutput("DEBUG: Placeholder created (id=" + initialPlaceholder.id() + ")");
 


### PR DESCRIPTION
* Added `PlaceholderFragment` class which is immediately shown in Workspace when usages/callgraph tasks are commenced
* This is replaced with the intended fragment when workspace is done
* Generally more tool outputs added to keep user informed

But for the life of me I can't figure out why the GUI is freezing... no one is using a common work pool thread. Something must be blocking on the result of this background task somewhere.

https://github.com/user-attachments/assets/fde2173f-07e8-47c3-bc08-52a368651ce4

