### PR TITLE
Service Reload improvements

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/VoiceInputButton.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/VoiceInputButton.java
@@ -157,12 +157,12 @@ public class VoiceInputButton extends JButton {
             setToolTipText("Speech-to-text unavailable — configure a transcription-capable model in Settings.");
         }
 
-        // Register for service/model reload notifications so we can update the button state dynamically.
+        // Register for service reload notifications so we can update the button state dynamically.
         try {
-            contextManager.addModelReloadListener(serviceListener);
+            contextManager.addServiceReloadListener(serviceListener);
         } catch (Exception e) {
             // Safe to ignore if contextManager doesn't support listeners for some reason.
-            logger.debug("Could not register model reload listener for VoiceInputButton", e);
+            logger.debug("Could not register service reload listener for VoiceInputButton", e);
         }
     }
 
@@ -197,7 +197,7 @@ public class VoiceInputButton extends JButton {
     public void removeNotify() {
         super.removeNotify();
         // Unregister the listener to prevent memory leaks
-        contextManager.removeModelReloadListener(serviceListener);
+        contextManager.removeServiceReloadListener(serviceListener);
     }
 
     /** Starts capturing audio from the default microphone to micBuffer on a background thread. */

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsDialog.java
@@ -303,7 +303,7 @@ public class SettingsDialog extends JDialog implements ThemeAware {
                         JOptionPane.WARNING_MESSAGE);
             } else {
                 tempProjectPanelForRetention.applyPolicy(); // This saves the policy
-                // No need to call parentProjectPanel.parentDialog.getChrome().getContextManager().reloadModelsAsync();
+                // No need to call parentProjectPanel.parentDialog.getChrome().getContextManager().reloadService();
                 // or parentProjectPanel.parentDialog.refreshGlobalModelsPanelPostPolicyChange();
                 // because this is a standalone dialog, Chrome isn't fully set up perhaps, and there's no SettingsDialog
                 // instance.

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -1167,6 +1167,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
                     refreshBalanceDisplay();
                     updateSignupLabelVisibility();
                     parentDialog.triggerDataRetentionPolicyRefresh(); // Key change might affect org policy
+                    chrome.getContextManager().reloadService(); // Reinitialize service with new auth/balance
                 } catch (IllegalArgumentException ex) {
                     JOptionPane.showMessageDialog(this, "Invalid Brokk Key", "Invalid Key", JOptionPane.ERROR_MESSAGE);
                     return false;
@@ -1180,12 +1181,14 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
                     refreshBalanceDisplay();
                     updateSignupLabelVisibility();
                     parentDialog.triggerDataRetentionPolicyRefresh();
+                    chrome.getContextManager().reloadService(); // Reinitialize service with new auth/balance
                 }
             } else { // newBrokkKeyFromField is empty
                 MainProject.setBrokkKey(newBrokkKeyFromField);
                 refreshBalanceDisplay();
                 updateSignupLabelVisibility();
                 parentDialog.triggerDataRetentionPolicyRefresh();
+                chrome.getContextManager().reloadService(); // Reinitialize service with cleared key
             }
         }
 

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
@@ -1628,11 +1628,6 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
             panel.saveSettings();
         }
 
-        // After applying data retention, model list might need refresh
-        chrome.getContextManager().submitBackgroundTask("Refreshing models due to policy change", () -> {
-            chrome.getContextManager().reloadModelsAsync();
-        });
-
         return true;
     }
 
@@ -1965,7 +1960,7 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
                                 .parentDialog
                                 .getChrome()
                                 .getContextManager()
-                                .reloadModelsAsync();
+                                .reloadService();
                         // Also need to refresh model selection UI in SettingsGlobalPanel
                         parentProjectPanel.parentDialog.refreshGlobalModelsPanelPostPolicyChange();
                     }

--- a/app/src/main/java/io/github/jbellis/brokk/util/ServiceWrapper.java
+++ b/app/src/main/java/io/github/jbellis/brokk/util/ServiceWrapper.java
@@ -37,14 +37,6 @@ public class ServiceWrapper {
         return get().quickModel();
     }
 
-    public String nameOf(StreamingChatModel model) {
-        return get().nameOf(model);
-    }
-
-    public StreamingChatModel quickestModel() {
-        return get().quickestModel();
-    }
-
     public static class ServiceInitializationException extends RuntimeException {
         public ServiceInitializationException(Exception e) {
             super(e);


### PR DESCRIPTION
This was triggered by trying to understand #1354

Key changes:
- Removed unnecessary service reload on settings changes
  - Service was reloading for every Project settings save (executor, timeout, etc.)
  - Now only reloads when data retention policy actually changes

 - Added missing service reload on Brokk key changes
  - Service now reinitializes when API key changes

- Renamed for clarity: "Models" → "Service"
  - reloadModelsAsync() → reloadService()
