### PR TITLE
feat: sync CI exclusions and analyzer languages in "Code Intelligence settings" (with BuildDetails)

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectBuildPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectBuildPanel.java
@@ -721,9 +721,7 @@ public class SettingsProjectBuildPanel extends JPanel {
             // Also refresh the CI exclusions list model in the parent SettingsProjectPanel
             try {
                 var spp = parentDialog.getProjectPanel();
-                if (spp != null) {
-                    spp.updateExcludedDirectories(details.excludedDirectories());
-                }
+                spp.updateExcludedDirectories(details.excludedDirectories());
             } catch (Exception ex) {
                 logger.warn("Failed to update CI exclusions list from agent details: {}", ex.getMessage(), ex);
             }

--- a/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/dialogs/SettingsProjectPanel.java
@@ -96,6 +96,8 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
 
     // Build panel instance (extracted)
     private SettingsProjectBuildPanel buildPanelInstance;
+
+    @Nullable
     private LanguagesTableModel languagesTableModel;
 
     public SettingsProjectPanel(
@@ -147,7 +149,7 @@ public class SettingsProjectPanel extends JPanel implements ThemeAware {
     }
 
     // Update CI exclusions list model safely and consistently (EDT, sorted, deduped case-insensitively)
-    public void updateExcludedDirectories(Collection<String> dirs) {
+    public void updateExcludedDirectories(@Nullable Collection<String> dirs) {
         Runnable r = () -> {
             try {
                 var unique = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);


### PR DESCRIPTION
fixes #1503

- Intent: Load and persist Code Intelligence "CI Exclusions" from/to BuildDetails and ensure analyzer language selections are consistently reflected in the UI and project model.
- Behaviour changes: Exclusions are canonicalized (trim, normalized where possible), deduplicated case-insensitively, and saved before build settings are applied. BuildAgent updates now propagate to the parent panel to refresh exclusions. Analyzer language selections are reloaded and persisted when applying settings.
- Implementation notes: Added updateExcludedDirectories with EDT safety, load/save helpers (loadCiExclusionsFromBuildDetails, saveCiExclusions, setAnalyzerLanguages), moved LanguagesTableModel to a field/inner class so it can be refreshed, and added defensive logging. Also removed a TypeScript test resource and trimmed project properties to only include JAVA for code intelligence.