### PR TITLE
Codeunit duplicates

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/analyzer/PythonAnalyzer.java
+++ b/app/src/main/java/io/github/jbellis/brokk/analyzer/PythonAnalyzer.java
@@ -219,6 +219,17 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer {
     // buildClassMemberSkeletons is no longer directly called for parent skeleton string generation.
 
     @Override
+    protected String buildParentFqName(String packageName, String classChain) {
+        // Python nested classes are named with "$" (e.g., Outer$Inner) while classChain uses ".".
+        // Convert the classChain to the Python class naming to resolve the correct parent CU.
+        if (classChain.isEmpty()) {
+            return packageName.isEmpty() ? "" : packageName;
+        }
+        String pythonClassChain = classChain.replace(".", "$");
+        return packageName.isEmpty() ? pythonClassChain : packageName + "." + pythonClassChain;
+    }
+
+    @Override
     protected LanguageSyntaxProfile getLanguageSyntaxProfile() {
         return PY_SYNTAX_PROFILE;
     }


### PR DESCRIPTION
fixes #1497

"fix duplicate codeunits" is the main fix
"handle nested classnames" is an inconsistency that gpt noticed while working on the main fix
and "log error and recover" is so we don't crash and burn if there are similar problems elsewhere (gpt thinks there's a handful of corner cases in python we could still hit, but they sound rare enough that I'm not going to try to tackle them tonight)