### PR TITLE
Add 'Plan' mode and consolidate search execution logic

### DIFF
--- a/app/src/main/java/ai/brokk/gui/terminal/TaskListPanel.java
+++ b/app/src/main/java/ai/brokk/gui/terminal/TaskListPanel.java
@@ -112,6 +112,7 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
     private final MaterialButton goStopButton;
     private final MaterialButton clearCompletedBtn = new MaterialButton();
     private final Chrome chrome;
+    private static @Nullable TaskListPanel INSTANCE = null;
 
     // Read-only state: when viewing a historical context, editing is disabled
     private boolean taskListEditable = true;
@@ -144,6 +145,7 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
         setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4));
 
         this.chrome = chrome;
+        INSTANCE = this;
 
         // Center: list with custom renderer
         list.setCellRenderer(new TaskRenderer());
@@ -2279,6 +2281,10 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
         return goStopButton;
     }
 
+    public static @Nullable TaskListPanel getInstance() {
+        return INSTANCE;
+    }
+
     /**
      * Ensure tasksTabBadgedIcon is created and applied to the enclosing JTabbedPane tab (if present).
      * Safe to call from any thread; UI work runs on the EDT. No-op if not hosted in a JTabbedPane or if theme
@@ -2622,9 +2628,7 @@ public class TaskListPanel extends JPanel implements ThemeAware, IContextManager
                 model.getSize(),
                 preExistingIncompleteTasks.size());
 
-        if (GlobalUiSettings.isAdvancedMode()) {
-            return;
-        }
+        
 
         if (queueActive) {
             return;


### PR DESCRIPTION
Introduce a new "Plan" action to generate task lists without auto-executing them, and refactor Search/Lutz execution into a single configurable method.

- Behavior: "Plan" is exposed in advanced UI only; it runs an agentic search that creates tasks but does not auto-run them. "Lutz"/Search continues to generate and (by default) trigger task execution. The action cycle now includes Plan when Advanced Mode is enabled.
- Implementation: extracted executeSearchWithObjective(...) to parameterize objective and auto-execution; runPlanCommand() calls it with TASKS_ONLY and autoExecute=false. Pre-existing incomplete tasks are captured, and after a successful Lutz run the TaskListPanel is asked to autoPlay any new tasks.
- UI: added menu item, tooltips, spinner text, mode labels, and validation for the new mode. TaskListPanel now exposes a singleton getter (getInstance) to support post-search automation.