### PR TITLE
feat: only re-render MOP content if really changed

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -711,11 +711,8 @@ public class HistoryOutputPanel extends JPanel {
      * @param main The final task to show in the main output section.
      */
     public void setLlmAndHistoryOutput(List<TaskEntry> history, TaskEntry main) {
-        // prioritize rendering live area, then history
-        setLlmOutput(main);
-        SwingUtilities.invokeLater(() -> {
-            llmStreamArea.replaceHistory(history);
-        });
+        // prioritize rendering live area, then history (explicitly sequenced with flush)
+        llmStreamArea.setMainThenHistoryAsync(main, history);
     }
 
     /** Appends text to the LLM output area */
@@ -882,10 +879,7 @@ public class HistoryOutputPanel extends JPanel {
             outputPanel.updateTheme(isDark);
             outputPanel.setBlocking(isBlockingMode);
             // Seed main content first, then history
-            outputPanel.setText(main);
-            SwingUtilities.invokeLater(() -> {
-                outputPanel.replaceHistory(history);
-            });
+            outputPanel.setMainThenHistoryAsync(main, history);
 
             // Create toolbar panel with capture button if not in blocking mode
             JPanel toolbarPanel = null;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SessionsDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SessionsDialog.java
@@ -361,19 +361,15 @@ public class SessionsDialog extends JDialog {
         if (taskHistory.isEmpty()) {
             // Fall back to parsed output for contexts that are not part of a task history
             if (context.getParsedOutput() != null) {
-                markdownOutputPanel.replaceHistory(List.of()); // explicit history clear
-                markdownOutputPanel.setText(context.getParsedOutput());
+                markdownOutputPanel.setMainThenHistoryAsync(
+                        context.getParsedOutput().messages(), List.of());
             } else {
-                markdownOutputPanel.clear(); // clears main view and history
+                markdownOutputPanel.clear(); // clears main view, history, and cache
             }
         } else {
             var history = taskHistory.subList(0, taskHistory.size() - 1);
             var main = taskHistory.getLast();
-            // render first the last message, then the history
-            markdownOutputPanel.setText(main);
-            SwingUtilities.invokeLater(() -> {
-                markdownOutputPanel.replaceHistory(history);
-            });
+            markdownOutputPanel.setMainThenHistoryAsync(main, history);
         }
     }
 


### PR DESCRIPTION
- Intent: 
1. only re-render history + main message when changed
2. ensure the "main" output is rendered first and the history is applied only after the WebView has flushed, reducing flicker.

[Screencast From 2025-09-23 12-50-22.webm](https://github.com/user-attachments/assets/e6efe929-40bc-4c04-afe5-34c93120b8e0)


- Behaviour changes: callers now use setMainThenHistoryAsync(...) (used in HistoryOutputPanel and SessionsDialog) instead of ad-hoc setText(...) + SwingUtilities.invokeLater(replaceHistory). MarkdownOutputPanel will skip updates when content or history hasn't changed, and respects blocking mode (no-ops when blocking).
- Key implementation ideas:
  - Added setMainThenHistoryAsync overloads that set the main content, call flushAsync(), then schedule history replacement on the EDT.
  - Added change-detection via lastHistorySignature/getHistorySignature to avoid re-sending identical histories.
  - Made replaceHistory private so history updates go through the new sequenced path.
  - Minor API tidy: setText now accepts List<? extends ChatMessage>, clear resets signature, and operations honor blocking mode.