### PR TITLE
fix task counter overcount

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/terminal/TaskListPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/terminal/TaskListPanel.java
@@ -885,7 +885,8 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
         // IMMEDIATE FEEDBACK: inform user tasks were submitted without waiting for LLM work
         int totalToRun = currentRunOrder != null ? currentRunOrder.size() : 1;
         int pos = (currentRunOrder != null) ? currentRunOrder.indexOf(idx) : -1;
-        final int numTask = (pos != -1) ? pos + 1 : 1;
+        // Calculate task number based on its position in the run queue, not its overall list index.
+        final int numTask = (pos >= 0) ? pos + 1 : 1;
         SwingUtilities.invokeLater(() -> chrome.showNotification(
                 IConsoleIO.NotificationRole.INFO,
                 "Submitted " + totalToRun + " task(s) for execution. Running task " + numTask + " of " + totalToRun


### PR DESCRIPTION
this fixes the issue where task list counter doesnt count the total number running tasks but total task

before update


<img width="785" height="414" alt="Capture d’écran 2025-10-14 à 10 37 58" src="https://github.com/user-attachments/assets/872e8878-a4c8-4222-a5c1-9fa5f1936949" />

after update
<img width="994" height="322" alt="Capture d’écran 2025-10-14 à 10 34 15" src="https://github.com/user-attachments/assets/8c557e2d-c6b5-4337-b373-8a88cda7cfb5" />

- **fix: TaskListPanel, show correct task position in notification**
- **fix: TaskListPanel: Correct task number calculation in notification**
