### PR TITLE
config: Remove watcher matrix and set native impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,10 @@ jobs:
     - name: Run tests with full static analysis (Windows)
       if: matrix.os == 'windows-latest'
       run: ./gradlew check -PexcludeGitRepoTest
-      env:
-        BROKK_WATCHSERVICE_IMPL: native
 
     - name: Run tests with full static analysis (Unix)
       if: matrix.os != 'windows-latest'
       run: ./gradlew check shadowJar
-      env:
-        BROKK_WATCHSERVICE_IMPL: native
 
   formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I recently added a matrix to run pipelines using both the native and legacy file watchers. Now that I've confirmed they are both passing,  I'm removing this.  Now it will run only with whatever is the default file watcher only.