### PR TITLE
fix: Sync master with master-snapshot

### DIFF
--- a/.github/workflows/sync-snapshot.yml
+++ b/.github/workflows/sync-snapshot.yml
@@ -18,10 +18,10 @@ jobs:
 
       - name: Push to master-snapshot
         run: |
-          git push origin master:master-snapshot --force
+          git push origin master:refs/heads/master-snapshot --force
 
       - name: Trigger jDeploy workflow
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run jdeploy.yml --ref master-snapshot
+          gh workflow run jdeploy.yml --ref refs/heads/master-snapshot


### PR DESCRIPTION
This fixes the sync snapshot workflow to deal with the fact that the master-snapshot branch has a tag by the same name