### PR TITLE
Disable reuse option when no available branches; validate worktree dialog

### DIFF
--- a/app/src/main/java/io/github/jbellis/brokk/gui/git/GitWorktreeTab.java
+++ b/app/src/main/java/io/github/jbellis/brokk/gui/git/GitWorktreeTab.java
@@ -571,7 +571,8 @@ public class GitWorktreeTab extends JPanel {
                     // Explain why the option is disabled so users understand why the choice is unavailable.
                     useExistingBranchRadio.setToolTipText("No existing branches available — create a new branch.");
                     branchComboBox.setToolTipText("No existing branches available to choose from.");
-                    // Informational, non-blocking notification so the user understands what will happen if they create a new branch.
+                    // Informational, non-blocking notification so the user understands what will happen if they create
+                    // a new branch.
                     chrome.showNotification(
                             IConsoleIO.NotificationRole.INFO,
                             "No existing branches are available — creating a new branch will use the selected 'From' branch.");
@@ -705,35 +706,35 @@ public class GitWorktreeTab extends JPanel {
             });
 
             try {
-            AddWorktreeDialogResult dialogResult = dialogFuture.get(); // Wait for dialog on background thread
-            if (!dialogResult.okPressed()) {
-            chrome.showNotification(IConsoleIO.NotificationRole.INFO, "Add worktree cancelled by user.");
-            return;
-            }
-            
-            String branchForWorktree = dialogResult.selectedBranch();
-            String sourceBranchForNew = dialogResult.sourceBranchForNew();
-            boolean isCreatingNewBranch = dialogResult.isCreatingNewBranch();
-            boolean copyWorkspace = dialogResult.copyWorkspace();
-            
-            // Defensive validation to guard against unexpected dialog results:
-            if (isCreatingNewBranch) {
-            // Require a non-null, non-empty branch name (trim whitespace)
-            if (branchForWorktree == null || branchForWorktree.trim().isEmpty()) {
-            chrome.toolError(
-            "New branch name cannot be empty. Please provide a valid branch name.",
-            "Invalid Branch Name");
-            return;
-            }
-            } else {
-            // Using existing branch: ensure the selected branch is actually available
-            if (branchForWorktree == null || !finalAvailableBranches.contains(branchForWorktree)) {
-            chrome.toolError(
-            "Selected branch is not available. Please choose an existing branch or create a new one.",
-            "Invalid Branch Selection");
-            return;
-            }
-            }
+                AddWorktreeDialogResult dialogResult = dialogFuture.get(); // Wait for dialog on background thread
+                if (!dialogResult.okPressed()) {
+                    chrome.showNotification(IConsoleIO.NotificationRole.INFO, "Add worktree cancelled by user.");
+                    return;
+                }
+
+                String branchForWorktree = dialogResult.selectedBranch();
+                String sourceBranchForNew = dialogResult.sourceBranchForNew();
+                boolean isCreatingNewBranch = dialogResult.isCreatingNewBranch();
+                boolean copyWorkspace = dialogResult.copyWorkspace();
+
+                // Defensive validation to guard against unexpected dialog results:
+                if (isCreatingNewBranch) {
+                    // Require a non-null, non-empty branch name (trim whitespace)
+                    if (branchForWorktree == null || branchForWorktree.trim().isEmpty()) {
+                        chrome.toolError(
+                                "New branch name cannot be empty. Please provide a valid branch name.",
+                                "Invalid Branch Name");
+                        return;
+                    }
+                } else {
+                    // Using existing branch: ensure the selected branch is actually available
+                    if (branchForWorktree == null || !finalAvailableBranches.contains(branchForWorktree)) {
+                        chrome.toolError(
+                                "Selected branch is not available. Please choose an existing branch or create a new one.",
+                                "Invalid Branch Selection");
+                        return;
+                    }
+                }
 
                 if (isCreatingNewBranch) {
                     if (branchForWorktree.isEmpty()) {


### PR DESCRIPTION
- Intent: Improve UX and robustness when adding a Git worktree by handling the case where no existing local branches are available to reuse and by validating dialog results defensively.

- Behavior changes:
  - If no existing branches are available, the "Use existing branch" radio and branch combo are disabled, accompanied by tooltips, an informational notification, and an inline dialog message guiding the user to create a new branch.
  - Removed the earlier blocking error/return when no available branches were found; the dialog now presents the appropriate choices instead.
  - After the dialog returns, defensive validation ensures a non-empty new branch name or that a selected existing branch is actually available; errors are shown via chrome.toolError.

- Implementation notes:
  - Adds hasAvailableBranches flag computed from finalAvailableBranches.
  - Sets UI states (enabled/selected/tooltips) and adds a JLabel when no branches are available.
  - Adds post-dialog validation to prevent invalid branch names or selections.