### PR TITLE
Feat: Enhance Search Agent Parallel Tool Calling & Instructions

### DIFF
--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -397,7 +397,8 @@ public class SearchAgent {
         }
 
         // Define Research tools explicitly for the model (no terminal duplication).
-        // We only list RESEARCH tools; terminals are documented elsewhere and hygiene tools are omitted to keep this concise.
+        // We only list RESEARCH tools; terminals are documented elsewhere and hygiene tools are omitted to keep this
+        // concise.
         if (!beastMode) {
             var researchList = calculateAllowedToolNames().stream()
                     .filter(name -> categorizeTool(name) == ToolCategory.RESEARCH)
@@ -676,7 +677,8 @@ public class SearchAgent {
 
     private enum ToolCategory {
         TERMINAL, // answer, createTaskList, workspaceComplete, abortSearch
-        WORKSPACE_HYGIENE, // dropWorkspaceFragments, appendNote (these modify the workspace; terminals are not executed in the same turn)
+        WORKSPACE_HYGIENE, // dropWorkspaceFragments, appendNote (these modify the workspace; terminals are not executed
+        // in the same turn)
         RESEARCH // everything else (non-final discovery/search; blocks terminals)
     }
 

--- a/app/src/main/java/ai/brokk/prompts/ArchitectPrompts.java
+++ b/app/src/main/java/ai/brokk/prompts/ArchitectPrompts.java
@@ -4,7 +4,6 @@ import ai.brokk.ContextManager;
 import ai.brokk.IContextManager;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.context.Context;
-import ai.brokk.context.ContextFragment;
 import ai.brokk.util.StyleGuideResolver;
 import dev.langchain4j.data.message.SystemMessage;
 import java.util.Comparator;


### PR DESCRIPTION
This PR updates the Search Agent's instructions to significantly enhance its use of parallel tool calls. The primary intent is to improve the agent's efficiency and effectiveness during discovery and context-gathering phases.

<img width="2743" height="1797" alt="image" src="https://github.com/user-attachments/assets/06aad500-2023-4b42-82c1-0c90f2562051" />


Key changes include:
*   **Mandatory Parallelization:** Explicitly instructs the Search Agent to issue multiple research tool calls in parallel on discovery turns.
*   **Optimized Tool Usage:** Encourages preferring several short, targeted calls over a single long one, and using at least two different tools for initial context.
*   **Clear Tool Invocation Examples:** Provides a detailed example of parallel tool invocation, clarifying the expected format.
*   **Beast Mode Exemption:** Clarifies that the parallelization mandate is waived when the agent enters beast mode.