### PR TITLE
Mention Lutz mode in TokenUsageBar no-context message

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/components/TokenUsageBar.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/components/TokenUsageBar.java
@@ -411,7 +411,7 @@ public class TokenUsageBar extends JComponent implements ThemeAware {
 
         if (!hasContext) {
             String msg =
-                    "No context yet - add some by clicking the paperclip icon or drag-and-drop files from the Project Files panel.";
+                    "No context yet - use Lutz mode to discover and add relevant files automatically, or click the paperclip icon or drag-and-drop files from the Project Files panel.";
             int maxTextWidth = Math.max(0, width - 2 * padding);
             String shown = elide(msg, fm, maxTextWidth);
 


### PR DESCRIPTION
Update the user-facing hint shown when no context is available to promote the new "Lutz mode" auto-discovery feature.

- Intent: steer users toward the automatic file-discovery option (Lutz mode) as an alternative to manually attaching files.
- Behaviour change: the no-context message in the TokenUsageBar now suggests using Lutz mode, while still referencing the paperclip icon and drag-and-drop from Project Files.
- Implementation: small string change in app/src/main/java/io/github/jbellis/brokk/gui/components/TokenUsageBar.java — no UI layout or logic altered, only the displayed help text was updated.

This is a purely textual update to improve discoverability of the Lutz mode feature.