### PR TITLE
Refresh task list visuals when adding tasks from output

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -2546,6 +2546,7 @@ public class Chrome implements AutoCloseable, IConsoleIO, IContextManager.Contex
         SwingUtilities.invokeLater(() -> {
             int idx = rightTabbedPanel.indexOfTab("Tasks");
             if (idx != -1) rightTabbedPanel.setSelectedIndex(idx);
+            taskListPanel.refreshFromManager();
         });
     }
 


### PR DESCRIPTION
this was a bit of an odd one

- if the task tab was already selected no visual update for the new tasks
- if the tab was not already selected the ui would refresh on select