### PR TITLE
console logging for headless executor

### DIFF
--- a/app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java
+++ b/app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java
@@ -1343,8 +1343,6 @@ public final class HeadlessExecutorMain {
             System.out.println("  execId:      " + execId);
             System.out.println("  listenAddr:  " + listenAddr);
             System.out.println("  workspaceDir: " + workspaceDir);
-            var logFileLocation = System.getProperty("user.home") + "/.brokk/debug.log";
-            System.out.println("  logFile:     " + logFileLocation);
             System.out.println();
             System.out.println("Health check endpoints (no auth required):");
             System.out.println("  GET /health/live  - executor liveness probe");


### PR DESCRIPTION
- finally catching errors and showing them in the console so that people using the headless executor directly can see the error