### PR TITLE
MultiLanguage Creates Analyzers via Parallel Stream

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/util/ExecutorServiceUtil.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/ExecutorServiceUtil.java
@@ -1,0 +1,33 @@
+package io.github.jbellis.brokk.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ExecutorServiceUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExecutorServiceUtil.class);
+
+    private ExecutorServiceUtil() {}
+
+    public static ExecutorService newFixedThreadExecutor(int parallelism, String threadPrefix) {
+        assert parallelism >= 1 : "parallelism must be >= 1";
+        var factory = new ThreadFactory() {
+            private final ThreadFactory delegate = Executors.defaultThreadFactory();
+            private int count = 0;
+
+            @Override
+            public synchronized Thread newThread(Runnable r) {
+                var t = delegate.newThread(r);
+                t.setName(threadPrefix + ++count);
+                t.setDaemon(true);
+                t.setUncaughtExceptionHandler(
+                        (thr, ex) -> logger.error("Unhandled exception in {}", thr.getName(), ex));
+                return t;
+            }
+        };
+        return Executors.newFixedThreadPool(parallelism, factory);
+    }
+}


### PR DESCRIPTION
* Creates all necessary analyzers in parallel for easy gains.
* Ensures this uses a fixed thread pool separate from the common pool to reduce pressure on other processes.