### PR TITLE
Improved fenced edit-block parsing: whitespace tolerance, comment-prefixed filenames, robustness

### DIFF
--- a/frontend-mop/src/lib/edit-block/fenced-edit-block.ts
+++ b/frontend-mop/src/lib/edit-block/fenced-edit-block.ts
@@ -55,6 +55,14 @@ export const tokenizeFencedEditBlock: Tokenizer = function (effects, ok, nok) {
     }
 
     function afterOpen(code: Code): State {
+        // Tolerate optional horizontal whitespace right after the opening fence
+        if (code === codes.space || code === codes.horizontalTab) {
+            fx.enter("chunk");
+            fx.consume(code);
+            fx.exit("chunk");
+            return afterOpen; // continue consuming any further spaces/tabs
+        }
+
         const next = eatEndLineAndCheckEof(code, afterOpen);
         if (next) return next;
 

--- a/frontend-mop/src/lib/edit-block/tokenizer/fence-open.ts
+++ b/frontend-mop/src/lib/edit-block/tokenizer/fence-open.ts
@@ -39,11 +39,7 @@ export const tokenizeFenceOpen: Tokenizer = function (effects, ok, nok) {
       return fx.nok(code);
     }
 
-    // Reject if there's a space or tab right after the fence (eager recognition)
-    if (code === codes.space || code === codes.horizontalTab) {
-      fx.exit('editBlockFenceOpen');
-      return fx.nok(code);
-    }
+    
 
     fx.exit('editBlockFenceOpen');
 

--- a/frontend-mop/src/lib/edit-block/tokenizer/filename.ts
+++ b/frontend-mop/src/lib/edit-block/tokenizer/filename.ts
@@ -16,6 +16,39 @@ export const tokenizeFilename: Tokenizer = function (effects, ok, nok) {
 
     let hasFilename = false;
 
+    // Helper tokenizer to detect and consume a leading '//' plus an optional single space.
+    // Used only on the "next line" filename path, so inline-filename strictness remains unchanged.
+    const tokenizeDoubleSlashPrefix: Tokenizer = function (effects, ok, nok) {
+        const fx2 = makeSafeFx('filenameCommentPrefix', effects, ctx as any, ok, nok);
+
+        return startComment;
+
+        function startComment(code: Code): State {
+            if (code !== codes.slash) return fx2.nok(code);
+            fx2.enter('chunk');
+            fx2.consume(code); // first '/'
+            fx2.exit('chunk');
+            return afterFirstSlash;
+        }
+
+        function afterFirstSlash(code: Code): State {
+            if (code !== codes.slash) return fx2.nok(code);
+            fx2.enter('chunk');
+            fx2.consume(code); // second '/'
+            fx2.exit('chunk');
+            return maybeSpaceAfterComment;
+        }
+
+        function maybeSpaceAfterComment(code: Code): State {
+            if (code === codes.space) {
+                fx2.enter('chunk');
+                fx2.consume(code); // optional single space
+                fx2.exit('chunk');
+            }
+            return fx2.ok(code);
+        }
+    };
+
     return start;
 
     function start(code: Code): State {
@@ -28,8 +61,29 @@ export const tokenizeFilename: Tokenizer = function (effects, ok, nok) {
             return fx.nok(code); // Reject space after fence
         }
 
-        fx.enter('editBlockFilename');
+        // Detect if we are at the beginning of a line. If so, treat this as the "next line" path
+        // even though the orchestrator consumed the newline already.
+        const atLineStart =
+            typeof (ctx as any).now === 'function' ? (ctx as any).now().column === 1 : false;
 
+        if (atLineStart) {
+            // Support a comment-prefixed filename line: // filename
+            if (code === codes.slash) {
+                return effects.check(
+                    { tokenize: tokenizeDoubleSlashPrefix, concrete: true },
+                    afterCommentCheck,
+                    notComment
+                )(code);
+            }
+
+            // Regular next-line filename (no internal whitespace allowed)
+            fx.enter('editBlockFilename');
+            hasFilename = true;
+            return nextLineFilename(code);
+        }
+
+        // Inline filename (same line as fence) stays strict
+        fx.enter('editBlockFilename');
         hasFilename = true;
         return inlineFilename(code);
     }
@@ -50,6 +104,41 @@ export const tokenizeFilename: Tokenizer = function (effects, ok, nok) {
             return fx.ok(code); // Header starts, no filename, succeed with zero length
         }
 
+        // Support a comment-prefixed filename line: // filename
+        if (code === codes.slash) {
+            return effects.check(
+                { tokenize: tokenizeDoubleSlashPrefix, concrete: true },
+                afterCommentCheck,
+                notComment
+            )(code);
+        }
+
+        fx.enter('editBlockFilename');
+        hasFilename = true;
+        return nextLineFilename(code);
+    }
+
+    function afterCommentCheck(code: Code): State {
+        // Actually consume the comment prefix now
+        return effects.attempt(
+            { tokenize: tokenizeDoubleSlashPrefix, concrete: true },
+            afterCommentConsumed,
+            fx.nok
+        )(code);
+    }
+
+    function afterCommentConsumed(code: Code): State {
+        // If nothing follows on the line, treat as "no filename" and let header parsing proceed.
+        if (markdownLineEnding(code) || code === codes.eof) {
+            return fx.ok(code);
+        }
+        fx.enter('editBlockFilename');
+        hasFilename = true;
+        return nextLineFilename(code);
+    }
+
+    function notComment(code: Code): State {
+        // Fall back to normal next-line filename parsing (e.g., for paths that start with '/')
         fx.enter('editBlockFilename');
         hasFilename = true;
         return nextLineFilename(code);


### PR DESCRIPTION
fixes #861

- Intent: be more lenient about small formatting variations after a fenced edit-block opener and support filename declarations on the next line that are prefixed by a comment marker (//). This improves robustness for authors who add a space/tab after the fence or put a filename on the next line as a comment.
- Behaviour changes:
  - Accepts optional horizontal whitespace (space or tab) immediately after the opening fence instead of rejecting it.
  - Removes the previous eager rejection in the fence-open tokenizer for a space/tab after the fence.
  - Allows a next-line filename prefixed with "//" (optionally followed by a single space). If the line is only "//" (no filename), it is treated as absent and header parsing proceeds.
  - Inline filename parsing (same-line as fence) remains strict (unchanged).
- Key implementation notes:
  - Added tolerant consumption in afterOpen to eat spaces/tabs as small "chunk" tokens.
  - Removed the space/tab rejection branch in fence-open.
  - Implemented tokenizeDoubleSlashPrefix to detect/consume a leading '//' and an optional single space, using effects.check to probe and effects.attempt to consume when appropriate.
  - Detected "next-line" context via ctx.now().column === 1 to decide the alternate filename path while preserving inline behavior.