### PR TITLE
Make left tab scrollable and initialize Git tabs/badge on project load

### DIFF
--- a/app/src/main/java/ai/brokk/gui/Chrome.java
+++ b/app/src/main/java/ai/brokk/gui/Chrome.java
@@ -2939,14 +2939,14 @@ public class Chrome
                     });
                 }
             }
-            
+
             // Update badge count immediately after adding tabs so the Changes tab badged icon reflects current state
             try {
-            updateGitTabBadge(getModifiedFiles().size());
+                updateGitTabBadge(getModifiedFiles().size());
             } catch (Exception ex) {
-            logger.debug("Failed to update Git tab badge after advanced-mode toggle", ex);
+                logger.debug("Failed to update Git tab badge after advanced-mode toggle", ex);
             }
-            
+
             leftTabbedPanel.revalidate();
             leftTabbedPanel.repaint();
 


### PR DESCRIPTION
Fix layout and initialization issues in the left tabbed pane and Git tabs.

- Ensure the left tabbed pane uses JTabbedPane.SCROLL_TAB_LAYOUT so tabs (and their icons) remain accessible when there are too many to fit.
- Always construct Git tab instances when a project has Git, even if Advanced Mode is off, preventing potential null references and making mode toggles more reliable.
- Only add the visible Git tabs when Advanced Mode is enabled, preserving the intended UI order and shortcuts.
- Immediately update the Changes tab badge after adding tabs and guard the update with a try/catch to avoid startup errors. Revalidate/repaint the panel afterward.