### PR TITLE
Improved SearchAgent tools

### DIFF
--- a/.brokk/style.md
+++ b/.brokk/style.md
@@ -16,13 +16,6 @@ or return value is not annotated @Nullable.
 1. **Favor Immutable Data Structures**: Prefer `List.of` and `Map.of`, as well as the Stream Collectors.
 1. **Provide Comprehensive Logging**: Log relevant information using log4j, including request/response details, errors, and other important events.
 1. **Use `var`**: Prefer `var` for local variable declarations. Exception: numeric types, such as `int`, `float`, etc.
-1. **Multiline parameters**: When calling a method with more parameters than reasonably fit on one line, DO NOT leave dangling open or close parens on separate lines; instead, align as follows:
-```
-   var combined = Streams.concat(currentContext().readonlyFiles(),
-                                 currentContext().virtualFragments(),
-                                 Stream.of(currentContext().getAutoContext()));
-```
-  When declaring a method with multiline parameters, align similarly and also put the opening brace on a new line.
 1. **Use asserts to validate assumptions**: Use `assert` to validate assumptions, and prefer making reasonable assumptions backed by assert to defensive `if` checks.
 1. **DRY**: Don't Repeat Yourself. Refactor similar code into a common method. But feature flag parameters are a design smell; if you would need to add flags, write separate methods instead.
 1. **Parsimony**: If you can write a general case that also generates correct results in the special case (empty input, maximum size, etc), then do so. Don't write special cases unless they are necessary.

--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -1372,6 +1372,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @param contextGenerator A function that takes the current live context and returns an updated context.
      * @return The new `liveContext`, or the existing `liveContext` if no changes were made by the generator.
      */
+    @Override
     public Context pushContext(Function<Context, Context> contextGenerator) {
         var oldLiveContext = liveContext();
         var newLiveContext = contextHistory.push(contextGenerator);

--- a/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -957,42 +957,55 @@ public class ContextManager implements IContextManager, AutoCloseable {
      */
     @Override
     public void updateBuildFragment(boolean success, String buildOutput) {
-        // Remove any existing BUILD_LOG fragments
-        var idsToDrop = liveContext()
-                .virtualFragments()
-                .filter(f -> f.getType() == ContextFragment.FragmentType.BUILD_LOG)
-                .map(ContextFragment::id)
-                .toList();
-        if (!idsToDrop.isEmpty()) {
-            pushContext(currentLiveCtx -> currentLiveCtx.removeFragmentsByIds(idsToDrop));
-        }
+        var desc = ContextFragment.BUILD_RESULTS.description();
+        pushContext(currentLiveCtx -> {
+            // Collect build-related fragments to drop:
+            //  - Legacy: BuildFragment (BUILD_LOG)
+            //  - New: StringFragment with description "Latest Build Results"
+            var idsToDrop = currentLiveCtx
+                    .virtualFragments()
+                    .filter(f -> f.getType() == ContextFragment.FragmentType.BUILD_LOG
+                            || (f.getType() == ContextFragment.FragmentType.STRING
+                                    && f instanceof ContextFragment.StringFragment sf
+                                    && desc.equals(sf.description())))
+                    .map(ContextFragment::id)
+                    .toList();
 
-        // Only add a new BuildFragment if the build failed
-        if (success) {
-            return;
-        }
+            var modified = idsToDrop.isEmpty() ? currentLiveCtx : currentLiveCtx.removeFragmentsByIds(idsToDrop);
 
-        var bf = new ContextFragment.BuildFragment(this, buildOutput);
-        addVirtualFragment(bf);
+            if (success) {
+                logger.debug(
+                        "Cleared {} previous build fragment(s); build succeeded so not adding new results.",
+                        idsToDrop.size());
+                return modified;
+            }
+
+            var sf = new ContextFragment.StringFragment(
+                    this, buildOutput, desc, ContextFragment.BUILD_RESULTS.syntaxStyle());
+
+            logger.debug(
+                    "Cleared {} previous build fragment(s); added new build results StringFragment {}",
+                    idsToDrop.size(),
+                    sf.id());
+            return modified.addVirtualFragment(sf);
+        });
     }
 
     @Override
     public String getProcessedBuildOutput() {
-        return liveContext()
+        // Prefer new StringFragment with the BUILD_RESULTS description
+        var latestString = liveContext()
                 .virtualFragments()
-                .filter(f -> f.getType() == ContextFragment.FragmentType.BUILD_LOG)
-                .findFirst()
-                .map(f -> {
-                    var bf = (ContextFragment.BuildFragment) f;
-                    // Extract content without the "# CURRENT BUILD STATUS\n\n" header
-                    String fullText = bf.text();
-                    String header = "# CURRENT BUILD STATUS\n\n";
-                    if (fullText.startsWith(header)) {
-                        return fullText.substring(header.length());
-                    }
-                    return fullText;
-                })
-                .orElse("");
+                .filter(f -> f.getType() == ContextFragment.FragmentType.STRING)
+                .filter(f -> f instanceof ContextFragment.StringFragment)
+                .map(f -> (ContextFragment.StringFragment) f)
+                .filter(sf -> sf.description().equals(ContextFragment.BUILD_RESULTS.description()))
+                .findFirst();
+
+        if (latestString.isPresent()) {
+            return latestString.get().text();
+        }
+        return "";
     }
 
     /**

--- a/app/src/main/java/io/github/jbellis/brokk/IContextManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/IContextManager.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -142,6 +143,10 @@ public interface IContextManager {
     }
 
     default Set<ProjectFile> getFilesInContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    default Context pushContext(Function<Context, Context> contextGenerator) {
         throw new UnsupportedOperationException();
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/io/github/jbellis/brokk/agents/SearchAgent.java
@@ -28,21 +28,15 @@ import io.github.jbellis.brokk.prompts.CodePrompts;
 import io.github.jbellis.brokk.prompts.McpPrompts;
 import io.github.jbellis.brokk.tools.ToolExecutionResult;
 import io.github.jbellis.brokk.tools.ToolRegistry;
-import io.github.jbellis.brokk.tools.ToolRegistry.SignatureUnit;
 import io.github.jbellis.brokk.tools.WorkspaceTools;
 import io.github.jbellis.brokk.util.Messages;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -80,10 +74,6 @@ public class SearchAgent {
 
     // Session-local conversation for this agent
     private final List<ChatMessage> sessionMessages = new ArrayList<>();
-
-    // Duplicate detection and linkage discovery
-    private final Set<SignatureUnit> toolCallSignatures = new HashSet<>();
-    private final Set<String> trackedClassNames = new HashSet<>();
 
     // State toggles
     private boolean beastMode;
@@ -189,7 +179,7 @@ public class SearchAgent {
             }
             var next = parseResponseToRequests(ai);
             if (next.isEmpty()) {
-                // If everything got filtered (e.g., duplicate -> forged -> still duplicate), force beast mode
+                // If everything got filtered (e.g., only terminal tool kept), force beast mode next turn if needed
                 beastMode = true;
                 continue;
             }
@@ -217,11 +207,6 @@ public class SearchAgent {
                     .toList();
             boolean executedDeferredTerminal = false;
             for (var req : sortedCalls) {
-                // Duplicate guard and class tracking before execution
-                var signatures = createToolCallSignatures(req);
-                toolCallSignatures.addAll(signatures);
-                trackClassNamesFromToolCall(req);
-
                 ToolExecutionResult exec;
                 try {
                     exec = toolRegistry.executeTool(this, req);
@@ -243,9 +228,6 @@ public class SearchAgent {
 
                 // Write to visible transcript and to Context history
                 sessionMessages.add(ToolExecutionResultMessage.from(req, display));
-
-                // Light composition: update discovery and flow
-                handleStateAfterTool(exec);
 
                 // Track if we executed a deferred terminal
                 if (req.name().equals("createTaskList") || req.name().equals("workspaceComplete")) {
@@ -466,7 +448,7 @@ public class SearchAgent {
         names.add("addSymbolUsagesToWorkspace");
         names.add("addCallGraphInToWorkspace");
         names.add("addCallGraphOutToWorkspace");
-        names.add("addTextToWorkspace");
+        names.add("appendNote");
         names.add("dropWorkspaceFragments");
 
         if (!mcpTools.isEmpty()) {
@@ -482,9 +464,7 @@ public class SearchAgent {
             return List.of();
         }
 
-        // 1) Isolate terminator tools BEFORE running any dedupe logic.
-        //    Terminal tools like answer/createTaskList/workspaceComplete/abortSearch do not have a list parameter
-        //    and must not be deduplicated; doing so can throw during signature extraction.
+        // Isolate terminator tools BEFORE any other handling.
         var firstFinal = response.toolExecutionRequests().stream()
                 .filter(r -> r.name().equals("answer")
                         || r.name().equals("createTaskList")
@@ -495,19 +475,15 @@ public class SearchAgent {
             return List.of(firstFinal.get());
         }
 
-        // 2) Otherwise, dedupe non-terminator tool requests and forge getRelatedClasses for duplicates.
-        var raw = response.toolExecutionRequests().stream()
-                .map(this::handleDuplicateRequestIfNeeded)
-                .toList();
-
-        return raw;
+        // No dedupe/forging: return all non-terminal tool requests in the order provided
+        return response.toolExecutionRequests();
     }
 
     private int priority(String toolName) {
         // Prioritize workspace pruning and adding summaries before deeper exploration.
         return switch (toolName) {
             case "dropWorkspaceFragments" -> 1;
-            case "addTextToWorkspace" -> 2;
+            case "addTextToWorkspace", "appendNote" -> 2;
             case "addClassSummariesToWorkspace", "addFileSummariesToWorkspace", "addMethodsToWorkspace" -> 3;
             case "addFilesToWorkspace", "addClassesToWorkspace", "addSymbolUsagesToWorkspace" -> 4;
             case "getRelatedClasses" -> 5;
@@ -586,7 +562,7 @@ public class SearchAgent {
             @P("A map of argument names to values for the tool. Can be null or empty if the tool takes no arguments.")
                     @Nullable
                     Map<String, Object> arguments) {
-        Map<String, Object> args = Objects.requireNonNullElseGet(arguments, HashMap::new);
+        Map<String, Object> args = java.util.Objects.requireNonNullElseGet(arguments, HashMap::new);
         var mcpToolOptional =
                 mcpTools.stream().filter(t -> t.toolName().equals(toolName)).findFirst();
 
@@ -665,22 +641,6 @@ public class SearchAgent {
                 .contains(toolName);
     }
 
-    private void handleStateAfterTool(@Nullable ToolExecutionResult exec) throws InterruptedException {
-        if (exec == null || exec.status() != ToolExecutionResult.Status.SUCCESS) {
-            return;
-        }
-        switch (exec.toolName()) {
-            case "searchSymbols" -> {
-                if (!exec.resultText().startsWith("No definitions found")) {
-                    trackClassNamesFromResult(exec.resultText());
-                }
-            }
-            case "getUsages", "getRelatedClasses", "getClassSkeletons", "getClassSources", "getMethodSources" ->
-                trackClassNamesFromResult(exec.resultText());
-            default -> {}
-        }
-    }
-
     private String summarizeResult(
             String query, ToolExecutionRequest request, String rawResult, @Nullable String reasoning)
             throws InterruptedException {
@@ -714,179 +674,6 @@ public class SearchAgent {
             return rawResult; // fallback to raw
         }
         return sr.text();
-    }
-
-    // =======================
-    // Duplicate forging & tracking
-    // =======================
-
-    private ToolExecutionRequest handleDuplicateRequestIfNeeded(ToolExecutionRequest request) {
-        if (!cm.getAnalyzerWrapper().providesInterproceduralAnalysis()) {
-            return request;
-        }
-
-        // Workspace mutation tools are never deduplicated
-        if (toolRegistry.isWorkspaceMutationTool(request.name())) {
-            return request;
-        }
-
-        var requestUnits = createToolCallSignatures(request);
-        if (requestUnits.isEmpty()) {
-            // Could not determine units; conservatively allow execution
-            return request;
-        }
-
-        var newUnits = requestUnits.stream()
-                .filter(u -> !toolCallSignatures.contains(u))
-                .toList();
-
-        if (newUnits.isEmpty()) {
-            // Nothing new in this request: treat as duplicate and consider forging getRelatedClasses
-            logger.debug("Duplicate call detected for {}; forging getRelatedClasses", request.name());
-            request = createRelatedClassesRequest();
-            var forgedUnits = createToolCallSignatures(request);
-            if (toolCallSignatures.containsAll(forgedUnits)) {
-                logger.debug("Forged getRelatedClasses would also be duplicate; switching to beast mode");
-                beastMode = true;
-            }
-            return request;
-        }
-
-        // Some items are new: rewrite the request to contain only the new items (avoid losing new work)
-        if (newUnits.size() < requestUnits.size()) {
-            var rewritten = toolRegistry.buildRequestFromUnits(request, newUnits);
-            return rewritten;
-        }
-
-        // All units are new: execute original request
-        return request;
-    }
-
-    private ToolExecutionRequest createRelatedClassesRequest() {
-        var classList = new ArrayList<>(trackedClassNames);
-        String args = toJsonArrayArg("classNames", classList);
-        return ToolExecutionRequest.builder()
-                .name("getRelatedClasses")
-                .arguments(args)
-                .build();
-    }
-
-    private String toJsonArrayArg(String param, List<String> values) {
-        var mapper = new ObjectMapper();
-        try {
-            return """
-                    { "%s": %s }
-                    """
-                    .stripIndent()
-                    .formatted(param, mapper.writeValueAsString(values));
-        } catch (JsonProcessingException e) {
-            logger.error("Error serializing array for {}", param, e);
-            return """
-                    { "%s": [] }
-                    """
-                    .stripIndent()
-                    .formatted(param);
-        }
-    }
-
-    private List<SignatureUnit> createToolCallSignatures(ToolExecutionRequest request) {
-        // Delegate to ToolRegistry which has validation/typing knowledge.
-        try {
-            return toolRegistry.signatureUnits(this, request);
-        } catch (Exception e) {
-            logger.error("Error creating signature units for {}: {}", request.name(), e.getMessage(), e);
-            return List.of();
-        }
-    }
-
-    private void trackClassNamesFromToolCall(ToolExecutionRequest request) {
-        try {
-            var args = getArgumentsMap(request);
-            switch (request.name()) {
-                case "getClassSkeletons", "getClassSources", "getRelatedClasses" -> {
-                    @SuppressWarnings("unchecked")
-                    List<String> cs = (List<String>) args.get("classNames");
-                    if (cs != null) trackedClassNames.addAll(cs);
-                }
-                case "getMethodSources" -> {
-                    @SuppressWarnings("unchecked")
-                    List<String> ms = (List<String>) args.get("methodNames");
-                    if (ms != null) {
-                        ms.stream()
-                                .map(this::extractClassNameFromMethod)
-                                .filter(Objects::nonNull)
-                                .forEach(trackedClassNames::add);
-                    }
-                }
-                case "getUsages" -> {
-                    @SuppressWarnings("unchecked")
-                    var symbols = (List<String>) args.get("symbols");
-                    if (symbols != null) {
-                        for (var sym : symbols) {
-                            var cn = extractClassNameFromSymbol(sym);
-                            cn.ifPresent(trackedClassNames::add);
-                        }
-                    }
-                }
-                default -> {}
-            }
-        } catch (Exception e) {
-            logger.error("Error tracking class names from tool call", e);
-        }
-    }
-
-    private void trackClassNamesFromResult(String resultText) throws InterruptedException {
-        if (resultText.isBlank() || resultText.startsWith("No ") || resultText.startsWith("Error:")) return;
-
-        // Handle compressed "[Common package prefix: 'x.y'] a, b"
-        String effective = resultText;
-        String prefix = "";
-        if (resultText.startsWith("[") && resultText.contains("] ")) {
-            int end = resultText.indexOf("] ");
-            int startQuote = resultText.indexOf("'");
-            int endQuote = resultText.lastIndexOf("'", end);
-            if (end > 0 && startQuote >= 0 && endQuote > startQuote) {
-                prefix = resultText.substring(startQuote + 1, endQuote);
-            }
-            effective = resultText.substring(end + 2).trim();
-        }
-
-        String fPrefix = prefix;
-        Set<String> potential = new HashSet<>(Arrays.stream(effective.split("[,\\s]+"))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .map(s -> fPrefix.isEmpty() ? s : fPrefix + "." + s)
-                .filter(s -> s.contains(".") && Character.isJavaIdentifierStart(s.charAt(0)))
-                .toList());
-
-        var classMatcher =
-                Pattern.compile("(?:Source code of |class )([\\w.$]+)").matcher(resultText);
-        while (classMatcher.find()) potential.add(classMatcher.group(1));
-
-        var usageMatcher = Pattern.compile("Usage in ([\\w.$]+)\\.").matcher(resultText);
-        while (usageMatcher.find()) potential.add(usageMatcher.group(1));
-
-        if (!potential.isEmpty()) {
-            Set<String> valid = new HashSet<>();
-            for (String p : potential) {
-                var className = extractClassNameFromSymbol(p);
-                className.ifPresent(valid::add);
-            }
-            if (!valid.isEmpty()) {
-                trackedClassNames.addAll(valid);
-            }
-        }
-    }
-
-    private @Nullable String extractClassNameFromMethod(String methodName) {
-        int lastDot = methodName.lastIndexOf('.');
-        if (lastDot > 0) return methodName.substring(0, lastDot);
-        return null;
-    }
-
-    private Optional<String> extractClassNameFromSymbol(String symbol) throws InterruptedException {
-        return cm.getAnalyzer().getDefinition(symbol).flatMap(cu -> cu.classUnit()
-                .map(CodeUnit::fqName));
     }
 
     private static Map<String, Object> getArgumentsMap(ToolExecutionRequest request) {

--- a/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
@@ -805,7 +805,7 @@ public interface ContextFragment {
 
     StringFragmentType BUILD_RESULTS =
             new StringFragmentType("Latest Build Results", SyntaxConstants.SYNTAX_STYLE_NONE);
-    StringFragmentType SEARCH_NOTES = new StringFragmentType("Task Notes", SyntaxConstants.SYNTAX_STYLE_MARKDOWN);
+    StringFragmentType SEARCH_NOTES = new StringFragmentType("Code Notes", SyntaxConstants.SYNTAX_STYLE_MARKDOWN);
     StringFragmentType DISCARDED_CONTEXT =
             new StringFragmentType("Discarded Context", SyntaxConstants.SYNTAX_STYLE_JSON);
 

--- a/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/ContextFragment.java
@@ -801,6 +801,14 @@ public interface ContextFragment {
         }
     }
 
+    record StringFragmentType(String description, String syntaxStyle) {}
+
+    StringFragmentType BUILD_RESULTS =
+            new StringFragmentType("Latest Build Results", SyntaxConstants.SYNTAX_STYLE_NONE);
+    StringFragmentType SEARCH_NOTES = new StringFragmentType("Task Notes", SyntaxConstants.SYNTAX_STYLE_MARKDOWN);
+    StringFragmentType DISCARDED_CONTEXT =
+            new StringFragmentType("Discarded Context", SyntaxConstants.SYNTAX_STYLE_JSON);
+
     class StringFragment extends VirtualFragment { // Non-dynamic, uses content hash
         private final String text;
         private final String description;
@@ -1717,52 +1725,6 @@ public interface ContextFragment {
         @Override
         public String toString() {
             return "SkeletonFragment('%s')".formatted(description());
-        }
-    }
-
-    class BuildFragment extends VirtualFragment {
-        private final String content;
-
-        public BuildFragment(IContextManager contextManager, String buildOutput) {
-            super(contextManager);
-            this.content = buildOutput;
-        }
-
-        @Override
-        public FragmentType getType() {
-            return FragmentType.BUILD_LOG;
-        }
-
-        @Override
-        public String description() {
-            return "Latest build results";
-        }
-
-        @Override
-        public String text() {
-            return "# CURRENT BUILD STATUS\n\n" + content;
-        }
-
-        @Override
-        public boolean isDynamic() {
-            return false;
-        }
-
-        @Override
-        public boolean isEligibleForAutoContext() {
-            // Do not seed auto-context from build output
-            return false;
-        }
-
-        @Override
-        public String syntaxStyle() {
-            // Build output may contain Markdown formatting
-            return SyntaxConstants.SYNTAX_STYLE_MARKDOWN;
-        }
-
-        @Override
-        public String toString() {
-            return "BuildFragment('%s')".formatted(description());
         }
     }
 

--- a/app/src/main/java/io/github/jbellis/brokk/context/DtoMapper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/context/DtoMapper.java
@@ -275,8 +275,15 @@ public class DtoMapper {
                         callGraphDto.isCalleeGraph());
             case CodeFragmentDto codeDto ->
                 new ContextFragment.CodeFragment(codeDto.id(), mgr, fromCodeUnitDto(codeDto.unit()));
-            case BuildFragmentDto bfDto ->
-                new ContextFragment.BuildFragment(mgr, reader.readContent(bfDto.contentId()));
+            case BuildFragmentDto bfDto -> {
+                // Backward compatibility: convert legacy BuildFragment to StringFragment with BUILD_RESULTS
+                var text = reader.readContent(bfDto.contentId());
+                yield new ContextFragment.StringFragment(
+                        mgr,
+                        text,
+                        ContextFragment.BUILD_RESULTS.description(),
+                        ContextFragment.BUILD_RESULTS.syntaxStyle());
+            }
             case HistoryFragmentDto historyDto -> {
                 var historyEntries = historyDto.history().stream()
                         .map(taskEntryDto -> _fromTaskEntryDto(
@@ -428,8 +435,6 @@ public class DtoMapper {
             case ContextFragment.CallGraphFragment cgf ->
                 new CallGraphFragmentDto(cgf.id(), cgf.getMethodName(), cgf.getDepth(), cgf.isCalleeGraph());
             case ContextFragment.CodeFragment cf -> new CodeFragmentDto(cf.id(), toCodeUnitDto(cf.getCodeUnit()));
-            case ContextFragment.BuildFragment bf ->
-                new BuildFragmentDto(bf.id(), writer.writeContent(bf.text(), null));
             case ContextFragment.HistoryFragment hf -> {
                 var historyDto = hf.entries().stream()
                         .map(te -> toTaskEntryDto(te, writer))

--- a/app/src/main/java/io/github/jbellis/brokk/tools/SearchTools.java
+++ b/app/src/main/java/io/github/jbellis/brokk/tools/SearchTools.java
@@ -5,7 +5,7 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.AnalyzerUtil;
 import io.github.jbellis.brokk.Completions;
-import io.github.jbellis.brokk.ContextManager;
+import io.github.jbellis.brokk.IContextManager;
 import io.github.jbellis.brokk.analyzer.*;
 import io.github.jbellis.brokk.context.ContextFragment;
 import io.github.jbellis.brokk.git.CommitInfo;
@@ -31,9 +31,9 @@ public class SearchTools {
 
     private static final Logger logger = LogManager.getLogger(SearchTools.class);
 
-    private final ContextManager contextManager; // Needed for file operations
+    private final IContextManager contextManager; // Needed for file operations
 
-    public SearchTools(ContextManager contextManager) {
+    public SearchTools(IContextManager contextManager) {
         this.contextManager = contextManager;
     }
 
@@ -66,7 +66,6 @@ public class SearchTools {
      */
     public static CompressedSymbols compressSymbolsWithPackagePrefix(List<String> symbols) {
         List<String[]> packageParts = symbols.stream()
-                .filter(Objects::nonNull) // Filter nulls just in case
                 .map(s -> s.split("\\."))
                 .filter(arr -> arr.length > 0) // Ensure split resulted in something
                 .toList();

--- a/app/src/main/java/io/github/jbellis/brokk/tools/SearchTools.java
+++ b/app/src/main/java/io/github/jbellis/brokk/tools/SearchTools.java
@@ -5,7 +5,7 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.AnalyzerUtil;
 import io.github.jbellis.brokk.Completions;
-import io.github.jbellis.brokk.IContextManager;
+import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.analyzer.*;
 import io.github.jbellis.brokk.context.ContextFragment;
 import io.github.jbellis.brokk.git.CommitInfo;
@@ -31,9 +31,9 @@ public class SearchTools {
 
     private static final Logger logger = LogManager.getLogger(SearchTools.class);
 
-    private final IContextManager contextManager; // Needed for file operations
+    private final ContextManager contextManager; // Needed for file operations
 
-    public SearchTools(IContextManager contextManager) {
+    public SearchTools(ContextManager contextManager) {
         this.contextManager = contextManager;
     }
 
@@ -839,5 +839,45 @@ public class SearchTools {
         var formattedTaskList = "# Task List\n" + lines + "\n";
         io.llmOutput("I've created the following tasks:\n" + formattedTaskList, ChatMessageType.AI, true, false);
         return formattedTaskList;
+    }
+
+    @Tool(
+            "Append a Markdown-formatted note to Task Notes in the Workspace. Use this to record findings, hypotheses, checklists, links, and decisions in Markdown.")
+    public String appendNote(@P("Markdown content to append to Task Notes") String markdown) {
+        if (markdown.isBlank()) {
+            throw new IllegalArgumentException("Note content cannot be empty");
+        }
+
+        final var description = ContextFragment.SEARCH_NOTES.description();
+        final var syntax = ContextFragment.SEARCH_NOTES.syntaxStyle();
+        final var appendedFlag = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        contextManager.pushContext(ctx -> {
+            var existing = ctx.virtualFragments()
+                    .filter(vf -> vf.getType() == ContextFragment.FragmentType.STRING)
+                    .filter(vf -> description.equals(vf.description()))
+                    .findFirst();
+
+            if (existing.isPresent()) {
+                appendedFlag.set(true);
+                var prev = existing.get();
+                String prevText = prev.text();
+                String combined = prevText.isBlank() ? markdown : prevText + "\n\n" + markdown;
+
+                var next = ctx.removeFragmentsByIds(java.util.List.of(prev.id()));
+                var newFrag = new ContextFragment.StringFragment(contextManager, combined, description, syntax);
+                logger.debug(
+                        "appendNote: replaced existing Task Notes fragment {} with updated content ({} chars).",
+                        prev.id(),
+                        combined.length());
+                return next.addVirtualFragment(newFrag);
+            } else {
+                var newFrag = new ContextFragment.StringFragment(contextManager, markdown, description, syntax);
+                logger.debug("appendNote: created new Task Notes fragment ({} chars).", markdown.length());
+                return ctx.addVirtualFragment(newFrag);
+            }
+        });
+
+        return appendedFlag.get() ? "Appended note to Task Notes." : "Created Task Notes and added the note.";
     }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/tools/WorkspaceTools.java
+++ b/app/src/main/java/io/github/jbellis/brokk/tools/WorkspaceTools.java
@@ -1,5 +1,6 @@
 package io.github.jbellis.brokk.tools;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import io.github.jbellis.brokk.Completions;
@@ -8,6 +9,7 @@ import io.github.jbellis.brokk.agents.ContextAgent;
 import io.github.jbellis.brokk.analyzer.*;
 import io.github.jbellis.brokk.context.ContextFragment;
 import io.github.jbellis.brokk.util.HtmlToMarkdown;
+import io.github.jbellis.brokk.util.Json;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -16,7 +18,9 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -241,30 +245,94 @@ public class WorkspaceTools {
 
     @Tool(
             value =
-                    "Remove specified fragments (files, text snippets, task history, analysis results) from the Workspace using their unique string IDs")
+                    "Remove specified fragments (files, text snippets, task history, analysis results) from the Workspace and record explanations in DISCARDED_CONTEXT as a JSON map.")
     public String dropWorkspaceFragments(
-            @P(
-                            "List of string IDs corresponding to the fragments visible in the workspace that you want to remove. Must not be empty.")
-                    List<String> fragmentIds) {
-        if (fragmentIds.isEmpty()) {
-            return "Fragment IDs list cannot be empty.";
+            @P("Map of { fragmentId -> explanation } for why each fragment is being discarded. Must not be empty.")
+                    Map<String, String> idToExplanation) {
+        if (idToExplanation.isEmpty()) {
+            return "Fragment map cannot be empty.";
         }
 
         var currentContext = contextManager.liveContext();
         var allFragments = currentContext.getAllFragmentsInDisplayOrder();
-        var idsToDropSet = new HashSet<>(fragmentIds);
 
-        var toDrop = allFragments.stream()
-                .filter(frag -> idsToDropSet.contains(frag.id()))
-                .toList();
+        var idsToDropSet = new HashSet<>(idToExplanation.keySet());
+        var toDrop =
+                allFragments.stream().filter(f -> idsToDropSet.contains(f.id())).toList();
+        var droppedIds = toDrop.stream().map(ContextFragment::id).collect(Collectors.toSet());
 
-        if (!toDrop.isEmpty()) {
-            contextManager.drop(toDrop);
-            var droppedReprs = toDrop.stream().map(ContextFragment::repr).collect(Collectors.joining(", "));
-            return "Dropped %d fragment(s): [%s]".formatted(toDrop.size(), droppedReprs);
-        } else {
-            return "No valid fragments found to drop for the given IDs: " + fragmentIds;
+        // Prepare existing DISCARDED_CONTEXT map if present
+        var discardedDescription = ContextFragment.DISCARDED_CONTEXT.description();
+        var existingDiscarded = currentContext
+                .virtualFragments()
+                .filter(vf -> vf.getType() == ContextFragment.FragmentType.STRING)
+                .filter(vf -> vf instanceof ContextFragment.StringFragment)
+                .map(vf -> (ContextFragment.StringFragment) vf)
+                .filter(sf -> discardedDescription.equals(sf.description()))
+                .findFirst();
+
+        var mapper = Json.getMapper();
+        Map<String, String> mergedDiscarded = new LinkedHashMap<>();
+        existingDiscarded.ifPresent(sf -> {
+            try {
+                var existing = mapper.readValue(sf.text(), new TypeReference<Map<String, String>>() {});
+                if (existing != null) {
+                    mergedDiscarded.putAll(existing);
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to parse existing DISCARDED_CONTEXT JSON; starting fresh", e);
+            }
+        });
+
+        // Merge explanations for successfully dropped fragments (new overwrites old)
+        for (var id : droppedIds) {
+            var explanation = idToExplanation.getOrDefault(id, "");
+            mergedDiscarded.put(id, explanation);
         }
+
+        // Serialize updated JSON
+        String discardedJson;
+        try {
+            discardedJson = mapper.writeValueAsString(mergedDiscarded);
+        } catch (Exception e) {
+            logger.error("Failed to serialize DISCARDED_CONTEXT JSON", e);
+            return "Error: Failed to serialize DISCARDED_CONTEXT JSON: " + e.getMessage();
+        }
+
+        // Atomically: drop requested fragments, refresh DISCARDED_CONTEXT as a StringFragment
+        contextManager.pushContext(ctx -> {
+            var next = ctx.removeFragmentsByIds(droppedIds);
+
+            // Remove previous DISCARDED_CONTEXT fragment if present
+            if (existingDiscarded.isPresent()) {
+                next = next.removeFragmentsByIds(List.of(existingDiscarded.get().id()));
+            }
+
+            // Add the updated DISCARDED_CONTEXT fragment
+            var fragment = new ContextFragment.StringFragment(
+                    contextManager,
+                    discardedJson,
+                    ContextFragment.DISCARDED_CONTEXT.description(),
+                    ContextFragment.DISCARDED_CONTEXT.syntaxStyle());
+
+            return next.addVirtualFragment(fragment);
+        });
+
+        var unknownIds =
+                idsToDropSet.stream().filter(id -> !droppedIds.contains(id)).collect(Collectors.toList());
+        logger.debug(
+                "dropWorkspaceFragments: dropped={}, unknown={}, updatedDiscardedEntries={}",
+                droppedIds.size(),
+                unknownIds.size(),
+                mergedDiscarded.size());
+
+        var droppedReprs = toDrop.stream().map(ContextFragment::repr).collect(Collectors.joining(", "));
+        var baseMsg = "Dropped %d fragment(s): [%s]. Updated DISCARDED_CONTEXT with %d entr%s."
+                .formatted(droppedIds.size(), droppedReprs, droppedIds.size(), droppedIds.size() == 1 ? "y" : "ies");
+        if (!unknownIds.isEmpty()) {
+            return baseMsg + " Unknown fragment IDs: " + String.join(", ", unknownIds);
+        }
+        return baseMsg;
     }
 
     @Tool(

--- a/app/src/main/java/io/github/jbellis/brokk/tools/WorkspaceTools.java
+++ b/app/src/main/java/io/github/jbellis/brokk/tools/WorkspaceTools.java
@@ -276,18 +276,16 @@ public class WorkspaceTools {
         existingDiscarded.ifPresent(sf -> {
             try {
                 var existing = mapper.readValue(sf.text(), new TypeReference<Map<String, String>>() {});
-                if (existing != null) {
-                    mergedDiscarded.putAll(existing);
-                }
+                mergedDiscarded.putAll(existing);
             } catch (Exception e) {
                 logger.warn("Failed to parse existing DISCARDED_CONTEXT JSON; starting fresh", e);
             }
         });
 
         // Merge explanations for successfully dropped fragments (new overwrites old)
-        for (var id : droppedIds) {
-            var explanation = idToExplanation.getOrDefault(id, "");
-            mergedDiscarded.put(id, explanation);
+        for (var f : toDrop) {
+            var explanation = idToExplanation.getOrDefault(f.id(), "");
+            mergedDiscarded.put(f.description(), explanation);
         }
 
         // Serialize updated JSON

--- a/app/src/main/java/io/github/jbellis/brokk/util/HistoryIo.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/HistoryIo.java
@@ -159,9 +159,9 @@ public final class HistoryIo {
                         Stream.concat(referencedDtosById.keySet().stream(), virtualDtosById.keySet().stream()),
                         taskDtosById.keySet().stream())
                 .distinct()
-                .forEach(id -> fragmentCache.computeIfAbsent(
-                        id,
-                        currentId -> DtoMapper.resolveAndBuildFragment(
+                .forEach(id -> fragmentCache.computeIfAbsent(id, currentId -> {
+                    try {
+                        return DtoMapper.resolveAndBuildFragment(
                                 currentId,
                                 referencedDtosById,
                                 virtualDtosById,
@@ -169,7 +169,12 @@ public final class HistoryIo {
                                 mgr,
                                 imageBytesMap,
                                 fragmentCache,
-                                contentReader)));
+                                contentReader);
+                    } catch (Exception e) {
+                        logger.error("Error resolving and building fragment for ID {}: {}", currentId, e);
+                        return null;
+                    }
+                }));
 
         var contexts = new ArrayList<Context>();
         for (String line : compactContextDtoLines) {

--- a/app/src/test/java/io/github/jbellis/brokk/context/ContextSerializationTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/context/ContextSerializationTest.java
@@ -757,28 +757,6 @@ public class ContextSerializationTest {
     }
 
     @Test
-    void testRoundTripBuildFragment() throws Exception {
-        var buildFragment = new ContextFragment.BuildFragment(mockContextManager, "Build successful\nAll tests passed");
-
-        var context = new Context(mockContextManager, "Test BuildFragment").addVirtualFragment(buildFragment);
-        ContextHistory originalHistory = new ContextHistory(context);
-
-        Path zipFile = tempDir.resolve("test_buildfrag_history.zip");
-        HistoryIo.writeZip(originalHistory, zipFile);
-        ContextHistory loadedHistory = HistoryIo.readZip(zipFile, mockContextManager);
-
-        Context loadedCtx = loadedHistory.getHistory().get(0);
-        var loadedBuildFrag = loadedCtx
-                .virtualFragments()
-                .filter(f -> f.getType() == ContextFragment.FragmentType.BUILD_LOG)
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("BUILD_LOG fragment not found after round-trip"));
-
-        assertTrue(loadedBuildFrag.isText());
-        assertTrue(loadedBuildFrag.text().contains("Build successful\nAll tests passed"));
-    }
-
-    @Test
     void testRoundTripSearchFragment() throws Exception {
         var projectFile = new ProjectFile(tempDir, "src/SearchTarget.java");
         Files.createDirectories(projectFile.absPath().getParent());


### PR DESCRIPTION
- Intent: migrate build-results and workspace-note handling to unified, describable StringFragments; add an append-note tool and persist discard explanations; simplify SearchAgent by removing duplicate-forging/tracking logic; remove one style rule.

- Behavior changes:
  - Build output is no longer a special BuildFragment; it’s stored/queried as a StringFragment with description "Latest Build Results" (backwards-compatible DTO conversion preserved).
  - New Task Notes (SEARCH_NOTES) StringFragment and a DISCARDED_CONTEXT StringFragment type are added.
  - New SearchTools.appendNote(markdown) appends or creates Task Notes in the workspace.
  - WorkspaceTools.dropWorkspaceFragments now accepts a map {fragmentId -> explanation}, removes fragments, and records/merges explanations into DISCARDED_CONTEXT JSON (atomic context update). This is a breaking API change.
  - SearchAgent: removed duplicate-detection/forging/tracking machinery and related state; non-terminal tool requests are no longer deduped/rewritten.

- Key implementation notes:
  - Introduced StringFragmentType constants and reuse existing StringFragment for typed text fragments.
  - ContextManager updates use pushContext lambdas to atomically remove/add fragments and log actions.
  - DtoMapper converts legacy BuildFragment DTOs into STRING fragments; build-fragment class removed.
  - WorkspaceTools uses Jackson to merge/serialize discarded explanations; SearchTools now depends on concrete ContextManager.