### PR TITLE
chore: Disabled win-arm64 builds in jDeploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "jdeploy": {
         "jdk": false,
         "args": [],
+        "fallbackToUniversal": false,
         "publishTargets": [{
             "name": "github: brokk",
             "type": "GITHUB",
@@ -25,17 +26,25 @@
                 "description": "Microphone permissions are required for transcribing prompts."
             }
         ],
-        "documentTypes": [
-            {
-                "type": "directory",
-                "role": "Editor",
-                "description": "Open folder as Brokk project"
-            }
-        ],
+        "documentTypes": [{
+            "role": "Editor",
+            "description": "Open folder as Brokk project",
+            "type": "directory"
+        }],
         "jar": "app/build/libs/brokk-*.jar",
         "javafx": true,
         "title": "Brokk",
-        "downloadPage": {"platforms": ["all"]}
+        "downloadPage": {"platforms": [
+            "debian-arm64",
+            "mac-arm64",
+            "linux-x64",
+            "windows-x64",
+            "mac-high-sierra",
+            "linux-arm64",
+            "debian-x64",
+            "mac-x64"
+        ]},
+        "platformBundlesEnabled": false
     },
     "dependencies": {
         "command-exists-promise": "^2.0.2",


### PR DESCRIPTION
Tree-sitter and the JavaFX webview aren't supported on win-arm64 yet, so it is better for windows users to always use the x64 builds.  On windows-arm it will still run x64 binaries, only in an emulation mode.

To address https://github.com/BrokkAi/brokk/issues/1404