### PR TITLE
fix: Handle Claude extended thinking mode in tool emulation

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/Llm.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Llm.java
@@ -1101,7 +1101,17 @@ public class Llm {
         // then result.chatResponse() is guaranteed to be non-null by StreamingResult's invariant.
         // This method is called in that context.
         NullSafeResponse cResponse = castNonNull(result.chatResponse());
-        String rawText = requireNonNull(cResponse.text());
+
+        // Claude sometimes uses extended thinking mode, putting JSON in reasoningContent instead of text
+        String rawText = cResponse.text();
+        if (rawText == null || rawText.isEmpty()) {
+            rawText = cResponse.reasoningContent();
+        }
+        if (rawText == null) {
+            throw new IllegalArgumentException(
+                    "No text content available for parsing (both text() and reasoningContent() are null)");
+        }
+
         logger.trace("parseJsonToToolRequests: rawText={}", rawText);
 
         JsonNode root;


### PR DESCRIPTION
 As part of the work on a search benchmark several models were tested. Sonnet 4 was experiencing a high failure rate (8/15 queries in SearchBench)  due to a NullPointerException when parsing tool calls.

The root cause was traced to: when Sonnet uses extended thinking for complex queries, it outputs reasoning followed by JSON tool calls, all placed in `reasoningContent()` instead of `text()`. The parser assumed JSON would always be in `text()`.

 Changes:
  - Check both `text()` and `reasoningContent()` when parsing JSON tool calls
  - Add validation to fail fast with clear diagnostics if messages are malformed
  - Fix affects all Claude usage with tool emulation, not just CLI

Verification: after the fix all queries now pass with Sonnet 4.