### PR TITLE
997 bug dependencies are racy

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
@@ -63,6 +63,7 @@ public final class DependenciesPanel extends JPanel {
     private final Set<ProjectFile> initialFiles;
     private boolean isProgrammaticChange = false;
     private static final String LOADING = "Loading...";
+    private static final String UNLOADING = "Unloading...";
 
     // UI pieces used to align the bottom area with WorkspacePanel
     private JPanel southContainerPanel;
@@ -72,6 +73,7 @@ public final class DependenciesPanel extends JPanel {
     private MaterialButton addButton;
     private MaterialButton removeButton;
     private boolean controlsLocked = false;
+    private @Nullable CompletableFuture<Void> inFlightToggleSave = null;
 
     private static class NumberRenderer extends DefaultTableCellRenderer {
         public NumberRenderer() {
@@ -111,7 +113,8 @@ public final class DependenciesPanel extends JPanel {
                 }
                 return cb;
             } else {
-                var lbl = new JLabel(LOADING);
+                var text = (value != null) ? value.toString() : "";
+                var lbl = new JLabel(text);
                 lbl.setHorizontalAlignment(CENTER);
                 lbl.setOpaque(isSelected);
                 if (isSelected) {
@@ -304,17 +307,26 @@ public final class DependenciesPanel extends JPanel {
                         String depName = (String) tableModel.getValueAt(row, 1);
                         boolean prev = !bool;
 
-                        // Show "Loading..." while saving the change only when enabling (checking).
-                        if (bool) {
+                        // If an operation is already in-flight or any row is Loading, revert this toggle.
+                        if (controlsLocked || (inFlightToggleSave != null && !inFlightToggleSave.isDone()) || anyRowLoading()) {
                             isProgrammaticChange = true;
-                            tableModel.setValueAt(LOADING, row, 0);
+                            tableModel.setValueAt(prev, row, 0);
                             isProgrammaticChange = false;
+                            return;
                         }
+
+                        // Lock UI early and stop editing to ensure renderer updates.
+                        setControlsLocked(true);
+
+                        // Show progress text while saving: "Loading..." when enabling, "Unloading..." when disabling.
+                        isProgrammaticChange = true;
+                        tableModel.setValueAt(bool ? LOADING : UNLOADING, row, 0);
+                        isProgrammaticChange = false;
 
                         final int rowIndex = row;
                         final boolean newVal = bool;
                         final boolean prevVal = prev;
-                        saveChangesAsync(Map.of(depName, Boolean.valueOf(bool)))
+                        inFlightToggleSave = saveChangesAsync(Map.of(depName, Boolean.valueOf(bool)))
                                 .whenComplete((r, ex) -> SwingUtilities.invokeLater(() -> {
                                     isProgrammaticChange = true;
                                     if (ex != null) {
@@ -328,6 +340,9 @@ public final class DependenciesPanel extends JPanel {
                                         tableModel.setValueAt(newVal, rowIndex, 0);
                                     }
                                     isProgrammaticChange = false;
+                                    inFlightToggleSave = null;
+                                    // Unlock UI after save completes (success or failure).
+                                    setControlsLocked(false);
                                 }));
                     }
                 }
@@ -344,6 +359,16 @@ public final class DependenciesPanel extends JPanel {
             if (editor != null) editor.stopCellEditing();
         }
         table.repaint();
+    }
+
+    private boolean anyRowLoading() {
+        for (int i = 0; i < tableModel.getRowCount(); i++) {
+            Object v = tableModel.getValueAt(i, 0);
+            if (LOADING.equals(v) || UNLOADING.equals(v)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
@@ -308,7 +308,9 @@ public final class DependenciesPanel extends JPanel {
                         boolean prev = !bool;
 
                         // If an operation is already in-flight or any row is Loading, revert this toggle.
-                        if (controlsLocked || (inFlightToggleSave != null && !inFlightToggleSave.isDone()) || anyRowLoading()) {
+                        if (controlsLocked
+                                || (inFlightToggleSave != null && !inFlightToggleSave.isDone())
+                                || anyRowLoading()) {
                             isProgrammaticChange = true;
                             tableModel.setValueAt(prev, row, 0);
                             isProgrammaticChange = false;


### PR DESCRIPTION
- prevent changes to the dependencies panel until the save is completed, the rest of the UI is accessible. This keeps the state in sync or at least more in sync than it was
- not the greatest user experience, but I am not sure how to solve this beyond batching ie going back to a check a bunch and then click save, but then we have to deal with how to prevent users from doing anything without realizing they're saved. I think this gets us through for now, but we are going to have to do a bigger deep dive into how we load and unload these and if we can do them in a way that is more concurrency friendly.
