### PR TITLE
Normalize Full Names with Generic Arguments

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/TreeSitterAnalyzer.java
@@ -465,7 +465,7 @@ public abstract class TreeSitterAnalyzer
 
     @Override
     public Optional<CodeUnit> getDefinition(String fqName) {
-        final String methodTarget = nearestMethodName(fqName);
+        final String methodTarget = normalizeFullName(fqName);
 
         List<CodeUnit> matches = uniqueCodeUnitList().stream()
                 .filter(cu -> cu.isFunction()
@@ -730,13 +730,14 @@ public abstract class TreeSitterAnalyzer
     }
 
     /**
-     * Assuming the fqName is an entity nested within a method, or is a method itself, will return the fqName of the
-     * method. This is mostly useful with escaping lambdas to their parent method.
+     * Assuming the fqName is an entity nested within a method, a type, or is a method itself, will return the fqName of
+     * the nearest method or type/class. This is useful with escaping lambdas to their parent method, or normalizing
+     * full names with generic type arguments.
      *
-     * @param fqName the fqName of a method.
-     * @return the surrounding method, or the given fqName otherwise.
+     * @param fqName the fqName of a code unit.
+     * @return the surrounding method or type, or the given fqName otherwise.
      */
-    protected String nearestMethodName(String fqName) {
+    protected String normalizeFullName(String fqName) {
         // Should be overridden by the subclasses
         return fqName;
     }

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
@@ -646,8 +646,7 @@ public class JavaTreeSitterAnalyzerTest {
 
         // Class lookup with generics on the type
         assertTrue(
-                analyzer.getClassSource("A<String>", false).isPresent(),
-                "Class lookup with generics should normalize");
+                analyzer.getClassSource("A<String>", false).isPresent(), "Class lookup with generics should normalize");
 
         // Method lookup with generics on the containing class
         assertTrue(
@@ -656,9 +655,7 @@ public class JavaTreeSitterAnalyzerTest {
 
         // Nested classes with generics on each segment
         assertTrue(
-                analyzer
-                        .getMethodSource(
-                                "A.AInner<List<String>>.AInnerInner<Map<Integer, String>>.method7", false)
+                analyzer.getMethodSource("A.AInner<List<String>>.AInnerInner<Map<Integer, String>>.method7", false)
                         .isPresent(),
                 "Nested class method with generics should normalize");
     }
@@ -666,9 +663,7 @@ public class JavaTreeSitterAnalyzerTest {
     @Test
     public void testNormalizationHandlesAnonymousAndLocationSuffix() {
         // Based on log example: createPopupMenu$anon$328:16
-        assertEquals(
-                "package.Class.method",
-                analyzer.normalizeFullName("package.Class.method$anon$328:16"));
+        assertEquals("package.Class.method", analyzer.normalizeFullName("package.Class.method$anon$328:16"));
 
         // Ensure anonymous + location suffix normalizes for real method lookups
         assertTrue(
@@ -694,8 +689,6 @@ public class JavaTreeSitterAnalyzerTest {
                 "Constructor lookup with generics on the type should normalize and resolve");
 
         // Also ensure plain constructor lookup works (control)
-        assertTrue(
-                analyzer.getMethodSource("B.B", true).isPresent(),
-                "Constructor lookup should resolve");
+        assertTrue(analyzer.getMethodSource("B.B", true).isPresent(), "Constructor lookup should resolve");
     }
 }

--- a/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/analyzer/JavaTreeSitterAnalyzerTest.java
@@ -460,15 +460,15 @@ public class JavaTreeSitterAnalyzerTest {
     @Test
     public void testNearestMethodName() {
         // regular method
-        assertEquals("package.Class.method", analyzer.nearestMethodName("package.Class.method"));
+        assertEquals("package.Class.method", analyzer.normalizeFullName("package.Class.method"));
         // method with lambda/anon class
-        assertEquals("package.Class.method", analyzer.nearestMethodName("package.Class.method$anon$357:32"));
+        assertEquals("package.Class.method", analyzer.normalizeFullName("package.Class.method$anon$357:32"));
         // method with anon class (just digits)
-        assertEquals("package.Class.method", analyzer.nearestMethodName("package.Class.method$1"));
+        assertEquals("package.Class.method", analyzer.normalizeFullName("package.Class.method$1"));
         // method in nested class
-        assertEquals("package.A.AInner.method", analyzer.nearestMethodName("package.A.AInner.method"));
+        assertEquals("package.A.AInner.method", analyzer.normalizeFullName("package.A.AInner.method"));
         // method with lambda in nested class
-        assertEquals("package.A.AInner.method", analyzer.nearestMethodName("package.A.AInner.method$anon$1"));
+        assertEquals("package.A.AInner.method", analyzer.normalizeFullName("package.A.AInner.method$anon$1"));
     }
 
     @Test
@@ -634,5 +634,68 @@ public class JavaTreeSitterAnalyzerTest {
         assertTrue(source.contains("The annotation value"), "Should contain annotation method description");
         assertTrue(source.contains("@return the value string"), "Should contain annotation method @return tag");
         assertTrue(source.contains("Priority level"), "Should contain priority method description");
+    }
+
+    @Test
+    public void testNormalizationStripsGenericsInClassNames() {
+        // Based on log example: SlidingWindowCache<K, V extends Disposable>.getCachedKeys
+        assertEquals(
+                "io.github.jbellis.brokk.util.SlidingWindowCache.getCachedKeys",
+                analyzer.normalizeFullName(
+                        "io.github.jbellis.brokk.util.SlidingWindowCache<K, V extends Disposable>.getCachedKeys"));
+
+        // Class lookup with generics on the type
+        assertTrue(
+                analyzer.getClassSource("A<String>", false).isPresent(),
+                "Class lookup with generics should normalize");
+
+        // Method lookup with generics on the containing class
+        assertTrue(
+                analyzer.getMethodSource("A<Integer>.method1", false).isPresent(),
+                "Method lookup with class generics should normalize");
+
+        // Nested classes with generics on each segment
+        assertTrue(
+                analyzer
+                        .getMethodSource(
+                                "A.AInner<List<String>>.AInnerInner<Map<Integer, String>>.method7", false)
+                        .isPresent(),
+                "Nested class method with generics should normalize");
+    }
+
+    @Test
+    public void testNormalizationHandlesAnonymousAndLocationSuffix() {
+        // Based on log example: createPopupMenu$anon$328:16
+        assertEquals(
+                "package.Class.method",
+                analyzer.normalizeFullName("package.Class.method$anon$328:16"));
+
+        // Ensure anonymous + location suffix normalizes for real method lookups
+        assertTrue(
+                analyzer.getMethodSource("A.method6$anon$1:42", false).isPresent(),
+                "Anonymous and location suffixes should normalize for method source lookup");
+
+        // Location suffix without anon
+        assertTrue(
+                analyzer.getMethodSource("A.method1:16", false).isPresent(),
+                "Location suffix alone should normalize for method source lookup");
+
+        // Anonymous with just digits
+        assertTrue(
+                analyzer.getMethodSource("A.method6$1", false).isPresent(),
+                "Anonymous digit suffix should normalize for method source lookup");
+    }
+
+    @Test
+    public void testDefinitionAndSourcesWithNormalizedConstructorNames() {
+        // Based on log example: Type.Type for constructor (and possibly with generics on the type)
+        assertTrue(
+                analyzer.getMethodSource("B<B>.B", true).isPresent(),
+                "Constructor lookup with generics on the type should normalize and resolve");
+
+        // Also ensure plain constructor lookup works (control)
+        assertTrue(
+                analyzer.getMethodSource("B.B", true).isPresent(),
+                "Constructor lookup should resolve");
     }
 }


### PR DESCRIPTION
* Refactored `nearestMethodName` to `normalizeFullName`
* Ensure all `getDefinition` calls are normalised 
* Normalize generic type arguments on full names
