### PR TITLE
Increase Linting Settle Delay + Improved Path Normalisation in Diagnostics

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspLanguageClient.java
@@ -5,6 +5,8 @@ import io.github.jbellis.brokk.analyzer.LintResult;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -117,20 +119,16 @@ public abstract class LspLanguageClient implements LanguageClient {
 
     /** Clears diagnostics for the specified files. */
     public void clearDiagnosticsForFiles(List<ProjectFile> files) {
-        files.stream()
-                .map(ProjectFile::absPath)
-                .map(this::safeResolvePath)
-                .map(Path::toString)
-                .forEach(fileDiagnostics::remove);
+        files.stream().map(ProjectFile::absPath).map(this::normalizeForKey).forEach(fileDiagnostics::remove);
     }
 
-    protected Path safeResolvePath(Path path) {
+    protected String normalizeForKey(Path path) {
         try {
-            return path.toRealPath();
+            // Use real path when possible (resolves symlinks); fallback to absolute normalized when file may not exist.
+            return path.toRealPath().toString();
         } catch (IOException e) {
-            logger.error("Cannot resolve path {}", path, e);
+            return path.toAbsolutePath().normalize().toString();
         }
-        return path;
     }
 
     @Override
@@ -177,10 +175,32 @@ public abstract class LspLanguageClient implements LanguageClient {
 
     protected String uriToFilePath(String uri) {
         try {
-            return Paths.get(URI.create(uri)).toRealPath().toString();
+            var u = URI.create(uri);
+            if (!"file".equalsIgnoreCase(u.getScheme())) {
+                return uri; // Non-file URIs are returned as-is
+            }
+            var path = Paths.get(u);
+            return normalizeForKey(path);
         } catch (Exception e) {
             logger.warn("Failed to convert URI to file path: {}", uri, e);
-            return uri;
+            // Lossy fallback: strip scheme and decode to get a best-effort local path that won't contain "file:///"
+            try {
+                var raw = uri;
+                if (raw.startsWith("file://")) {
+                    raw = raw.substring("file://".length());
+                    // file:///C:/... -> C:/... (Windows)
+                    if (raw.startsWith("/")
+                            && raw.length() >= 3
+                            && Character.isLetter(raw.charAt(1))
+                            && raw.charAt(2) == ':') {
+                        raw = raw.substring(1);
+                    }
+                }
+                var decoded = URLDecoder.decode(raw, StandardCharsets.UTF_8);
+                return normalizeForKey(Paths.get(decoded));
+            } catch (Exception ignored) {
+                return uri; // absolute last resort
+            }
         }
     }
 
@@ -188,9 +208,8 @@ public abstract class LspLanguageClient implements LanguageClient {
     public List<LintResult.LintDiagnostic> getDiagnosticsForFiles(List<ProjectFile> files) {
         return files.stream()
                 .map(ProjectFile::absPath)
-                .map(this::safeResolvePath)
-                .map(Path::toString)
-                .flatMap(filePath -> fileDiagnostics.getOrDefault(filePath, List.of()).stream())
+                .map(this::normalizeForKey)
+                .flatMap(key -> fileDiagnostics.getOrDefault(key, List.of()).stream())
                 .toList();
     }
 
@@ -201,7 +220,7 @@ public abstract class LspLanguageClient implements LanguageClient {
     public CompletableFuture<Void> waitForDiagnosticsToSettle() {
         try {
             // We need to give diagnostics a moment to start
-            Thread.sleep(500);
+            Thread.sleep(1500);
         } catch (InterruptedException e) {
             logger.warn("Interrupted while waiting for diagnostics to settle");
         }

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspServer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/lsp/LspServer.java
@@ -3,6 +3,7 @@ package io.github.jbellis.brokk.analyzer.lsp;
 import io.github.jbellis.brokk.AbstractProject;
 import io.github.jbellis.brokk.BuildInfo;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
+import io.github.jbellis.brokk.util.ExecutorServiceUtil;
 import io.github.jbellis.brokk.util.FileUtil;
 import java.io.File;
 import java.io.IOException;
@@ -259,8 +260,7 @@ public abstract class LspServer {
         this.serverProcess = pb.start();
 
         // Create a dedicated thread pool for the LSP client
-        this.lspExecutor =
-                Executors.newFixedThreadPool(4, runnable -> new Thread(runnable, language + "-lsp-client-thread"));
+        this.lspExecutor = ExecutorServiceUtil.newFixedThreadExecutor(4, "lsp-client-thread-");
 
         // will be reduced by one when server signals readiness
         this.serverReadyLatch = new CountDownLatch(1);


### PR DESCRIPTION
* The settle delay before waiting for all diagnostics to come in is increased by 1 second to try sync with the LSP server. Ultimately, this is where the flakiness comes from as diagnostics are sent without an indication of "are there more coming?". Slower machines, such as CI/CD runners may need more grace.
* Improved normalisation of paths and URIs in diagnostics to attempt to resolve the issue in the stack trace of https://github.com/BrokkAi/brokk/issues/1109