### PR TITLE
enh: Improve TokenUsageBar text readability and accessibility

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/components/TokenUsageBar.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/components/TokenUsageBar.java
@@ -7,8 +7,8 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Locale;
 import javax.swing.*;
-import org.jetbrains.annotations.Nullable;
 import org.apache.commons.text.WordUtils;
+import org.jetbrains.annotations.Nullable;
 
 public class TokenUsageBar extends JComponent implements ThemeAware {
 
@@ -173,7 +173,9 @@ public class TokenUsageBar extends JComponent implements ThemeAware {
         }
     }
 
-    /** Elide a string with "..." using Apache Commons Text WordUtils.abbreviate, sized to fit within maxWidth pixels. */
+    /**
+     * Elide a string with "..." using Apache Commons Text WordUtils.abbreviate, sized to fit within maxWidth pixels.
+     */
     private static String elide(String text, FontMetrics fm, int maxWidth) {
         if (maxWidth <= 0) return "";
         if (text.isEmpty()) return "";


### PR DESCRIPTION
- fixes #1391
- when the context is zero we get a message to add more via the paperclip icon or drag and drop

<img width="848" height="96" alt="Capture d’écran 2025-10-13 à 10 35 14" src="https://github.com/user-attachments/assets/da38c526-8126-4cec-9103-8b4819170dd8" />
<img width="865" height="134" alt="Capture d’écran 2025-10-13 à 10 34 58" src="https://github.com/user-attachments/assets/6c387bba-6932-49c7-b247-b4b0c93fd5d5" />

