### PR TITLE
Default `autocompleteDefinitions` Overapproximates for Possible Acronyms

### DIFF
--- a/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
+++ b/app/src/test/java/io/github/jbellis/brokk/CompletionsTest.java
@@ -61,14 +61,8 @@ public class CompletionsTest {
 
     @Test
     public void testCamelCaseCompletion() {
-        var seeded = createTestAnalyzer();
-        var mock = new TestAnalyzer(seeded.getAllDeclarations(), seeded.getMethodsMap()) {
-            @Override
-            public List<CodeUnit> autocompleteDefinitions(String query) {
-                // give all for the sake of testing camel case fuzzy matching
-                return super.autocompleteDefinitions(".*");
-            }
-        };
+        var mock = createTestAnalyzer();
+
         // Input "CC" -> should match "test.CamelClass" due to camel case matching
         var completions = Completions.completeSymbols("CC", mock);
         var values = toValues(completions);


### PR DESCRIPTION
If the query to `IAnalyzer.autocompleteDefinitions` is shorter than 5 characters, this adds an additional query to `searchDefinitions` comprising adding wildcards between characters for a case-insensitive search, e.g., `cc` becomes `(?i).*c.*c.*`.

This should provide sufficient candidates for the FuzzyMatcher to later use the camel-case heuristic on. This is not necessarily performant, but TreeSitterAnalyzer does override this with a more performant approach.