### PR TITLE
feat: Add infrastructure for distinguishing binary and text files in …

### DIFF
--- a/app/src/main/java/ai/brokk/gui/changes/ChangeClassifier.java
+++ b/app/src/main/java/ai/brokk/gui/changes/ChangeClassifier.java
@@ -1,0 +1,62 @@
+package ai.brokk.gui.changes;
+
+import ai.brokk.analyzer.BrokkFile;
+import java.util.Objects;
+
+/**
+ * Classifies a file change pair (left/right content) as TEXT, BINARY, or OVERSIZED using simple, deterministic
+ * heuristics:
+ *
+ * <ul>
+ *   <li>Binary detection: uses {@link BrokkFile#isBinary(String)} on either side</li>
+ *   <li>Size heuristics:
+ *       <ul>
+ *         <li>If combined length exceeds {@code maxCombined} => OVERSIZED</li>
+ *         <li>If either side exceeds {@code maxSingle} => OVERSIZED</li>
+ *         <li>Otherwise => TEXT</li>
+ *       </ul>
+ *   </li>
+ * </ul>
+ *
+ * This centralizes the logic so callers can consistently decide whether to run an expensive diff or show a placeholder.
+ */
+public final class ChangeClassifier {
+
+    private ChangeClassifier() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * Classify a pair of file contents.
+     *
+     * @param left        content of the "old" side; may be null (treated as empty)
+     * @param right       content of the "new" side; may be null (treated as empty)
+     * @param maxCombined maximum combined length (left+right) beyond which the file is considered OVERSIZED
+     * @param maxSingle   maximum length for either side beyond which the file is considered OVERSIZED
+     * @return the computed {@link ChangeFileStatus}
+     */
+    public static ChangeFileStatus classify(String left, String right, int maxCombined, int maxSingle) {
+        String l = Objects.requireNonNullElse(left, "");
+        String r = Objects.requireNonNullElse(right, "");
+
+        try {
+            // Binary heuristic
+            if (BrokkFile.isBinary(l) || BrokkFile.isBinary(r)) {
+                return ChangeFileStatus.BINARY;
+            }
+        } catch (Throwable t) {
+            // Defensive: if binary detection fails, log at debug in callers; here fall through to size checks.
+        }
+
+        int combined = l.length() + r.length();
+        if (combined > maxCombined) {
+            return ChangeFileStatus.OVERSIZED;
+        }
+
+        if (l.length() > maxSingle || r.length() > maxSingle) {
+            return ChangeFileStatus.OVERSIZED;
+        }
+
+        return ChangeFileStatus.TEXT;
+    }
+}

--- a/app/src/main/java/ai/brokk/gui/changes/ChangeFileStatus.java
+++ b/app/src/main/java/ai/brokk/gui/changes/ChangeFileStatus.java
@@ -1,0 +1,21 @@
+package ai.brokk.gui.changes;
+
+/**
+ * Status classification for files shown in the Review/Changes UI.
+ */
+public enum ChangeFileStatus {
+    /**
+     * Plain text file suitable for diffing.
+     */
+    TEXT,
+
+    /**
+     * Binary or non-text file; textual diffing should be avoided.
+     */
+    BINARY,
+
+    /**
+     * File whose content is too large to reasonably diff; avoid expensive diffing and mark as oversized.
+     */
+    OVERSIZED
+}

--- a/app/src/main/java/ai/brokk/gui/changes/ChangeLabelUtil.java
+++ b/app/src/main/java/ai/brokk/gui/changes/ChangeLabelUtil.java
@@ -1,0 +1,26 @@
+package ai.brokk.gui.changes;
+
+/**
+ * Small utilities to produce user-facing labels for changed files based on their classification.
+ */
+public final class ChangeLabelUtil {
+
+    private ChangeLabelUtil() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * Returns a display label for the given path augmented with a suffix when the file is binary or too large.
+     *
+     * @param path   the file path to display (must be non-null)
+     * @param status the classification of the file (must be non-null)
+     * @return a human-friendly display label; never null
+     */
+    public static String makeDisplayLabel(String path, ChangeFileStatus status) {
+        return switch (status) {
+            case BINARY -> path + " (binary)";
+            case OVERSIZED -> path + " (too large)";
+            case TEXT -> path;
+        };
+    }
+}

--- a/app/src/main/java/ai/brokk/gui/changes/package-info.java
+++ b/app/src/main/java/ai/brokk/gui/changes/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ai.brokk.gui.changes;
+
+import org.jspecify.annotations.NullMarked;

--- a/app/src/test/java/ai/brokk/gui/changes/ChangeClassifierTest.java
+++ b/app/src/test/java/ai/brokk/gui/changes/ChangeClassifierTest.java
@@ -1,0 +1,44 @@
+package ai.brokk.gui.changes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ChangeClassifierTest {
+
+    @Test
+    public void classify_smallTextContents_isText() {
+        String left = "line1\nline2\nline3";
+        String right = "line1\nline2 modified\nline3";
+        ChangeFileStatus status = ChangeClassifier.classify(left, right, 10_000, 5_000);
+        assertEquals(ChangeFileStatus.TEXT, status);
+    }
+
+    @Test
+    public void classify_containsNulCharacter_isBinary() {
+        String left = "some\u0000binary";
+        String right = "other";
+        ChangeFileStatus statusLeftBinary = ChangeClassifier.classify(left, right, 10_000, 5_000);
+        assertEquals(ChangeFileStatus.BINARY, statusLeftBinary);
+
+        // also when right side contains NUL
+        ChangeFileStatus statusRightBinary = ChangeClassifier.classify("normal", "bad\u0000data", 10_000, 5_000);
+        assertEquals(ChangeFileStatus.BINARY, statusRightBinary);
+    }
+
+    @Test
+    public void classify_oversizedByCombinedLength_isOversized() {
+        String left = "a".repeat(800);
+        String right = "b".repeat(800);
+        ChangeFileStatus status = ChangeClassifier.classify(left, right, 1000, 2000);
+        assertEquals(ChangeFileStatus.OVERSIZED, status);
+    }
+
+    @Test
+    public void classify_oversizedBySingleSide_isOversized() {
+        String left = "a".repeat(3000);
+        String right = "b".repeat(10);
+        ChangeFileStatus status = ChangeClassifier.classify(left, right, 100_000, 2000);
+        assertEquals(ChangeFileStatus.OVERSIZED, status);
+    }
+}

--- a/app/src/test/java/ai/brokk/gui/changes/ChangeLabelUtilTest.java
+++ b/app/src/test/java/ai/brokk/gui/changes/ChangeLabelUtilTest.java
@@ -1,0 +1,26 @@
+package ai.brokk.gui.changes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ChangeLabelUtilTest {
+
+    @Test
+    public void textFile_hasNoSuffix() {
+        String label = ChangeLabelUtil.makeDisplayLabel("a.txt", ChangeFileStatus.TEXT);
+        assertEquals("a.txt", label);
+    }
+
+    @Test
+    public void binaryFile_appendsBinarySuffix() {
+        String label = ChangeLabelUtil.makeDisplayLabel("image.png", ChangeFileStatus.BINARY);
+        assertEquals("image.png (binary)", label);
+    }
+
+    @Test
+    public void oversizedFile_appendsTooLargeSuffix() {
+        String label = ChangeLabelUtil.makeDisplayLabel("huge.log", ChangeFileStatus.OVERSIZED);
+        assertEquals("huge.log (too large)", label);
+    }
+}


### PR DESCRIPTION
…diffs

- Add ChangeClassifier to classify files as TEXT, BINARY, or OVERSIZED
- Add ChangeFileStatus enum with TEXT, BINARY, OVERSIZED values
- Add ChangeLabelUtil to generate appropriate labels for each status
- Add size limit constants to HistoryOutputPanel
- Add tests for ChangeClassifier and ChangeLabelUtil

This provides the foundation for avoiding expensive diff calculations on binary or oversized files.