### PR TITLE
Ensure `GitRepoFactory.initRepo` Commit is Unsigned

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/git/GitRepoFactory.java
+++ b/app/src/main/java/io/github/jbellis/brokk/git/GitRepoFactory.java
@@ -53,7 +53,11 @@ public class GitRepoFactory {
         try (var git = Git.init().setDirectory(root.toFile()).call()) {
             logger.info("Git repository initialized at {}.", root);
             ensureBrokkIgnored(root);
-            git.commit().setAllowEmpty(true).setMessage("Initial commit").call();
+            git.commit()
+                    .setAllowEmpty(true)
+                    .setMessage("Initial commit")
+                    .setSign(false)
+                    .call();
         }
     }
 


### PR DESCRIPTION
For systems that have GPG signing in place, this would prevent failures.

fyi @jbellis 