### PR TITLE
Persist other-models vendor preference and remove auto-detection

### DIFF
--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -403,7 +403,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         // Apply persisted preference if present and valid; otherwise fall back to Default
         String persistedVendor = MainProject.getOtherModelsVendorPreference();
         String vendorToSelect;
-        if (persistedVendor != null && !persistedVendor.isBlank() && vendors.contains(persistedVendor)) {
+        if (!persistedVendor.isBlank() && vendors.contains(persistedVendor)) {
             vendorToSelect = persistedVendor;
         } else {
             vendorToSelect = "Default";

--- a/app/src/main/java/ai/brokk/project/MainProject.java
+++ b/app/src/main/java/ai/brokk/project/MainProject.java
@@ -1430,7 +1430,7 @@ public final class MainProject extends AbstractProject {
 
     public static void setOtherModelsVendorPreference(String vendor) {
         var props = loadGlobalProperties();
-        if (vendor == null || vendor.isBlank()) {
+        if (vendor.isBlank()) {
             props.remove(OTHER_MODELS_VENDOR_KEY);
         } else {
             props.setProperty(OTHER_MODELS_VENDOR_KEY, vendor.trim());


### PR DESCRIPTION
This change removes brittle, implicit vendor auto-detection and introduces an explicit persisted preference for the "other models" vendor selection. Key changes:

- Remove auto-detection logic that inferred vendor from model configs and instead try to apply a stored preference from MainProject when rebuilding the vendor combo.
- Add MainProject.getOtherModelsVendorPreference() and setOtherModelsVendorPreference() to read/write a new global property key (otherModelsVendor).
- Persist the selected vendor when settings are applied; saving an empty value removes the preference.
- Avoid rewriting model configs when "Default" or unknown vendors are selected (only the preference is stored).

These changes favor explicit user preference, reduce unexpected model rewrites, and simplify vendor selection behavior.