### PR TITLE
feat: MOP in external windows: show initial messages

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -1052,9 +1052,8 @@ public class HistoryOutputPanel extends JPanel {
             outputPanel = new MarkdownOutputPanel();
             outputPanel.withContextForLookups(parentPanel.contextManager, parentPanel.chrome);
             outputPanel.updateTheme(isDark);
-            outputPanel.setBlocking(isBlockingMode);
             // Seed main content first, then history
-            outputPanel.setMainThenHistoryAsync(main, history);
+            outputPanel.setMainThenHistoryAsync(main, history).thenRun(() -> outputPanel.setBlocking(isBlockingMode));
 
             // Create toolbar panel with capture button if not in blocking mode
             JPanel toolbarPanel = null;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/mop/MarkdownOutputPanel.java
@@ -124,8 +124,8 @@ public class MarkdownOutputPanel extends JPanel implements ThemeAware, Scrollabl
     }
 
     private void setMainIfChanged(List<? extends ChatMessage> newMessages) {
-        if (isBlocking()) {
-            logger.debug("Ignoring setMainIfChanged() while blocking is enabled.");
+        if (isBlocking() && !messages.isEmpty()) {
+            logger.debug("Ignoring setMainIfChanged() while blocking is enabled and content already exists.");
             return;
         }
         if (getRawMessages().equals(newMessages)) {
@@ -152,8 +152,8 @@ public class MarkdownOutputPanel extends JPanel implements ThemeAware, Scrollabl
      */
     public java.util.concurrent.CompletableFuture<Void> setMainThenHistoryAsync(
             List<? extends ChatMessage> mainMessages, List<TaskEntry> history) {
-        if (isBlocking()) {
-            logger.debug("Ignoring setMainThenHistoryAsync() while blocking is enabled.");
+        if (isBlocking() && !messages.isEmpty()) {
+            logger.debug("Ignoring setMainThenHistoryAsync() while blocking is enabled and content already exists.");
             return java.util.concurrent.CompletableFuture.completedFuture(null);
         }
         setMainIfChanged(mainMessages);


### PR DESCRIPTION
fixes #1170

- Intent: ensure the MarkdownOutputPanel is seeded with initial content before switching into blocking mode, and avoid blocking logic preventing the very first content load.
- Behaviour changes:
  - The panel now delays calling setBlocking(...) until after setMainThenHistoryAsync(...) completes, so the initial main+history content is always applied.
  - setMainIfChanged() and setMainThenHistoryAsync() no longer short-circuit when blocking is enabled if the panel currently has no messages — they only ignore updates when blocking is enabled and content already exists.
  - Log messages were clarified to reflect the more specific condition.
- Implementation notes:
  - Moved setBlocking to a CompletableFuture.thenRun(...) callback after asynchronous seeding in HistoryOutputPanel.
  - Added a messages.isEmpty() check alongside isBlocking() in MarkdownOutputPanel to allow the first populate to proceed even if blocking is set.