### PR TITLE
feat: add copy button for each task (MOP); button under MOP copies all (task + history)

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -819,13 +819,23 @@ public class HistoryOutputPanel extends JPanel {
         copyButton.setMnemonic(KeyEvent.VK_T);
         copyButton.setToolTipText("Copy the output to clipboard");
         copyButton.addActionListener(e -> {
-            String text = llmStreamArea.getText();
-            if (!text.isBlank()) {
-                java.awt.Toolkit.getDefaultToolkit()
-                        .getSystemClipboard()
-                        .setContents(new java.awt.datatransfer.StringSelection(text), null);
-                chrome.systemOutput("Copied to clipboard");
+            var ctx = contextManager.selectedContext();
+            if (ctx == null) {
+                chrome.systemOutput("No active context to copy from.");
+                return;
             }
+
+            var historyOpt = ctx.getAllFragmentsInDisplayOrder().stream()
+                    .filter(f -> f.getType() == ContextFragment.FragmentType.HISTORY)
+                    .reduce((first, second) -> second); // use the most recent HISTORY fragment
+
+            if (historyOpt.isEmpty()) {
+                chrome.systemOutput("No conversation history found in the current workspace.");
+                return;
+            }
+
+            var historyFrag = historyOpt.get();
+            chrome.getContextPanel().performContextActionAsync(WorkspacePanel.ContextAction.COPY, List.of(historyFrag));
         });
         // Set minimum size
         copyButton.setMinimumSize(copyButton.getPreferredSize());

--- a/frontend-mop/src/components/ThreadBlock.svelte
+++ b/frontend-mop/src/components/ThreadBlock.svelte
@@ -8,6 +8,7 @@
     import { rendererPlugins } from '../lib/renderer-plugins';
     import { getBubbleDisplayDefaults } from '../lib/bubble-utils';
     import { deleteHistoryTaskByThreadId } from '../stores/historyStore';
+    import ThreadMeta from './ThreadMeta.svelte';
 
     export let threadId: number;
     export let bubbles: BubbleState[];
@@ -76,25 +77,15 @@
                 <span>...</span>
             {/if}
         </div>
-        <span class="thread-meta">
-            {#if showEdits}
-                <span class="adds">+{threadTotals.adds}</span>
-                <span class="dels">-{threadTotals.dels}</span>
-                <span class="sep">•</span>
-            {/if}
-            {msgLabel} • {totalLinesAll} lines
-        </span>
-        {#if taskSequence !== undefined}
-            <button
-                type="button"
-                class="delete-btn"
-                on:click|stopPropagation|preventDefault={handleDelete}
-                aria-label="Delete history task"
-                title="Delete history task"
-            >
-                <Icon icon="mdi:delete-outline" style="color: var(--diff-del);" />
-            </button>
-        {/if}
+        <ThreadMeta
+            adds={threadTotals.adds}
+            dels={threadTotals.dels}
+            showEdits={showEdits}
+            msgLabel={msgLabel}
+            totalLines={totalLinesAll}
+            {taskSequence}
+            onDelete={handleDelete}
+        />
     </header>
 
     <!-- Thread body (always rendered; visually collapsed via CSS when data-collapsed="true") -->
@@ -116,6 +107,19 @@
                 />
             </button>
             <div class="bubble-container">
+                {#if !collapsed}
+                    <div class="thread-meta-inline">
+                        <ThreadMeta
+                            adds={threadTotals.adds}
+                            dels={threadTotals.dels}
+                            showEdits={showEdits}
+                            msgLabel={msgLabel}
+                            totalLines={totalLinesAll}
+                            {taskSequence}
+                            onDelete={handleDelete}
+                        />
+                    </div>
+                {/if}
                 {#if !collapsed}
                     <div
                         class="first-line-hit-area"
@@ -194,43 +198,6 @@
         margin: 0;
         font-weight: normal;
     }
-    .thread-meta {
-        font-size: 0.9em;
-        color: var(--badge-foreground);
-        white-space: nowrap;
-    }
-    .thread-meta .adds {
-        color: var(--diff-add);
-        margin-right: 0.25em;
-    }
-    .thread-meta .dels {
-        color: var(--diff-del);
-        margin-right: 0.45em;
-    }
-    .thread-meta .sep {
-        color: var(--badge-foreground);
-        margin-right: 0.45em;
-    }
-
-    /* Delete button */
-    .delete-btn {
-        background: transparent;
-        border: none;
-        padding: 0.25em;
-        color: var(--chat-text);
-        cursor: pointer;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 0.35em;
-    }
-    .delete-btn:hover {
-        background: color-mix(in srgb, var(--chat-background) 70%, var(--message-background));
-    }
-    .delete-btn:focus-visible {
-        outline: 2px solid var(--focus-ring, #5b9dd9);
-        outline-offset: 2px;
-    }
 
     /* --- Expanded View --- */
     .first-bubble-wrapper {
@@ -303,5 +270,25 @@
         overflow: hidden;
         padding: 0;
         margin: 0;
+    }
+
+    /* Expanded inline metadata overlay aligned with the first line (tag row) */
+    .thread-meta-inline {
+        position: absolute;
+        top: -5px;
+        right: 40px;
+        z-index: 3; /* Above the first-line hit area (z-index:1) so delete is clickable */
+        height: var(--thread-first-line-hit-height, 2.25em);
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        padding-left: 0.5em;
+        padding-right: 0.2em;
+        pointer-events: none; /* Let clicks fall through except on the delete button */
+    }
+
+
+    .thread-meta-inline .delete-btn {
+        pointer-events: auto; /* Make delete button clickable */
     }
 </style>

--- a/frontend-mop/src/components/ThreadBlock.svelte
+++ b/frontend-mop/src/components/ThreadBlock.svelte
@@ -55,10 +55,10 @@
         deleteHistoryTaskByThreadId(threadId);
     }
 
-    async function handleCopy(event: CustomEvent<{ threadId: number | undefined }>) {
-        // Only act if the event is for this thread (when provided)
-        const detailThreadId = event?.detail?.threadId;
-        if (detailThreadId !== undefined && detailThreadId !== threadId) {
+    async function handleCopy(event: CustomEvent<{ threadId: number }>) {
+        // Only act if the event is for this thread
+        const detailThreadId = event.detail.threadId;
+        if (detailThreadId !== threadId) {
             return;
         }
 

--- a/frontend-mop/src/components/ThreadBlock.svelte
+++ b/frontend-mop/src/components/ThreadBlock.svelte
@@ -83,6 +83,7 @@
             showEdits={showEdits}
             msgLabel={msgLabel}
             totalLines={totalLinesAll}
+            threadId={threadId}
             {taskSequence}
             onDelete={handleDelete}
         />
@@ -115,6 +116,7 @@
                             showEdits={showEdits}
                             msgLabel={msgLabel}
                             totalLines={totalLinesAll}
+                            threadId={threadId}
                             {taskSequence}
                             onDelete={handleDelete}
                         />

--- a/frontend-mop/src/components/ThreadBlock.svelte
+++ b/frontend-mop/src/components/ThreadBlock.svelte
@@ -49,19 +49,11 @@
         threadStore.toggleThread(threadId);
     }
 
-    function handleDelete(e: MouseEvent) {
-        e.stopPropagation();
-        e.preventDefault();
-        deleteHistoryTaskByThreadId(threadId);
+    function handleDelete(threadIdParam: number) {
+        deleteHistoryTaskByThreadId(threadIdParam);
     }
 
-    async function handleCopy(event: CustomEvent<{ threadId: number }>) {
-        // Only act if the event is for this thread
-        const detailThreadId = event.detail.threadId;
-        if (detailThreadId !== threadId) {
-            return;
-        }
-
+    async function handleCopy(threadIdParam: number) {
         const xmlMessages = bubbles
             .map(b => {
                 const t = b.type.toLowerCase();
@@ -120,8 +112,8 @@
             totalLines={totalLinesAll}
             threadId={threadId}
             {taskSequence}
+            onCopy={handleCopy}
             onDelete={handleDelete}
-            on:copy-thread={handleCopy}
         />
     </header>
 
@@ -154,8 +146,8 @@
                             totalLines={totalLinesAll}
                             threadId={threadId}
                             {taskSequence}
+                            onCopy={handleCopy}
                             onDelete={handleDelete}
-                            on:copy-thread={handleCopy}
                         />
                     </div>
                 {/if}

--- a/frontend-mop/src/components/ThreadBlock.svelte
+++ b/frontend-mop/src/components/ThreadBlock.svelte
@@ -53,19 +53,18 @@
         deleteHistoryTaskByThreadId(threadIdParam);
     }
 
-    async function handleCopy(threadIdParam: number) {
-        const xmlMessages = bubbles
+    async function handleCopy() {
+        const xml = bubbles
             .map(b => {
                 const t = b.type.toLowerCase();
-                return `  <message type="${t}">${b.markdown}</message>`;
+                return `<message type="${t}">\n${b.markdown}\n</message>`;
             })
-            .join('\n');
+            .join('\n\n');
 
-        const xml = `<thread>\n${xmlMessages}\n</thread>`;
 
         try {
             await navigator.clipboard.writeText(xml);
-        } catch (err) {
+        } catch (serr) {
             try {
                 const ta = document.createElement('textarea');
                 ta.value = xml;
@@ -138,17 +137,19 @@
             <div class="bubble-container">
                 {#if !collapsed}
                     <div class="thread-meta-inline">
-                        <ThreadMeta
-                            adds={threadTotals.adds}
-                            dels={threadTotals.dels}
-                            showEdits={showEdits}
-                            msgLabel={msgLabel}
-                            totalLines={totalLinesAll}
-                            threadId={threadId}
-                            {taskSequence}
-                            onCopy={handleCopy}
-                            onDelete={handleDelete}
-                        />
+                        <div class="meta-actions">
+                            <ThreadMeta
+                                adds={threadTotals.adds}
+                                dels={threadTotals.dels}
+                                showEdits={showEdits}
+                                msgLabel={msgLabel}
+                                totalLines={totalLinesAll}
+                                threadId={threadId}
+                                {taskSequence}
+                                onCopy={handleCopy}
+                                onDelete={handleDelete}
+                            />
+                        </div>
                     </div>
                 {/if}
                 {#if !collapsed}
@@ -306,7 +307,7 @@
     /* Expanded inline metadata overlay aligned with the first line (tag row) */
     .thread-meta-inline {
         position: absolute;
-        top: -5px;
+        top: -10px;
         right: 40px;
         z-index: 3; /* Above the first-line hit area (z-index:1) so delete is clickable */
         height: var(--thread-first-line-hit-height, 2.25em);
@@ -319,7 +320,10 @@
     }
 
 
-    .thread-meta-inline .delete-btn {
-        pointer-events: auto; /* Make delete button clickable */
+    .thread-meta-inline .meta-actions {
+        pointer-events: auto;
+        display: inline-flex;
+        align-items: center;
+        height: 100%;
     }
 </style>

--- a/frontend-mop/src/components/ThreadMeta.svelte
+++ b/frontend-mop/src/components/ThreadMeta.svelte
@@ -11,11 +11,11 @@
 
     // Thread identifier to include in copy-thread event detail.
     // Detail contains only { threadId }; parent component assembles the text to copy.
-    export let threadId: number | undefined;
+    export let threadId: number;
 
     export let onDelete: ((e: MouseEvent) => void) | undefined;
 
-    const dispatch = createEventDispatcher<{ 'copy-thread': { threadId: number | undefined } }>();
+    const dispatch = createEventDispatcher<{ 'copy-thread': { threadId: number } }>();
 
     let copied = false;
     let copyResetTimer: ReturnType<typeof setTimeout> | null = null;

--- a/frontend-mop/src/components/ThreadMeta.svelte
+++ b/frontend-mop/src/components/ThreadMeta.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import Icon from '@iconify/svelte';
-    import { createEventDispatcher, onDestroy } from 'svelte';
+    import { onDestroy } from 'svelte';
 
     export let adds: number;
     export let dels: number;
@@ -8,14 +8,11 @@
     export let msgLabel: string;
     export let totalLines: number;
     export let taskSequence: number | undefined;
-
-    // Thread identifier to include in copy-thread event detail.
-    // Detail contains only { threadId }; parent component assembles the text to copy.
     export let threadId: number;
 
-    export let onDelete: ((e: MouseEvent) => void) | undefined;
+    export let onCopy: ((threadId: number) => void) | undefined;
+    export let onDelete: ((threadId: number) => void) | undefined;
 
-    const dispatch = createEventDispatcher<{ 'copy-thread': { threadId: number } }>();
 
     let copied = false;
     let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
@@ -27,20 +24,22 @@
         }
     });
 
-    function handleDelete(e: MouseEvent) {
+    function handleDelete() {
         if (onDelete) {
-            onDelete(e);
+            onDelete(threadId);
         }
     }
 
-    function handleCopy(e: MouseEvent) {
-        // Provide lightweight visual feedback and dispatch event upward.
+    function handleCopy() {
+        // Provide lightweight visual feedback and call onCopy prop.
         if (copyResetTimer) {
             clearTimeout(copyResetTimer);
             copyResetTimer = null;
         }
         copied = true;
-        dispatch('copy-thread', { threadId });
+        if (onCopy) {
+            onCopy(threadId);
+        }
         copyResetTimer = setTimeout(() => {
             copied = false;
             copyResetTimer = null;
@@ -128,16 +127,5 @@
     .spacer {
         display: inline-block;
         width: 20px;
-    }
-
-    /* Subtle feedback animation when copy is triggered */
-    .delete-btn.copied {
-        animation: copy-pulse 180ms ease-in-out;
-    }
-
-    @keyframes copy-pulse {
-        0% { transform: scale(1); opacity: 1; }
-        50% { transform: scale(0.93); opacity: 0.9; }
-        100% { transform: scale(1); opacity: 1; }
     }
 </style>

--- a/frontend-mop/src/components/ThreadMeta.svelte
+++ b/frontend-mop/src/components/ThreadMeta.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+    import Icon from '@iconify/svelte';
+
+    export let adds: number;
+    export let dels: number;
+    export let showEdits: boolean;
+    export let msgLabel: string;
+    export let totalLines: number;
+    export let taskSequence: number | undefined;
+    export let onDelete: ((e: MouseEvent) => void) | undefined;
+
+    function handleDelete(e: MouseEvent) {
+        if (onDelete) {
+            onDelete(e);
+        }
+    }
+</script>
+
+<span class="thread-meta">
+  {#if showEdits}
+    <span class="adds">+{adds}</span>
+    <span class="dels">-{dels}</span>
+    <span class="sep">•</span>
+  {/if}
+    {msgLabel} • {totalLines} lines
+    {#if taskSequence !== undefined}
+    <button
+            type="button"
+            class="delete-btn"
+            on:click|stopPropagation|preventDefault={handleDelete}
+            aria-label="Delete history task"
+            title="Delete history task"
+    >
+      <Icon icon="mdi:delete-outline" style="color: var(--diff-del);"/>
+    </button>
+  {:else}
+    <span class="spacer"/>
+  {/if}
+</span>
+
+<style>
+    .thread-meta {
+        font-size: 0.9em;
+        color: var(--badge-foreground);
+        white-space: nowrap;
+    }
+
+    .thread-meta .adds {
+        color: var(--diff-add);
+        margin-right: 0.25em;
+    }
+
+    .thread-meta .dels {
+        color: var(--diff-del);
+        margin-right: 0.45em;
+    }
+
+    .thread-meta .sep {
+        color: var(--badge-foreground);
+        margin-right: 0.45em;
+    }
+
+    .delete-btn {
+        background: transparent;
+        border: none;
+        padding: 0.25em;
+        color: var(--chat-text);
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 0.35em;
+    }
+
+    .delete-btn:hover {
+        background: color-mix(in srgb, var(--chat-background) 70%, var(--message-background));
+    }
+
+    .delete-btn:focus-visible {
+        outline: 2px solid var(--focus-ring, #5b9dd9);
+        outline-offset: 2px;
+    }
+
+    .spacer {
+        display: inline-block;
+        width: 20px;
+    }
+</style>

--- a/frontend-mop/src/components/ThreadMeta.svelte
+++ b/frontend-mop/src/components/ThreadMeta.svelte
@@ -54,7 +54,6 @@
     <span class="sep">•</span>
   {/if}
     {msgLabel} • {totalLines} lines
-    {#if taskSequence !== undefined}
     <button
             type="button"
             class="delete-btn"
@@ -66,6 +65,7 @@
     >
       <Icon icon={copied ? 'mdi:check' : 'mdi:content-copy'} style={copied ? 'color: var(--diff-add);' : ''}/>
     </button>
+    {#if taskSequence !== undefined}
     <button
             type="button"
             class="delete-btn"

--- a/frontend-mop/src/components/ThreadMeta.svelte
+++ b/frontend-mop/src/components/ThreadMeta.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import Icon from '@iconify/svelte';
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher, onDestroy } from 'svelte';
 
     export let adds: number;
     export let dels: number;
@@ -19,6 +19,13 @@
 
     let copied = false;
     let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+    onDestroy(() => {
+        if (copyResetTimer) {
+            clearTimeout(copyResetTimer);
+            copyResetTimer = null;
+        }
+    });
 
     function handleDelete(e: MouseEvent) {
         if (onDelete) {
@@ -52,7 +59,9 @@
     <button
             type="button"
             class="delete-btn"
+            class:copied={copied}
             on:click|stopPropagation|preventDefault={handleCopy}
+            on:keydown|stopPropagation={() => {}}
             aria-label="Copy thread"
             title="Copy thread"
     >
@@ -62,6 +71,7 @@
             type="button"
             class="delete-btn"
             on:click|stopPropagation|preventDefault={handleDelete}
+            on:keydown|stopPropagation={() => {}}
             aria-label="Delete history task"
             title="Delete history task"
     >
@@ -118,5 +128,16 @@
     .spacer {
         display: inline-block;
         width: 20px;
+    }
+
+    /* Subtle feedback animation when copy is triggered */
+    .delete-btn.copied {
+        animation: copy-pulse 180ms ease-in-out;
+    }
+
+    @keyframes copy-pulse {
+        0% { transform: scale(1); opacity: 1; }
+        50% { transform: scale(0.93); opacity: 0.9; }
+        100% { transform: scale(1); opacity: 1; }
     }
 </style>

--- a/frontend-mop/src/stores/historyStore.ts
+++ b/frontend-mop/src/stores/historyStore.ts
@@ -50,15 +50,16 @@ export function onHistoryEvent(evt: BrokkEvent): void {
                     });
                 } else {
                     (evt.messages ?? []).forEach(msg => {
+                        const isReasoning = !!msg.reasoning;
                         entries.push({
                             seq: nextHistoryBubbleSeq++,
                             threadId: threadId,
                             type: msg.msgType,
                             markdown: msg.text,
                             streaming: false,
-                            reasoning: msg.reasoning,
-                            reasoningComplete: msg.reasoning,
-                            isCollapsed: msg.reasoning,
+                            reasoning: isReasoning,
+                            reasoningComplete: isReasoning,
+                            isCollapsed: isReasoning,
                         });
                     });
                 }

--- a/frontend-mop/src/styles/global.scss
+++ b/frontend-mop/src/styles/global.scss
@@ -77,3 +77,5 @@ body {
 *::-webkit-scrollbar-corner {
   background: var(--scrollbar-track);
 }
+
+

--- a/frontend-mop/src/types.ts
+++ b/frontend-mop/src/types.ts
@@ -24,7 +24,7 @@ export type BrokkEvent =
       taskSequence: number;
       compressed: boolean;
       summary?: string;
-      messages?: { text: string; msgType: 'USER' | 'AI' | 'SYSTEM', reasoning: boolean }[];
+      messages?: { text: string; msgType: 'USER' | 'AI' | 'SYSTEM'; reasoning?: boolean }[];
     };
 
 export type Bubble = {


### PR DESCRIPTION
fixes #1192

<img width="2615" height="607" alt="image" src="https://github.com/user-attachments/assets/7fd44d29-0710-4eee-90b6-1891d9b27a86" />


<img width="2615" height="607" alt="image" src="https://github.com/user-attachments/assets/3e40f3da-0343-4fe1-8bc2-683b8b96b435" />


- Intent: improve copy/delete UX for conversation threads and align the desktop "copy" button with workspace context handling; refactor thread metadata into a reusable component and harden reasoning flags handling.

- Behaviour changes:
  - Desktop copy button now copies the most recent HISTORY fragment from the selected workspace via performContextActionAsync(COPY) and reports when no context/history exists.
  - Thread UI gains a reusable ThreadMeta component used both in the header and inline overlay; it exposes copy and delete buttons, with a brief "copied" visual feedback.
  - Frontend copy produces an XML representation of the thread and writes to the clipboard with a navigator.clipboard path and a textarea fallback.
  - Message reasoning flags are normalized to boolean in the history store; types updated to make reasoning optional.

- Key implementation notes:
  - New ThreadMeta.svelte encapsulates meta display, copy/delete handlers, and a short timer to show a check icon.
  - ThreadBlock.svelte now imports and uses ThreadMeta in two places and delegates copy/delete actions; CSS updated to position the inline overlay and allow pointer-events only on action elements.
  - HistoryOutputPanel Java change obtains the selected context, finds the most recent HISTORY fragment, and triggers the workspace COPY action instead of directly reading the LLm stream text.
  - historyStore coerces msg.reasoning to a boolean and types.ts marks reasoning optional.