### PR TITLE
chore: disable jbr

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "version": "1.0.0",
     "jdeploy": {
         "jdk": false,
-        "jdkProvider": "jbr",
         "args": [],
         "fallbackToUniversal": false,
         "configFileMac": "{{ path(user.home, \"Library\", \"Application Support\", \"Brokk\", \"jdeploy.json\") }}",


### PR DESCRIPTION
The JBR WatchService implementation is different than the OpenJDK implementation, and it causes too many file errors, since it keeps the file descriptors.  OpenJDK must use either a native approach or polling.