### PR TITLE
Suppress IncompatibleMethodReference and add test

### DIFF
--- a/app/src/main/java/ai/brokk/agents/CodeAgent.java
+++ b/app/src/main/java/ai/brokk/agents/CodeAgent.java
@@ -920,8 +920,10 @@ public class CodeAgent {
             IProblem.CannotInferElidedTypes,
             IProblem.CannotInferInvocationType,
             IProblem.GenericInferenceError,
-            IProblem.MissingTypeForInference
+            IProblem.MissingTypeForInference,
             // Verified by PJ-19 (missing external type via var inference ignored)
+            IProblem.IncompatibleMethodReference
+            // PJ-22: method ref return type vs generic descriptor mismatch without full classpath
             );
 
     /**


### PR DESCRIPTION
- Intent: Avoid spurious lint/errors where ECJ cannot fully resolve method reference return types due to missing external types or incomplete generic resolution

This reduces false positives from cross-file/classpath inference limitations. Fixes #2064