### PR TITLE
[java TS] Record Parameters Parsed as Fields

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SymbolSelectionPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SymbolSelectionPanel.java
@@ -31,11 +31,11 @@ public class SymbolSelectionPanel extends JPanel {
         // Build text input with autocomplete at the top
         symbolInput = new JTextField(30);
         var provider = createSymbolCompletionProvider(analyzer);
-        // Enable auto-activation so suggestions appear on every keystroke (immediate popup).
+        // Enable auto-activation with a small debounce so suggestions don't flash on every keystroke.
         provider.setAutoActivationRules(true, "._$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
         autoCompletion = new AutoCompletion(provider);
         autoCompletion.setAutoActivationEnabled(true);
-        autoCompletion.setAutoActivationDelay(0);
+        autoCompletion.setAutoActivationDelay(500);
         autoCompletion.install(symbolInput);
 
         JPanel inputPanel = new JPanel(new BorderLayout());

--- a/app/src/main/java/io/github/jbellis/brokk/gui/terminal/TaskListPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/terminal/TaskListPanel.java
@@ -1446,7 +1446,6 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
     }
 
     static List<String> normalizeSplitLines(String input) {
-        if (input == null) return java.util.Collections.emptyList();
         return Arrays.stream(input.split("\\R+"))
                 .map(String::strip)
                 .filter(s -> !s.isEmpty())
@@ -1517,9 +1516,7 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
         for (int idx : indices) {
             if (idx >= 0 && idx < model.getSize()) {
                 TaskItem item = model.get(idx);
-                if (item != null && item.text() != null) {
-                    taskTexts.add(item.text());
-                }
+                taskTexts.add(item.text());
             }
         }
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/terminal/TaskListPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/terminal/TaskListPanel.java
@@ -1446,6 +1446,7 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
     }
 
     static List<String> normalizeSplitLines(@Nullable String input) {
+        if (input == null) return java.util.Collections.emptyList();
         return Arrays.stream(input.split("\\R+"))
                 .map(String::strip)
                 .filter(s -> !s.isEmpty())

--- a/app/src/main/resources/treesitter/java.scm
+++ b/app/src/main/resources/treesitter/java.scm
@@ -35,8 +35,8 @@
 
 ; Field declarations
 (field_declaration
-    declarator: (variable_declarator name: (identifier) @field.name
-    )
+  (variable_declarator
+    name: (identifier) @field.name)
 ) @field.definition
 
 ; Enum declarations
@@ -46,6 +46,15 @@
 ; Enum constants
 (enum_constant
   name: (identifier) @field.name) @field.definition
+
+; Record components (implicit fields created by record components)
+; Primary: Java grammar where record components are formal_parameters on the 'parameters' field
+(record_declaration
+  parameters: (formal_parameters
+    (formal_parameter
+      name: (identifier) @field.name) @field.definition
+  )
+)
 
 ; Annotations to strip
 (annotation) @annotation

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerSearchTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerSearchTest.java
@@ -258,4 +258,18 @@ public class JavaTreeSitterAnalyzerSearchTest {
                 dotNames.contains("A.AInner.AInnerInner"),
                 "Dot-hierarchy query should match nested class FQN with '.' separators");
     }
+
+    @Test
+    public void testAutocomplete_RecordComponentsAsFields() {
+        // Record component should be treated as an implicit field
+        var resFull = analyzer.autocompleteDefinitions("C.Foo.x");
+        var namesFull = resFull.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
+        assertTrue(namesFull.contains("C.Foo.x"), "Should find record component as field 'C.Foo.x'");
+
+        // Single-letter query still includes fields (autocomplete fallback ensures this)
+        var resShort = analyzer.autocompleteDefinitions("x");
+        var namesShort = resShort.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
+        assertTrue(
+                namesShort.contains("C.Foo.x"), "Single-letter query should include record component field 'C.Foo.x'");
+    }
 }


### PR DESCRIPTION
* Fixed issue where `JavaTreeSitterAnalyzer` did not parse `record` class format parameters as field code units
* This fixes an issue where over auto-complete did not fetch record fields
* (Misc.) Reverts `JavaAnalyzer` chaining of the future for the LSP client back to having a separate field if the future completed.