### PR TITLE
fix: Improve responsiveness of window close by using async shutdown

### DIFF
--- a/app/src/main/java/ai/brokk/Brokk.java
+++ b/app/src/main/java/ai/brokk/Brokk.java
@@ -836,6 +836,16 @@ public class Brokk {
                         JOptionPane.WARNING_MESSAGE);
                 if (choice == JOptionPane.NO_OPTION) {
                     return;
+                } else {
+                    // User confirmed close while an LLM task was active — interrupt it immediately.
+                    try {
+                        logger.debug(
+                                "Interrupting active LLM action during window close for project {}",
+                                projectPath.getFileName());
+                        ourChromeInstance.getContextManager().interruptLlmAction();
+                    } catch (Throwable t) {
+                        logger.debug("Failed to interrupt active LLM action during window close", t);
+                    }
                 }
             }
             projectBeingClosed = ourChromeInstance.getContextManager().getProject();
@@ -888,6 +898,8 @@ public class Brokk {
         // Standard cleanup
         Chrome removedChrome = openProjectWindows.remove(projectPath);
         if (removedChrome != null) {
+            // NOTE: Chrome.close() initiates an asynchronous ContextManager shutdown and must NOT block the EDT.
+            // It will dispose the UI and start background shutdown work; do not attempt to wait for that work here.
             removedChrome.close();
         }
         logger.debug("Removed project from open windows map: {}", projectPath);
@@ -937,12 +949,31 @@ public class Brokk {
             // We are about to exit the application.
             // Do NOT remove this project from the persistent "open projects" list.
             logger.info("Last project window ({}) closed. App exiting. It remains MRU.", projectPath);
-            try {
-                ContextFragment.shutdownFragmentExecutor();
-            } catch (Throwable t) {
-                logger.debug("Error during fragment executor shutdown on window close", t);
-            }
-            System.exit(0);
+
+            // IMPORTANT:
+            // The fragment-executor shutdown can be slow and must NOT run on the EDT since it may block
+            // waiting for background fragment computations, causing the UI to hang. We therefore:
+            //  - Schedule ContextFragment.shutdownFragmentExecutor() to run off-EDT via CompletableFuture.runAsync(...)
+            //  - After shutdown completes (or if scheduling fails), call System.exit(0) to terminate the JVM.
+            //  - Return immediately from this method so that the EDT remains responsive; the shutdown continues
+            //    in the background and will call System.exit(0) when finished.
+            CompletableFuture.runAsync(() -> {
+                        try {
+                            ContextFragment.shutdownFragmentExecutor();
+                        } catch (Throwable t) {
+                            logger.debug("Error during fragment executor shutdown on window close", t);
+                        } finally {
+                            System.exit(0);
+                        }
+                    })
+                    .exceptionally(ex -> {
+                        logger.debug("Asynchronous fragment executor shutdown failed to start", ex);
+                        // Fallback: ensure we still exit to prevent leaving the process alive.
+                        System.exit(0);
+                        return null;
+                    });
+            // Return immediately so the EDT is not blocked further.
+            return;
         } else {
             // Other projects are still open or other projects are pending reopening.
             // This one is just closing, so remove it from the persistent "open projects" list.

--- a/app/src/main/java/ai/brokk/gui/Chrome.java
+++ b/app/src/main/java/ai/brokk/gui/Chrome.java
@@ -1695,8 +1695,43 @@ public class Chrome
     public void close() {
         logger.info("Closing Chrome UI");
 
-        contextManager.close();
-        frame.dispose();
+        // IMPORTANT: This method MUST NOT block the Swing Event Dispatch Thread (EDT).
+        // The ContextManager.shutdown/close can perform potentially slow operations
+        // (executor shutdown, flushing logs, network calls, etc.). Blocking here would
+        // make the UI unresponsive and can lead to deadlocks during window close.
+        //
+        // Policy: initiate shutdown asynchronously and do not wait on the EDT.
+        // - We call ContextManager.closeAsync(...) to start shutdown off-EDT.
+        // - Any completion handling (logging, cleanup) runs asynchronously on completion.
+        // - We dispose the frame immediately so the window visibly closes promptly.
+        //
+        // Placing the shutdown initiation inside a try/catch prevents any unexpected
+        // exceptions from escaping the EDT.
+        try {
+            logger.debug(
+                    "Initiating asynchronous ContextManager.closeAsync(1_000) for project {} (non-blocking EDT)",
+                    contextManager.getProject().getRoot());
+            var shutdownFuture = contextManager.closeAsync(1_000);
+            logger.debug("ContextManager.closeAsync(1_000) invoked (shutdown proceeding asynchronously)");
+            shutdownFuture.whenComplete((v, t) -> {
+                if (t != null) {
+                    logger.warn("Asynchronous ContextManager shutdown completed with error", t);
+                } else {
+                    logger.debug("Asynchronous ContextManager shutdown completed successfully");
+                }
+            });
+        } catch (Throwable t) {
+            // Defensive: never let shutdown initiation throw on the EDT
+            logger.warn("Failed to initiate asynchronous ContextManager shutdown", t);
+        }
+
+        // Dispose UI immediately so window close is responsive.
+        try {
+            frame.dispose();
+        } catch (Throwable t) {
+            logger.warn("Error while disposing frame", t);
+        }
+
         // Unregister this instance
         openInstances.remove(this);
     }


### PR DESCRIPTION
- Chrome.close() now uses closeAsync() to avoid blocking EDT
- Add shuttingDown flag to ContextManager for early task termination
- Add shutdown check in submitLlmAction() to reject new LLM tasks
- Add shutdown checks in compressHistoryAsync() and compressHistory()
- Interrupt active LLM action on closeAsync()
- Make Brokk window close interrupt active LLM action before closing
- Make System.exit() run asynchronously to avoid blocking EDT