### PR TITLE
fix: disable error prone except for `check` and `analyze`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -251,6 +251,9 @@ tasks.register<JavaCompile>("compileJavaErrorProne") {
     group = "verification"
     description = "Compile with Error Prone and NullAway enabled"
 
+    // Ensure generated sources (e.g., BuildConfig) exist before compiling
+    dependsOn("generateBuildConfig")
+
     // Use same sources as main compilation
     source = sourceSets.main.get().java
     classpath = sourceSets.main.get().compileClasspath


### PR DESCRIPTION
asked gpt to investigate the NoClassDefFound errors, it says

> Root cause: your build is forcing Gradle incremental compilation on the main sources while using the Error Prone compiler (with NullAway sometimes enabled). Error Prone’s javac plugin is not compatible with Gradle’s incremental Java compilation; when you re‑enable it, Gradle will sometimes compile only a subset of sources and leave build/classes/java/main incomplete. Which class is “missing” varies with what did (or didn’t) get incrementally recompiled, so it surfaces as random NoClassDefFoundErrors at runtime. Packaging with shadowJar hides the issue because the fat JAR is produced after a full, consistent compile and loads from a single artifact.
