### PR TITLE
Replace List with LinkedHashSet for deterministic EditBlock ordering and adjust tests

### DIFF
--- a/app/src/main/java/ai/brokk/EditBlock.java
+++ b/app/src/main/java/ai/brokk/EditBlock.java
@@ -9,6 +9,7 @@ import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.SequencedSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -282,7 +283,7 @@ public class EditBlock {
         }
     }
 
-    public record ParseResult(List<SearchReplaceBlock> blocks, @Nullable String parseError) {}
+    public record ParseResult(SequencedSet<SearchReplaceBlock> blocks, @Nullable String parseError) {}
 
     public record ExtendedParseResult(List<OutputBlock> blocks, @Nullable String parseError) {}
 

--- a/app/src/main/java/ai/brokk/prompts/EditBlockParser.java
+++ b/app/src/main/java/ai/brokk/prompts/EditBlockParser.java
@@ -5,6 +5,7 @@ import static ai.brokk.prompts.EditBlockUtils.*;
 import ai.brokk.EditBlock;
 import ai.brokk.analyzer.ProjectFile;
 import java.util.*;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -28,7 +29,7 @@ public class EditBlockParser {
         var editBlocks = all.blocks().stream()
                 .map(EditBlock.OutputBlock::block)
                 .filter(Objects::nonNull)
-                .toList();
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         if (!editBlocks.isEmpty() || all.parseError() != null) {
             return new EditBlock.ParseResult(editBlocks, all.parseError());

--- a/app/src/test/java/ai/brokk/EditBlockParserTest.java
+++ b/app/src/test/java/ai/brokk/EditBlockParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import ai.brokk.EditBlock.OutputBlock;
 import ai.brokk.prompts.EditBlockParser;
+import java.util.ArrayList;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -366,12 +367,12 @@ class EditBlockParserTest {
 
             @Test
             >>>>>>> REPLACE
-            ```
+        ```
         """;
 
         var editsOnly = EditBlockParser.instance.parseEditBlocks(input, Set.of());
         assertNull(editsOnly.parseError(), "No parse errors expected");
-        var blocks = editsOnly.blocks();
+        var blocks = new ArrayList<>(editsOnly.blocks());
         assertEquals(3, blocks.size(), "Should parse exactly three edit blocks");
 
         // Block 1 assertions

--- a/app/src/test/java/ai/brokk/EditBlockSyntaxTest.java
+++ b/app/src/test/java/ai/brokk/EditBlockSyntaxTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -53,9 +54,7 @@ public class EditBlockSyntaxTest {
 
     @AfterEach
     void teardownEach() {
-        if (testProject != null) {
-            testProject.close();
-        }
+        testProject.close();
     }
 
     // ==================== BRK_FUNCTION Tests ====================
@@ -908,9 +907,10 @@ public class EditBlockSyntaxTest {
     }
 
     private List<EditBlock.SearchReplaceBlock> parseBlocks(String response, TestContextManager ctx) {
-        return EditBlockParser.instance
+        var blocks = EditBlockParser.instance
                 .parseEditBlocks(response, ctx.getFilesInContext())
                 .blocks();
+        return new ArrayList<>(blocks);
     }
 
     /**

--- a/app/src/test/java/ai/brokk/EditBlockTest.java
+++ b/app/src/test/java/ai/brokk/EditBlockTest.java
@@ -40,7 +40,7 @@ class EditBlockTest {
                       Hope you like it!
                       """;
 
-        EditBlock.SearchReplaceBlock[] blocks = parseBlocks(edit, Set.of("foo.txt"));
+        var blocks = parseBlocks(edit, Set.of("foo.txt"));
         assertEquals(1, blocks.length);
         assertEquals("foo.txt", blocks[0].rawFileName().toString());
         assertEquals("Two\n", blocks[0].beforeText());
@@ -66,7 +66,7 @@ class EditBlockTest {
                       Hope you like it!
                       """;
 
-        EditBlock.SearchReplaceBlock[] blocks = parseBlocks(edit, Set.of("foo.txt"));
+        var blocks = parseBlocks(edit, Set.of("foo.txt"));
         assertEquals(1, blocks.length);
         assertEquals("foo.txt", blocks[0].rawFileName().toString());
         assertEquals("Two\n", blocks[0].beforeText());
@@ -100,7 +100,7 @@ class EditBlockTest {
                       Hope you like it!
                       """;
 
-        EditBlock.SearchReplaceBlock[] blocks = parseBlocks(edit, Set.of("foo.txt"));
+        var blocks = parseBlocks(edit, Set.of("foo.txt"));
         assertEquals(2, blocks.length);
         // first block
         assertEquals("foo.txt", blocks[0].rawFileName().toString());
@@ -134,7 +134,7 @@ class EditBlockTest {
                       >>>>>>> REPLACE
                       ```"""; // no final newline
 
-        EditBlock.SearchReplaceBlock[] blocks = parseBlocks(edit, Set.of("foo/coder.py"));
+        var blocks = parseBlocks(edit, Set.of("foo/coder.py"));
         assertEquals(2, blocks.length);
         assertEquals("lineA\n", blocks[0].beforeText());
         assertEquals("lineB\n", blocks[0].afterText());
@@ -171,7 +171,7 @@ class EditBlockTest {
                       Hope you like it!
                       """;
 
-        EditBlock.SearchReplaceBlock[] blocks = parseBlocks(edit, Set.of("filename/to/a/file1.txt"));
+        var blocks = parseBlocks(edit, Set.of("filename/to/a/file1.txt"));
         assertEquals(2, blocks.length);
         assertEquals("filename/to/a/file2.txt", blocks[0].rawFileName());
         assertEquals("BRK_ENTIRE_FILE\n", blocks[0].beforeText());

--- a/app/src/test/java/ai/brokk/agents/CodeAgentJavaParseTest.java
+++ b/app/src/test/java/ai/brokk/agents/CodeAgentJavaParseTest.java
@@ -8,6 +8,7 @@ import dev.langchain4j.data.message.UserMessage;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -26,7 +27,7 @@ public class CodeAgentJavaParseTest extends CodeAgentTest {
 
         var cs = createConversationState(List.of(), new UserMessage("req"));
         var es = new CodeAgent.EditState(
-                List.of(), // pending blocks
+                new LinkedHashSet<>(), // pending blocks
                 0, // parse failures
                 0, // apply failures
                 0, // build failures
@@ -178,7 +179,7 @@ public class CodeAgentJavaParseTest extends CodeAgentTest {
 
         var cs = createConversationState(List.of(), new UserMessage("req"));
         var es = new CodeAgent.EditState(
-                List.of(), 0, 0, 0, 1, "", new HashSet<>(Set.of(f1, f2)), new HashMap<>(), new HashMap<>());
+                new LinkedHashSet<>(), 0, 0, 0, 1, "", new HashSet<>(Set.of(f1, f2)), new HashMap<>(), new HashMap<>());
 
         var result = codeAgent.parseJavaPhase(cs, es, null);
         var diags = result.es().javaLintDiagnostics();
@@ -441,7 +442,7 @@ public class CodeAgentJavaParseTest extends CodeAgentTest {
 
         var cs = createConversationState(List.of(), new UserMessage("req"));
         var es = new CodeAgent.EditState(
-                List.of(), // pending blocks
+                new LinkedHashSet<>(), // pending blocks
                 0, // parse failures
                 0, // apply failures
                 0, // build failures

--- a/app/src/test/java/ai/brokk/agents/CodeAgentSemanticRetryTest.java
+++ b/app/src/test/java/ai/brokk/agents/CodeAgentSemanticRetryTest.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +44,7 @@ public class CodeAgentSemanticRetryTest extends CodeAgentTest {
         var cs = new CodeAgent.ConversationState(List.of(), null, 0);
 
         var es = new CodeAgent.EditState(
-                List.of(badSemanticBlock), // pendingBlocks
+                new LinkedHashSet<>(List.of(badSemanticBlock)), // pendingBlocks
                 0, // consecutiveParseFailures
                 0, // consecutiveApplyFailures
                 0, // consecutiveBuildFailures
@@ -115,7 +116,7 @@ public class CodeAgentSemanticRetryTest extends CodeAgentTest {
                         .stripIndent());
 
         var cs = new CodeAgent.ConversationState(new ArrayList<>(), null, 0);
-        var es = new CodeAgent.EditState(List.of(), 0, 0, 0, 0, "", Set.of(), Map.of(), Map.of());
+        var es = new CodeAgent.EditState(new LinkedHashSet<>(), 0, 0, 0, 0, "", Set.of(), Map.of(), Map.of());
 
         // parsePhase
         var parseStep = codeAgent.parsePhase(cs, es, llmText, false, EditBlockParser.instance, null);

--- a/app/src/test/java/ai/brokk/agents/CodeAgentTest.java
+++ b/app/src/test/java/ai/brokk/agents/CodeAgentTest.java
@@ -114,7 +114,7 @@ class CodeAgentTest {
     private CodeAgent.EditState createEditState(
             List<EditBlock.SearchReplaceBlock> pendingBlocks, int blocksAppliedWithoutBuild) {
         return new CodeAgent.EditState(
-                new ArrayList<>(pendingBlocks), // Modifiable copy
+                new LinkedHashSet<>(pendingBlocks), // Convert to SequencedSet
                 0, // consecutiveParseFailures
                 0, // consecutiveApplyFailures
                 0, // consecutiveBuildFailures
@@ -391,7 +391,7 @@ class CodeAgentTest {
         // otherwise verifyPhase will short-circuit because blocksAppliedWithoutBuild is 0 from the Retry step.
         var cs2 = retryStep.cs();
         var es2 = new CodeAgent.EditState(
-                List.of(), // pending blocks are empty
+                new LinkedHashSet<>(), // pending blocks are empty
                 retryStep.es().consecutiveParseFailures(),
                 retryStep.es().consecutiveApplyFailures(),
                 retryStep.es().consecutiveBuildFailures(),
@@ -604,7 +604,7 @@ class CodeAgentTest {
         // Turn 1: apply "hello world" -> "goodbye world"
         var block1 = new EditBlock.SearchReplaceBlock(file.toString(), "hello world", "goodbye world");
         var es1 = new CodeAgent.EditState(
-                new ArrayList<>(List.of(block1)),
+                new LinkedHashSet<>(List.of(block1)),
                 0,
                 0,
                 0,
@@ -627,7 +627,7 @@ class CodeAgentTest {
         // Prepare next turn state with empty per-turn baseline and a new change: "goodbye world" -> "ciao world"
         var block2 = new EditBlock.SearchReplaceBlock(file.toString(), "goodbye world", "ciao world");
         var es2 = new CodeAgent.EditState(
-                new ArrayList<>(List.of(block2)),
+                new LinkedHashSet<>(List.of(block2)),
                 0,
                 0,
                 0,
@@ -665,7 +665,7 @@ class CodeAgentTest {
         file.write(revised);
 
         var es = new CodeAgent.EditState(
-                List.of(), // pending blocks
+                new LinkedHashSet<>(), // pending blocks
                 0,
                 0,
                 0,
@@ -704,7 +704,8 @@ class CodeAgentTest {
         var revised = String.join("\n", List.of("alpha", "beta", "ALPHA", "gamma")) + "\n";
         file.write(revised);
 
-        var es = new CodeAgent.EditState(List.of(), 0, 0, 0, 1, "", changedFiles, originalMap, Collections.emptyMap());
+        var es = new CodeAgent.EditState(
+                new LinkedHashSet<>(), 0, 0, 0, 1, "", changedFiles, originalMap, Collections.emptyMap());
 
         var blocks = es.toSearchReplaceBlocks();
         assertEquals(1, blocks.size(), "Should produce a single unique block");
@@ -731,7 +732,8 @@ class CodeAgentTest {
         var revised = String.join("\n", List.of("line1", "TARGET", "middle", "TARGET", "line5")) + "\n";
         file.write(revised);
 
-        var es = new CodeAgent.EditState(List.of(), 0, 0, 0, 1, "", changedFiles, originalMap, Collections.emptyMap());
+        var es = new CodeAgent.EditState(
+                new LinkedHashSet<>(), 0, 0, 0, 1, "", changedFiles, originalMap, Collections.emptyMap());
 
         var blocks = es.toSearchReplaceBlocks();
 


### PR DESCRIPTION
Intent: Make edit block collections preserve insertion order and avoid duplicate entries by switching from List to a SequencedSet/LinkedHashSet where appropriate. Key changes:

- EditBlock.ParseResult now uses SequencedSet<SearchReplaceBlock> to represent unique, ordered blocks.
- CodeAgent.toSearchReplaceBlocks() returns a SequencedSet and constructs results using LinkedHashSet to preserve order and deduplicate items.
- EditBlockParser collects parsed blocks into a LinkedHashSet to maintain insertion order when generating ParseResult.
- Tests updated to adapt to the new collection type: converted usages to concrete List copies (ArrayList) or var where arrays were used previously, and ensured teardown in tests always closes test projects.

Behavioural impact: The change ensures deterministic ordering and removes duplicate edit blocks while keeping API semantics similar. Tests are adapted to materialize the SequencedSet into List/ArrayList where indexing or array semantics were required. This prevents flaky tests due to non-deterministic ordering and simplifies history compaction logic.

Implementation notes:
- LinkedHashSet is used to implement SequencedSet semantics at runtime.
- Test code copies the SequencedSet into ArrayList when ordering/indexing is needed.
- Minor cleanup of test teardown to avoid null checks.