### PR TITLE
Use FavoriteModel objects in model selection combos

### DIFF
--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -1836,7 +1836,8 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
             preferredCodeModelCombo.repaint();
             primaryModelCombo.revalidate();
             primaryModelCombo.repaint();
-        } catch (Exception ignore) {
+        } catch (Exception e) {
+            logger.warn("Failed to refresh favorite model combos", e);
         }
     }
 


### PR DESCRIPTION
Switch model selection UI to use Service.FavoriteModel objects instead of raw model-name strings. Intent: keep UI tied to the user’s favorites (alias + config) and make selection/synchronization robust against name-only mismatches. Key changes:

- Replace JComboBox<String> with JComboBox<Service.FavoriteModel> for preferred code and primary model controls.
- Populate combos from SettingsData.favoriteModels and display alias (falling back to name) via a custom renderer.
- Selection and sync logic now compare ModelConfig equality (config.equals(...)) rather than matching names.
- Default-selection logic matches config names when picking GPT_5/HAIKU_4_5 and falls back to index 0.
- Saving uses the selected favorite’s ModelConfig (favorite.config()) instead of string names.

These changes improve correctness when aliases or object-equality matter and centralize model metadata handling.