### PR TITLE
Feat/search agent fragment order

### DIFF
--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -166,11 +166,12 @@ public class SearchAgent {
             // Build read-only workspace messages (combine summaries) and editable fragments in insertion order.
             // We render editable fragments in insertion order here (context.allFragments preserves insertion order),
             // while other callers continue to use the mtime-ordered helpers.
-            var readOnlyMessages = new ArrayList<>(CodePrompts.instance.getWorkspaceReadOnlyMessages(context, /*combineSummaries=*/true));
-            var editableFragmentsInInsertionOrder = context.allFragments()
-                    .filter(f -> f.getType().isEditable())
-                    .toList();
-            var workspaceMessages = new ArrayList<>(CodePrompts.instance.getWorkspaceContentsMessages(readOnlyMessages, editableFragmentsInInsertionOrder));
+            var readOnlyMessages = new ArrayList<>(
+                    CodePrompts.instance.getWorkspaceReadOnlyMessages(context, /*combineSummaries=*/ true));
+            var editableFragmentsInInsertionOrder =
+                    context.allFragments().filter(f -> f.getType().isEditable()).toList();
+            var workspaceMessages = new ArrayList<>(CodePrompts.instance.getWorkspaceContentsMessages(
+                    readOnlyMessages, editableFragmentsInInsertionOrder));
 
             var workspaceTokens = Messages.getApproximateMessageTokens(workspaceMessages);
             if (!beastMode && inputLimit > 0 && workspaceTokens > WORKSPACE_CRITICAL * inputLimit) {

--- a/app/src/main/java/ai/brokk/prompts/CodePrompts.java
+++ b/app/src/main/java/ai/brokk/prompts/CodePrompts.java
@@ -698,7 +698,8 @@ public abstract class CodePrompts {
      * @param editableFragmentsInOrder editable fragments in the desired order
      * @return a List containing one UserMessage (possibly multimodal) and one AiMessage acknowledgment, or empty if no content
      */
-    public final List<ChatMessage> getWorkspaceContentsMessages(Collection<ChatMessage> readOnlyMessages, List<ContextFragment> editableFragmentsInOrder) {
+    public final List<ChatMessage> getWorkspaceContentsMessages(
+            Collection<ChatMessage> readOnlyMessages, List<ContextFragment> editableFragmentsInOrder) {
         var combinedText = new StringBuilder();
         var allImages = new ArrayList<ImageContent>();
 

--- a/app/src/test/java/ai/brokk/prompts/CodePromptsOrderingTest.java
+++ b/app/src/test/java/ai/brokk/prompts/CodePromptsOrderingTest.java
@@ -1,18 +1,15 @@
 package ai.brokk.prompts;
 
-import ai.brokk.IConsoleIO;
+import static org.junit.jupiter.api.Assertions.*;
+
 import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
-import ai.brokk.context.Context;
 import ai.brokk.context.ContextFragment;
 import ai.brokk.testutil.TestContextManager;
 import ai.brokk.testutil.TestProject;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -20,8 +17,8 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for verifying ordering behavior in CodePrompts:
@@ -42,7 +39,8 @@ public class CodePromptsOrderingTest {
                         .forEach(p -> {
                             try {
                                 Files.deleteIfExists(p);
-                            } catch (Exception ignored) {}
+                            } catch (Exception ignored) {
+                            }
                         });
             }
         }


### PR DESCRIPTION
**Summary**

Addresses part of #1565 
Make SearchAgent render editable fragments in the order they were added, while keeping the existing mtime-based ordering for everyone else.

**What and why**

What: Switch SearchAgent to insertion order for editable fragments; add tiny overloads in CodePrompts to support this.
Why: Search steps read better in the order they were curated. Other callers keep current behavior.

**Changes**

Added `CodePrompts.getWorkspaceEditableMessages(List<ContextFragment>)`.
Added `CodePrompts.getWorkspaceContentsMessages(Collection<ChatMessage>, List<ContextFragment>)`
Refactored `SearchAgent.executeInternal()` to use the new helpers.
Tests: `CodePromptsOrderingTest` asserts both mtime (legacy) and insertion (new) ordering.

**Impact**

Backward compatible; existing APIs unchanged.
Multimodal formatting (text + images) preserved.
How to test

Run unit tests; see CodePromptsOrderingTest for ordering checks.