### PR TITLE
`MultiAnalyzer.getMethodSources` Treat `Set.empty` as `Optional.empty`

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/AnalyzerWrapper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/AnalyzerWrapper.java
@@ -268,6 +268,12 @@ public class AnalyzerWrapper implements IWatchService.Listener, IAnalyzerWrapper
                     project.getRoot());
             if (analyzer instanceof CanCommunicate communicativeAnalyzer) {
                 communicativeAnalyzer.setIo(io);
+            } else if (analyzer instanceof MultiAnalyzer multiAnalyzer) {
+                multiAnalyzer.getDelegates().values().forEach(delegate -> {
+                    if (delegate instanceof CanCommunicate communicativeAnalyzer) {
+                        communicativeAnalyzer.setIo(io);
+                    }
+                });
             }
         } catch (Throwable th) {
             // cache missing or corrupt, rebuild

--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/MultiAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/MultiAnalyzer.java
@@ -87,8 +87,9 @@ public class MultiAnalyzer
 
     @Override
     public Set<String> getMethodSources(String fqName, boolean includeComments) {
-        return findFirst(analyzer ->
-                        analyzer.as(SourceCodeProvider.class).map(scp -> scp.getMethodSources(fqName, includeComments)))
+        return findFirst(analyzer -> analyzer.as(SourceCodeProvider.class)
+                        .map(scp -> scp.getMethodSources(fqName, includeComments))
+                        .filter(sources -> !sources.isEmpty()))
                 .orElse(Collections.emptySet());
     }
 


### PR DESCRIPTION
When fetching method source code from delegates, if the "wrong" analyzer is pinged first it will return an empty set, which is treated as a valid result. This change filters `Set.empty` out of the `Optional` stream to treat it as an `Optional.empty`.

Misc fix., delegates for `MultiAnalyzer` that implement `CanCommunicate` were possibly being ignored, thus now we give IO to `MultiAnalyzer` delegates.