### PR TITLE
feat: add pop-out Review tab and Review window

### DIFF
--- a/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
@@ -2026,6 +2026,21 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
             });
         });
 
+        // Select the Review tab when the header (or its label) is clicked
+        MouseAdapter headerSelectListener = new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                int i = tabs.indexOfTabComponent(headerPanel);
+                if (i >= 0) {
+                    tabs.setSelectedIndex(i);
+                }
+            }
+        };
+        headerPanel.addMouseListener(headerSelectListener);
+        if (reviewTabHeaderLabel != null) {
+            reviewTabHeaderLabel.addMouseListener(headerSelectListener);
+        }
+
         var buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
         buttonPanel.setOpaque(false);
         buttonPanel.add(reviewTabHeaderButton);
@@ -2033,6 +2048,7 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
 
         try {
             tabs.setTabComponentAt(idx, headerPanel);
+            tabs.setMnemonicAt(idx, KeyEvent.VK_R);
         } catch (IndexOutOfBoundsException ex) {
             logger.debug("Failed to set custom Review tab header", ex);
         }


### PR DESCRIPTION
This PR adds a dedicated Review tab header with a pop-out button that opens the Review (Changes) content in a standalone, resizable window. Key changes: 


https://github.com/user-attachments/assets/3641a194-eefc-4240-8720-ff82ca63c1c1



closes #2079

- Introduces a custom tab header (label + pop-out MaterialButton) for the Review tab; prevents tab activation on button clicks and supports keyboard accessibility.
- Adds ReviewWindow (singleton per panel) to display aggregated diffs; supports live updates, theme propagation, and proper lifecycle (dispose/reuse).
- Extracts a side-effect-free builder (buildAggregatedReviewView) returning container + BrokkDiffPanel for reuse by tab and window.
- Enhances metrics formatting (plain/HTML) with theme-aware colors and updates tab title/tooltip handling robustly.
- Tracks uncommitted-working-tree state in CumulativeChanges and threads update results to the Review window.

These changes improve UX by enabling focused review in a separate window while keeping tab behavior consistent and accessible.