### PR TITLE
Fix test corrupting global Brokk API key

### DIFF
--- a/app/src/test/java/ai/brokk/executor/AskModeSearchAgentTest.java
+++ b/app/src/test/java/ai/brokk/executor/AskModeSearchAgentTest.java
@@ -53,14 +53,8 @@ public class AskModeSearchAgentTest {
         Files.createFile(gitDir.resolve("refs").resolve("heads").resolve("master"));
 
         var execId = UUID.randomUUID();
-        // Configure tests to use localhost proxy and a dummy Brokk key to avoid external network/calls in CI.
-        // This mirrors other integration tests which use LOCALHOST proxy + dummy key so model creation
-        // doesn't require a real Brokk API key.
-        MainProject.setLlmProxySetting(MainProject.LlmProxySetting.LOCALHOST);
-        MainProject.setBrokkKey("brk+" + UUID.randomUUID() + "+test");
-
+        // TestService is a mock that doesn't make real API calls, so no proxy/key config needed.
         var project = new MainProject(tempWorkspace);
-        // Use a TestService provider to avoid external network calls and model lookups in CI.
         var contextManager = new ContextManager(project, TestService.provider(project));
 
         // random token
@@ -80,10 +74,6 @@ public class AskModeSearchAgentTest {
 
     @AfterEach
     public void tearDown() {
-        // Restore global settings to avoid cross-test leakage of proxy/key configuration.
-        MainProject.setLlmProxySetting(MainProject.LlmProxySetting.BROKK);
-        MainProject.setBrokkKey("");
-
         if (executor != null) {
             try {
                 executor.stop(0);


### PR DESCRIPTION
  Summary

  - AskModeSearchAgentTest was calling `MainProject.setBrokkKey("")` in @AfterEach, which wrote to the reals global brokk.properties file
  - The test new uses TestService, a mock that doesn't make real API calls, so proxy/key configuration was unnecessary

  Why the bug was intermittent

  The bug happened every test run, but was often self-healing:
  1. Test removes key from disk
  2. If Brokk app was already running, its in-memory cache still had the key
  3. Any save operation (zoom, theme, model change) would overwrite disk from cache, restoring the key

  Changes

  - Removed MainProject.setLlmProxySetting() and MainProject.setBrokkKey() calls from test setup/teardown
  - Added comment clarifying that TestService doesn't need real API configuration

Fixes #2117 
On the plus side this could hardly affect users, which was my main worry, as this was an internal test

@foundev why was this done this way?