### PR TITLE
Fix UnifiedDiffPanel not computing diffs

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/difftool/doc/FileDocument.java
+++ b/app/src/main/java/io/github/jbellis/brokk/difftool/doc/FileDocument.java
@@ -48,7 +48,11 @@ public class FileDocument extends AbstractBufferDocument {
     public Reader getReader() {
         try {
             if (!file.exists() || !file.canRead()) {
-                logger.warn("File does not exist or cannot be read: " + file.getAbsolutePath());
+                logger.warn(
+                        "FileDocument.getReader: File does not exist or cannot be read: {} (exists={}, canRead={})",
+                        file.getAbsolutePath(),
+                        file.exists(),
+                        file.canRead());
                 // Return a reader for an empty string if file is inaccessible
                 return new BufferedReader(new InputStreamReader(
                         new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8));

--- a/app/src/main/java/io/github/jbellis/brokk/difftool/ui/BufferDiffPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/difftool/ui/BufferDiffPanel.java
@@ -207,8 +207,11 @@ public class BufferDiffPanel extends AbstractDiffPanel implements SlidingWindowC
         BufferDocumentIF leftDocument = bnLeft != null ? bnLeft.getDocument() : null;
         BufferDocumentIF rightDocument = bnRight != null ? bnRight.getDocument() : null;
 
-        // Calculate the diff to get the patch with actual differences
-        diffNode.diff();
+        // Calculate the diff to get the patch with actual differences (if not already computed)
+        var existingPatch = diffNode.getPatch();
+        if (existingPatch == null || existingPatch.getDeltas().isEmpty()) {
+            diffNode.diff();
+        }
         this.patch = diffNode.getPatch(); // new Patch or null
 
         // Initialize selectedDelta to first change for proper navigation button states

--- a/app/src/main/java/io/github/jbellis/brokk/difftool/ui/HybridFileComparison.java
+++ b/app/src/main/java/io/github/jbellis/brokk/difftool/ui/HybridFileComparison.java
@@ -99,22 +99,13 @@ public class HybridFileComparison {
             try {
                 long diffStartTime = System.currentTimeMillis();
 
-                // Create diff node and compute diff synchronously
+                // Create diff node (panels will compute diff in their initialization)
                 var diffNode = FileComparisonHelper.createDiffNode(
                         leftSource, rightSource, contextManager, isMultipleCommitsContext);
 
                 long diffCreationTime = System.currentTimeMillis() - diffStartTime;
                 if (diffCreationTime > PerformanceConstants.SLOW_UPDATE_THRESHOLD_MS / 2) {
                     logger.warn("Slow diff node creation: {}ms", diffCreationTime);
-                }
-
-                diffStartTime = System.currentTimeMillis();
-                diffNode.diff(); // Fast for small files
-
-                long diffComputeTime = System.currentTimeMillis() - diffStartTime;
-                if (diffComputeTime > PerformanceConstants.SLOW_UPDATE_THRESHOLD_MS) {
-                    logger.warn(
-                            "Slow diff computation (sync): {}ms - consider lowering size threshold", diffComputeTime);
                 }
 
                 // Create appropriate panel type based on view mode
@@ -136,12 +127,7 @@ public class HybridFileComparison {
                 long totalElapsedTime = System.currentTimeMillis() - startTime;
 
                 if (totalElapsedTime > PerformanceConstants.SLOW_UPDATE_THRESHOLD_MS) {
-                    logger.warn(
-                            "Slow sync diff creation: {}ms (diff: {}ms, total: {}ms)",
-                            diffComputeTime,
-                            totalElapsedTime,
-                            totalElapsedTime);
-                } else {
+                    logger.warn("Slow sync diff creation: {}ms", totalElapsedTime);
                 }
 
             } catch (RuntimeException ex) {

--- a/app/src/main/java/io/github/jbellis/brokk/difftool/ui/unified/UnifiedDiffPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/difftool/ui/unified/UnifiedDiffPanel.java
@@ -149,11 +149,19 @@ public class UnifiedDiffPanel extends AbstractDiffPanel implements ThemeAware {
 
     /** Generate the unified diff content from JMDiffNode (preferred approach). */
     private void generateDiffFromDiffNode(JMDiffNode diffNode) {
+        // Compute the diff to populate the patch with deltas (if not already computed)
+        var patch = diffNode.getPatch();
+        if (patch == null || patch.getDeltas().isEmpty()) {
+            diffNode.diff();
+        }
 
         // Generate the UnifiedDiffDocument (for line number metadata and display content)
         this.unifiedDocument = UnifiedDiffGenerator.generateFromDiffNode(diffNode, contextMode);
 
         if (unifiedDocument == null) {
+            logger.warn(
+                    "UnifiedDiffPanel.generateDiffFromDiffNode: Failed to generate diff content for {}",
+                    diffNode.getName());
             textArea.setText("ERROR: Failed to generate diff content for " + diffNode.getName());
             this.navigator = new UnifiedDiffNavigator("", textArea);
             return;
@@ -178,7 +186,6 @@ public class UnifiedDiffPanel extends AbstractDiffPanel implements ThemeAware {
         }
 
         String plainTextContent = textBuilder.toString();
-
         textArea.setText(plainTextContent);
 
         // Link the UnifiedDiffDocument to the custom line number list


### PR DESCRIPTION
This PR reduces unnecessary diff computations and tightens logging to make updates faster and diagnostics clearer. Key changes:

Fixes #1349

- Compute diffs when needed: components now check for an existing Patch (non-null and with deltas) before calling diff(), avoiding redundant work in BufferDiffPanel and UnifiedDiffPanel.
- Delegate diff work to panels: HybridFileComparison no longer forces synchronous diff computation; panels compute diffs as part of their initialization.

These changes reduce CPU work for larger files and fixes "Compare All to Local" feature