### PR TITLE
Fix/empty workspace

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -118,7 +118,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         }
         lastTabToggleTime = currentTime;
 
-        if (leftTabbedPanel.getSelectedIndex() == tabIndex) {
+        if (!sidebarCollapsed && leftTabbedPanel.getSelectedIndex() == tabIndex) {
             // Tab already selected: capture current expanded width (if not already minimized), then minimize
             int currentLocation = bottomSplitPane.getDividerLocation();
             if (currentLocation >= SIDEBAR_COLLAPSED_THRESHOLD) {
@@ -127,15 +127,17 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
             leftTabbedPanel.setSelectedIndex(0); // Always show Project Files when collapsed
             bottomSplitPane.setDividerSize(0);
             bottomSplitPane.setDividerLocation(40);
+            sidebarCollapsed = true;
         } else {
             leftTabbedPanel.setSelectedIndex(tabIndex);
             // Restore panel if it was minimized
-            if (bottomSplitPane.getDividerLocation() < SIDEBAR_COLLAPSED_THRESHOLD) {
+            if (sidebarCollapsed) {
                 bottomSplitPane.setDividerSize(originalBottomDividerSize);
                 int target = (lastExpandedSidebarLocation > 0)
                         ? lastExpandedSidebarLocation
                         : computeInitialSidebarWidth() + bottomSplitPane.getDividerSize();
                 bottomSplitPane.setDividerLocation(target);
+                sidebarCollapsed = false;
             }
         }
     }
@@ -146,6 +148,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     // Remember the last non-minimized divider location of the left sidebar
     // Used to restore the previous width when re-expanding after a minimize
     private int lastExpandedSidebarLocation = -1;
+    private boolean sidebarCollapsed = false;
 
     // Swing components:
     final JFrame frame;
@@ -1572,6 +1575,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         if (properDividerLocation < SIDEBAR_COLLAPSED_THRESHOLD) {
             bottomSplitPane.setDividerSize(0);
             leftTabbedPanel.setSelectedIndex(0); // Show Project Files when collapsed
+            sidebarCollapsed = true;
         } else {
             lastExpandedSidebarLocation = properDividerLocation;
         }


### PR DESCRIPTION
- Intent: improve window/split layout reliability and make sidebar behavior consistent and configurable. Fixes a startup bug where the main window could appear empty/gray when workspace properties were missing.

Fixes #1070 

with a deleted `workspace.properties` file now you get a default layout:

<img width="1920" height="1080" alt="screenshot-Brokk Userscquirozcodebrokk aibrokk-2025-09-22-10-46-10" src="https://github.com/user-attachments/assets/52c8478f-f86e-45d8-9913-9f25a61ebd8a" />

- Behaviour changes:
-   - Startup now completes layout synchronously (pack + validate) before showing the frame so split panes get correct sizes even when no saved workspace properties exist.
  - Introduces readable constants for default split ratios, sidebar min/max fractions and collapse threshold instead of magic numbers.
  - Split positions are saved/restored via centralized listeners; last expanded sidebar location is tracked only for non-collapsed positions.
  - Logs when no saved workspace properties are found.

