### PR TITLE
fix: prevent history compression from freezing session navigation

### DIFF
--- a/app/src/main/java/ai/brokk/Llm.java
+++ b/app/src/main/java/ai/brokk/Llm.java
@@ -546,6 +546,18 @@ public class Llm {
         return sendMessageWithRetry(messages, ToolContext.empty(), MAX_ATTEMPTS);
     }
 
+    /**
+     * Sends messages to the model with a custom max retry count. Useful for non-critical tasks
+     * like history compression where we don't want to block for too long on failures.
+     *
+     * @param messages The messages to send
+     * @param maxAttempts Maximum number of attempts (1 = no retries)
+     * @return The final response from the LLM
+     */
+    public StreamingResult sendRequest(List<ChatMessage> messages, int maxAttempts) throws InterruptedException {
+        return sendMessageWithRetry(messages, ToolContext.empty(), maxAttempts);
+    }
+
     /** Sends messages to a model with possible tools and a chosen tool usage policy. */
     public StreamingResult sendRequest(List<ChatMessage> messages, ToolContext toolContext)
             throws InterruptedException {


### PR DESCRIPTION
## Summary

Fixes #1851 - History Compression Failures Freeze Session Navigation

**Root cause:** `compressHistoryAsync()` used `submitExclusiveAction()` which blocked the single-threaded user executor. When LLM timeouts occurred, the retry logic (8 attempts with exponential backoff) blocked for minutes, preventing session switching and freezing the UI.

**Changes:**
- Change `compressHistoryAsync` to use `submitLlmAction` (cancellable via Stop button)
- Reduce compression retry attempts from 8 to 3 (compression is non-critical)
- Properly handle interruption and cancel remaining futures when stopped
- Add `sendRequest(messages, maxAttempts)` overload to `Llm.java`

## Test plan

- [ ] **Maintainer testing requested** - I was unable to test manually as I had no existing sessions with task history and no account balance to generate new conversations
- [x] Code compiles successfully
- [x] Static analysis passes (NullAway + spotless)
- [x] Existing unit tests pass (ContextManagerTest, LlmTest, SessionManagerTest)

### Expected behavior after fix:
1. Compression can be cancelled via Stop button
2. Session switching not blocked by failing compression
3. Compression fails faster (3 attempts vs 8) when LLM is unavailable
