### PR TITLE
Implement configurable history compression concurrency

### DIFF
--- a/app/src/main/java/ai/brokk/MainProject.java
+++ b/app/src/main/java/ai/brokk/MainProject.java
@@ -1302,6 +1302,7 @@ public final class MainProject extends AbstractProject {
     private static final String FORCE_TOOL_EMULATION_KEY = "forceToolEmulation";
     private static final String HISTORY_AUTO_COMPRESS_KEY = "historyAutoCompress";
     private static final String HISTORY_AUTO_COMPRESS_THRESHOLD_PERCENT_KEY = "historyAutoCompressThresholdPercent";
+    private static final String HISTORY_COMPRESSION_CONCURRENCY_KEY = "historyCompressionConcurrency";
 
     public static String getUiScalePref() {
         var props = loadGlobalProperties();
@@ -1418,6 +1419,34 @@ public final class MainProject extends AbstractProject {
             props.remove(HISTORY_AUTO_COMPRESS_THRESHOLD_PERCENT_KEY);
         } else {
             props.setProperty(HISTORY_AUTO_COMPRESS_THRESHOLD_PERCENT_KEY, Integer.toString(clamped));
+        }
+        saveGlobalProperties(props);
+    }
+
+    public static int getHistoryCompressionConcurrency() {
+        var props = loadGlobalProperties();
+        String value = props.getProperty(HISTORY_COMPRESSION_CONCURRENCY_KEY);
+        int def = 2;
+        if (value == null || value.isBlank()) {
+            return def;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            if (parsed < 1) parsed = 1;
+            if (parsed > 8) parsed = 8;
+            return parsed;
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
+
+    public static void setHistoryCompressionConcurrency(int value) {
+        int clamped = Math.max(1, Math.min(8, value));
+        var props = loadGlobalProperties();
+        if (clamped == 2) {
+            props.remove(HISTORY_COMPRESSION_CONCURRENCY_KEY);
+        } else {
+            props.setProperty(HISTORY_COMPRESSION_CONCURRENCY_KEY, Integer.toString(clamped));
         }
         saveGlobalProperties(props);
     }

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -97,6 +97,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
     // Compression settings
     private JCheckBox autoCompressCheckbox = new JCheckBox("Auto-compress conversation history");
     private JSpinner autoCompressThresholdSpinner = new JSpinner();
+    private JSpinner compressionConcurrencySpinner = new JSpinner();
 
     @Nullable
     private JCheckBox forceToolEmulationCheckbox; // Dev-only
@@ -1365,6 +1366,26 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         autoCompressCheckbox.addActionListener(
                 e -> autoCompressThresholdSpinner.setEnabled(autoCompressCheckbox.isSelected()));
 
+        // Max concurrent compression threads
+        gbc.gridx = 0;
+        gbc.gridy = row++;
+        gbc.weightx = 0.0;
+        gbc.fill = GridBagConstraints.NONE;
+        panel.add(new JLabel("Max concurrent compression threads:"), gbc);
+
+        var concurrencyModel = new SpinnerNumberModel(2, 1, 8, 1);
+        compressionConcurrencySpinner.setModel(concurrencyModel);
+        compressionConcurrencySpinner.setEditor(new JSpinner.NumberEditor(compressionConcurrencySpinner, "#0"));
+
+        var concurrencyPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        concurrencyPanel.add(compressionConcurrencySpinner);
+
+        gbc.gridx = 1;
+        gbc.gridy = row - 1;
+        gbc.weightx = 1.0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        panel.add(concurrencyPanel, gbc);
+
         // filler
         gbc.gridx = 0;
         gbc.gridy = row;
@@ -1436,6 +1457,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         autoCompressCheckbox.setSelected(MainProject.getHistoryAutoCompress());
         autoCompressThresholdSpinner.setValue(MainProject.getHistoryAutoCompressThresholdPercent());
         autoCompressThresholdSpinner.setEnabled(autoCompressCheckbox.isSelected());
+        compressionConcurrencySpinner.setValue(MainProject.getHistoryCompressionConcurrency());
 
         // Appearance Tab
         String currentTheme = MainProject.getTheme();
@@ -1664,6 +1686,8 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         MainProject.setHistoryAutoCompress(autoCompressCheckbox.isSelected());
         int thresholdPercent = ((Number) autoCompressThresholdSpinner.getValue()).intValue();
         MainProject.setHistoryAutoCompressThresholdPercent(thresholdPercent);
+        int cc = ((Number) compressionConcurrencySpinner.getValue()).intValue();
+        MainProject.setHistoryCompressionConcurrency(cc);
 
         // General Tab - Advanced Mode
         // Only apply if the setting actually changed to avoid unnecessary UI refreshes


### PR DESCRIPTION
This PR introduces a configurable concurrency limit for conversation history compression. Previously, `parallelStream()` could lead to an uncontrolled number of concurrent requests to the LLM provider, potentially causing rate limit issues or instability.

Key changes:
*   Replaced `parallelStream()` with a bounded `ExecutorService` in `ContextManager` for history compression, limiting concurrent LLM calls.
*   Added a new global setting ("Max concurrent compression threads") in `SettingsGlobalPanel`, allowing users to control this limit (default 2, range 1-8).
*   Improved robustness: failed compression tasks will now fall back to the original, uncompressed history entry.
*   Addresses the "TODO: Get off common FJP" comment.