### PR TITLE
fix: Add concurrency group to release workflows

### DIFF
--- a/.github/workflows/jdeploy.yml
+++ b/.github/workflows/jdeploy.yml
@@ -8,6 +8,10 @@ on:
     branches: [ 'master-snapshot', 'jdeploy-test' ]
   workflow_dispatch:
 
+concurrency:
+  group: jdeploy-release-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: jdeploy-release-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added concurrency group to workflows that perform jdeploy releases to ensure that only one can run at a time on the repo, to prevent data loss in the jdeploy tag's package-info.json file.