### PR TITLE
fix: [Bug]: Cannot look at git diff and do a git commit with the output window is running

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitCommitTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitCommitTab.java
@@ -532,7 +532,7 @@ public class GitCommitTab extends JPanel {
             }
         }
 
-        contextManager.submitExclusiveAction(() -> {
+        contextManager.submitBackgroundTask("Opening diff for uncommitted files", () -> {
             try {
                 var builder = new BrokkDiffPanel.Builder(chrome.getTheme(), contextManager);
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/util/GitUiUtil.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/util/GitUiUtil.java
@@ -144,7 +144,7 @@ public final class GitUiUtil {
     public static void viewFileAtRevision(ContextManager cm, Chrome chrome, String commitId, String filePath) {
         var repo = cm.getProject().getRepo();
 
-        cm.submitExclusiveAction(() -> {
+        cm.submitBackgroundTask("View file at revision", () -> {
             var file = new ProjectFile(cm.getRoot(), filePath);
             try {
                 final String content = repo.getFileContent(commitId, file);
@@ -576,7 +576,7 @@ public final class GitUiUtil {
     }
 
     public static void compareCommitToLocal(ContextManager contextManager, Chrome chrome, ICommitInfo commitInfo) {
-        contextManager.submitExclusiveAction(() -> {
+        contextManager.submitBackgroundTask("Comparing commit to local", () -> {
             try {
                 var changedFiles = commitInfo.changedFiles();
                 if (changedFiles.isEmpty()) {
@@ -826,7 +826,7 @@ public final class GitUiUtil {
             ContextManager contextManager, Chrome chrome, GHPullRequest pr, String targetFileName) {
         String targetFilePath = extractFilePathFromDisplay(targetFileName);
 
-        contextManager.submitExclusiveAction(() -> {
+        contextManager.submitBackgroundTask("Opening PR diff", () -> {
             try {
                 var repo = (GitRepo) contextManager.getProject().getRepo();
 


### PR DESCRIPTION
Closes #1201: 

I fixed it for read-only git operations (view diff or file at revision, etc) for now, because when there is an llm task in progress, code changes might be happening at that time (though e.g. commit would probably not do any harm, but we could end up committing partial changes and similar). 

I thought about distinguishing Ask vs Code, but then Ask logic might be part of architect task and/or do code search, so I didn't want to go there without broader discussion for now.