### PR TITLE
Add Push and Pull support to HistoryOutputPanel

### DIFF
--- a/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
@@ -2876,7 +2876,7 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
 
                     SwingUtilities.invokeLater(() -> {
                         hideSpinner();
-                        if (pullResult == null || pullResult.isEmpty()) {
+                        if (pullResult.isEmpty()) {
                             chrome.showNotification(IConsoleIO.NotificationRole.INFO, "Pull completed successfully.");
                         } else {
                             chrome.showNotification(IConsoleIO.NotificationRole.INFO, "Pull: " + pullResult);
@@ -2919,7 +2919,7 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
 
                     SwingUtilities.invokeLater(() -> {
                         hideSpinner();
-                        if (pushResult == null || pushResult.isEmpty()) {
+                        if (pushResult.isEmpty()) {
                             chrome.showNotification(IConsoleIO.NotificationRole.INFO, "Push completed successfully.");
                         } else {
                             chrome.showNotification(IConsoleIO.NotificationRole.INFO, "Push: " + pushResult);


### PR DESCRIPTION
This change adds first-class push/pull support to the history UI. It introduces performPull and performPush methods that run GitWorkflow operations asynchronously with a spinner, notifications, error handling and logging. The branch-diff computation now populates a PushPullState into CumulativeChanges so the UI can determine whether pull/push are possible (checks upstream presence and unpushed commits). Pull and Push buttons are added to the history button bar and are enabled only when appropriate (no uncommitted changes and branch state allows it). The implementation keeps GitRepo checks and falls back safely when repository details are unavailable, and refreshes the branch diff and repo state after operations.