### PR TITLE
Trigger symbol refresh on analyzer-ready

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/mop/webview/MOPBridge.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/mop/webview/MOPBridge.java
@@ -616,6 +616,11 @@ public final class MOPBridge {
         boolean ready = contextManager != null && contextManager.isAnalyzerReady();
         sendEnvironmentInfo(ready);
 
+        // If analyzer is already ready when bridge initializes, trigger symbol lookup for existing content
+        if (ready) {
+            onAnalyzerReadyResponse(getContextCacheId());
+        }
+
         if (hostComponent instanceof MOPWebViewHost host) {
             host.onBridgeReady();
         }

--- a/frontend-mop/src/components/ContentAwareCode.svelte
+++ b/frontend-mop/src/components/ContentAwareCode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {onMount} from 'svelte';
-  import {symbolCacheStore, requestSymbolResolution, subscribeKey, type SymbolCacheEntry} from '../stores/symbolCacheStore';
+  import {symbolCacheStore, requestSymbolResolution, subscribeKey, type SymbolCacheEntry, symbolRefreshTrigger} from '../stores/symbolCacheStore';
   import {filePathCacheStore, requestFilePathResolution, subscribeKey as subscribeFilePathKey, type FilePathCacheEntry, type ProjectFileMatch} from '../stores/filePathCacheStore';
   import {tryFilePathDetection} from '../lib/filePathDetection';
   import {createLogger} from '../lib/logging';
@@ -195,6 +195,16 @@
       // Content has changed, reset and reprocess
       resetState();
       processContent(propsText);
+    }
+  });
+
+  // Watch for symbol refresh trigger - when cache is cleared, re-validate
+  $effect(() => {
+    const trigger = $symbolRefreshTrigger;
+    if (trigger > 0 && extractedText && extractedText === lastProcessedText) {
+      // Cache was cleared, reset fallback state and re-validate existing content
+      hasTriedSymbolFallback = false;
+      validateAndRequestContent(extractedText);
     }
   });
 

--- a/frontend-mop/src/stores/symbolCacheStore.ts
+++ b/frontend-mop/src/stores/symbolCacheStore.ts
@@ -1,3 +1,4 @@
+import { writable } from 'svelte/store';
 import { createLogger } from '../lib/logging';
 import { createBatchedCache, type CacheEntry } from './batchedCache';
 import { mockExtractSymbol } from '../dev/mockSymbolExtractor';
@@ -21,6 +22,9 @@ export interface SymbolLookupResult {
 export type SymbolCacheEntry = CacheEntry<SymbolLookupResult>;
 
 const log = createLogger('symbol-cache-store');
+
+// Refresh trigger store - increment to signal all components to re-detect symbols
+export const symbolRefreshTrigger = writable(0);
 
 const CONFIG = {
   immediateThreshold: 100,
@@ -105,10 +109,14 @@ export function getSymbolCacheEntry(symbol: string, contextId: string = 'main-co
 
 export function clearContextCache(contextId: string): void {
   cache.clearContextCache(contextId);
+  // Trigger refresh for all components
+  symbolRefreshTrigger.update(n => n + 1);
 }
 
 export function clearSymbolCache(): void {
   cache.clearAll();
+  // Trigger refresh for all components
+  symbolRefreshTrigger.update(n => n + 1);
 }
 
 export function getCacheStats() {

--- a/frontend-mop/src/styles/markdown.scss
+++ b/frontend-mop/src/styles/markdown.scss
@@ -147,7 +147,7 @@ li > p {
   cursor: default; /* Remove pointer cursor from entire element */
   contain: style;
   color: var(--link-color-hex); /* Match the base symbol-exists color */
-  font-weight: normal;
+  font-weight: var(--code-block-font-weight);
 }
 
 :not(pre) > code.symbol-exists.partial-match::after {
@@ -186,12 +186,13 @@ li > p {
   text-decoration-color: var(--link-color-hex);
   cursor: pointer; /* Ensure partial match highlights are clickable */
   color: var(--link-color-hex); /* Match exact match color */
-  font-weight: normal; /* Match exact match base font weight */
+  font-weight: var(--code-block-font-weight); /* Match exact match base font weight */
 }
 
 /* Ensure non-highlighted spans have no interactive hover effects but inherit base styling */
 .symbol-non-highlight {
   cursor: default;
+  font-weight: var(--code-block-font-weight);
 }
 
 .symbol-non-highlight:hover {


### PR DESCRIPTION
Symbol resolution is not running every time at the startup depending on the order on which analyzer is ready.
This patch ensures symbol resolution and UI consistency when analyzer state or caches change.

Key changes:

- Backend: MOPBridge now immediately triggers onAnalyzerReadyResponse when the analyzer is already ready at bridge initialization, causing symbol lookup for existing content.
- Frontend: Introduces a symbolRefreshTrigger Svelte store that increments when clearContextCache or clearSymbolCache are called; ContentAwareCode subscribes to the trigger and re-validates/re-requests symbols for the current content when the trigger fires.
- Styling: Unifies code span font weight by using a CSS variable (--code-block-font-weight) for symbol highlight and non-highlight classes.