### PR TITLE
fix: LocalFileRepo hangs on large repos

### DIFF
--- a/app/src/main/java/ai/brokk/git/LocalFileRepo.java
+++ b/app/src/main/java/ai/brokk/git/LocalFileRepo.java
@@ -12,6 +12,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -20,6 +21,8 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 public class LocalFileRepo implements IGitRepo {
     private static final Logger logger = LogManager.getLogger(LocalFileRepo.class);
     private final Path root;
+
+    @Nullable
     private Set<ProjectFile> trackedFilesCache;
 
     public LocalFileRepo(Path root) {


### PR DESCRIPTION
This adds a tracked file cache to the LocalFileRepo, just like the IGitRepo. If you open a project with lots of files that doesn't use git, then it would just hang because it would be crawling the entire directory for each node of the file tree, on the EDT.  This fixes that.