### PR TITLE
fix: insert token non-empty content for Anthropic

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/Llm.java
+++ b/app/src/main/java/io/github/jbellis/brokk/Llm.java
@@ -1451,7 +1451,8 @@ public class Llm {
         }
 
         public AiMessage aiMessage() {
-            var messageText = text == null ? "" : text;
+            // Anthropic does not allow empty content. Token content for pure tool calls.
+            var messageText = text == null ? (toolRequests.isEmpty() ? "" : "tool call") : text;
             return new AiMessage(messageText, reasoningContent, toolRequests);
         }
     }


### PR DESCRIPTION
Partially fixes BrokkAI/brokk-llm#34

rationale for proposing a fix on this side:

1.) Avoid scanning every message in each request and making assumptions
2.) Avoid inserting our own arbitrary tokens into the chat as the proxy