### PR TITLE
Streamline Model Role Configuration

### DIFF
--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -89,10 +89,13 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
     private JComboBox<String> preferredCodeModelCombo = new JComboBox<>();
     private JComboBox<String> primaryModelCombo = new JComboBox<>();
     private JComboBox<String> otherModelsVendorCombo = new JComboBox<>();
+
     @Nullable
     private JLabel otherModelsVendorLabel;
+
     @Nullable
     private JPanel otherModelsVendorHolder;
+
     private JTextField balanceField = new JTextField();
     private BrowserLabel signupLabel = new BrowserLabel("", ""); // Initialized with dummy values
     private JCheckBox showCostNotificationsCheckbox = new JCheckBox("Show LLM cost notifications");


### PR DESCRIPTION
This PR simplifies how users configure various LLM roles in the global settings.

*   **Consolidated 'Other Models'**: The Quick, Quick Edit, Quickest, and Scan model selectors are replaced with a single "Vendor for Other Models" dropdown (Anthropic, OpenAI, Default). This allows users to quickly apply vendor-specific default configurations for these roles.
*   **Direct Model Selection**: The "Primary Model" and "Lutz Code Model" dropdowns now directly list all available models, instead of relying on favorite aliases. This makes it easier to select any available model for these key roles.
*   **Updated Defaults**: The "Defaults" button now resets the "Vendor for Other Models" to "Default" and sets the Primary and Lutz Code models to recommended defaults.
*   **Improved Tooltips**: Tooltips provide clearer explanations for the new vendor selection.