### PR TITLE
chore: [1584] Use watch service polling implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jdeploy": {
         "jdk": false,
         "jdkProvider": "jbr",
-        "args": [],
+        "args": ["-Dwatch.service.polling=true"],
         "fallbackToUniversal": false,
         "configFileMac": "{{ path(user.home, \"Library\", \"Application Support\", \"Brokk\", \"jdeploy.json\") }}",
         "configFileWin": "{{ path(env.APPDATA ?? path(user.home, \"AppData\", \"Roaming\"), \"Brokk\", \"jdeploy.json\") }}",


### PR DESCRIPTION
A mitigation for the too many open files issue when using JBR.  This will use the polling implementation for watch service instead of the native one that holds file descriptors for each directory registered so we don't hit the too many opened files error. https://github.com/BrokkAi/brokk/issues/1584