### PR TITLE
prevent chippanel from overlapping with tokenusagebar in instructions panel

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -234,6 +234,12 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         }
 
         @Override
+        public Dimension getMinimumSize() {
+            Dimension pref = getPreferredSize();
+            return new Dimension(0, pref.height);
+        }
+
+        @Override
         public Dimension getMaximumSize() {
             Dimension pref = getPreferredSize();
             return new Dimension(Integer.MAX_VALUE, pref.height);


### PR DESCRIPTION
there was no minimum size on the contextareacontainer so it would compress to a level where the rows werent visible