### PR TITLE
Simplified tool request explanations: removed enum, added headline mapping, new headlines

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -1035,7 +1035,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
      * return only the messages from `main`. Typically this use called with a single UserMessage in `main` to reset the
      * output to a fresh state for a new task.
      *
-     * You should probably call ContextManager::beginTask instead of calling this directly.
+     * <p>You should probably call ContextManager::beginTask instead of calling this directly.
      */
     public void setLlmAndHistoryOutput(List<TaskEntry> history, TaskEntry main) {
         SwingUtilities.invokeLater(() -> historyOutputPanel.setLlmAndHistoryOutput(history, main));

--- a/app/src/main/java/io/github/jbellis/brokk/tools/ToolRegistry.java
+++ b/app/src/main/java/io/github/jbellis/brokk/tools/ToolRegistry.java
@@ -108,8 +108,7 @@ public class ToolRegistry {
             Map.entry("addCallGraphOutToWorkspace", "Adding callees to workspace"),
             Map.entry("dropWorkspaceFragments", "Removing from workspace"),
             Map.entry("recommendContext", "Recommending context"),
-            Map.entry("createTaskList", "Creating task list")
-    );
+            Map.entry("createTaskList", "Creating task list"));
 
     /** Returns a human-readable headline for the given tool. Falls back to the tool name if there is no mapping. */
     private static String headlineFor(String toolName) {


### PR DESCRIPTION
fixes #1171

- Intent: simplify how tool request explanations are rendered by removing the heavy enum-based metadata (icons + headline) and replacing it with a lightweight mapping of tool names to headlines. Also add a couple of new tool headlines.
- Behavior changes:
  - Explanations now show only a headline (no emoji/icon) above the YAML block.
  - Unknown tool names fall back to the raw tool name as the headline (previous enum used to log a warning; that logging-path was removed).
  - New tool headlines added for "recommendContext" and "createTaskList".
  - Minor javadoc formatting change in Chrome.java (added a paragraph tag).
- Key implementation ideas:
  - Removed the ToolDisplayMeta enum and its switch-based lookup.
  - Introduced a static Map HEADLINES and a headlineFor(toolName) helper to look up headlines with a default fallback.
  - Updated getExplanationForToolRequest to format the header using the new headline lookup and to omit icon handling.