### PR TITLE
add back addNotify

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/terminal/TaskListPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/terminal/TaskListPanel.java
@@ -1586,6 +1586,23 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
     }
 
     @Override
+    public void addNotify() {
+        super.addNotify();
+        // Re-register the listener if it was previously removed.
+        if (registeredContextManager == null) {
+            try {
+                IContextManager cm = chrome.getContextManager();
+                registeredContextManager = cm;
+                cm.addContextListener(this);
+                // Refresh tasks, in case the model changed while the panel was not showing.
+                loadTasksForCurrentSession();
+            } catch (Exception e) {
+                logger.debug("Unable to re-register TaskListPanel as context listener", e);
+            }
+        }
+    }
+
+    @Override
     public void removeNotify() {
         try {
             saveTasksForCurrentSession();


### PR DESCRIPTION
I believe this got dropped when I moved this to the tabpanel, now tasks update when switching sessions without having to switch tabs
