### PR TITLE
feat: Improve commit message generation with multi-line format

### DIFF
--- a/app/src/main/java/ai/brokk/AbstractService.java
+++ b/app/src/main/java/ai/brokk/AbstractService.java
@@ -665,26 +665,35 @@ public abstract class AbstractService implements ExceptionReporter.ReportingServ
 
     public StreamingChatModel getScanModel() {
         // First attempt: use project-configured scan model if available
-        try {
-            var cfg = project.getMainProject().getScanModelConfig();
-            var model = getModel(cfg);
-            if (model != null) {
-                return model;
-            }
-        } catch (Exception e) {
-            logger.debug(
-                    "Failed to get project-configured scan model, falling back to dynamic selection: {}",
-                    e.getMessage());
+        var cfg = project.getMainProject().getScanModelConfig();
+        var model = getModel(cfg);
+        if (model != null) {
+            return model;
         }
 
         // Fallback: dynamic selection preferring GEMINI_2_5_FLASH if available, else GPT_5_MINI
         var modelName = modelLocations.containsKey(GEMINI_2_5_FLASH) ? GEMINI_2_5_FLASH : GPT_5_MINI;
-        var model = getModel(new ModelConfig(modelName, ReasoningLevel.DEFAULT));
+        model = getModel(new ModelConfig(modelName, ReasoningLevel.DEFAULT));
         if (model == null) {
             logger.error("Failed to get scan model '{}'", modelName);
             return new UnavailableStreamingModel();
         }
         return model;
+    }
+
+    /**
+     * Returns the model to use for inferring Git commit messages.
+     * First attempt: use project-configured commit model if available.
+     */
+    public StreamingChatModel getCommitModel() {
+        // First attempt: use project-configured commit model if available
+        var cfg = project.getMainProject().getCommitModelConfig();
+        var model = getModel(cfg);
+        if (model != null) {
+            return model;
+        }
+
+        return quickModel;
     }
 
     public boolean hasSttModel() {

--- a/app/src/main/java/ai/brokk/git/GitWorkflow.java
+++ b/app/src/main/java/ai/brokk/git/GitWorkflow.java
@@ -85,7 +85,7 @@ public final class GitWorkflow {
 
         var messages = CommitPrompts.instance.collectMessages(cm.getProject(), diff);
         Llm.StreamingResult result;
-        result = cm.getLlm(cm.getService().quickestModel(), "Infer commit message")
+        result = cm.getLlm(cm.getService().getCommitModel(), "Infer commit message")
                 .sendRequest(messages);
 
         return result.error() == null ? result.text() : taskDescription;

--- a/app/src/main/java/ai/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/ai/brokk/gui/InstructionsPanel.java
@@ -64,7 +64,6 @@ import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.swing.*;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
@@ -447,8 +446,8 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         });
 
         modelSelector = new ModelSelector(chrome);
-        modelSelector.selectConfig(chrome.getProject().getArchitectModelConfig());
-        modelSelector.addSelectionListener(cfg -> chrome.getProject().setArchitectModelConfig(cfg));
+        modelSelector.selectConfig(chrome.getProject().getPrimaryModelConfig());
+        modelSelector.addSelectionListener(cfg -> chrome.getProject().setPrimaryModelConfig(cfg));
         // Also recompute token/cost indicator when model changes
         modelSelector.addSelectionListener(cfg -> updateTokenCostIndicator());
         // Ensure model selector component is focusable

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -395,7 +395,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         }
 
         // Populate Primary Model combo with favorites
-        var currentPlannerConfig = chrome.getProject().getMainProject().getArchitectModelConfig();
+        var currentPlannerConfig = chrome.getProject().getMainProject().getPrimaryModelConfig();
         primaryModelCombo.removeAllItems();
         for (Service.FavoriteModel favorite : loadedFavorites) {
             primaryModelCombo.addItem(favorite);
@@ -2177,7 +2177,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
         // Save Primary Model (from favorite config)
         if (selectedPrimaryFavorite != null) {
-            chrome.getProject().getMainProject().setArchitectModelConfig(selectedPrimaryFavorite.config());
+            chrome.getProject().getMainProject().setPrimaryModelConfig(selectedPrimaryFavorite.config());
             chrome.getInstructionsPanel().selectPlannerModelConfig(selectedPrimaryFavorite.config());
         }
 

--- a/app/src/main/java/ai/brokk/project/IProject.java
+++ b/app/src/main/java/ai/brokk/project/IProject.java
@@ -297,11 +297,11 @@ public interface IProject extends AutoCloseable {
         throw new UnsupportedOperationException();
     }
 
-    default AbstractService.ModelConfig getArchitectModelConfig() {
+    default AbstractService.ModelConfig getPrimaryModelConfig() {
         throw new UnsupportedOperationException();
     }
 
-    default void setArchitectModelConfig(AbstractService.ModelConfig config) {
+    default void setPrimaryModelConfig(AbstractService.ModelConfig config) {
         throw new UnsupportedOperationException();
     }
 

--- a/app/src/main/java/ai/brokk/project/MainProject.java
+++ b/app/src/main/java/ai/brokk/project/MainProject.java
@@ -455,6 +455,16 @@ public final class MainProject extends AbstractProject {
         return ModelProperties.ModelType.SCAN.preferredConfig();
     }
 
+    /**
+     * Returns the code-defined default ModelConfig for the Commit role.
+     *
+     * <p>This reflects the preferred default in {@link ModelProperties} and is independent of any
+     * persisted user settings or overrides.
+     */
+    public static ModelConfig getDefaultCommitModelConfig() {
+        return ModelProperties.ModelType.COMMIT.preferredConfig();
+    }
+
     private void setModelConfigInternal(ModelType modelType, ModelConfig config) {
         var props = loadGlobalProperties();
         ModelProperties.setModelConfig(props, modelType, config);
@@ -482,13 +492,13 @@ public final class MainProject extends AbstractProject {
     }
 
     @Override
-    public ModelConfig getArchitectModelConfig() {
-        return getModelConfigInternal(ModelType.ARCHITECT);
+    public ModelConfig getPrimaryModelConfig() {
+        return getModelConfigInternal(ModelType.PRIMARY);
     }
 
     @Override
-    public void setArchitectModelConfig(ModelConfig config) {
-        setModelConfigInternal(ModelType.ARCHITECT, config);
+    public void setPrimaryModelConfig(ModelConfig config) {
+        setModelConfigInternal(ModelType.PRIMARY, config);
     }
 
     public ModelConfig getQuickEditModelConfig() {
@@ -513,6 +523,14 @@ public final class MainProject extends AbstractProject {
 
     public void setScanModelConfig(ModelConfig config) {
         setModelConfigInternal(ModelType.SCAN, config);
+    }
+
+    public ModelConfig getCommitModelConfig() {
+        return getModelConfigInternal(ModelType.COMMIT);
+    }
+
+    public void setCommitModelConfig(ModelConfig config) {
+        setModelConfigInternal(ModelType.COMMIT, config);
     }
 
     @Override

--- a/app/src/main/java/ai/brokk/project/ModelProperties.java
+++ b/app/src/main/java/ai/brokk/project/ModelProperties.java
@@ -1,5 +1,6 @@
 package ai.brokk.project;
 
+import ai.brokk.AbstractService;
 import ai.brokk.AbstractService.ModelConfig;
 import ai.brokk.Service;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -127,10 +128,11 @@ public final class ModelProperties {
     enum ModelType {
         QUICK("quickConfig", new ModelConfig(Service.GEMINI_2_0_FLASH)),
         CODE("codeConfig", new ModelConfig(Service.HAIKU_4_5)),
-        ARCHITECT("architectConfig", new ModelConfig(Service.GPT_5)),
+        PRIMARY("architectConfig", new ModelConfig(Service.GPT_5)),
         QUICK_EDIT("quickEditConfig", new ModelConfig("cerebras/gpt-oss-120b")),
         QUICKEST("quickestConfig", new ModelConfig("gemini-2.0-flash-lite")),
-        SCAN("scanConfig", new ModelConfig(Service.GPT_5_MINI));
+        SCAN("scanConfig", new ModelConfig(Service.GPT_5_MINI)),
+        COMMIT("commitConfig", new ModelConfig(Service.HAIKU_4_5, AbstractService.ReasoningLevel.DISABLE));
 
         private final String propertyKey;
         private final ModelConfig preferredConfig;

--- a/app/src/main/java/ai/brokk/project/WorktreeProject.java
+++ b/app/src/main/java/ai/brokk/project/WorktreeProject.java
@@ -108,13 +108,13 @@ public final class WorktreeProject extends AbstractProject {
     }
 
     @Override
-    public AbstractService.ModelConfig getArchitectModelConfig() {
-        return parent.getArchitectModelConfig();
+    public AbstractService.ModelConfig getPrimaryModelConfig() {
+        return parent.getPrimaryModelConfig();
     }
 
     @Override
-    public void setArchitectModelConfig(AbstractService.ModelConfig config) {
-        parent.setArchitectModelConfig(config);
+    public void setPrimaryModelConfig(AbstractService.ModelConfig config) {
+        parent.setPrimaryModelConfig(config);
     }
 
     @Override

--- a/app/src/main/java/ai/brokk/prompts/CommitPrompts.java
+++ b/app/src/main/java/ai/brokk/prompts/CommitPrompts.java
@@ -44,40 +44,47 @@ public class CommitPrompts {
         var formatInstructions = project.getCommitMessageFormat();
 
         var context = """
-        <diff>
-        %s
-        </diff>
-        """.formatted(trimmedDiff);
+            <diff>
+            %s
+            </diff>
+            """.formatted(trimmedDiff);
 
         var instructions =
                 """
-        <goal>
-        Here is my diff, please give me a concise commit message based on the format instructions provided in the system prompt.
-        </goal>
-        """;
+            <goal>
+            Here is my diff. Write a complete Git commit message with:
+            - A single-line subject as described in the system prompt,
+            - A blank line,
+            - A short, wrapped body summarizing the change.
+            </goal>
+            """;
         return List.of(
                 new SystemMessage(systemIntro(formatInstructions)), new UserMessage(context + "\n\n" + instructions));
     }
 
     private String systemIntro(String formatInstructions) {
         return """
-               You are an expert software engineer that generates concise,
-               one-line Git commit messages based on the provided diffs.
-               Review the provided context and diffs which are about to be committed to a git repo.
-               Review the diffs carefully.
-               Generate a one-line commit message for those changes, following the format instructions below.
-               %s
+                          You are an expert software engineer that generates high-quality,
+                          conventional Git commit messages from the provided diffs.
 
-               Ensure the commit message:
-               - Follows the specified format.
-               - Is in the imperative mood (e.g., "Add feature" not "Added feature" or "Adding feature").
-               - Does not exceed 72 characters.
+                          Produce a multi-line commit message with this structure:
+                          - First line: a concise subject in the imperative mood (e.g., "Add feature"),
+                              no trailing period, and no more than 72 characters.
+                          - Then a blank line.
+                          - Then a short body (1–3 paragraphs and/or bullet points) explaining the intent,
+                              key changes, and rationale.
 
-               Additionally, if a single file is changed be sure to include the short filename (not the path, not the extension).
+                          Guidelines:
+                          - Wrap body lines at approximately 72 characters.
+                          - Use plain text; avoid markdown headings and code fences. Simple '-' bullets are OK.
+                          - Reference relevant files or subsystems using backticks when helpful.
+                          - Avoid ticket numbers, emojis, or unnecessary verbosity.
+                          - If exactly one file is changed, consider including its short filename (no path,
+                              no extension) in the subject when helpful.
 
-               Reply only with the one-line commit message, without any additional text, explanations,
-               or line breaks.
-               """
+                          Follow any additional format or style preferences:
+                          %s
+                          """
                 .formatted(formatInstructions);
     }
 


### PR DESCRIPTION
This commit updates the commit message generation process to produce multi-line commit messages. The changes include:

- Modifying the `CommitPrompts` class to instruct the LLM to generate messages with a subject line, a blank line, and a body.
- Updating the `systemIntro` method to provide detailed instructions on the desired commit message format.
- Changed the model used for commit message generation to Haiku 4.5 with reasoning disabled, falling back to the quick model if unavailable.
- Updated `GitWorkflow` to use the new model.