### PR TITLE
Refresh UI after commit dialog closes

### DIFF
--- a/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
@@ -3250,6 +3250,18 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
 
                     content.applyTheme(chrome.getTheme());
 
+                    // Add window listener to refresh UI after commit dialog closes
+                    dialog.addWindowListener(new WindowAdapter() {
+                        @Override
+                        public void windowClosed(WindowEvent e) {
+                            refreshBranchDiffPanel();
+                            var commitTab = chrome.getGitCommitTab();
+                            if (commitTab != null) {
+                                commitTab.updateCommitPanel();
+                            }
+                        }
+                    });
+
                     dialog.setVisible(true);
                 });
             });


### PR DESCRIPTION
Add a window listener to ensure the UI updates when the commit dialog is closed.

- Intent: avoid stale UI state after a user finishes a commit by triggering relevant panel updates automatically.
- Behaviour change: when the commit dialog is closed, the branch diff panel is refreshed and the Git commit tab (if present) has its commit panel updated.
- Implementation: in HistoryOutputPanel, a WindowAdapter is attached to the commit dialog with an override of windowClosed calling refreshBranchDiffPanel() and commitTab.updateCommitPanel() if not null. The listener is added before dialog.setVisible(true).
- Benefit: improves UX by ensuring commit-related views reflect repository changes immediately.