### PR TITLE
feat: JBR support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "version": "1.0.0",
     "jdeploy": {
         "jdk": false,
+        "jdkProvider": "jbr",
         "args": [],
         "fallbackToUniversal": false,
         "configFileMac": "{{ path(user.home, \"Library\", \"Application Support\", \"Brokk\", \"jdeploy.json\") }}",


### PR DESCRIPTION
Change jdeploy to ship with JBR instead of OpenJDK JRE

See https://www.jdeploy.com/docs/releases/5.4/release-notes.html#_jetbrains_runtime_jbr_support for details about JBR support.