### PR TITLE
chore: Enabled automatic exception reporting by default

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/MainProject.java
+++ b/app/src/main/java/io/github/jbellis/brokk/MainProject.java
@@ -1109,7 +1109,7 @@ public final class MainProject extends AbstractProject {
 
     public static boolean getExceptionReportingEnabled() {
         var props = loadGlobalProperties();
-        return Boolean.parseBoolean(props.getProperty(EXCEPTION_REPORTING_ENABLED_KEY, "false"));
+        return Boolean.parseBoolean(props.getProperty(EXCEPTION_REPORTING_ENABLED_KEY, "true"));
     }
 
     public static void setExceptionReportingEnabled(boolean enabled) {


### PR DESCRIPTION
Now that the end-point should be enabled on prod, it should be safe to enable. Related to https://github.com/BrokkAi/brokk/issues/1401