### PR TITLE
Fix Blocking Call on EDT Regression

### DIFF
--- a/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
@@ -3178,7 +3178,7 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
                         return new DiffService.CumulativeChanges(0, 0, 0, List.of(), null);
                     }
                 })
-                .thenApplyAsync(result -> {
+                .thenApply(result -> {
                     // Precompute titles/contents and sorting OFF the EDT
                     List<Map.Entry<String, Context.DiffEntry>> preparedSummaries = preparePerFileSummaries(result);
                     // Update UI on EDT


### PR DESCRIPTION
* Moved Review tab aggregation off the EDT by precomputing in `refreshCumulativeChangesAsync` and deferring UI updates via `SwingUtilities.invokeLater`.
* Added an `AggregatedFileChange` record to hold path and left/right contents for each file change.
* Introduced `prepareAggregatedFileChanges` to sort by `Context.DiffEntry.title` and extract contents off the EDT.
* Replaced `updateChangesTabContent` with EDT-only `updateChangesTabContentUi` that takes the precomputed list.
* Modified `buildAggregatedChangesPanel` to consume the precomputed list and avoid calling `Context.DiffEntry::title` on the EDT.
* Kept `setChangesTabTitleAndTooltip` and `BrokkDiffPanel` disposal on the EDT and preserved the loading spinner behavior during recomputation.