### PR TITLE
feat: [1442] Refresh preview contents when they change on disk

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewImagePanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewImagePanel.java
@@ -108,6 +108,46 @@ public class PreviewImagePanel extends JPanel {
         frame.setVisible(true);
     }
 
+    /**
+     * Gets the BrokkFile associated with this preview panel.
+     *
+     * @return The BrokkFile, or null if this preview is not associated with a file
+     */
+    @Nullable
+    public BrokkFile getFile() {
+        return file;
+    }
+
+    /** Refreshes the image from disk if the file has changed. */
+    public void refreshFromDisk() {
+        if (file == null) {
+            return;
+        }
+
+        try {
+            // Check if file still exists
+            if (!java.nio.file.Files.exists(file.absPath())) {
+                SwingUtilities.invokeLater(() -> {
+                    JOptionPane.showMessageDialog(
+                            this, "Image file has been deleted: " + file, "File Deleted", JOptionPane.WARNING_MESSAGE);
+                });
+                return;
+            }
+
+            // Reload the image
+            var newImage = ImageIO.read(file.absPath().toFile());
+            if (newImage == null) {
+                return; // Could not read image, keep current one
+            }
+
+            // Update the displayed image
+            setImage(newImage);
+
+        } catch (IOException e) {
+            // Silently fail - keep existing image displayed
+        }
+    }
+
     /** Registers ESC key to close the preview panel */
     private void registerEscapeKey() {
         // Register ESC key to close the dialog


### PR DESCRIPTION
 Refresh Preview Contents When They Change on Disk

  Fixes #1442

  Summary

  Preview windows now automatically refresh when the underlying file changes on disk, either from external edits or from saves in other preview windows.

  Changes

  Core Infrastructure (Chrome.java):
  - Added Map<ProjectFile, JFrame> to track which preview windows display which files
  - Implemented IContextManager.AnalyzerCallback.onTrackedFileChange() to trigger refreshes when files change
  - Added refreshPreviewsForFiles() method to coordinate preview updates

  Preview Panels:
  - PreviewTextPanel: Implemented refreshFromDisk() that reloads content while preserving caret position and viewport state. Skips refresh if there are unsaved local edits.
  - PreviewImagePanel: Implemented refreshFromDisk() that reloads images when changed externally.

  Key Features:
  - ✅ Automatically refreshes when files change externally (editor, git, etc.)
  - ✅ Preserves unsaved edits - won't refresh if you have local changes
  - ✅ Maintains caret position and scroll position after refresh
  - ✅ Multiple windows of same file stay in sync
  - ✅ Handles file deletion gracefully
  - ✅ Excludes the saving window from refresh to avoid flicker

  Bug Fix:
  Fixed issue where textArea.setText() during refresh triggered document listener, incorrectly marking content as "unsaved" and preventing subsequent refreshes. Solution: temporarily remove/re-add the document listener during programmatic updates.

  Testing

  - Manual testing confirms refresh works correctly for multiple sequential file changes
  - Verified preservation of unsaved edits
  - Tested with external editors and git operations
