### PR TITLE
Sessions sync

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/IProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/IProject.java
@@ -348,6 +348,10 @@ public interface IProject extends AutoCloseable {
         throw new UnsupportedOperationException();
     }
 
+    default String getRemoteProjectName() {
+        throw new UnsupportedOperationException();
+    }
+
     enum CodeAgentTestScope {
         ALL,
         WORKSPACE;

--- a/app/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -163,7 +163,7 @@ public final class MainProject extends AbstractProject {
         this.styleGuidePath = this.masterRootPathForConfig.resolve(BROKK_DIR).resolve(STYLE_GUIDE_FILE);
         this.reviewGuidePath = this.masterRootPathForConfig.resolve(BROKK_DIR).resolve(REVIEW_GUIDE_FILE);
         var sessionsDir = this.masterRootPathForConfig.resolve(BROKK_DIR).resolve(SESSIONS_DIR);
-        this.sessionManager = new SessionManager(sessionsDir);
+        this.sessionManager = new SessionManager(this, sessionsDir);
 
         this.projectProps = new Properties();
 
@@ -1790,5 +1790,17 @@ public final class MainProject extends AbstractProject {
         for (var chrome : allChromes) {
             SwingUtilities.invokeLater(() -> chrome.getHistoryOutputPanel().updateSessionComboBox());
         }
+    }
+
+    @Override
+    public String getRemoteProjectName() {
+        String result = null;
+        if (hasGit()) {
+            result = getRepo().getRemoteUrl();
+        }
+        if (result == null) {
+            result = getRoot().getFileName().toString();
+        }
+        return result;
     }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
@@ -222,4 +222,9 @@ public final class WorktreeProject extends AbstractProject {
     public void sessionsListChanged() {
         parent.sessionsListChanged();
     }
+
+    @Override
+    public String getRemoteProjectName() {
+        return parent.getRemoteProjectName();
+    }
 }


### PR DESCRIPTION
### Session Synchronization with Remote Storage

This pull request introduces a comprehensive session synchronization feature, enabling users to back up, share, and synchronize their work sessions across different machines via a remote storage service.

#### Summary of Changes

The core of this feature is the ability to treat a remote server as a source of truth for sessions associated with a project. Local changes are uploaded, remote changes are downloaded, and the local session list is kept in sync with the remote. This provides a seamless experience for users working on the same project from multiple locations.

#### Key Functionalities

*   **Automatic Upload of Local Changes:**
    *   Any new session, modification (e.g., a new conversation step), or rename is automatically marked as "dirty" and queued for upload.
    *   On application startup and periodically in the background (every 30 seconds), the client uploads these pending changes to the remote server.
    *   When the application is closed, a final attempt is made to upload any remaining unsynced changes.

*   **Synchronization from Remote:**
    *   On startup, after uploading local changes, the application fetches the list of all sessions for the project from the remote server.
    *   It downloads any sessions that exist remotely but not locally.
    *   It updates local sessions if a newer version is available on the server (based on modification timestamps).
    *   It removes local sessions that have been deleted from the remote, ensuring the local view doesn't retain stale data.

*   **Conflict-Free Deletion:**
    *   When a session is deleted locally, it is not immediately removed. Instead, it is moved to a temporary "deleted" location and marked as `PENDING_DELETION`.
    *   The background sync process informs the server of the deletion. Once the server confirms, the local copy is marked as fully `DELETED`. This prevents a session deleted locally from being re-downloaded from the remote before the deletion is synced.

*   **On-Demand Updates:**
    *   Before a session is loaded (e.g., when a user switches to it in the UI), the application performs a quick check to see if a more recent version exists on the server based on the cached remote sessions metadata. If so, it downloads the latest version before loading it, ensuring the user works with the most up-to-date session content before background sync process is complete.
    * This is useful during initial loading of active sessions and when users switch to other sessions before background sync is complete to prevent session content divergence (either automatic with `Loaded external changes` and similar, or by users modifying sessions before sync is complete). 
    * This does not lead to degraded performance every time we load session history because we check the session info against cached remote metadata.

#### Workflow Overview

1.  **Startup:**
    *   The application first uploads any local sessions that have been created or modified since the last sync.
    *   It then synchronizes with the remote, downloading new/updated sessions and processing deletions.
    *   A background task is scheduled to periodically upload local changes.

2.  **During Use:**
    *   Creating, renaming, or interacting with a session marks it for the next upload cycle.
    *   Deleting a session marks it for remote deletion.
    *   Switching to a session may trigger a download if a newer version is found remotely.

3.  **Shutdown:**
    *   A final upload of all pending local changes is attempted to ensure no work is lost.

#### Technical Implementation Notes

*   A `SyncStatus` (`PENDING_SYNC`, `SYNCED`, `PENDING_DELETION`, `DELETED`) has been added to the session metadata (`SessionInfo`) to track the state of each session relative to the remote.
*   The `Service` class now includes methods for interacting with the new `/api/sessions` backend endpoints (list, get, write, delete).
*   The `SessionManager` contains the primary logic for handling the synchronization state machine, managing uploads, downloads, and deletions.
*   Projects are identified on the remote server primarily by their Git remote URL, falling back to the project's root directory name. This is exposed via a new `getRemoteProjectName()` method on the `IProject` interface.
