### PR TITLE
feat: Require jdk for jdeploy deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "repository": "",
     "version": "1.0.0",
     "jdeploy": {
-        "jdk": false,
+        "jdk": true,
         "args": ["--add-modules jdk.incubator.vector"],
         "publishTargets": [{
             "name": "github: brokk",


### PR DESCRIPTION
This will cause JDeploy installer to use full JDK instead of just JRE. It seems that some things require a JDK, so it just makes sense. Part of solution for error that appears in JDK detection dialog. https://github.com/BrokkAi/brokk/issues/1061