### PR TITLE
refactor: Use global Plan First preference for worktrees and MainProject

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/AbstractProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/AbstractProject.java
@@ -324,19 +324,6 @@ public abstract sealed class AbstractProject implements IProject permits MainPro
         }
     }
 
-    @Override
-    public boolean getInstructionsAskMode() {
-        String v = workspaceProps.getProperty(PROP_INSTRUCTIONS_ASK);
-        // default to true (Ask mode) if not set
-        return v == null ? true : Boolean.parseBoolean(v);
-    }
-
-    @Override
-    public void setInstructionsAskMode(boolean ask) {
-        workspaceProps.setProperty(PROP_INSTRUCTIONS_ASK, String.valueOf(ask));
-        saveWorkspaceProperties();
-    }
-
     public final Optional<UUID> getLastActiveSession() {
         String sessionIdStr = workspaceProps.getProperty("lastActiveSession");
         if (sessionIdStr != null && !sessionIdStr.isBlank()) {
@@ -358,7 +345,6 @@ public abstract sealed class AbstractProject implements IProject permits MainPro
     private static final String PROP_BUILD_LANGUAGE = "build.language";
     private static final String PROP_COMMAND_EXECUTOR = "commandExecutor";
     private static final String PROP_EXECUTOR_ARGS = "commandExecutorArgs";
-    private static final String PROP_INSTRUCTIONS_ASK = "instructions.ask";
 
     // Terminal drawer per-project persistence
     private static final String PROP_DRAWER_TERM_OPEN = "drawers.terminal.open";

--- a/app/src/main/java/io/github/jbellis/brokk/IProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/IProject.java
@@ -213,6 +213,22 @@ public interface IProject extends AutoCloseable {
         throw new UnsupportedOperationException();
     }
 
+    default boolean getPlanFirst() {
+        throw new UnsupportedOperationException();
+    }
+
+    default void setPlanFirst(boolean enabled) {
+        throw new UnsupportedOperationException();
+    }
+
+    default boolean getSearch() {
+        throw new UnsupportedOperationException();
+    }
+
+    default void setSearch(boolean enabled) {
+        throw new UnsupportedOperationException();
+    }
+
     default boolean getInstructionsAskMode() {
         throw new UnsupportedOperationException();
     }

--- a/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/WorktreeProject.java
@@ -211,4 +211,34 @@ public final class WorktreeProject extends AbstractProject {
     public void sessionsListChanged() {
         parent.sessionsListChanged();
     }
+
+    @Override
+    public boolean getPlanFirst() {
+        return parent.getPlanFirst();
+    }
+
+    @Override
+    public void setPlanFirst(boolean v) {
+        parent.setPlanFirst(v);
+    }
+
+    @Override
+    public boolean getSearch() {
+        return parent.getSearch();
+    }
+
+    @Override
+    public void setSearch(boolean v) {
+        parent.setSearch(v);
+    }
+
+    @Override
+    public boolean getInstructionsAskMode() {
+        return parent.getInstructionsAskMode();
+    }
+
+    @Override
+    public void setInstructionsAskMode(boolean ask) {
+        parent.setInstructionsAskMode(ask);
+    }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -242,15 +242,8 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         // Load persisted checkbox states (default to checked)
         var proj = chrome.getProject();
         modeSwitch.setSelected(proj.getInstructionsAskMode());
-        if (proj instanceof MainProject mp) {
-            codeCheckBox.setSelected(mp.getPlanFirst());
-            // Default to Search checked for Ask mode, but use persisted preference when available
-            searchProjectCheckBox.setSelected(mp.getSearchFirst());
-        } else {
-            // Fallback: both checked
-            codeCheckBox.setSelected(true);
-            searchProjectCheckBox.setSelected(true);
-        }
+        codeCheckBox.setSelected(proj.getPlanFirst());
+        searchProjectCheckBox.setSelected(proj.getSearch());
 
         // default stored action: Search (Ask + Search)
         storedAction = ACTION_SEARCH;
@@ -291,18 +284,14 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                 // Inverted semantics: checked = Architect (Plan First)
                 storedAction = codeCheckBox.isSelected() ? ACTION_ARCHITECT : ACTION_CODE;
             }
-            if (chrome.getProject() instanceof MainProject mp) {
-                mp.setPlanFirst(codeCheckBox.isSelected());
-            }
+            proj.setPlanFirst(codeCheckBox.isSelected());
         });
 
         searchProjectCheckBox.addActionListener(e -> {
             if (modeSwitch.isSelected()) {
                 storedAction = searchProjectCheckBox.isSelected() ? ACTION_SEARCH : ACTION_ASK;
             }
-            if (chrome.getProject() instanceof MainProject mp) {
-                mp.setSearchFirst(searchProjectCheckBox.isSelected());
-            }
+            proj.setSearch(searchProjectCheckBox.isSelected());
         });
 
         // Initial checkbox visibility is handled by the optionsPanel (CardLayout) in buildBottomPanel().


### PR DESCRIPTION
plan first, search, code/ask toggle all now go through MainProject and they each

- save to project specific properties if enabled
- save to global properties always
- project specific properties take priority if present
- fallback is to global properties
- the instructions panel no longer has to think about this and just makes calls to getProject()
- WorktreeProject just delegates all of these properties to the parent