### PR TITLE
Fix Missing Java Enum Constants & Method Modifiers

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzer.java
@@ -56,7 +56,8 @@ public class JavaTreeSitterAnalyzer extends TreeSitterAnalyzer {
                     "annotation.definition", SkeletonType.CLASS_LIKE, // for @interface
                     "method.definition", SkeletonType.FUNCTION_LIKE,
                     "constructor.definition", SkeletonType.FUNCTION_LIKE,
-                    "field.definition", SkeletonType.FIELD_LIKE),
+                    "field.definition", SkeletonType.FIELD_LIKE,
+                    "enum.constant", SkeletonType.FIELD_LIKE),
             "", // async keyword node type
             Set.of("modifiers") // modifier node types
             );

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzer.java
@@ -56,8 +56,7 @@ public class JavaTreeSitterAnalyzer extends TreeSitterAnalyzer {
                     "annotation.definition", SkeletonType.CLASS_LIKE, // for @interface
                     "method.definition", SkeletonType.FUNCTION_LIKE,
                     "constructor.definition", SkeletonType.FUNCTION_LIKE,
-                    "field.definition", SkeletonType.FIELD_LIKE,
-                    "enum.constant", SkeletonType.FIELD_LIKE),
+                    "field.definition", SkeletonType.FIELD_LIKE),
             "", // async keyword node type
             Set.of("modifiers") // modifier node types
             );
@@ -154,6 +153,53 @@ public class JavaTreeSitterAnalyzer extends TreeSitterAnalyzer {
         }
 
         return signature;
+    }
+
+    @Override
+    protected String formatFieldSignature(
+            TSNode fieldNode,
+            String src,
+            String exportPrefix,
+            String signatureText,
+            String baseIndent,
+            ProjectFile file) {
+        if (ENUM_CONSTANT.equals(fieldNode.getType())) {
+            return formatEnumConstant(fieldNode, signatureText, baseIndent);
+        }
+        return super.formatFieldSignature(fieldNode, src, exportPrefix, signatureText, baseIndent, file);
+    }
+
+    private String formatEnumConstant(TSNode fieldNode, String signatureText, String baseIndent) {
+        TSNode parent = fieldNode.getParent();
+        if (parent != null) {
+            int childCount = parent.getNamedChildCount();
+            boolean hasFollowingConstant = false;
+
+            // Compare by byte range to reliably identify the same node
+            int targetStart = fieldNode.getStartByte();
+            int targetEnd = fieldNode.getEndByte();
+
+            for (int i = 0; i < childCount; i++) {
+                TSNode child = parent.getNamedChild(i);
+                if (child != null
+                        && !child.isNull()
+                        && child.getStartByte() == targetStart
+                        && child.getEndByte() == targetEnd) {
+                    // Check if any subsequent named child is also an enum_constant
+                    for (int j = i + 1; j < childCount; j++) {
+                        TSNode next = parent.getNamedChild(j);
+                        if (next != null && !next.isNull() && ENUM_CONSTANT.equals(next.getType())) {
+                            hasFollowingConstant = true;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+            return baseIndent + signatureText + (hasFollowingConstant ? "," : "");
+        }
+        // Fallback: if structure not as expected, do not add terminating punctuation
+        return baseIndent + signatureText;
     }
 
     @Override

--- a/app/src/main/resources/treesitter/java.scm
+++ b/app/src/main/resources/treesitter/java.scm
@@ -41,13 +41,11 @@
 
 ; Enum declarations
 (enum_declaration
-  name: (identifier) @enum.name
-  body: (enum_body
-    (enum_constant
-      name: (identifier) @enum.constant
-    )
-  )
-) @enum.definition
+  name: (identifier) @enum.name) @enum.definition
+
+; Enum constants
+(enum_constant
+  name: (identifier) @field.name) @field.definition
 
 ; Annotations to strip
 (annotation) @annotation

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
@@ -116,7 +116,7 @@ public class JavaTreeSitterAnalyzerTest {
         final var source = sourceOpt.get();
         // Verify the source contains class definition and methods
         assertTrue(source.contains("class A {"));
-        assertTrue(source.contains("public void method1()"));
+        assertTrue(source.contains("void method1()"));
         assertTrue(source.contains("public String method2(String input)"));
     }
 
@@ -180,21 +180,21 @@ public class JavaTreeSitterAnalyzerTest {
                 """
                 public class A {
                   void method1()
-                  String method2(String input)
-                  String method2(String input, int otherInput)
-                  Function<Integer, Integer> method3()
-                  int method4(double foo, Integer bar)
-                  void method5()
-                  void method6()
-                  void run()
+                  public String method2(String input)
+                  public String method2(String input, int otherInput)
+                  public Function<Integer, Integer> method3()
+                  public static int method4(double foo, Integer bar)
+                  public void method5()
+                  public void method6()
+                  public void run()
                   public class AInner {
                     public class AInnerInner {
-                      void method7()
+                      public void method7()
                     }
                   }
                   public static class AInnerStatic {
                   }
-                  void usesInnerClass()
+                  private void usesInnerClass()
                 }
                 """
                         .trim()
@@ -213,12 +213,30 @@ public class JavaTreeSitterAnalyzerTest {
                 public class D {
                   public static int field1;
                   private String field2;
-                  void methodD1()
-                  void methodD2()
+                  public void methodD1()
+                  public void methodD2()
                   private static class DSubStatic {
                   }
                   private class DSub {
                   }
+                }
+                """
+                        .trim()
+                        .stripIndent();
+        assertEquals(expected, skeleton);
+    }
+
+    @Test
+    public void getSkeletonTestEnum() {
+        final var skeletonOpt = analyzer.getSkeleton("EnumClass");
+        assertTrue(skeletonOpt.isPresent());
+        final var skeleton = skeletonOpt.get().trim().stripIndent();
+
+        final var expected =
+                """
+                public enum EnumClass {
+                  Foo,
+                  Bar;
                 }
                 """
                         .trim()
@@ -271,6 +289,7 @@ public class JavaTreeSitterAnalyzerTest {
                 "D.DSub",
                 "D.DSubStatic",
                 "E",
+                "EnumClass",
                 "F",
                 "Interface",
                 "MethodReturner",

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
@@ -235,8 +235,8 @@ public class JavaTreeSitterAnalyzerTest {
         final var expected =
                 """
                 public enum EnumClass {
-                  Foo,
-                  Bar;
+                  FOO,
+                  BAR
                 }
                 """
                         .trim()

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JdtAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JdtAnalyzerTest.java
@@ -150,7 +150,7 @@ public class JdtAnalyzerTest {
         final var source = sourceOpt.get().stripIndent();
         // Verify the source contains class definition and methods
         assertTrue(source.contains("class A {"));
-        assertTrue(source.contains("public void method1()"));
+        assertTrue(source.contains("void method1()"));
         assertTrue(source.contains("public String method2(String input)"));
     }
 
@@ -201,7 +201,7 @@ public class JdtAnalyzerTest {
         final var source = sourceOpt.get().stripIndent();
         // Verify that the class fallback works if subclasses (or anonymous classes) aren't resolved
         assertTrue(source.contains("class A {"));
-        assertTrue(source.contains("public void method1()"));
+        assertTrue(source.contains("void method1()"));
         assertTrue(source.contains("public String method2(String input)"));
     }
 
@@ -243,7 +243,7 @@ public class JdtAnalyzerTest {
                 """
                 public class A {
                   public A() {...}
-                  public void method1() {...}
+                  void method1() {...}
                   public String method2(String input) {...}
                   public String method2(String input, int otherInput) {...}
                   public Function<Integer, Integer> method3() {...}
@@ -260,7 +260,7 @@ public class JdtAnalyzerTest {
                   public static class AInnerStatic {
                     public AInnerStatic() {...}
                   }
-                  public void usesInnerClass() {...}
+                  private void usesInnerClass() {...}
                 }
                 """
                         .trim()

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JdtAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JdtAnalyzerTest.java
@@ -340,6 +340,7 @@ public class JdtAnalyzerTest {
                 "D.DSub",
                 "D.DSubStatic",
                 "E",
+                "EnumClass",
                 "F",
                 "Foo",
                 "Interface",

--- a/app/src/test/resources/testcode-java/A.java
+++ b/app/src/test/resources/testcode-java/A.java
@@ -1,7 +1,7 @@
 import java.util.function.Function;
 
 public class A {
-    public void method1() {
+    void method1() {
         System.out.println("hello");
     }
 
@@ -46,7 +46,7 @@ public class A {
 
     public static class AInnerStatic {}
 
-    public void usesInnerClass() {
+    private void usesInnerClass() {
         System.out.println(new AInner());
     }
 }

--- a/app/src/test/resources/testcode-java/EnumClass.java
+++ b/app/src/test/resources/testcode-java/EnumClass.java
@@ -1,0 +1,3 @@
+public enum EnumClass {
+    FOO, BAR;
+}

--- a/app/src/test/resources/testcode-java/EnumClass.java
+++ b/app/src/test/resources/testcode-java/EnumClass.java
@@ -1,3 +1,3 @@
 public enum EnumClass {
-    FOO, BAR;
+    FOO, BAR
 }


### PR DESCRIPTION
* Fix issue where `TreeSitterAnalyzer` function skeleton building ignored modifiers
* Included special handling for enum constant skeleton building and fixed tree sitter query to match expectations
* Updated unit tests to verify behaviour

Example summary:

<img width="472" height="213" alt="Screenshot 2025-09-22 at 12 51 44" src="https://github.com/user-attachments/assets/8021878d-2990-49b1-8856-9ab89d557bd7" />
