### PR TITLE
Fix: Ensure ActionSplitButton keeps custom painting after theme changes

### DIFF
--- a/app/src/main/java/ai/brokk/gui/InstructionsPanel.java
+++ b/app/src/main/java/ai/brokk/gui/InstructionsPanel.java
@@ -2803,6 +2803,7 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
 
         @Override
         protected void paintComponent(Graphics g) {
+            // 1) Custom rounded background
             Graphics2D g2 = (Graphics2D) g.create();
             try {
                 g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -2818,15 +2819,23 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                 }
                 g2.setColor(bg);
                 g2.fillRoundRect(0, 0, getWidth(), getHeight(), arc, arc);
+            } finally {
+                g2.dispose();
+            }
 
-                // Draw divider line and dropdown icon only if dropdown is enabled and not in stop mode
-                if (!inStopMode && dropdownEnabled) {
+            // 2) Let the LAF draw text/icon (with contentAreaFilled=false this won't overpaint our bg)
+            super.paintComponent(g);
+
+            // 3) Draw divider + dropdown chevron on top so they can't be overpainted by the LAF
+            if (!inStopMode && dropdownEnabled) {
+                Graphics2D g3 = (Graphics2D) g.create();
+                try {
+                    g3.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
                     int dropdownX = getWidth() - DROPDOWN_WIDTH;
                     boolean isHighContrast = GuiTheme.THEME_HIGH_CONTRAST.equalsIgnoreCase(MainProject.getTheme());
-                    g2.setColor(isHighContrast ? Color.BLACK : Color.WHITE);
-                    g2.drawLine(dropdownX, 6, dropdownX, getHeight() - 6);
+                    g3.setColor(isHighContrast ? Color.BLACK : Color.WHITE);
+                    g3.drawLine(dropdownX, 6, dropdownX, getHeight() - 6);
 
-                    // Lazy-load and paint dropdown icon centered in the dropdown area
                     if (dropdownIcon == null) {
                         dropdownIcon = Icons.KEYBOARD_DOWN_LIGHT;
                     }
@@ -2836,20 +2845,18 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                     Icon iconToPaint = (dropdownIcon instanceof SwingUtil.ThemedIcon themedIcon)
                             ? themedIcon.delegate()
                             : dropdownIcon;
-                    // Apply high-contrast processing to dropdown icon
                     iconToPaint = ColorUtil.createHighContrastIcon(iconToPaint, getBackground(), isHighContrast);
                     if (iconToPaint != null) {
                         int iw = iconToPaint.getIconWidth();
                         int ih = iconToPaint.getIconHeight();
                         int ix = dropdownX + Math.max(0, (DROPDOWN_WIDTH - iw) / 2);
                         int iy = Math.max(0, (getHeight() - ih) / 2);
-                        iconToPaint.paintIcon(this, g2, ix, iy);
+                        iconToPaint.paintIcon(this, g3, ix, iy);
                     }
+                } finally {
+                    g3.dispose();
                 }
-            } finally {
-                g2.dispose();
             }
-            super.paintComponent(g);
         }
 
         @Override
@@ -2896,6 +2903,10 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
                 }
             }
 
+            // Ensure custom painting is not overpainted by LAF after theme changes
+            setContentAreaFilled(false);
+            setOpaque(false);
+
             // Now update icon - this will trigger high-contrast processing with the new background
             if (this.originalIcon != null) {
                 setIcon(this.originalIcon);
@@ -2908,6 +2919,19 @@ public class InstructionsPanel extends JPanel implements IContextManager.Context
         @Override
         public void applyTheme(GuiTheme guiTheme) {
             applyTheme(guiTheme, false);
+        }
+
+        @Override
+        public void updateUI() {
+            super.updateUI();
+            // Prevent LAF from painting a full rectangular background over our custom rendering
+            setContentAreaFilled(false);
+            setOpaque(false);
+            // Re-apply compact custom border that uses current theme border color
+            Color borderColor = UIManager.getColor("Component.borderColor");
+            if (borderColor == null) borderColor = Color.GRAY;
+            setBorder(BorderFactory.createCompoundBorder(
+                    new LineBorder(borderColor, 1, true), BorderFactory.createEmptyBorder(4, 0, 4, 8)));
         }
     }
 


### PR DESCRIPTION
fixes #2153

The bad behavior can be triggered with a theme change

[

https://github.com/user-attachments/assets/3b6030c3-2ee6-41a9-bf73-b12e04151e7d

](url)

What? 

Override updateUI() to call super then re-assert setContentAreaFilled(false) and setOpaque(false) (and restore its custom border). Also re-assert these in applyTheme().

Why?
MaterialButton.updateUI() sets contentAreaFilled(true) on LAF updates, causing the LAF to paint a full rectangular background that overdraws our rounded background and the divider/chevron. This made the splitter/arrow appear to “disappear” (though still clickable) after theme switches or Stop-mode cycles. The fix preserves the intended visuals consistently.