### PR TITLE
Make MaterialButton automatically borderless for icon-only and compact SplitButton

### DIFF
--- a/app/src/main/java/ai/brokk/gui/components/MaterialButton.java
+++ b/app/src/main/java/ai/brokk/gui/components/MaterialButton.java
@@ -108,14 +108,18 @@ public class MaterialButton extends JButton {
         updateTooltip();
     }
 
+    private void applyBorderless() {
+        putClientProperty("JButton.buttonType", "borderless");
+        setBorder(null);
+        setBorderPainted(false);
+    }
+
     @Override
     public void setText(@Nullable String text) {
         super.setText(text);
 
         if (isForceBorderless()) {
-            putClientProperty("JButton.buttonType", "borderless");
-            setBorder(null);
-            setBorderPainted(false);
+            applyBorderless();
             return;
         }
 
@@ -138,9 +142,7 @@ public class MaterialButton extends JButton {
         updateCursorForEnabledState();
         updateTooltip();
         if (isForceBorderless()) {
-            putClientProperty("JButton.buttonType", "borderless");
-            setBorder(null);
-            setBorderPainted(false);
+            applyBorderless();
         } else {
             applyBorderlessIfIconOnly();
         }
@@ -224,14 +226,15 @@ public class MaterialButton extends JButton {
 
     private boolean isForceBorderless() {
         Object v = getClientProperty("MaterialButton.forceBorderless");
-        return v instanceof Boolean && (Boolean) v;
+        if (v instanceof Boolean b) {
+            return b;
+        }
+        return false;
     }
 
     private void applyBorderlessIfIconOnly() {
         if (isIconOnly()) {
-            putClientProperty("JButton.buttonType", "borderless");
-            setBorder(null);
-            setBorderPainted(false);
+            applyBorderless();
         }
     }
 

--- a/app/src/main/java/ai/brokk/gui/components/MaterialLoadingButton.java
+++ b/app/src/main/java/ai/brokk/gui/components/MaterialLoadingButton.java
@@ -75,10 +75,14 @@ public class MaterialLoadingButton extends MaterialButton {
     }
 
     @Override
-    public void setText(String text) {
+    public void setText(@Nullable String text) {
         super.setText(text);
         if (isEnabled()) { // Only update idleText if not in loading state (isEnabled is false during loading)
-            this.idleText = text;
+            if (text == null) {
+                this.idleText = "";
+            } else {
+                this.idleText = text;
+            }
         }
     }
 

--- a/app/src/main/java/ai/brokk/gui/components/SplitButton.java
+++ b/app/src/main/java/ai/brokk/gui/components/SplitButton.java
@@ -193,7 +193,7 @@ public class SplitButton extends JComponent {
     private static void applyCompactStyling(MaterialButton b) {
         // Maximum compactness: zero margins, zero padding, no border, no minimum width
         b.putClientProperty("JButton.buttonType", "borderless");
-        b.putClientProperty("MaterialButton.forceBorderless", Boolean.TRUE);
+        b.putClientProperty("MaterialButton.forceBorderless", true);
         b.putClientProperty("JButton.minimumWidth", 0);
         b.putClientProperty("Button.padding", new Insets(0, 0, 0, 0));
         b.setMargin(new Insets(0, 0, 0, 0));


### PR DESCRIPTION
Make icon-only MaterialButton instances render borderless and add a forced borderless mode for compact SplitButtons. Key changes:

- MaterialButton constructor now chooses between regular bordered styling and a borderless mode when MaterialButton.forceBorderless is set.
- setText and updateUI were overridden to re-evaluate border state at runtime, ensuring text changes and L&F updates toggle the border appropriately.
- New helpers (isIconOnly, isForceBorderless, applyBorderlessIfIconOnly) encapsulate logic for deciding when to remove borders.
- SplitButton.applyCompactStyling now sets MaterialButton.forceBorderless to true so compact split buttons remain borderless.

This preserves rollover/content-area behavior while making icon-only and compact buttons visually consistent and compact.