### PR TITLE
Mouse over on chips should have k tokens

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/WorkspaceItemsChipPanel.java
@@ -285,7 +285,7 @@ public class WorkspaceItemsChipPanel extends JPanel implements ThemeAware, Scrol
                 String text = fragment.text();
                 int loc = text.split("\\r?\\n", -1).length;
                 int tokens = Messages.getApproximateTokens(text);
-                return "<div>" + formatCount(loc) + " LOC \u2022 ~" + formatCount(tokens) + " tokens</div><br/>";
+                return String.format("<div>%s LOC \u2022 ~%s tokens</div><br/>", formatCount(loc), formatCount(tokens));
             }
         } catch (Exception ignored) {
             // Best effort; if anything goes wrong, just return no metrics


### PR DESCRIPTION
- less than 1K shows the full token amount
- more than 1K abbreviates it

over 1K
<img width="1218" height="252" alt="image" src="https://github.com/user-attachments/assets/e5ad0468-1a2c-436a-b037-fa585796ddf0" />

under 1K

<img width="440" height="221" alt="image" src="https://github.com/user-attachments/assets/ad876aae-40c3-4e49-a472-a97bacc6dfe8" />
