### PR TITLE
fix: Make max memory configurable at runtime in jDeploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,3 +80,4 @@ jobs:
         uses: shannah/jdeploy@master
         with:
           github_token: ${{ github.token }}
+          jdeploy_version: "5.2.1"

--- a/app/src/main/java/io/github/jbellis/brokk/gui/util/JDeploySettingsUtil.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/util/JDeploySettingsUtil.java
@@ -1,132 +1,126 @@
 package io.github.jbellis.brokk.gui.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.jbellis.brokk.MainProject;
+import io.github.jbellis.brokk.util.Json;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-/** Utility to update the per-user JDeploy argument file (e.g. ~/.brokk/jdeploy.args) with JVM memory settings. */
+/**
+ * Utility to update the per-user JDeploy JSON config file (e.g. ~/.config/brokk/jdeploy.json) with JVM memory settings.
+ */
 public class JDeploySettingsUtil {
     private static final Logger logger = LogManager.getLogger(JDeploySettingsUtil.class);
 
-    // Argfile we maintain in the user's home directory
-    private static final String ARGFILE_NAME = "jdeploy.args";
+    // JSON config file we maintain in the user's config directory
+    private static final String CONFIG_FILE_NAME = "jdeploy.json";
 
     private JDeploySettingsUtil() {
         // utility
     }
 
     /**
-     * Update the per-user argfile with the provided JVM memory settings.
+     * Update the per-user JSON config file with the provided JVM memory settings.
      *
-     * <p>Behavior: - Ensures the user's ~/.brokk directory exists. - Reads existing ~/.brokk/jdeploy.args if present,
-     * preserving all non -Xmx lines. - Removes any existing -Xmx* lines. - If settings.automatic() is false and
-     * manualMb() > 0, appends a single -XmxNNNm line.
+     * <p>Behavior: - Ensures the user's ~/.config/brokk directory exists. - Reads existing ~/.config/brokk/jdeploy.json
+     * if present, preserving all non -Xmx args. - Removes any existing -Xmx* args. - If settings.automatic() is false
+     * and manualMb() > 0, appends a single -XmxNNNm arg.
      */
     public static void updateJvmMemorySettings(MainProject.JvmMemorySettings settings) {
-        Objects.requireNonNull(settings, "settings");
-
         var home = System.getProperty("user.home");
         if (home == null || home.isBlank()) {
-            logger.warn("Cannot determine user.home; skipping JDeploy user-argfile update");
+            logger.warn("Cannot determine user.home; skipping JDeploy config update");
             return;
         }
 
         try {
-            updateUserJdeployArgs(settings);
+            updateUserJdeployConfig(settings);
         } catch (Exception e) {
-            logger.warn("Failed to update user jdeploy argfile", e);
+            logger.warn("Failed to update user jdeploy config file", e);
         }
     }
 
     /**
-     * Update the per-user jdeploy args file at ~/.brokk/jdeploy.args so a centralized per-user argfile may be used.
-     * This preserves all non -Xmx lines, removes any existing -Xmx lines, and appends a single -XmxNNNm when manual
-     * memory is selected with a positive size. If the file or directory do not exist they will be created.
+     * Update the per-user jdeploy config file at ~/.config/brokk/jdeploy.json. This preserves all non -Xmx args,
+     * removes any existing -Xmx args, and appends a single -XmxNNNm when manual memory is selected with a positive
+     * size. If the file or directory do not exist they will be created.
      */
-    private static void updateUserJdeployArgs(MainProject.JvmMemorySettings settings) {
+    private static void updateUserJdeployConfig(MainProject.JvmMemorySettings settings) {
         var home = System.getProperty("user.home");
         if (home == null || home.isBlank()) {
-            logger.warn("Cannot determine user.home; skipping user jdeploy args update");
+            logger.warn("Cannot determine user.home; skipping user jdeploy config update");
             return;
         }
 
-        var jdeployDir = Path.of(home, ".jdeploy", "gh-packages");
+        var configDir = Path.of(home, ".config", "brokk");
         try {
-            Files.createDirectories(jdeployDir);
+            Files.createDirectories(configDir);
         } catch (IOException e) {
-            logger.warn("Failed to create user .jdeploy directory {}: {}", jdeployDir, e.getMessage());
+            logger.warn("Failed to create user config directory {}: {}", configDir, e.getMessage());
             return;
         }
 
-        Optional<Path> maybeAppDir;
-        try (var childStream = Files.list(jdeployDir)) {
-            maybeAppDir = childStream
-                    .filter(Files::isDirectory)
-                    .filter(dir -> dir.getFileName().toString().endsWith(".brokk"))
-                    .findFirst();
-            if (maybeAppDir.isEmpty())
-                throw new RuntimeException(
-                        "Unable to find Brokk JDeploy directory! Brokk must not be running via JDeploy.");
-        } catch (Exception e) {
-            logger.error(
-                    "Exception encountered while determining application directory! Memory settings will not be persisted.");
-            return;
-        }
-        final Path appDir = maybeAppDir.get();
+        var configFile = configDir.resolve(CONFIG_FILE_NAME);
+        ObjectNode config;
 
-        var userArgfile = appDir.resolve(ARGFILE_NAME);
-        List<String> existingLines = new ArrayList<>();
-        if (Files.exists(userArgfile)) {
+        // Read existing config or create new one
+        if (Files.exists(configFile)) {
             try {
-                existingLines = Files.readAllLines(userArgfile, StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                logger.warn("Failed to read existing user argfile {}: {}", userArgfile, e.getMessage());
-                // fallthrough to create/overwrite below
+                String content = Files.readString(configFile, StandardCharsets.UTF_8);
+                JsonNode root = Json.getMapper().readTree(content);
+                config = root.isObject() ? (ObjectNode) root : Json.getMapper().createObjectNode();
+            } catch (Exception e) {
+                logger.warn("Failed to read existing config file {}: {}", configFile, e.getMessage());
+                config = Json.getMapper().createObjectNode();
             }
         } else {
-            // Provide a minimal header so file is never empty unless we decide to write no content.
-            existingLines.add("# Brokk JVM argument file (managed by Brokk)");
-            existingLines.add("");
+            config = Json.getMapper().createObjectNode();
         }
 
-        // Filter out existing -Xmx lines (trimmed)
-        var preserved = new ArrayList<String>();
-        for (var line : existingLines) {
-            var t = line.trim();
-            if (!t.startsWith("-Xmx")) {
-                preserved.add(line);
+        // Get existing args array or create new one
+        ArrayNode args;
+        if (config.has("args") && config.get("args").isArray()) {
+            args = (ArrayNode) config.get("args");
+        } else {
+            args = Json.getMapper().createArrayNode();
+        }
+
+        // Filter out existing -Xmx args
+        ArrayNode filteredArgs = Json.getMapper().createArrayNode();
+        for (JsonNode arg : args) {
+            String argStr = arg.asText();
+            if (!argStr.trim().startsWith("-Xmx")) {
+                filteredArgs.add(argStr);
             }
         }
 
-        var sb = new StringBuilder();
-        for (var line : preserved) {
-            sb.append(line).append('\n');
-        }
-
+        // Add new -Xmx arg if manual memory is set
         if (!settings.automatic()) {
             int mb = settings.manualMb();
             if (mb > 0) {
-                sb.append("-Xmx").append(mb).append("m").append('\n');
-                logger.info("Updated user argfile {}: wrote -Xmx{}m", userArgfile, mb);
+                filteredArgs.add("-Xmx" + mb + "m");
+                logger.info("Updated user config {}: wrote -Xmx{}m", configFile, mb);
             } else {
-                logger.info("Manual memory was non-positive ({} MB); not adding -Xmx to {}", mb, userArgfile);
+                logger.info("Manual memory was non-positive ({} MB); not adding -Xmx to {}", mb, configFile);
             }
         } else {
-            logger.info("Automatic memory selected; ensuring no -Xmx in {}", userArgfile);
+            logger.info("Automatic memory selected; ensuring no -Xmx in {}", configFile);
         }
 
+        // Update config and write to file
+        config.set("args", filteredArgs);
+
         try {
-            Files.writeString(userArgfile, sb.toString(), StandardCharsets.UTF_8);
+            String json = Json.toJson(config);
+            Files.writeString(configFile, json, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            logger.warn("Failed to write user argfile {}: {}", userArgfile, e.getMessage());
+            logger.warn("Failed to write user config file {}: {}", configFile, e.getMessage());
         }
     }
 }

--- a/app/src/test/java/io/github/jbellis/brokk/gui/util/JDeploySettingsUtilTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/gui/util/JDeploySettingsUtilTest.java
@@ -1,0 +1,242 @@
+package io.github.jbellis.brokk.gui.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.jbellis.brokk.MainProject;
+import io.github.jbellis.brokk.util.Json;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JDeploySettingsUtilTest {
+
+    @TempDir
+    Path tempHome;
+
+    /** Helper to invoke updateJvmMemorySettings with a custom user.home */
+    private void updateWithCustomHome(MainProject.JvmMemorySettings settings, Path customHome) {
+        String originalHome = System.getProperty("user.home");
+        try {
+            System.setProperty("user.home", customHome.toString());
+            JDeploySettingsUtil.updateJvmMemorySettings(settings);
+        } finally {
+            if (originalHome != null) {
+                System.setProperty("user.home", originalHome);
+            }
+        }
+    }
+
+    /** Helper to read and parse the jdeploy.json file */
+    private JsonNode readConfig(Path home) throws Exception {
+        Path configFile = home.resolve(".config/brokk/jdeploy.json");
+        assertTrue(Files.exists(configFile), "Config file should exist");
+        String content = Files.readString(configFile);
+        return Json.getMapper().readTree(content);
+    }
+
+    @Test
+    void createsConfigFileWhenItDoesNotExist() throws Exception {
+        var settings = new MainProject.JvmMemorySettings(false, 2048);
+        updateWithCustomHome(settings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        assertTrue(config.has("args"), "Config should have args array");
+        JsonNode args = config.get("args");
+        assertTrue(args.isArray(), "args should be an array");
+        assertEquals(1, args.size(), "args should have one element");
+        assertEquals("-Xmx2048m", args.get(0).asText());
+    }
+
+    @Test
+    void automaticModeRemovesXmxArgs() throws Exception {
+        // First create a config with manual memory
+        var manualSettings = new MainProject.JvmMemorySettings(false, 2048);
+        updateWithCustomHome(manualSettings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        assertEquals(1, config.get("args").size(), "Should have one arg after manual update");
+
+        // Now switch to automatic mode
+        var autoSettings = new MainProject.JvmMemorySettings(true, 0);
+        updateWithCustomHome(autoSettings, tempHome);
+
+        config = readConfig(tempHome);
+        JsonNode args = config.get("args");
+        assertEquals(0, args.size(), "Automatic mode should remove -Xmx args");
+    }
+
+    @Test
+    void preservesNonXmxArgs() throws Exception {
+        // Manually create a config file with various args
+        Path configDir = tempHome.resolve(".config/brokk");
+        Files.createDirectories(configDir);
+        Path configFile = configDir.resolve("jdeploy.json");
+
+        String initialConfig =
+                """
+                {
+                  "args": [
+                    "-Dfoo=bar",
+                    "-Xmx1024m",
+                    "-XX:+UseG1GC",
+                    "-Xmx512m"
+                  ]
+                }
+                """;
+        Files.writeString(configFile, initialConfig);
+
+        // Update with new memory settings
+        var settings = new MainProject.JvmMemorySettings(false, 4096);
+        updateWithCustomHome(settings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        JsonNode args = config.get("args");
+        assertEquals(3, args.size(), "Should preserve non-Xmx args plus new Xmx");
+
+        // Check that non-Xmx args are preserved
+        assertEquals("-Dfoo=bar", args.get(0).asText());
+        assertEquals("-XX:+UseG1GC", args.get(1).asText());
+        assertEquals("-Xmx4096m", args.get(2).asText());
+    }
+
+    @Test
+    void replacesExistingXmxArg() throws Exception {
+        // Create initial config with one Xmx setting
+        var settings1 = new MainProject.JvmMemorySettings(false, 1024);
+        updateWithCustomHome(settings1, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        assertEquals("-Xmx1024m", config.get("args").get(0).asText());
+
+        // Update with different memory setting
+        var settings2 = new MainProject.JvmMemorySettings(false, 8192);
+        updateWithCustomHome(settings2, tempHome);
+
+        config = readConfig(tempHome);
+        JsonNode args = config.get("args");
+        assertEquals(1, args.size(), "Should have exactly one arg");
+        assertEquals("-Xmx8192m", args.get(0).asText());
+    }
+
+    @Test
+    void manualModeWithZeroMbDoesNotAddXmx() throws Exception {
+        var settings = new MainProject.JvmMemorySettings(false, 0);
+        updateWithCustomHome(settings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        JsonNode args = config.get("args");
+        assertEquals(0, args.size(), "Zero MB should not add -Xmx arg");
+    }
+
+    @Test
+    void manualModeWithNegativeMbDoesNotAddXmx() throws Exception {
+        var settings = new MainProject.JvmMemorySettings(false, -100);
+        updateWithCustomHome(settings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        JsonNode args = config.get("args");
+        assertEquals(0, args.size(), "Negative MB should not add -Xmx arg");
+    }
+
+    @Test
+    void handlesCorruptedJsonGracefully() throws Exception {
+        // Create a corrupted JSON file
+        Path configDir = tempHome.resolve(".config/brokk");
+        Files.createDirectories(configDir);
+        Path configFile = configDir.resolve("jdeploy.json");
+        Files.writeString(configFile, "{corrupted json");
+
+        // Should still work - creates new config
+        var settings = new MainProject.JvmMemorySettings(false, 2048);
+        updateWithCustomHome(settings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        assertEquals(1, config.get("args").size());
+        assertEquals("-Xmx2048m", config.get("args").get(0).asText());
+    }
+
+    @Test
+    void handlesNonArrayArgsField() throws Exception {
+        // Create config with args as non-array
+        Path configDir = tempHome.resolve(".config/brokk");
+        Files.createDirectories(configDir);
+        Path configFile = configDir.resolve("jdeploy.json");
+        Files.writeString(configFile, "{\"args\": \"not-an-array\"}");
+
+        var settings = new MainProject.JvmMemorySettings(false, 3072);
+        updateWithCustomHome(settings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        assertTrue(config.get("args").isArray(), "args should be converted to array");
+        assertEquals(1, config.get("args").size());
+        assertEquals("-Xmx3072m", config.get("args").get(0).asText());
+    }
+
+    @Test
+    void preservesOtherConfigFields() throws Exception {
+        // Create config with additional fields
+        Path configDir = tempHome.resolve(".config/brokk");
+        Files.createDirectories(configDir);
+        Path configFile = configDir.resolve("jdeploy.json");
+
+        String initialConfig =
+                """
+                {
+                  "version": "1.0",
+                  "args": ["-Xmx1024m"],
+                  "otherField": "value"
+                }
+                """;
+        Files.writeString(configFile, initialConfig);
+
+        var settings = new MainProject.JvmMemorySettings(false, 2048);
+        updateWithCustomHome(settings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        assertEquals("1.0", config.get("version").asText(), "Should preserve version field");
+        assertEquals("value", config.get("otherField").asText(), "Should preserve otherField");
+        assertEquals("-Xmx2048m", config.get("args").get(0).asText());
+    }
+
+    @Test
+    void multipleXmxArgsAreAllRemoved() throws Exception {
+        // Create config with multiple Xmx args
+        Path configDir = tempHome.resolve(".config/brokk");
+        Files.createDirectories(configDir);
+        Path configFile = configDir.resolve("jdeploy.json");
+
+        String initialConfig =
+                """
+                {
+                  "args": [
+                    "-Xmx512m",
+                    "-Dfoo=bar",
+                    "-Xmx1024m",
+                    "-XX:+UseG1GC",
+                    "-Xmx2048m"
+                  ]
+                }
+                """;
+        Files.writeString(configFile, initialConfig);
+
+        var settings = new MainProject.JvmMemorySettings(false, 4096);
+        updateWithCustomHome(settings, tempHome);
+
+        JsonNode config = readConfig(tempHome);
+        JsonNode args = config.get("args");
+        assertEquals(3, args.size(), "Should have 2 non-Xmx args + 1 new Xmx");
+
+        // Verify all old Xmx args are gone and only new one remains
+        long xmxCount = 0;
+        for (JsonNode arg : args) {
+            String argStr = arg.asText();
+            if (argStr.startsWith("-Xmx")) {
+                xmxCount++;
+                assertEquals("-Xmx4096m", argStr);
+            }
+        }
+        assertEquals(1, xmxCount, "Should have exactly one -Xmx arg");
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,11 +9,8 @@
     "version": "1.0.0",
     "jdeploy": {
         "jdk": false,
-        "args": ["@jdeploy.args"],
-        "files" : [{
-            "dir": ".",
-            "includes": "jdeploy.args"
-        }],
+        "args": ["--add-modules jdk.incubator.vector"],
+        "configFile": "{{ user.home }}/.config/brokk/jdeploy.json",
         "publishTargets": [{
             "name": "github: brokk",
             "type": "GITHUB",


### PR DESCRIPTION
- Update jDeploy to 5.2.1 in release workflow
- Specify runtime config file to be used by jDeploy launcher at `~/.config/brokk/jdeploy.json`
- Changed JDeploySettingsUtil to update the new runtime config file.
- Added unit test for JDeploySettingsUtil

This resolves a few issues:
- https://github.com/BrokkAi/brokk/issues/944
- https://github.com/BrokkAi/brokk/issues/1092
- https://github.com/BrokkAi/brokk/issues/1216