### PR TITLE
Tweak Memory Watcher Parameters for Earlier Warning

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/util/LowMemoryWatcherManager.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/LowMemoryWatcherManager.java
@@ -27,9 +27,9 @@ public final class LowMemoryWatcherManager implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(LowMemoryWatcherManager.class);
 
-    private static final long MEM_THRESHOLD = 5 /*MB*/ * 1024 * 1024;
+    private static final long MEM_THRESHOLD = 25 /*MB*/ * 1024 * 1024;
     private static final long GC_TIME_THRESHOLD = 10_000; // 10 seconds
-    private static final float OCCUPIED_MEMORY_THRESHOLD = 0.90f;
+    private static final float OCCUPIED_MEMORY_THRESHOLD = 0.85f;
 
     private final AtomicLong lastGcTime = new AtomicLong();
 


### PR DESCRIPTION
Added larger available memory minimum and occupied memory percentage to give earlier warnings about high memory consumption.