### PR TITLE
fix: Refactor Copy enable logic and reduce WebView logging

### DIFF
--- a/app/src/main/java/ai/brokk/gui/mop/MarkdownOutputPanel.java
+++ b/app/src/main/java/ai/brokk/gui/mop/MarkdownOutputPanel.java
@@ -259,7 +259,9 @@ public class MarkdownOutputPanel extends JPanel implements ThemeAware, Scrollabl
         try {
             return webHost.getSelectedText().get(200, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            logger.warn("Failed to fetch selected text from WebView", e);
+            logger.debug(
+                    "Failed to fetch selected text from WebView: {}",
+                    e.getClass().getSimpleName());
             return "";
         }
     }


### PR DESCRIPTION
fixes #1978 

This PR cleans up the Copy action enable/disable logic and reduces noisy logging from the Markdown WebView. Key changes:

- Replace repeated null checks with a local focusOwner variable and early returns to make the flow clearer and easier to maintain.
- For the instructions text area, enable Copy only when there is a selection or any text present.
- Always enable Copy when focus is inside the LLM output (MarkdownOutputPanel) and when focus is in workspace or history table; the copy handler will decide between selection and full content.
- Downgrade WebView selected-text failures from WARN to DEBUG and log only the exception class name to avoid spamming logs.

These changes simplify branching, improve UX when LLM output selection retrieval is unreliable, and reduce log noise.