### PR TITLE
Move Tests & Git tabs; embed Dependencies in Project Files

### DIFF
--- a/app/src/main/java/ai/brokk/gui/Chrome.java
+++ b/app/src/main/java/ai/brokk/gui/Chrome.java
@@ -1383,7 +1383,6 @@ public class Chrome
             }
         });
 
-
         // Cmd/Ctrl+T => switch to terminal tab
         KeyStroke switchToTerminalTabKeyStroke = GlobalUiSettings.getKeybinding(
                 "drawer.switchToTerminal",
@@ -2844,7 +2843,8 @@ public class Chrome
                     var idx = leftTabbedPanel.indexOfComponent(gitCommitTab);
                     var ks = GlobalUiSettings.getKeybinding(
                             "panel.switchToChanges", KeyboardShortcutUtil.createAltShortcut(KeyEvent.VK_3));
-                    gitTabLabel = createSquareTabLabel(gitTabBadgedIcon, "Changes (" + KeyboardShortcutUtil.formatKeyStroke(ks) + ")");
+                    gitTabLabel = createSquareTabLabel(
+                            gitTabBadgedIcon, "Changes (" + KeyboardShortcutUtil.formatKeyStroke(ks) + ")");
                     leftTabbedPanel.setTabComponentAt(idx, gitTabLabel);
                     final int tabIdx = idx;
                     gitTabLabel.addMouseListener(new MouseAdapter() {

--- a/app/src/main/java/ai/brokk/gui/MenuBar.java
+++ b/app/src/main/java/ai/brokk/gui/MenuBar.java
@@ -631,7 +631,6 @@ public class MenuBar {
                     windowMenu.add(issuesItem);
                 }
 
-
                 windowMenu.addSeparator();
 
                 Window currentChromeWindow = chrome.getFrame();

--- a/app/src/main/java/ai/brokk/gui/ProjectFilesPanel.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectFilesPanel.java
@@ -83,7 +83,7 @@ public class ProjectFilesPanel extends JPanel {
         searchBarPanel.add(buttonPanel, BorderLayout.EAST);
 
         add(searchBarPanel, BorderLayout.NORTH);
-        
+
         // Create split pane: ProjectTree (top) | Dependencies (bottom, initially hidden)
         var projectTreeScrollPane = new JScrollPane(projectTree);
         contentSplitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
@@ -93,16 +93,16 @@ public class ProjectFilesPanel extends JPanel {
         contentSplitPane.setDividerSize(5); // Show divider
         contentSplitPane.setDividerLocation(0.7); // Set initial position
         dependenciesPanel.addNotify(); // Trigger initialization
-        
+
         add(contentSplitPane, BorderLayout.CENTER);
         updateBorderTitle(); // Set initial title with branch name
     }
-    
+
     private void toggleDependenciesPanel() {
         dependenciesVisible = !dependenciesVisible;
         if (dependenciesVisible) {
-            contentSplitPane.setDividerSize(contentSplitPane.getDividerSize() > 0 ? 
-                contentSplitPane.getDividerSize() : 5);
+            contentSplitPane.setDividerSize(
+                    contentSplitPane.getDividerSize() > 0 ? contentSplitPane.getDividerSize() : 5);
             contentSplitPane.setDividerLocation(0.7);
             dependenciesPanel.addNotify(); // Trigger initialization
         } else {


### PR DESCRIPTION
- Intent: Reorganize the left sidebar tabs to make Tests more prominent, embed Dependencies into the Project Files panel, and reorder Git-related tabs with updated shortcuts.

- Behavior changes:
  - Tests tab moved up to a top-level left-tab position (Alt/Cmd+2) instead of being last.
  - Dependencies is no longer a standalone left tab; it is embedded as the bottom pane of a JSplitPane inside ProjectFilesPanel and toggled from Chrome.showDependenciesTab().
  - Git tabs updated to: Changes (Alt+3), Log (Alt+4), Worktrees (Alt+5). Menu items and keyboard bindings were updated accordingly.

- Key implementation notes:
  - ProjectFilesPanel now accepts DependenciesPanel in its constructor and manages a vertical JSplitPane with a dependenciesVisible flag and toggle logic.
  - showDependenciesTab selects ProjectFiles and triggers the embedded toggle. New getters for GitLogTab/GitWorktreeTab were added and advanced-mode tab add/remove logic adjusted.
  - MenuBar entries and keybindings were updated to match the new tab ordering.