### PR TITLE
Use softer fill color for light fast-forward icon

### DIFF
--- a/app/src/main/resources/icons/light/fast_forward.svg
+++ b/app/src/main/resources/icons/light/fast_forward.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M100-240v-480l360 240-360 240Zm400 0v-480l360 240-360 240ZM180-480Zm400 0Zm-400 90 136-90-136-90v180Zm400 0 136-90-136-90v180Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#E3E3E3"><path d="M100-240v-480l360 240-360 240Zm400 0v-480l360 240-360 240ZM180-480Zm400 0Zm-400 90 136-90-136-90v180Zm400 0 136-90-136-90v180Z"/></svg>


### PR DESCRIPTION
This PR updates the light-theme fast-forward SVG to use a softer grey fill (#E3E3E3) instead of pure black. Intent: align the icon color with the light theme palette so it appears less harsh and more consistent with other UI elements.

- Changed app/src/main/resources/icons/light/fast_forward.svg: updated the SVG fill attribute from #000000 to #E3E3E3.
- No other structural or path data changes; the icon geometry and size remain identical.
- No runtime behavior changes; this is a visual adjustment to improve aesthetic consistency across the app.