### PR TITLE
Move workspace into instructions

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -1132,7 +1132,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         rootPane.getActionMap().put("toggleDependenciesDrawer", new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                var dependenciesPanel = new DependenciesDrawerPanel(Chrome.this, new JSplitPane());
+                var dependenciesPanel = new DependenciesDrawerPanel(Chrome.this);
                 showPreviewFrame(getContextManager(), "Manage Dependencies", dependenciesPanel);
                 dependenciesPanel.openPanel();
             }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -74,6 +74,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     // Track active preview windows for reuse
     private final Map<String, JFrame> activePreviewWindows = new ConcurrentHashMap<>();
     private @Nullable Rectangle dependenciesDialogBounds = null;
+
     @Nullable
     private JDialog dependenciesDialog = null;
 
@@ -2994,8 +2995,8 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     }
 
     /**
-     * Toggle collapsing the Workspace (top of Workspace|Instructions split) and hide/show
-     * the divider between Output and the bottom stack.
+     * Toggle collapsing the Workspace (top of Workspace|Instructions split) and hide/show the divider between Output
+     * and the bottom stack.
      */
     public void toggleWorkspaceCollapsed() {
         setWorkspaceCollapsed(!workspaceCollapsed);
@@ -3004,18 +3005,16 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
     /**
      * Collapse/expand the Workspace area.
      *
-     * New behavior:
-     * - When collapsed, completely remove the Workspace+Instructions split from the bottom stack and
-     *   show only the Instructions/Drawer as the bottom component. The Output↔Bottom divider remains visible.
-     * - When expanded, restore the original Workspace+Instructions split as the bottom component and
-     *   restore the previous divider location for the top split (Workspace↔Instructions).
+     * <p>New behavior: - When collapsed, completely remove the Workspace+Instructions split from the bottom stack and
+     * show only the Instructions/Drawer as the bottom component. The Output↔Bottom divider remains visible. - When
+     * expanded, restore the original Workspace+Instructions split as the bottom component and restore the previous
+     * divider location for the top split (Workspace↔Instructions).
      */
     public void setWorkspaceCollapsed(boolean collapsed) {
         Runnable r = () -> {
             if (this.workspaceCollapsed == collapsed) {
                 return;
             }
-
 
             if (collapsed) {
                 // Also save as a proportion for robust restore after resizes
@@ -3045,8 +3044,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                         int maxFromTop = Math.max(0, tsTotal - tsDivider);
                         int minBottom = (bottom != null) ? Math.max(0, bottom.getMinimumSize().height) : 0;
                         instructionsHeightPx = Math.min(
-                                Math.max(minBottom, instructionsDrawerSplit.getMinimumSize().height),
-                                maxFromTop);
+                                Math.max(minBottom, instructionsDrawerSplit.getMinimumSize().height), maxFromTop);
                     }
                 } catch (Exception ignored) {
                     // Defensive; we'll clamp during restore regardless
@@ -3059,9 +3057,8 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
 
                 // Revalidate layout, then set the main divider so bottom == pinned Instructions height
                 mainVerticalSplitPane.revalidate();
-                SwingUtilities.invokeLater(() ->
-                        applyMainDividerForExactBottomHeight(Math.max(0, pinnedInstructionsHeightPx))
-                );
+                SwingUtilities.invokeLater(
+                        () -> applyMainDividerForExactBottomHeight(Math.max(0, pinnedInstructionsHeightPx)));
 
                 this.workspaceCollapsed = true;
             } else {
@@ -3084,7 +3081,8 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
                     p = Math.max(0.05, Math.min(0.95, p));
 
                     // Compute the target bottom height so that Instructions stays at pinnedInstructionsHeightPx
-                    // For a vertical JSplitPane: bottomHeight = (1 - p) * T - dividerSize  =>  T = (pinned + dividerSize) / (1 - p)
+                    // For a vertical JSplitPane: bottomHeight = (1 - p) * T - dividerSize  =>  T = (pinned +
+                    // dividerSize) / (1 - p)
                     int dividerSizeTS = topSplitPane.getDividerSize();
                     int pinned = Math.max(0, pinnedInstructionsHeightPx);
                     int desiredBottom = (int) Math.round((pinned + dividerSizeTS) / Math.max(0.05, (1.0 - p)));
@@ -3122,11 +3120,10 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         }
     }
 
-
     /**
-     * Set the Output↔Bottom divider so that the bottom height equals the exact desired pixel height,
-     * clamped to the bottom component's minimum size. This is used when collapsing Workspace to
-     * guarantee the Instructions area does not resize at all.
+     * Set the Output↔Bottom divider so that the bottom height equals the exact desired pixel height, clamped to the
+     * bottom component's minimum size. This is used when collapsing Workspace to guarantee the Instructions area does
+     * not resize at all.
      */
     private void applyMainDividerForExactBottomHeight(int desiredBottomPx) {
         int total = mainVerticalSplitPane.getHeight();

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -1012,7 +1012,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         dependenciesButton.setFocusable(false);
         dependenciesButton.setOpaque(false);
         dependenciesButton.addActionListener(e -> {
-            var panel = new DependenciesDrawerPanel(chrome, new JSplitPane());
+            var panel = new DependenciesDrawerPanel(chrome);
             chrome.showPreviewFrame(contextManager, "Manage Dependencies", panel);
             panel.openPanel();
         });

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -719,8 +719,8 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
 
         // Let chips wrap naturally; provide reasonable min/height
         container.setMinimumSize(new Dimension(100, 28));
-        // Keep suggestion bar height consistent with previous UI
-        container.setPreferredSize(new Dimension(100, 32));
+        // Set suggestion bar height to allow for two rows of chips
+        container.setPreferredSize(new Dimension(100, 64));
         container.setMaximumSize(new Dimension(Integer.MAX_VALUE, 120));
 
         // Insert beneath the command-input area (index 2)

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -47,10 +47,6 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import javax.swing.border.TitledBorder;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.event.PopupMenuEvent;
-import javax.swing.event.PopupMenuListener;
 import javax.swing.text.*;
 import javax.swing.undo.UndoManager;
 import org.apache.logging.log4j.LogManager;
@@ -730,8 +726,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
             var cm = chrome.getContextManager();
             if (cm.isLlmTaskInProgress()) {
                 chrome.showNotification(
-                        IConsoleIO.NotificationRole.INFO,
-                        "An action is running; cannot modify Workspace now.");
+                        IConsoleIO.NotificationRole.INFO, "An action is running; cannot modify Workspace now.");
                 return;
             }
             cm.drop(List.of(fragment));
@@ -906,7 +901,9 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         }
     }
 
-    /** Recomputes the compact token/cost indicator to mirror the Workspace panel summary. Safe to call from any thread. */
+    /**
+     * Recomputes the compact token/cost indicator to mirror the Workspace panel summary. Safe to call from any thread.
+     */
     private void updateTokenCostIndicator() {
         var ctx = chrome.getContextManager().selectedContext();
         if (ctx == null || ctx.isEmpty()) {
@@ -935,7 +932,9 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
 
         // Compute tokens off-EDT
         chrome.getContextManager()
-                .submitBackgroundTask("Compute token estimate (Instructions)", () -> Messages.getApproximateTokens(fullText.toString()))
+                .submitBackgroundTask(
+                        "Compute token estimate (Instructions)",
+                        () -> Messages.getApproximateTokens(fullText.toString()))
                 .thenAccept(approxTokens -> SwingUtilities.invokeLater(() -> {
                     try {
                         var service = chrome.getContextManager().getService();
@@ -1407,7 +1406,6 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
      * @param myGen The generation number of this specific task.
      * @param snapshot The input text captured when this task was initiated.
      */
-
 
     /**
      * Checks if the new text/embeddings are semantically different from the last processed state
@@ -2083,7 +2081,6 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
     public void addModelSelectionListener(Consumer<Service.ModelConfig> listener) {
         modelSelector.addSelectionListener(listener);
     }
-
 
     private static class ThemeAwareRoundedButton extends MaterialButton implements ThemeAware {
         private static final long serialVersionUID = 1L;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -699,6 +699,19 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         // Replace former suggestion table with the workspace chips panel
         this.workspaceItemsChipPanel = new WorkspaceItemsChipPanel(this.contextManager);
 
+        // Wire chip removal behavior: block while LLM running; otherwise drop and refocus input
+        workspaceItemsChipPanel.setOnRemoveFragment(fragment -> {
+            var cm = chrome.getContextManager();
+            if (cm.isLlmTaskInProgress()) {
+                chrome.showNotification(
+                        IConsoleIO.NotificationRole.INFO,
+                        "An action is running; cannot modify Workspace now.");
+                return;
+            }
+            cm.drop(List.of(fragment));
+            requestCommandInputFocus();
+        });
+
         var container = new JPanel(new BorderLayout(H_GLUE, 0));
         container.setOpaque(false);
         container.setBorder(BorderFactory.createEmptyBorder(V_GLUE, H_PAD, V_GLUE, H_PAD));

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -222,6 +222,13 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                     }
                 }));
 
+        // Keyboard shortcut: Cmd/Ctrl+Shift+I opens the Attach Context dialog
+        io.github.jbellis.brokk.gui.util.KeyboardShortcutUtil.registerGlobalShortcut(
+                chrome.getFrame().getRootPane(),
+                io.github.jbellis.brokk.gui.util.KeyboardShortcutUtil.createPlatformShiftShortcut(KeyEvent.VK_I),
+                "attachContext",
+                () -> SwingUtilities.invokeLater(() -> chrome.getContextPanel().attachContextViaDialog()));
+
         // Load persisted checkbox states (default to checked)
         var proj = chrome.getProject();
         modeSwitch.setSelected(proj.getInstructionsAskMode());

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -1767,7 +1767,12 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
 
     @Override
     public void contextChanged(Context newCtx) {
-        // No-op; WorkspaceItemsChipPanel observes context changes directly.
+        var all = newCtx.getAllFragmentsInDisplayOrder();
+        var pathFragments = all.stream()
+                .filter(f -> f.getType().isPath())
+                .toList();
+        logger.debug("Context updated: {} fragments ({} path)", all.size(), pathFragments.size());
+        workspaceItemsChipPanel.setFragments(pathFragments);
     }
 
     void enableButtons() {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -314,6 +314,14 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         tokenCostLabel.setOpaque(false);
         tokenCostLabel.setBorder(new EmptyBorder(0, 4, 0, 8));
         tokenCostLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
+        // Make it clickable to toggle Workspace collapse/expand
+        tokenCostLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        tokenCostLabel.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override
+            public void mouseClicked(java.awt.event.MouseEvent e) {
+                chrome.toggleWorkspaceCollapsed();
+            }
+        });
 
         // Top Bar (History, Configure Models, Stop) (North)
         JPanel topBarPanel = buildTopBarPanel();

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -936,9 +936,13 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                         var costEstimate = calculateCostEstimate(approxTokens, service);
                         String costText = costEstimate.isBlank() ? "n/a" : costEstimate;
                         tokenCostLabel.setText("%,dK tokens \u2248 %s/req".formatted(approxTokens / 1000, costText));
-                        tokenCostLabel.setToolTipText(
-                                "Total: %,d LOC is ~%,d tokens with an estimated cost of %s per request"
-                                        .formatted(totalLinesFinal, approxTokens, costText));
+                        tokenCostLabel.setToolTipText(String.format(
+                                "<html>"
+                                        + "Shows full Workspace context size and estimated cost.<br/>"
+                                        + "Total: %,d LOC is ~%,d tokens with an estimated cost of %s per request.<br/>"
+                                        + "<i>Click to show/hide the Workspace panel.</i>"
+                                        + "</html>",
+                                totalLinesFinal, approxTokens, costText));
                         tokenCostLabel.setVisible(true);
                     } catch (Exception ex) {
                         logger.debug("Failed to update token cost indicator", ex);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -21,6 +21,7 @@ import io.github.jbellis.brokk.gui.components.ModelSelector;
 import io.github.jbellis.brokk.gui.components.OverlayPanel;
 import io.github.jbellis.brokk.gui.components.SplitButton;
 import io.github.jbellis.brokk.gui.components.SwitchIcon;
+import io.github.jbellis.brokk.gui.dependencies.DependenciesDrawerPanel;
 import io.github.jbellis.brokk.gui.dialogs.SettingsDialog;
 import io.github.jbellis.brokk.gui.dialogs.SettingsGlobalPanel;
 import io.github.jbellis.brokk.gui.git.GitWorktreeTab;
@@ -1004,6 +1005,21 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         bottomPanel.add(attachButton);
         bottomPanel.add(Box.createHorizontalStrut(4));
 
+        // Dependencies button
+        var dependenciesButton = new MaterialButton();
+        SwingUtilities.invokeLater(() -> dependenciesButton.setIcon(Icons.MANAGE_DEPENDENCIES));
+        dependenciesButton.setToolTipText("Manage project dependencies");
+        dependenciesButton.setFocusable(false);
+        dependenciesButton.setOpaque(false);
+        dependenciesButton.addActionListener(e -> {
+            var panel = new DependenciesDrawerPanel(chrome, new JSplitPane());
+            chrome.showPreviewFrame(contextManager, "Manage Dependencies", panel);
+            panel.openPanel();
+        });
+        dependenciesButton.setAlignmentY(Component.CENTER_ALIGNMENT);
+        bottomPanel.add(dependenciesButton);
+        bottomPanel.add(Box.createHorizontalStrut(4));
+
         // Wand button (Magic Ask) on the right
         wandButton.setAlignmentY(Component.CENTER_ALIGNMENT);
         // Size set after fixedHeight is computed below
@@ -1038,6 +1054,9 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         attachButton.setPreferredSize(iconButtonSize);
         attachButton.setMinimumSize(iconButtonSize);
         attachButton.setMaximumSize(iconButtonSize);
+        dependenciesButton.setPreferredSize(iconButtonSize);
+        dependenciesButton.setMinimumSize(iconButtonSize);
+        dependenciesButton.setMaximumSize(iconButtonSize);
         wandButton.setPreferredSize(iconButtonSize);
         wandButton.setMinimumSize(iconButtonSize);
         wandButton.setMaximumSize(iconButtonSize);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -1780,12 +1780,9 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
 
     @Override
     public void contextChanged(Context newCtx) {
-        var all = newCtx.getAllFragmentsInDisplayOrder();
-        var pathFragments = all.stream()
-                .filter(f -> f.getType().isPath())
-                .toList();
-        logger.debug("Context updated: {} fragments ({} path)", all.size(), pathFragments.size());
-        workspaceItemsChipPanel.setFragments(pathFragments);
+        var fragments = newCtx.getAllFragmentsInDisplayOrder();
+        logger.debug("Context updated: {} fragments", fragments.size());
+        workspaceItemsChipPanel.setFragments(fragments);
     }
 
     void enableButtons() {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -697,7 +697,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
      */
     private void initializeReferenceFileTable() {
         // Replace former suggestion table with the workspace chips panel
-        this.workspaceItemsChipPanel = new WorkspaceItemsChipPanel(this.contextManager);
+        this.workspaceItemsChipPanel = new WorkspaceItemsChipPanel(this.chrome);
 
         // Wire chip removal behavior: block while LLM running; otherwise drop and refocus input
         workspaceItemsChipPanel.setOnRemoveFragment(fragment -> {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -99,7 +99,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
     private final MaterialButton actionButton;
     private final WandButton wandButton;
     private final ModelSelector modelSelector;
-    private final JLabel tokenCostLabel;
+    private final MaterialButton tokenCostLabel;
     private String storedAction;
     private final ContextManager contextManager;
     private WorkspaceItemsChipPanel workspaceItemsChipPanel;
@@ -316,19 +316,14 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         modelSelector.getComponent().setFocusable(true);
 
         // Initialize compact token/cost indicator (left of Attach button)
-        tokenCostLabel = new JLabel(" ");
+        tokenCostLabel = new MaterialButton(" ");
+        tokenCostLabel.setFocusable(false);
         tokenCostLabel.setVisible(false);
         tokenCostLabel.setOpaque(false);
         tokenCostLabel.setBorder(new EmptyBorder(0, 4, 0, 8));
         tokenCostLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
         // Make it clickable to toggle Workspace collapse/expand
-        tokenCostLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-        tokenCostLabel.addMouseListener(new java.awt.event.MouseAdapter() {
-            @Override
-            public void mouseClicked(java.awt.event.MouseEvent e) {
-                chrome.toggleWorkspaceCollapsed();
-            }
-        });
+        tokenCostLabel.addActionListener(e -> chrome.toggleWorkspaceCollapsed());
 
         // Top Bar (History, Configure Models, Stop) (North)
         JPanel topBarPanel = buildTopBarPanel();

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -706,6 +706,8 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
 
         // Let chips wrap naturally; provide reasonable min/height
         container.setMinimumSize(new Dimension(100, 28));
+        // Keep suggestion bar height consistent with previous UI
+        container.setPreferredSize(new Dimension(100, 32));
         container.setMaximumSize(new Dimension(Integer.MAX_VALUE, 120));
 
         // Insert beneath the command-input area (index 2)

--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -697,7 +697,8 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         JScrollPane commandScrollPane = new JScrollPane(instructionsArea);
         commandScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
         commandScrollPane.setPreferredSize(new Dimension(600, 80)); // Use preferred size for layout
-        commandScrollPane.setMinimumSize(new Dimension(100, 80));
+        // Make the scroll area the flexible piece so chips + toolbar remain visible under tight space
+        commandScrollPane.setMinimumSize(new Dimension(100, 0));
 
         // Create layered pane with overlay
         this.inputLayeredPane = commandInputOverlay.createLayeredPane(commandScrollPane);
@@ -740,11 +741,14 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         container.setBorder(BorderFactory.createEmptyBorder(V_GLUE, H_PAD, V_GLUE, H_PAD));
         container.add(workspaceItemsChipPanel, BorderLayout.CENTER);
 
-        // Let chips wrap naturally; provide reasonable min/height
-        container.setMinimumSize(new Dimension(100, 28));
-        // Set suggestion bar height to allow for two rows of chips
-        container.setPreferredSize(new Dimension(100, 64));
-        container.setMaximumSize(new Dimension(Integer.MAX_VALUE, 120));
+        // Fixed height to always show exactly two rows of chips and never move.
+        // Compute a DPI/theme-aware height: approx chip row height = font height + padding.
+        int fmH = instructionsArea.getFontMetrics(instructionsArea.getFont()).getHeight();
+        int rowH = Math.max(24, fmH + 8); // ensure enough room for chip borders/padding
+        int fixedChipAreaHeight = (rowH * 2) + 4; // two rows + FlowLayout vgap (4)
+        container.setMinimumSize(new Dimension(100, fixedChipAreaHeight));
+        container.setPreferredSize(new Dimension(100, fixedChipAreaHeight));
+        container.setMaximumSize(new Dimension(Integer.MAX_VALUE, fixedChipAreaHeight));
 
         // Insert beneath the command-input area (index 2)
         centerPanel.add(container, 2);
@@ -1170,6 +1174,10 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         wandButton.setMaximumSize(iconButtonSize);
 
         bottomPanel.add(actionButton);
+
+        // Lock bottom toolbar height so BorderLayout keeps it visible
+        Dimension bottomPref = bottomPanel.getPreferredSize();
+        bottomPanel.setMinimumSize(new Dimension(0, bottomPref.height));
 
         return bottomPanel;
     }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -3,12 +3,15 @@ package io.github.jbellis.brokk.gui;
 import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.context.ContextFragment;
 import io.github.jbellis.brokk.gui.mop.ThemeColors;
+import io.github.jbellis.brokk.gui.util.ContextMenuUtils;
 import io.github.jbellis.brokk.gui.util.Icons;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Insets;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -121,6 +124,24 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         chip.add(close);
 
         styleChip(chip, label, chrome.getTheme().isDarkTheme());
+
+        chip.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                maybeShowPopup(e);
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                maybeShowPopup(e);
+            }
+
+            private void maybeShowPopup(MouseEvent e) {
+                if (e.isPopupTrigger()) {
+                    ContextMenuUtils.showContextFragmentMenu(chip, e.getX(), e.getY(), fragment, chrome);
+                }
+            }
+        });
 
         return chip;
     }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -90,6 +90,13 @@ public class WorkspaceItemsChipPanel extends JPanel implements IContextManager.C
         chip.setBorder(new CompoundBorder(outer, inner));
 
         var label = new JLabel(fragment.shortDescription());
+        // Improve discoverability and accessibility
+        try {
+            label.setToolTipText(fragment.description());
+            label.getAccessibleContext().setAccessibleDescription(fragment.description());
+        } catch (Exception ignored) {
+            // Defensive: avoid issues if any accessor fails
+        }
 
         var close = new JButton(Icons.CLOSE);
         close.setFocusable(false);
@@ -100,6 +107,11 @@ public class WorkspaceItemsChipPanel extends JPanel implements IContextManager.C
         close.setMargin(new Insets(0, 0, 0, 0));
         close.setPreferredSize(new Dimension(16, 16));
         close.setToolTipText("Remove from Workspace");
+        try {
+            close.getAccessibleContext().setAccessibleName("Remove " + fragment.shortDescription());
+        } catch (Exception ignored) {
+            // best-effort accessibility improvements
+        }
         close.addActionListener(e -> {
             if (onRemoveFragment != null) {
                 onRemoveFragment.accept(fragment);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -1,8 +1,6 @@
 package io.github.jbellis.brokk.gui;
 
 import io.github.jbellis.brokk.ContextManager;
-import io.github.jbellis.brokk.IContextManager;
-import io.github.jbellis.brokk.context.Context;
 import io.github.jbellis.brokk.context.ContextFragment;
 import io.github.jbellis.brokk.gui.mop.ThemeColors;
 import io.github.jbellis.brokk.gui.util.Icons;
@@ -14,7 +12,6 @@ import java.awt.Insets;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
-import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -11,6 +11,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Image;
+import java.awt.Cursor;
 import java.awt.Insets;
 import java.awt.Graphics2D;
 import java.awt.event.MouseAdapter;
@@ -167,6 +168,12 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
             if (d == null) d = "";
             sb.append(htmlEscape(d));
         }
+        // Add preview hint
+        if (sb.length() > 0) {
+            sb.append("<br/><br/><i>Click to preview contents</i>");
+        } else {
+            sb.append("<i>Click to preview contents</i>");
+        }
         return wrapTooltipHtml(sb.toString(), 420);
     }
 
@@ -180,6 +187,7 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         if (d == null) d = "";
         // Preserve existing newlines as line breaks for readability
         String html = htmlEscape(d).replace("\r\n", "\n").replace("\r", "\n").replace("\n", "<br/>");
+        html = html + "<br/><br/><i>Click to preview contents</i>";
         return wrapTooltipHtml(html, 420);
     }
 
@@ -249,6 +257,17 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         } catch (Exception ignored) {
             // Defensive: avoid issues if any accessor fails
         }
+
+        // Make label clickable to open preview
+        label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        label.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 1) {
+                    chrome.openFragmentPreview(fragment);
+                }
+            }
+        });
 
         var originalIcon = Icons.CLOSE;
 
@@ -323,6 +342,14 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
             @Override
             public void mouseReleased(MouseEvent e) {
                 maybeShowPopup(e);
+            }
+
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                // Open preview on left-click anywhere on the chip (excluding close button which handles its own events)
+                if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 1) {
+                    chrome.openFragmentPreview(fragment);
+                }
             }
 
             private void maybeShowPopup(MouseEvent e) {

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -28,8 +28,7 @@ import org.jetbrains.annotations.Nullable;
  * Displays current workspace items as "chips" with a close button to remove them from the workspace.
  * Listens to context changes and updates itself accordingly.
  */
-public class WorkspaceItemsChipPanel extends JPanel
-        implements IContextManager.ContextListener, ThemeAware {
+public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
 
     private final Chrome chrome;
     private final ContextManager contextManager;
@@ -40,11 +39,6 @@ public class WorkspaceItemsChipPanel extends JPanel
         setOpaque(false);
         this.chrome = chrome;
         this.contextManager = chrome.getContextManager();
-        this.contextManager.addContextListener(this);
-
-        // Initialize with the current context
-        var fragments = contextManager.topContext().getAllFragmentsInDisplayOrder();
-        SwingUtilities.invokeLater(() -> updateChips(fragments));
     }
 
     /**
@@ -63,11 +57,6 @@ public class WorkspaceItemsChipPanel extends JPanel
         this.onRemoveFragment = listener;
     }
 
-    @Override
-    public void contextChanged(Context newCtx) {
-        var fragments = newCtx.getAllFragmentsInDisplayOrder();
-        SwingUtilities.invokeLater(() -> updateChips(fragments));
-    }
 
     private void updateChips(List<ContextFragment> fragments) {
         removeAll();

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -1,35 +1,49 @@
 package io.github.jbellis.brokk.gui;
 
+import io.github.jbellis.brokk.AnalyzerWrapper;
 import io.github.jbellis.brokk.ContextManager;
-import io.github.jbellis.brokk.context.ContextFragment;
+import io.github.jbellis.brokk.IConsoleIO;
+import io.github.jbellis.brokk.analyzer.ProjectFile;
 import io.github.jbellis.brokk.context.Context;
+import io.github.jbellis.brokk.context.ContextFragment;
+import io.github.jbellis.brokk.gui.components.MaterialButton;
+import io.github.jbellis.brokk.gui.dialogs.DropActionDialog;
 import io.github.jbellis.brokk.gui.mop.ThemeColors;
 import io.github.jbellis.brokk.gui.util.ContextMenuUtils;
 import io.github.jbellis.brokk.gui.util.Icons;
 import io.github.jbellis.brokk.util.Messages;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
-import java.awt.Image;
-import java.awt.Cursor;
-import java.awt.Insets;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Insets;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.swing.ImageIcon;
-import io.github.jbellis.brokk.gui.components.MaterialButton;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
+import javax.swing.TransferHandler;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -37,6 +51,7 @@ import org.jetbrains.annotations.Nullable;
  * Listens to context changes and updates itself accordingly.
  */
 public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
+    private static final Logger logger = LogManager.getLogger(WorkspaceItemsChipPanel.class);
 
     private final Chrome chrome;
     private final ContextManager contextManager;
@@ -47,6 +62,7 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         setOpaque(false);
         this.chrome = chrome;
         this.contextManager = chrome.getContextManager();
+        setTransferHandler(createFileDropHandler());
     }
 
     /**
@@ -508,5 +524,119 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
                 }
             }
         });
+    }
+
+    private boolean isAnalyzerReady() {
+        if (!contextManager.getAnalyzerWrapper().isReady()) {
+            chrome.systemNotify(
+                    AnalyzerWrapper.ANALYZER_BUSY_MESSAGE,
+                    AnalyzerWrapper.ANALYZER_BUSY_TITLE,
+                    JOptionPane.INFORMATION_MESSAGE);
+            return false;
+        }
+        return true;
+    }
+
+    private TransferHandler createFileDropHandler() {
+        return new TransferHandler() {
+            @Override
+            public boolean canImport(TransferSupport support) {
+                return support.isDataFlavorSupported(DataFlavor.javaFileListFlavor);
+            }
+
+            @Override
+            public boolean importData(TransferSupport support) {
+                if (!canImport(support)) {
+                    return false;
+                }
+
+                if (contextManager.isLlmTaskInProgress()) {
+                    chrome.systemNotify("Cannot add to workspace while an action is running.", "Workspace", JOptionPane.INFORMATION_MESSAGE);
+                    return false;
+                }
+
+                try {
+                    @SuppressWarnings("unchecked")
+                    List<File> files =
+                            (List<File>) support.getTransferable().getTransferData(DataFlavor.javaFileListFlavor);
+                    if (files.isEmpty()) {
+                        return false;
+                    }
+
+                    var projectRoot = contextManager
+                            .getProject()
+                            .getRoot()
+                            .toAbsolutePath()
+                            .normalize();
+                    // Map to ProjectFile inside this project; ignore anything outside
+                    var projectFiles = files.stream()
+                            .map(File::toPath)
+                            .map(Path::toAbsolutePath)
+                            .map(Path::normalize)
+                            .filter(p -> {
+                                boolean inside = p.startsWith(projectRoot);
+                                if (!inside) {
+                                    logger.debug("Ignoring dropped file outside project: {}", p);
+                                }
+                                return inside;
+                            })
+                            .map(p -> projectRoot.relativize(p))
+                            .map(rel -> new ProjectFile(projectRoot, rel))
+                            .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
+
+                    if (projectFiles.isEmpty()) {
+                        chrome.showNotification(IConsoleIO.NotificationRole.INFO, "No project files found in drop");
+                        return false;
+                    }
+
+                    // Ask the user what to do
+                    var analyzedExts = contextManager.getProject().getAnalyzerLanguages().stream()
+                            .flatMap(lang -> lang.getExtensions().stream())
+                            .collect(Collectors.toSet());
+                    boolean canSummarize = projectFiles.stream().anyMatch(pf -> analyzedExts.contains(pf.extension()));
+                    java.awt.Point pointer = null;
+                    try {
+                        var pi = java.awt.MouseInfo.getPointerInfo();
+                        if (pi != null) {
+                            pointer = pi.getLocation();
+                        }
+                    } catch (Exception ignore) {
+                        // ignore
+                    }
+                    var selection = DropActionDialog.show(chrome.getFrame(), canSummarize, pointer);
+                    if (selection == null) {
+                        chrome.showNotification(IConsoleIO.NotificationRole.INFO, "Drop canceled");
+                        return false;
+                    }
+                    switch (selection) {
+                        case EDIT -> {
+                            // Only allow editing tracked files; others are silently ignored by editFiles
+                            contextManager.submitContextTask(() -> {
+                                contextManager.addFiles(projectFiles);
+                            });
+                        }
+                        case SUMMARIZE -> {
+                            if (!isAnalyzerReady()) {
+                                return false;
+                            }
+                            contextManager.submitContextTask(() -> {
+                                contextManager.addSummaries(
+                                        new java.util.HashSet<>(projectFiles), Collections.emptySet());
+                            });
+                        }
+                        default -> {
+                            logger.warn("Unexpected drop selection: {}", selection);
+                            return false;
+                        }
+                    }
+
+                    return true;
+                } catch (Exception ex) {
+                    logger.error("Error importing dropped files into workspace", ex);
+                    chrome.toolError("Failed to import dropped files: " + ex.getMessage());
+                    return false;
+                }
+            }
+        };
     }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -22,7 +22,6 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Insets;
 import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.Transferable;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -33,7 +32,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.swing.ImageIcon;
-import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -47,8 +45,8 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Displays current workspace items as "chips" with a close button to remove them from the workspace.
- * Listens to context changes and updates itself accordingly.
+ * Displays current workspace items as "chips" with a close button to remove them from the workspace. Listens to context
+ * changes and updates itself accordingly.
  */
 public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
     private static final Logger logger = LogManager.getLogger(WorkspaceItemsChipPanel.class);
@@ -66,21 +64,20 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
     }
 
     /**
-     * Programmatically set the fragments to display as chips. Safe to call from any thread; updates are
-     * marshaled to the EDT.
+     * Programmatically set the fragments to display as chips. Safe to call from any thread; updates are marshaled to
+     * the EDT.
      */
     public void setFragments(List<ContextFragment> fragments) {
         SwingUtilities.invokeLater(() -> updateChips(fragments));
     }
 
     /**
-     * Sets a listener invoked when a chip's remove button is clicked. If not set, the panel will
-     * default to removing from the ContextManager.
+     * Sets a listener invoked when a chip's remove button is clicked. If not set, the panel will default to removing
+     * from the ContextManager.
      */
     public void setOnRemoveFragment(Consumer<ContextFragment> listener) {
         this.onRemoveFragment = listener;
     }
-
 
     private void updateChips(List<ContextFragment> fragments) {
         removeAll();
@@ -93,7 +90,11 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         repaint();
     }
 
-    private enum ChipKind { EDIT, SUMMARY, OTHER }
+    private enum ChipKind {
+        EDIT,
+        SUMMARY,
+        OTHER
+    }
 
     // Rounded chip container that paints a rounded background and border
     private static final class RoundedChipPanel extends JPanel {
@@ -113,7 +114,8 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         protected void paintComponent(Graphics g) {
             Graphics2D g2 = (Graphics2D) g.create();
             try {
-                g2.setRenderingHint(java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setRenderingHint(
+                        java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
                 Color bg = getBackground();
                 if (bg == null) {
                     bg = getParent() != null ? getParent().getBackground() : Color.LIGHT_GRAY;
@@ -132,7 +134,8 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         protected void paintBorder(Graphics g) {
             Graphics2D g2 = (Graphics2D) g.create();
             try {
-                g2.setRenderingHint(java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setRenderingHint(
+                        java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
                 int w = getWidth();
                 int h = getHeight();
                 g2.setColor(borderColor);
@@ -204,18 +207,15 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         return raw;
     }
 
-
     private static String buildSummaryLabel(ContextFragment fragment) {
-        int n = (int) fragment.files().stream()
-                .map(f -> f.toString())
-                .distinct()
-                .count();
+        int n = (int)
+                fragment.files().stream().map(f -> f.toString()).distinct().count();
         return "Summary" + (n > 0 ? " (" + n + ")" : "");
     }
 
     /**
-     * Builds an HTML snippet showing approximate size metrics (LOC and tokens) for the fragment.
-     * Returns an empty string if metrics are not applicable (e.g., non-text/image fragments).
+     * Builds an HTML snippet showing approximate size metrics (LOC and tokens) for the fragment. Returns an empty
+     * string if metrics are not applicable (e.g., non-text/image fragments).
      */
     private static String buildMetricsHtml(ContextFragment fragment) {
         try {
@@ -224,8 +224,8 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
                 String text = fragment.text();
                 int loc = text.split("\\r?\\n", -1).length;
                 int tokens = Messages.getApproximateTokens(text);
-                return "<div><b>Size:</b> " + String.format("%,d", loc)
-                        + " LOC \u2022 ~" + String.format("%,d", tokens) + " tokens</div><br/>";
+                return "<div><b>Size:</b> " + String.format("%,d", loc) + " LOC \u2022 ~" + String.format("%,d", tokens)
+                        + " tokens</div><br/>";
             }
         } catch (Exception ignored) {
             // Best effort; if anything goes wrong, just return no metrics
@@ -281,7 +281,8 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
         if (d == null) d = "";
 
         // Preserve existing newlines as line breaks for readability
-        String descriptionHtml = htmlEscape(d).replace("\r\n", "\n").replace("\r", "\n").replace("\n", "<br/>");
+        String descriptionHtml =
+                htmlEscape(d).replace("\r\n", "\n").replace("\r", "\n").replace("\n", "<br/>");
 
         StringBuilder body = new StringBuilder();
 
@@ -365,9 +366,8 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
 
         // Use a compact label for SUMMARY chips; otherwise use the fragment's shortDescription
         ChipKind kindForLabel = classify(fragment);
-        String labelText = (kindForLabel == ChipKind.SUMMARY)
-                ? buildSummaryLabel(fragment)
-                : fragment.shortDescription();
+        String labelText =
+                (kindForLabel == ChipKind.SUMMARY) ? buildSummaryLabel(fragment) : fragment.shortDescription();
         var label = new JLabel(labelText);
 
         // Improve discoverability and accessibility with wrapped HTML tooltips
@@ -551,7 +551,10 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware {
                 }
 
                 if (contextManager.isLlmTaskInProgress()) {
-                    chrome.systemNotify("Cannot add to workspace while an action is running.", "Workspace", JOptionPane.INFORMATION_MESSAGE);
+                    chrome.systemNotify(
+                            "Cannot add to workspace while an action is running.",
+                            "Workspace",
+                            JOptionPane.INFORMATION_MESSAGE);
                     return false;
                 }
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -1,0 +1,91 @@
+package io.github.jbellis.brokk.gui;
+
+import io.github.jbellis.brokk.ContextManager;
+import io.github.jbellis.brokk.IContextManager;
+import io.github.jbellis.brokk.context.Context;
+import io.github.jbellis.brokk.context.ContextFragment;
+import io.github.jbellis.brokk.gui.util.Icons;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Insets;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.MatteBorder;
+
+/**
+ * Displays current workspace items as "chips" with a close button to remove them from the workspace.
+ * Listens to context changes and updates itself accordingly.
+ */
+public class WorkspaceItemsChipPanel extends JPanel implements IContextManager.ContextListener {
+
+    private final ContextManager contextManager;
+
+    public WorkspaceItemsChipPanel(ContextManager contextManager) {
+        super(new FlowLayout(FlowLayout.LEFT, 6, 4));
+        setOpaque(false);
+        this.contextManager = contextManager;
+        this.contextManager.addContextListener(this);
+
+        // Initialize with the current context
+        var fragments = contextManager.topContext().getAllFragmentsInDisplayOrder();
+        SwingUtilities.invokeLater(() -> updateChips(fragments));
+    }
+
+    @Override
+    public void contextChanged(Context newCtx) {
+        var fragments = newCtx.getAllFragmentsInDisplayOrder();
+        SwingUtilities.invokeLater(() -> updateChips(fragments));
+    }
+
+    private void updateChips(List<ContextFragment> fragments) {
+        removeAll();
+
+        for (var fragment : fragments) {
+            add(createChip(fragment));
+        }
+
+        revalidate();
+        repaint();
+    }
+
+    private Component createChip(ContextFragment fragment) {
+        var chip = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 0));
+        chip.setOpaque(false);
+
+        Color borderColor = javax.swing.UIManager.getColor("Component.borderColor");
+        if (borderColor == null) {
+            borderColor = Color.GRAY;
+        }
+        var outer = new MatteBorder(1, 1, 1, 1, borderColor);
+        var inner = new EmptyBorder(2, 8, 2, 6);
+        chip.setBorder(new CompoundBorder(outer, inner));
+
+        var label = new JLabel(fragment.shortDescription());
+
+        var close = new JButton(Icons.CLOSE);
+        close.setFocusable(false);
+        close.setOpaque(false);
+        close.setContentAreaFilled(false);
+        close.setBorderPainted(false);
+        close.setFocusPainted(false);
+        close.setMargin(new Insets(0, 0, 0, 0));
+        close.setPreferredSize(new Dimension(16, 16));
+        close.setToolTipText("Remove from Workspace");
+        close.addActionListener(e -> contextManager.drop(Collections.singletonList(fragment)));
+
+        chip.add(label);
+        chip.add(close);
+
+        return chip;
+    }
+}

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -1145,7 +1145,7 @@ public class WorkspacePanel extends JPanel {
         if (popupMenuMode == PopupMenuMode.FULL) {
             // Add button to show Add popup (same menu as table's Add)
             var addButton = new MaterialButton();
-            addButton.setIcon(Icons.ATTACH_FILE);
+            SwingUtilities.invokeLater(() -> addButton.setIcon(Icons.ATTACH_FILE));
             addButton.setToolTipText("Add content to workspace (Ctrl/Cmd+Shift+I)");
             addButton.setFocusable(false);
             addButton.setOpaque(false);
@@ -1160,7 +1160,7 @@ public class WorkspacePanel extends JPanel {
                     () -> SwingUtilities.invokeLater(this::attachContextViaDialog));
 
             // Create a trash button to drop selected fragment(s)
-            dropSelectedButton.setIcon(Icons.TRASH);
+            SwingUtilities.invokeLater(() -> dropSelectedButton.setIcon(Icons.TRASH));
             dropSelectedButton.setToolTipText("Drop selected item(s) from workspace");
             dropSelectedButton.setFocusable(false);
             dropSelectedButton.setOpaque(false);

--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspacePanel.java
@@ -24,7 +24,6 @@ import io.github.jbellis.brokk.gui.dialogs.DropActionDialog;
 import io.github.jbellis.brokk.gui.dialogs.SymbolSelectionDialog;
 import io.github.jbellis.brokk.gui.util.ContextMenuUtils;
 import io.github.jbellis.brokk.gui.util.Icons;
-import io.github.jbellis.brokk.gui.util.KeyboardShortcutUtil;
 import io.github.jbellis.brokk.prompts.CopyExternalPrompts;
 import io.github.jbellis.brokk.tools.WorkspaceTools;
 import io.github.jbellis.brokk.util.HtmlToMarkdown;
@@ -2402,5 +2401,4 @@ public class WorkspacePanel extends JPanel {
         // Update drop-selected button
         updateDropSelectedButtonEnabled();
     }
-
 }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesDrawerPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesDrawerPanel.java
@@ -1,232 +1,37 @@
 package io.github.jbellis.brokk.gui.dependencies;
 
 import io.github.jbellis.brokk.gui.Chrome;
-import io.github.jbellis.brokk.gui.components.MaterialToggleButton;
-import io.github.jbellis.brokk.gui.util.Icons;
 import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Dimension;
 import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
 import javax.swing.JPanel;
-import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
-/** A drawer panel that can host development tools. The drawer can be collapsed when no tools are active. */
+/** A panel for managing project dependencies. */
 public class DependenciesDrawerPanel extends JPanel {
-    private static final Logger logger = LogManager.getLogger(DependenciesDrawerPanel.class);
-
-    // Core components
-    private final JPanel drawerContentPanel;
-    private final JPanel drawerToolBar;
-    private final MaterialToggleButton dependenciesToggle;
     private @Nullable DependenciesPanel activeDependenciesPanel;
-
-    // Drawer state management
-    private double lastDividerLocation = -1.0;
-    private int originalDividerSize;
-
-    // Dependencies
     private final Chrome chrome;
-    private final JSplitPane parentSplitPane;
 
     /**
-     * Creates a new terminal drawer panel.
+     * Creates a new dependencies panel.
      *
      * @param chrome main ui
-     * @param parentSplitPane The split pane this drawer is part of
      */
-    public DependenciesDrawerPanel(Chrome chrome, JSplitPane parentSplitPane) {
+    public DependenciesDrawerPanel(Chrome chrome) {
         super(new BorderLayout());
         this.chrome = chrome;
-        this.parentSplitPane = parentSplitPane;
-        this.originalDividerSize = parentSplitPane.getDividerSize();
-
         setBorder(BorderFactory.createEmptyBorder());
-
-        // Create vertical icon bar on the EAST side
-        drawerToolBar = new JPanel();
-        drawerToolBar.setLayout(new BoxLayout(drawerToolBar, BoxLayout.Y_AXIS));
-        drawerToolBar.setOpaque(false);
-        drawerToolBar.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4));
-
-        dependenciesToggle = new MaterialToggleButton(Icons.MANAGE_DEPENDENCIES);
-        dependenciesToggle.setToolTipText("Toggle Manage Dependencies");
-        dependenciesToggle.setBorderHighlightOnly(true);
-        dependenciesToggle.setFocusPainted(false);
-        dependenciesToggle.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4));
-        dependenciesToggle.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-        // Edge selection highlight is applied by MaterialToggleButton; LAF handles hover background.
-
-        drawerToolBar.add(dependenciesToggle);
-
-        add(drawerToolBar, BorderLayout.EAST);
-
-        // Content area for the drawer (where TerminalPanel and future tools will appear)
-        drawerContentPanel = new JPanel(new BorderLayout());
-        add(drawerContentPanel, BorderLayout.CENTER);
-
-        // Wire the toggle to create/show/hide a Depedencies
-        dependenciesToggle.addActionListener(ev -> {
-            if (dependenciesToggle.isSelected()) {
-                if (activeDependenciesPanel == null) {
-                    createPanel();
-                } else {
-                    showDrawer();
-                }
-            } else {
-                if (activeDependenciesPanel != null) {
-                    hideDepedenciesDrawer();
-                }
-            }
-        });
     }
 
-    /** Opens the panel in the drawer */
+    /** Creates and shows the panel contents. */
     public void openPanel() {
         SwingUtilities.invokeLater(() -> {
-            if (!dependenciesToggle.isSelected()) {
-                dependenciesToggle.doClick();
-                return;
-            }
-
             if (activeDependenciesPanel == null) {
-                createPanel();
-            } else {
-                showDrawer();
+                activeDependenciesPanel = new DependenciesPanel(chrome);
+                add(activeDependenciesPanel, BorderLayout.CENTER);
+                revalidate();
+                repaint();
             }
         });
-    }
-
-    /** Opens the drawer synchronously before first layout to avoid startup motion. */
-    public void openInitially() {
-        if (activeDependenciesPanel == null) {
-            activeDependenciesPanel = new DependenciesPanel(chrome);
-            drawerContentPanel.add(activeDependenciesPanel, BorderLayout.CENTER);
-        }
-        // Ensure divider visible and set initial proportions
-        if (originalDividerSize > 0) {
-            parentSplitPane.setDividerSize(originalDividerSize);
-        }
-        // Prefer workspace side but leave drawer visible
-        parentSplitPane.setResizeWeight(0.67);
-        // Remove any minimum width constraint for collapsed state
-        setMinimumSize(null);
-
-        // Use a proportional divider for the first layout
-        double loc = lastDividerLocation;
-        if (loc <= 0.0 || loc >= 1.0 || Math.abs(loc - 0.5) < 1e-6) {
-            loc = 0.67;
-        }
-        parentSplitPane.setDividerLocation(loc);
-
-        // Reflect toggle selected state without firing the action listener
-        dependenciesToggle.setSelected(true);
-
-        revalidate();
-        repaint();
-    }
-
-    private void hideDepedenciesDrawer() {
-        SwingUtilities.invokeLater(() -> {
-            if (activeDependenciesPanel != null) {
-                drawerContentPanel.remove(activeDependenciesPanel);
-                drawerContentPanel.revalidate();
-                drawerContentPanel.repaint();
-                collapseIfEmpty();
-            }
-        });
-    }
-
-    /** Shows the drawer by restoring the divider to its last known position. */
-    public void showDrawer() {
-        SwingUtilities.invokeLater(() -> {
-            if (activeDependenciesPanel != null && activeDependenciesPanel.getParent() == null) {
-                drawerContentPanel.add(activeDependenciesPanel, BorderLayout.CENTER);
-                drawerContentPanel.revalidate();
-                drawerContentPanel.repaint();
-            }
-
-            // Restore original divider size
-            if (originalDividerSize > 0) {
-                parentSplitPane.setDividerSize(originalDividerSize);
-            }
-
-            // Set resize weight for 67/33 split (workspace gets more space)
-            parentSplitPane.setResizeWeight(0.67);
-
-            // Remove minimum size constraint from this drawer panel
-            setMinimumSize(null);
-
-            // Use saved location if reasonable, otherwise default to 67/33 split
-            double loc = lastDividerLocation;
-            if (loc <= 0.0 || loc >= 1.0 || Math.abs(loc - 0.5) < 1e-6) {
-                loc = 0.67;
-            }
-
-            parentSplitPane.setDividerLocation(loc);
-        });
-    }
-
-    /** Collapses the drawer if no tools are active, showing only the toolbar. */
-    public void collapseIfEmpty() {
-        SwingUtilities.invokeLater(() -> {
-            if (drawerContentPanel.getComponentCount() == 0) {
-                try {
-                    // Remember last divider location only if not already collapsed
-                    int current = parentSplitPane.getDividerLocation();
-                    int total = parentSplitPane.getWidth();
-                    if (total > 0) {
-                        double currentProp = (double) current / (double) total;
-                        if (currentProp > 0.0 && currentProp < 0.95) {
-                            lastDividerLocation = currentProp;
-                        }
-                    }
-
-                    // Calculate the minimum width needed for the toolbar
-                    int toolbarWidth = drawerToolBar.getPreferredSize().width;
-                    final int MIN_COLLAPSE_WIDTH = toolbarWidth;
-
-                    int totalWidth = parentSplitPane.getWidth();
-                    if (totalWidth <= 0) {
-                        return;
-                    }
-
-                    // Set resize weight so left panel gets all extra space
-                    parentSplitPane.setResizeWeight(1.0);
-
-                    // Set minimum size on this drawer panel to keep toolbar visible
-                    setMinimumSize(new Dimension(MIN_COLLAPSE_WIDTH, 0));
-
-                    // Position divider to show only the toolbar
-                    int dividerLocation = totalWidth - MIN_COLLAPSE_WIDTH;
-                    parentSplitPane.setDividerLocation(dividerLocation);
-
-                    // Hide the divider
-                    parentSplitPane.setDividerSize(0);
-
-                    // Force layout update
-                    parentSplitPane.revalidate();
-                    parentSplitPane.repaint();
-                } catch (Exception ex) {
-                    logger.debug("Error collapsing drawer", ex);
-                }
-            }
-        });
-    }
-
-    private void createPanel() {
-        var dependenciesPanel = new DependenciesPanel(chrome);
-        activeDependenciesPanel = dependenciesPanel;
-
-        drawerContentPanel.add(dependenciesPanel, BorderLayout.CENTER);
-        drawerContentPanel.revalidate();
-        drawerContentPanel.repaint();
-        showDrawer();
-        dependenciesToggle.setSelected(true);
     }
 }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dependencies/DependenciesPanel.java
@@ -278,7 +278,8 @@ public final class DependenciesPanel extends JPanel {
                     setControlsLocked(false);
                 }
             };
-            ImportDependencyDialog.show(chrome, listener);
+            var parentWindow = SwingUtilities.getWindowAncestor(DependenciesPanel.this);
+            ImportDependencyDialog.show(chrome, parentWindow, listener);
         });
 
         removeButton.addActionListener(e -> removeSelectedDependency());

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/ImportDependencyDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/ImportDependencyDialog.java
@@ -14,12 +14,12 @@ import io.github.jbellis.brokk.gui.dependencies.DependenciesPanel;
 import io.github.jbellis.brokk.util.CloneOperationTracker;
 import io.github.jbellis.brokk.util.FileUtil;
 import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Container;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.Component;
-import java.awt.Container;
 import java.awt.Window;
 import java.io.File;
 import java.io.IOException;
@@ -106,8 +106,7 @@ public class ImportDependencyDialog {
         @Nullable
         private GitRepo.RemoteInfo remoteInfo;
 
-        DialogHelper(
-                Chrome chrome, Window owner, @Nullable DependenciesPanel.DependencyLifecycleListener listener) {
+        DialogHelper(Chrome chrome, Window owner, @Nullable DependenciesPanel.DependencyLifecycleListener listener) {
             this.chrome = chrome;
             this.owner = owner;
             this.dependenciesRoot = chrome.getProject()

--- a/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
@@ -276,8 +276,7 @@ public final class ContextMenuUtils {
      * @param fragment The context fragment for which to show the menu
      * @param chrome The Chrome instance for UI integration
      */
-    public static void showContextFragmentMenu(
-            Component owner, int x, int y, ContextFragment fragment, Chrome chrome) {
+    public static void showContextFragmentMenu(Component owner, int x, int y, ContextFragment fragment, Chrome chrome) {
         var cm = chrome.getContextManager();
         var menu = new JPopupMenu();
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
@@ -266,6 +266,78 @@ public final class ContextMenuUtils {
         menu.show(owner, x, y);
     }
 
+    /**
+     * Shows a context menu for a context fragment at the specified position.
+     *
+     * @param owner The component that owns the popup (where it will be displayed)
+     * @param x The x position for the menu relative to the owner
+     * @param y The y position for the menu relative to the owner
+     * @param fragment The context fragment for which to show the menu
+     * @param chrome The Chrome instance for UI integration
+     */
+    public static void showContextFragmentMenu(
+            Component owner, int x, int y, ContextFragment fragment, Chrome chrome) {
+        var cm = chrome.getContextManager();
+        var menu = new JPopupMenu();
+
+        // "Show Contents" is applicable to almost all fragments
+        var showContentsItem = new JMenuItem("Show Contents");
+        showContentsItem.addActionListener(e -> chrome.openFragmentPreview(fragment));
+        menu.add(showContentsItem);
+        menu.addSeparator();
+
+        // File-specific actions
+        if (fragment instanceof ContextFragment.PathFragment pathFragment
+                && pathFragment.file() instanceof ProjectFile projectFile) {
+            var showInTreeItem = new JMenuItem("Show in Project Tree");
+            showInTreeItem.addActionListener(e -> chrome.getProjectTree().selectFile(projectFile));
+            menu.add(showInTreeItem);
+            menu.addSeparator();
+
+            // Edit option
+            var editItem = new JMenuItem("Edit " + projectFile);
+            editItem.addActionListener(e1 -> {
+                withTemporaryListenerDetachment(chrome, () -> {
+                    cm.addFiles(List.of(projectFile));
+                });
+            });
+            // Disable for dependency projects
+            if (!cm.getProject().hasGit()) {
+                editItem.setEnabled(false);
+                editItem.setToolTipText("Editing not available without Git");
+            }
+            menu.add(editItem);
+
+            // Summarize option
+            var summarizeItem = new JMenuItem("Summarize " + projectFile);
+            summarizeItem.addActionListener(e1 -> {
+                if (!cm.getAnalyzerWrapper().isReady()) {
+                    cm.getIo()
+                            .systemNotify(
+                                    AnalyzerWrapper.ANALYZER_BUSY_MESSAGE,
+                                    AnalyzerWrapper.ANALYZER_BUSY_TITLE,
+                                    JOptionPane.INFORMATION_MESSAGE);
+                    return;
+                }
+                withTemporaryListenerDetachment(chrome, () -> {
+                    boolean success = cm.addSummaries(Set.of(projectFile), Set.of());
+                    if (!success) {
+                        chrome.toolError("No summarizable code found");
+                    }
+                });
+            });
+            menu.add(summarizeItem);
+            menu.addSeparator();
+        }
+
+        // "Remove" is always applicable
+        var removeItem = new JMenuItem("Remove");
+        removeItem.addActionListener(e -> cm.drop(List.of(fragment)));
+        menu.add(removeItem);
+
+        menu.show(owner, x, y);
+    }
+
     /** Helper method to detach context listener temporarily while performing operations. */
     private static void withTemporaryListenerDetachment(Chrome chrome, Runnable action) {
         // Access the contextManager from Chrome and call submitContextTask on it

--- a/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/util/ContextMenuUtils.java
@@ -1,6 +1,7 @@
 package io.github.jbellis.brokk.gui.util;
 
 import io.github.jbellis.brokk.AnalyzerWrapper;
+import io.github.jbellis.brokk.analyzer.ProjectFile;
 import io.github.jbellis.brokk.context.ContextFragment;
 import io.github.jbellis.brokk.gui.Chrome;
 import io.github.jbellis.brokk.gui.TableUtils;
@@ -290,7 +291,7 @@ public final class ContextMenuUtils {
         if (fragment instanceof ContextFragment.PathFragment pathFragment
                 && pathFragment.file() instanceof ProjectFile projectFile) {
             var showInTreeItem = new JMenuItem("Show in Project Tree");
-            showInTreeItem.addActionListener(e -> chrome.getProjectTree().selectFile(projectFile));
+            showInTreeItem.addActionListener(e -> chrome.getProjectFilesPanel().showFileInTree(projectFile));
             menu.add(showInTreeItem);
             menu.addSeparator();
 


### PR DESCRIPTION
- We now have collapsed workspace that remembers if it was collapsed between restarts
- mini-workspace underneath the instructions box, this replaces the old suggestions code. It is not fully complete yet (colors I don't like, I have not added the right clicks cause I think we don't need them, and I havent removed the old drag and drop behavior because I want feedback first) but I think it is ready to use and get feedback. It does have, add, remove, mouse over loc and tokens per file, mouse over files in summary, ability to click and preview and it has support for drag and drop.
- dependencies is a button and a dialog now, I will do a second pass and add a badge, but every time I do that it is a time sink and this was a big enough PR
- final bit the story isnt great yet if the workspace it too big.. you just won't see it. but the trick I did with the summaries helps a lot and I just need to make a another pass and handle indication of overflow..click here to see full workspace. 

<img width="2880" height="1800" alt="Capture d’écran du 2025-10-07 23-05-57" src="https://github.com/user-attachments/assets/bf73815a-b59f-4280-ad5b-8f7e712d3d9f" />

video demo of drag and drop


https://github.com/user-attachments/assets/e4ad8c6d-2b9c-4599-9078-64e6721689cb


video of expanding workspace

https://github.com/user-attachments/assets/274921f1-1a65-4478-be06-2a3e9ce1a0be

