### PR TITLE
Enforce minimum sidebar width and clamp divider

### DIFF
--- a/app/src/main/java/ai/brokk/gui/Chrome.java
+++ b/app/src/main/java/ai/brokk/gui/Chrome.java
@@ -2928,8 +2928,7 @@ public class Chrome
 
             // Treat the UI as "collapsed" when the divider is hidden or very close to the left edge.
             // In that state we do NOT clamp or persist positions, so collapse via tab toggle works.
-            boolean isCollapsedUi =
-                    bottomSplitPane.getDividerSize() == 0 || newPos < SIDEBAR_COLLAPSED_THRESHOLD;
+            boolean isCollapsedUi = bottomSplitPane.getDividerSize() == 0 || newPos < SIDEBAR_COLLAPSED_THRESHOLD;
             if (isCollapsedUi) {
                 return;
             }


### PR DESCRIPTION
This change prevents the left sidebar from being shrunk to an unusable size by introducing an absolute minimum width and stronger enforcement in layout and divider logic. Key points:

- Add MIN_SIDEBAR_WIDTH_PX (220px) and raise MIN_SIDEBAR_WIDTH_FRACTION from 10% to 12%.
- Apply the absolute minimum to leftTabbedPanel, leftVerticalSplitPane and bottomSplitPane minimum sizes so the whole sidebar region respects the limit.
- Update the JSplitPane divider listener to early-return when not showing or invalid, clamp expanded positions below the computed minimum, and preserve existing persistence/last-expanded behavior.
- Introduce computeMinSidebarWidthPx() to centralize min-width computation and use SwingUtilities.invokeLater to correct the divider visually when required.

This improves usability on small and large displays while keeping backward-compatible persistence behavior for expanded sidebar positions.