### PR TITLE
JBR-aware fractional UI scaling and spinner support

### DIFF
--- a/app/src/main/java/ai/brokk/SystemScaleDetector.java
+++ b/app/src/main/java/ai/brokk/SystemScaleDetector.java
@@ -16,26 +16,23 @@ public final class SystemScaleDetector {
     public static @Nullable Double detectLinuxUiScale(SystemScaleProvider provider) {
         var kde = tryDetectScaleViaKscreenDoctor(provider);
         if (kde != null) {
-            return normalizeUiScaleToAllowed(kde);
+            return kde;
         }
 
         var gnomeModern = tryDetectScaleViaGnomeDBus(provider);
         if (gnomeModern != null) {
-            return normalizeUiScaleToAllowed(gnomeModern);
+            return gnomeModern;
         }
 
         var gnome = tryDetectScaleViaGsettings(provider);
         if (gnome != null) {
-            return normalizeUiScaleToAllowed(gnome);
+            return gnome;
         }
         return null;
     }
 
     public static double normalizeUiScaleToAllowed(double v) {
-        int rounded = (int) Math.round(v);
-        if (rounded < 1) rounded = 1;
-        if (rounded > 5) rounded = 5;
-        return (double) rounded;
+        return v;
     }
 
     public static @Nullable Double tryDetectScaleViaKscreenDoctor(SystemScaleProvider provider) {

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -111,6 +111,9 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
     @Nullable
     private JComboBox<String> uiScaleCombo; // Hidden on macOS
 
+    @Nullable
+    private JSpinner uiScaleSpinner; // Hidden on macOS
+
     // JVM memory settings controls (General tab)
     private JRadioButton memoryAutoRadio = new JRadioButton("Automatic (recommended)");
     private JRadioButton memoryManualRadio = new JRadioButton("Manual:");
@@ -396,6 +399,18 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         } catch (Exception e) {
             return ks.toString();
         }
+    }
+
+    /**
+     * Clamp a UI scale value to the inclusive fractional bounds [0.5, 5.0] without rounding.
+     * This is intended for use when fractional UI scaling is enabled.
+     */
+    private static double clampToFractionalBounds(double value) {
+        if (Double.isNaN(value)) return 1.0;
+        if (Double.isInfinite(value)) return value > 0 ? 5.0 : 0.5;
+        if (value < 0.5) return 0.5;
+        if (value > 5.0) return 5.0;
+        return value;
     }
 
     private static KeyStroke captureKeyStroke(Component parent) {
@@ -850,8 +865,13 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
         gbc.insets = new Insets(2, 5, 2, 5); // reset spacing
 
-        // UI Scale controls (hidden on macOS)
-        if (!Environment.isMacOs()) {
+        // UI Scale controls (hidden on macOS and when running under JetBrains Runtime)
+        var vmVendor = System.getProperty("java.vm.vendor", "");
+        var runtimeName = System.getProperty("java.runtime.name", "");
+        boolean isJbr = vmVendor.toLowerCase(Locale.ROOT).contains("jetbrains")
+                || runtimeName.toLowerCase(Locale.ROOT).contains("jetbrains");
+
+        if (!Environment.isMacOs() && !isJbr) {
             gbc.insets = new Insets(10, 5, 2, 5); // spacing before next section
             gbc.gridx = 0;
             gbc.gridy = row;
@@ -865,19 +885,8 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
             scaleGroup.add(uiScaleAutoRadio);
             scaleGroup.add(uiScaleCustomRadio);
 
-            uiScaleCombo = new JComboBox<>();
-            final JComboBox<String> combo = uiScaleCombo;
-            var uiScaleModel = new DefaultComboBoxModel<String>();
-            uiScaleModel.addElement("1.0");
-            uiScaleModel.addElement("2.0");
-            uiScaleModel.addElement("3.0");
-            uiScaleModel.addElement("4.0");
-            uiScaleModel.addElement("5.0");
-            combo.setModel(uiScaleModel);
-            combo.setEnabled(false);
-
-            uiScaleAutoRadio.addActionListener(e -> combo.setEnabled(false));
-            uiScaleCustomRadio.addActionListener(e -> combo.setEnabled(true));
+            // Detect if fractional UI scaling is enabled
+            boolean fractionalEnabled = "true".equalsIgnoreCase(System.getProperty("sun.java2d.uiScale.enabled"));
 
             gbc.gridx = 1;
             gbc.gridy = row++;
@@ -887,7 +896,33 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
             var customPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
             customPanel.add(uiScaleCustomRadio);
-            customPanel.add(combo);
+
+            if (fractionalEnabled) {
+                // Use spinner for fractional UI scaling
+                uiScaleSpinner = new JSpinner(new SpinnerNumberModel(1.0, 0.5, 5.0, 0.1));
+                uiScaleSpinner.setEditor(new JSpinner.NumberEditor(uiScaleSpinner, "#0.0"));
+                uiScaleSpinner.setEnabled(false);
+                customPanel.add(uiScaleSpinner);
+
+                uiScaleAutoRadio.addActionListener(e -> uiScaleSpinner.setEnabled(false));
+                uiScaleCustomRadio.addActionListener(e -> uiScaleSpinner.setEnabled(true));
+            } else {
+                // Use combo box for fixed UI scaling (current behavior)
+                uiScaleCombo = new JComboBox<>();
+                final JComboBox<String> combo = uiScaleCombo;
+                var uiScaleModel = new DefaultComboBoxModel<String>();
+                uiScaleModel.addElement("1.0");
+                uiScaleModel.addElement("2.0");
+                uiScaleModel.addElement("3.0");
+                uiScaleModel.addElement("4.0");
+                uiScaleModel.addElement("5.0");
+                combo.setModel(uiScaleModel);
+                combo.setEnabled(false);
+                customPanel.add(combo);
+
+                uiScaleAutoRadio.addActionListener(e -> combo.setEnabled(false));
+                uiScaleCustomRadio.addActionListener(e -> combo.setEnabled(true));
+            }
 
             gbc.gridy = row++;
             appearancePanel.add(customPanel, gbc);
@@ -902,6 +937,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
             uiScaleAutoRadio = null;
             uiScaleCustomRadio = null;
             uiScaleCombo = null;
+            uiScaleSpinner = null;
         }
 
         // Terminal font size
@@ -1303,36 +1339,68 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         wordWrapCheckbox.setSelected(MainProject.getCodeBlockWrapMode());
 
         // UI Scale (if present; hidden on macOS)
-        if (uiScaleAutoRadio != null && uiScaleCustomRadio != null && uiScaleCombo != null) {
+        if (uiScaleAutoRadio != null && uiScaleCustomRadio != null) {
             String pref = MainProject.getUiScalePref();
-            if ("auto".equalsIgnoreCase(pref)) {
-                uiScaleAutoRadio.setSelected(true);
-                uiScaleCombo.setSelectedItem("1.0");
-                uiScaleCombo.setEnabled(false);
-            } else {
-                uiScaleCustomRadio.setSelected(true);
-                var model = (DefaultComboBoxModel<String>) uiScaleCombo.getModel();
-                String selected = pref;
-                boolean found = false;
-                for (int i = 0; i < model.getSize(); i++) {
-                    if (pref.equals(model.getElementAt(i))) {
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) {
+
+            // Spinner path: fractional UI scaling enabled
+            if (uiScaleSpinner != null) {
+                if ("auto".equalsIgnoreCase(pref)) {
+                    uiScaleAutoRadio.setSelected(true);
+                    uiScaleSpinner.setValue(1.0);
+                    uiScaleSpinner.setEnabled(false);
+                } else {
                     try {
                         double v = Double.parseDouble(pref);
-                        int nearest = (int) Math.round(v);
-                        if (nearest < 1) nearest = 1;
-                        if (nearest > 5) nearest = 5;
-                        selected = nearest + ".0";
+                        // Clamp to fractional bounds without rounding
+                        v = clampToFractionalBounds(v);
+                        // Clamp to spinner model bounds
+                        SpinnerNumberModel spinnerModel = (SpinnerNumberModel) uiScaleSpinner.getModel();
+                        double min = ((Number) spinnerModel.getMinimum()).doubleValue();
+                        double max = ((Number) spinnerModel.getMaximum()).doubleValue();
+                        if (v < min) v = min;
+                        if (v > max) v = max;
+                        uiScaleCustomRadio.setSelected(true);
+                        uiScaleSpinner.setValue(v);
+                        uiScaleSpinner.setEnabled(true);
                     } catch (NumberFormatException ignore) {
-                        selected = "1.0";
+                        // Invalid preference; fall back to auto
+                        uiScaleAutoRadio.setSelected(true);
+                        uiScaleSpinner.setValue(1.0);
+                        uiScaleSpinner.setEnabled(false);
                     }
                 }
-                uiScaleCombo.setSelectedItem(selected);
-                uiScaleCombo.setEnabled(true);
+            }
+            // Combo box path: fixed UI scaling (existing behavior)
+            else if (uiScaleCombo != null) {
+                if ("auto".equalsIgnoreCase(pref)) {
+                    uiScaleAutoRadio.setSelected(true);
+                    uiScaleCombo.setSelectedItem("1.0");
+                    uiScaleCombo.setEnabled(false);
+                } else {
+                    uiScaleCustomRadio.setSelected(true);
+                    var model = (DefaultComboBoxModel<String>) uiScaleCombo.getModel();
+                    String selected = pref;
+                    boolean found = false;
+                    for (int i = 0; i < model.getSize(); i++) {
+                        if (pref.equals(model.getElementAt(i))) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        try {
+                            double v = Double.parseDouble(pref);
+                            int nearest = (int) Math.round(v);
+                            if (nearest < 1) nearest = 1;
+                            if (nearest > 5) nearest = 5;
+                            selected = nearest + ".0";
+                        } catch (NumberFormatException ignore) {
+                            selected = "1.0";
+                        }
+                    }
+                    uiScaleCombo.setSelectedItem(selected);
+                    uiScaleCombo.setEnabled(true);
+                }
             }
         }
 
@@ -1514,7 +1582,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         }
 
         // UI Scale preference (if present; hidden on macOS)
-        if (uiScaleAutoRadio != null && uiScaleCustomRadio != null && uiScaleCombo != null) {
+        if (uiScaleAutoRadio != null && uiScaleCustomRadio != null) {
             String before = MainProject.getUiScalePref();
             if (uiScaleAutoRadio.isSelected()) {
                 if (!"auto".equalsIgnoreCase(before)) {
@@ -1523,21 +1591,41 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
                     logger.debug("Applied UI scale preference: auto");
                 }
             } else {
-                String txt = String.valueOf(uiScaleCombo.getSelectedItem()).trim();
-                var allowed = Set.of("1.0", "2.0", "3.0", "4.0", "5.0");
-                if (!allowed.contains(txt)) {
-                    JOptionPane.showMessageDialog(
-                            this,
-                            "Select a scale from 1.0, 2.0, 3.0, 4.0, or 5.0.",
-                            "Invalid UI Scale",
-                            JOptionPane.ERROR_MESSAGE);
-                    return false;
-                }
-                if (!txt.equals(before)) {
-                    double v = Double.parseDouble(txt);
-                    MainProject.setUiScalePrefCustom(v);
-                    parentDialog.markRestartNeededForUiScale();
-                    logger.debug("Applied UI scale preference: {}", v);
+                // Custom selected
+                if (uiScaleSpinner != null) {
+                    // Fractional mode: spinner (save exact fractional value; no rounding)
+                    double v = ((Number) uiScaleSpinner.getValue()).doubleValue();
+                    v = clampToFractionalBounds(v);
+                    // Check if value changed
+                    double beforeValue;
+                    try {
+                        beforeValue = "auto".equalsIgnoreCase(before) ? 1.0 : Double.parseDouble(before);
+                    } catch (NumberFormatException e) {
+                        beforeValue = 1.0;
+                    }
+                    if (v != beforeValue) {
+                        MainProject.setUiScalePrefCustom(v);
+                        parentDialog.markRestartNeededForUiScale();
+                        logger.debug("Applied UI scale preference: {}", v);
+                    }
+                } else if (uiScaleCombo != null) {
+                    // Fixed mode: combo box
+                    String txt = String.valueOf(uiScaleCombo.getSelectedItem()).trim();
+                    var allowed = Set.of("1.0", "2.0", "3.0", "4.0", "5.0");
+                    if (!allowed.contains(txt)) {
+                        JOptionPane.showMessageDialog(
+                                this,
+                                "Select a scale from 1.0, 2.0, 3.0, 4.0, or 5.0.",
+                                "Invalid UI Scale",
+                                JOptionPane.ERROR_MESSAGE);
+                        return false;
+                    }
+                    if (!txt.equals(before)) {
+                        double v = Double.parseDouble(txt);
+                        MainProject.setUiScalePrefCustom(v);
+                        parentDialog.markRestartNeededForUiScale();
+                        logger.debug("Applied UI scale preference: {}", v);
+                    }
                 }
             }
         }

--- a/app/src/test/java/ai/brokk/ScreenScaleDetectionTest.java
+++ b/app/src/test/java/ai/brokk/ScreenScaleDetectionTest.java
@@ -162,9 +162,9 @@ class ScreenScaleDetectionTest {
 
     @Test
     void normalizeUiScaleToAllowed_edgeCases() {
-        assertEquals(2.0, SystemScaleDetector.normalizeUiScaleToAllowed(2.4), 1e-9);
-        assertEquals(5.0, SystemScaleDetector.normalizeUiScaleToAllowed(4.9), 1e-9);
-        assertEquals(1.0, SystemScaleDetector.normalizeUiScaleToAllowed(0.9), 1e-9);
+        assertEquals(2.4, SystemScaleDetector.normalizeUiScaleToAllowed(2.4), 1e-9);
+        assertEquals(4.9, SystemScaleDetector.normalizeUiScaleToAllowed(4.9), 1e-9);
+        assertEquals(0.9, SystemScaleDetector.normalizeUiScaleToAllowed(0.9), 1e-9);
         assertEquals(3.0, SystemScaleDetector.normalizeUiScaleToAllowed(3.0), 1e-9);
     }
 


### PR DESCRIPTION
This change improves UI scale handling by adding JetBrains Runtime (JBR) awareness and proper fractional-scaling support.

- Detect JBR and skip the app's custom sun.java2d.uiScale logic when JBR is present to avoid conflicting HiDPI handling.
- Respect existing sun.java2d.uiScale first. If sun.java2d.uiScale.enabled is false and ide.ui.scale is set, apply it. Otherwise apply saved user preference, then platform detection (Windows/Linux). Skip environment detection when fractional scaling is enabled.
- SystemScaleDetector no longer rounds/normalizes detected values; it returns raw doubles.
- SettingsGlobalPanel: add a spinner for fractional UI scale (0.5–5.0, step 0.1), clamp values without rounding, preserve exact fractional prefs, and hide controls on macOS/JBR.
- Updated tests to match new non-normalizing behavior.