### PR TITLE
chore: [2029] Bump jdeploy java version to 25

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
             "type": "GITHUB",
             "url": "https://github.com/shannah/brokk"
         }],
-        "javaVersion": "21",
+        "javaVersion": "25",
         "permissions": [
             {
                 "name": "user_notifications",


### PR DESCRIPTION
Addresses https://github.com/BrokkAi/brokk/issues/2029