### PR TITLE
Populate Commit dialog and choose safe owner Frame

### DIFF
--- a/app/src/main/java/ai/brokk/gui/MenuBar.java
+++ b/app/src/main/java/ai/brokk/gui/MenuBar.java
@@ -528,6 +528,8 @@ public class MenuBar {
         var commitItem = new JMenuItem("Changes");
         commitItem.addActionListener(e -> {
             var content = new GitCommitTab(chrome, chrome.getContextManager());
+            // Start an initial refresh so the dialog is populated with repository status
+            content.updateCommitPanel();
             showDialog(chrome, "Changes", content, null);
         });
         gitMenu.add(commitItem);

--- a/app/src/main/java/ai/brokk/gui/git/GitCommitTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitCommitTab.java
@@ -238,8 +238,14 @@ public class GitCommitTab extends JPanel {
                 return;
             }
 
+            // Determine a safe owner Frame for the CommitDialog:
+            // - prefer the immediate window ancestor if it's a Frame (typical for the main UI)
+            // - otherwise fall back to the main application frame (chrome.getFrame())
+            Window ancestor = SwingUtilities.getWindowAncestor(GitCommitTab.this);
+            Frame ownerFrame = (ancestor instanceof Frame) ? (Frame) ancestor : chrome.getFrame();
+
             CommitDialog dialog = new CommitDialog(
-                    (Frame) SwingUtilities.getWindowAncestor(this),
+                    ownerFrame,
                     chrome,
                     contextManager,
                     workflowService,


### PR DESCRIPTION
Intent: Ensure the Commit dialog opens with current repository status and avoid unsafe casting when determining its owner Frame.

- When the user opens the "Changes"/Commit view, the code now triggers an initial refresh (updateCommitPanel) so the dialog is immediately populated with repository status instead of showing empty data.
- When creating the CommitDialog, determine a safe owner Frame by checking SwingUtilities.getWindowAncestor(GitCommitTab.this); if the ancestor is not a Frame, fall back to chrome.getFrame().

Key implementation: call updateCommitPanel() from the MenuBar before showing the dialog, and replace the direct cast with an instanceof check and fallback to prevent ClassCastException and ensure a valid owner Frame.