### PR TITLE
Bug/sync branch visuals between project drawer, gitlog tab, and branch selector in instructions panel

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/git/GitRepo.java
@@ -1363,7 +1363,13 @@ public class GitRepo implements Closeable, IGitRepo {
                     throw new GitWrappedIOException(ex);
                 }
                 if (head != null) {
-                    return head.getName(); // Return the commit SHA in detached HEAD state
+                    try (var reader = repository.newObjectReader()) {
+                        var abbrev = reader.abbreviate(head);
+                        return abbrev.name();
+                    } catch (IOException ioEx) {
+                        // Fallback to full SHA on error
+                        return head.getName();
+                    }
                 }
                 throw new GitRepoException("Repository has no HEAD", new NullPointerException());
             }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -607,15 +607,15 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                                     IGitRepo r = project.getRepo();
                                     r.checkout(b);
                                     SwingUtilities.invokeLater(() -> {
-                                try {
-                                    branchSplitButton.setText("branch: " + r.getCurrentBranch());
-                                } catch (Exception ex) {
-                                    logger.debug("Error updating branch label after checkout", ex);
-                                }
-                                // Update Project Files drawer title with the new branch name
-                                GitUiUtil.updatePanelBorderWithBranch(chrome.getProjectFilesPanel(), "Project Files", b);
-                                chrome.systemOutput("Checked out: " + b);
-                            });
+                    try {
+                        branchSplitButton.setText("branch: " + r.getCurrentBranch());
+                    } catch (Exception ex) {
+                        logger.debug("Error updating branch label after checkout", ex);
+                    }
+                    // Update Project Files drawer title with the new branch name
+                    updateProjectFilesDrawerTitle(b);
+                    chrome.systemOutput("Checked out: " + b);
+                });
                                 } catch (Exception ex) {
                                     logger.error("Error checking out branch {}", b, ex);
                                     SwingUtilities.invokeLater(
@@ -679,7 +679,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                                         logger.debug("Error updating branch label after branch creation", ex);
                                     }
                                     // Update Project Files drawer title with the new branch name
-                                    GitUiUtil.updatePanelBorderWithBranch(chrome.getProjectFilesPanel(), "Project Files", sanitized);
+                                    updateProjectFilesDrawerTitle(sanitized);
                                     chrome.systemOutput("Created and checked out: " + sanitized);
                                 });
                             } catch (Exception ex) {
@@ -1012,6 +1012,16 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
             instructionsTitledBorder.setTitle(askMode ? "Instructions - Ask" : "Instructions - Code");
             revalidate();
             repaint();
+        }
+    }
+
+    /** Updates the Project Files drawer title to reflect the current Git branch. Ensures EDT execution. */
+    private void updateProjectFilesDrawerTitle(String branchName) {
+        var panel = chrome.getProjectFilesPanel();
+        if (SwingUtilities.isEventDispatchThread()) {
+            GitUiUtil.updatePanelBorderWithBranch(panel, "Project Files", branchName);
+        } else {
+            SwingUtilities.invokeLater(() -> GitUiUtil.updatePanelBorderWithBranch(panel, "Project Files", branchName));
         }
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -609,12 +609,13 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                                     r.checkout(b);
                                     SwingUtilities.invokeLater(() -> {
                     try {
-                        requireNonNull(branchSplitButton).setText("branch: " + r.getCurrentBranch());
+                        var currentBranch = r.getCurrentBranch();
+                        var displayBranch = currentBranch.isBlank() ? b : currentBranch;
+                        refreshBranchUi(displayBranch);
                     } catch (Exception ex) {
-                        logger.debug("Error updating branch label after checkout", ex);
+                        logger.debug("Error updating branch UI after checkout", ex);
+                        refreshBranchUi(b);
                     }
-                    // Update Project Files drawer title with the new branch name
-                    updateProjectFilesDrawerTitle(b);
                     chrome.systemOutput("Checked out: " + b);
                 });
                                 } catch (Exception ex) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -1042,6 +1042,10 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
             }
             branchSplitButton.setText("branch: " + branchName);
             updateProjectFilesDrawerTitle(branchName);
+
+            // Also notify the Git Log tab to refresh and select the current branch
+            chrome.updateLogTab();
+            chrome.selectCurrentBranchInLogTab();
         };
         if (SwingUtilities.isEventDispatchThread()) {
             task.run();

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -30,6 +30,7 @@ import io.github.jbellis.brokk.gui.git.GitWorktreeTab;
 import io.github.jbellis.brokk.gui.mop.ThemeColors;
 import io.github.jbellis.brokk.gui.util.AddMenuFactory;
 import io.github.jbellis.brokk.gui.util.ContextMenuUtils;
+import io.github.jbellis.brokk.gui.util.GitUiUtil;
 import io.github.jbellis.brokk.gui.util.Icons;
 import io.github.jbellis.brokk.gui.wand.WandButton;
 import io.github.jbellis.brokk.prompts.CodePrompts;
@@ -606,13 +607,15 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                                     IGitRepo r = project.getRepo();
                                     r.checkout(b);
                                     SwingUtilities.invokeLater(() -> {
-                                        try {
-                                            branchSplitButton.setText("branch: " + r.getCurrentBranch());
-                                        } catch (Exception ex) {
-                                            logger.debug("Error updating branch label after checkout", ex);
-                                        }
-                                        chrome.systemOutput("Checked out: " + b);
-                                    });
+                                try {
+                                    branchSplitButton.setText("branch: " + r.getCurrentBranch());
+                                } catch (Exception ex) {
+                                    logger.debug("Error updating branch label after checkout", ex);
+                                }
+                                // Update Project Files drawer title with the new branch name
+                                GitUiUtil.updatePanelBorderWithBranch(chrome.getProjectFilesPanel(), "Project Files", b);
+                                chrome.systemOutput("Checked out: " + b);
+                            });
                                 } catch (Exception ex) {
                                     logger.error("Error checking out branch {}", b, ex);
                                     SwingUtilities.invokeLater(

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -737,12 +737,10 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                                 }
                                 SwingUtilities.invokeLater(() -> {
                                     try {
-                                        requireNonNull(branchSplitButton).setText("branch: " + r.getCurrentBranch());
+                                        refreshBranchUi(sanitized);
                                     } catch (Exception ex) {
-                                        logger.debug("Error updating branch label after branch creation", ex);
+                                        logger.debug("Error updating branch UI after branch creation", ex);
                                     }
-                                    // Update Project Files drawer title with the new branch name
-                                    updateProjectFilesDrawerTitle(sanitized);
                                     chrome.systemOutput("Created and checked out: " + sanitized);
                                 });
                             } catch (Exception ex) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -1036,9 +1036,11 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
             if (!chrome.getProject().hasGit()) {
                 return;
             }
-            if (branchSplitButton != null) {
-                branchSplitButton.setText("branch: " + branchName);
+            if (branchSplitButton == null) {
+                // Selector not initialized (e.g., no Git or UI not yet built) -> no-op
+                return;
             }
+            branchSplitButton.setText("branch: " + branchName);
             updateProjectFilesDrawerTitle(branchName);
         };
         if (SwingUtilities.isEventDispatchThread()) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -1029,8 +1029,8 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
     }
 
     /**
-     * Public hook to refresh branch UI (branch selector label and Project Files drawer title).
-     * Ensures EDT compliance and no-ops if not a git project or selector not initialized.
+     * Public hook to refresh branch UI (branch selector label and Project Files drawer title). Ensures EDT compliance
+     * and no-ops if not a git project or selector not initialized.
      */
     public void refreshBranchUi(String branchName) {
         Runnable task = () -> {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -678,6 +678,8 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                                     } catch (Exception ex) {
                                         logger.debug("Error updating branch label after branch creation", ex);
                                     }
+                                    // Update Project Files drawer title with the new branch name
+                                    GitUiUtil.updatePanelBorderWithBranch(chrome.getProjectFilesPanel(), "Project Files", sanitized);
                                     chrome.systemOutput("Created and checked out: " + sanitized);
                                 });
                             } catch (Exception ex) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
@@ -712,6 +712,15 @@ public class GitLogTab extends JPanel {
                 } else {
                     getRepo().checkout(branchName);
                 }
+
+                // After successful checkout, update branch selector and Project Files title on EDT
+                String currentActualBranch = getRepo().getCurrentBranch();
+                SwingUtilities.invokeLater(() -> {
+                    chrome.updateGitRepo();
+                    chrome.getInstructionsPanel().refreshBranchUi(currentActualBranch);
+                });
+
+                // Refresh the log tab view
                 update();
             } catch (GitAPIException e) {
                 logger.error("Error checking out branch: {}", branchName, e);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
@@ -790,7 +790,16 @@ public class GitLogTab extends JPanel {
                 }
 
                 // Refresh UI to reflect changes
-                SwingUtilities.invokeLater(this::update);
+                SwingUtilities.invokeLater(() -> {
+                    // Update commit/branch tables
+                    this.update();
+                    // Also refresh the branch selector + Project Files drawer title
+                    try {
+                        chrome.getInstructionsPanel().refreshBranchUi(repo.getCurrentBranch());
+                    } catch (GitAPIException ex) {
+                        logger.error("Error refreshing branch UI after merge: {}", ex.getMessage());
+                    }
+                });
             }
 
             return null;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
@@ -852,7 +852,10 @@ public class GitLogTab extends JPanel {
             contextManager.submitExclusiveAction(() -> {
                 try {
                     getRepo().createAndCheckoutBranch(newName, sourceBranch);
-                    update();
+                    SwingUtilities.invokeLater(() -> {
+                        chrome.updateGitRepo();
+                        chrome.getInstructionsPanel().refreshBranchUi(newName);
+                    });
                     chrome.systemOutput(
                             "Created and checked out new branch '" + newName + "' from '" + sourceBranch + "'");
                 } catch (GitAPIException e) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
@@ -724,7 +724,8 @@ public class GitLogTab extends JPanel {
                 // After successful checkout, update branch selector and Project Files title on EDT
                 var currentActualBranch = getRepo().getCurrentBranch();
                 if (createdTracking) {
-                    // If JGit reports a non-local name (e.g. remote-ref or detached), use the expected local tracking name
+                    // If JGit reports a non-local name (e.g. remote-ref or detached), use the expected local tracking
+                    // name
                     var localsAfter = getRepo().listLocalBranches();
                     if (!localsAfter.contains(currentActualBranch)) {
                         currentActualBranch = localTrackingName;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
@@ -873,6 +873,7 @@ public class GitLogTab extends JPanel {
                 try {
                     getRepo().createAndCheckoutBranch(newName, sourceBranch);
                     refreshAllGitUi(newName);
+                    update();
                     chrome.systemOutput(
                             "Created and checked out new branch '" + newName + "' from '" + sourceBranch + "'");
                 } catch (GitAPIException e) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitLogTab.java
@@ -731,9 +731,6 @@ public class GitLogTab extends JPanel {
                     }
                 }
                 refreshAllGitUi(currentActualBranch);
-
-                // Refresh the log tab view
-                update();
             } catch (GitAPIException e) {
                 logger.error("Error checking out branch: {}", branchName, e);
                 chrome.toolError(Objects.toString(e.getMessage(), "Unknown error during checkout."));
@@ -821,7 +818,6 @@ public class GitLogTab extends JPanel {
                 final String branchForUiRefreshFinal = branchForUiRefresh;
                 SwingUtilities.invokeLater(() -> {
                     // Update commit/branch tables
-                    this.update();
                     if (branchForUiRefreshFinal != null) {
                         refreshAllGitUi(branchForUiRefreshFinal);
                     }
@@ -888,7 +884,6 @@ public class GitLogTab extends JPanel {
                 try {
                     getRepo().createAndCheckoutBranch(newName, sourceBranch);
                     refreshAllGitUi(newName);
-                    update();
                     chrome.systemOutput(
                             "Created and checked out new branch '" + newName + "' from '" + sourceBranch + "'");
                 } catch (GitAPIException e) {


### PR DESCRIPTION
- Use abbreviated commit IDs for detached HEAD displays: GitRepo now tries to abbreviate the head object via an ObjectReader and falls back to the full SHA on IO errors.
- Wire up the branch selector as a persistent field and add robust UI refresh logic: InstructionsPanel now stores branchSplitButton, adds refreshBranchUi(...) and updateProjectFilesDrawerTitle(...) helpers that run on the EDT, update the branch label, update the Project Files drawer title (via GitUiUtil), and trigger Git log refresh/selection.
- Improve branch menu handling: separate local branch listing, iterate local branches for the dropdown, and safely show popups with a requireNonNull check.
- Better remote-branch checkout handling in GitLogTab: if the requested branch is not local, treat remote refs as tracking branches (derive local tracking name when "remote/branch"), create tracking branches, and ensure the UI refreshes with the correct local name.
- Replace ad-hoc update() calls with refreshAllGitUi(...) to consistently refresh repo state and related UI across checkout/merge/create flows.