### PR TITLE
fix: [2225] Use LegacyWatchService as default on Windows and Linux

### DIFF
--- a/app/src/main/java/ai/brokk/WatchServiceFactory.java
+++ b/app/src/main/java/ai/brokk/WatchServiceFactory.java
@@ -114,6 +114,12 @@ public class WatchServiceFactory {
             String implProp,
             String os) {
 
+        // Linux always uses legacy due to native implementation issues (high CPU, missing updates)
+        if (os.contains("linux")) {
+            logger.debug("Detected Linux, using legacy watch service (forced, no override)");
+            return new LegacyProjectWatchService(root, gitRepoRoot, globalGitignorePath, listeners);
+        }
+
         if (WATCH_SERVICE_IMPL_LEGACY.equalsIgnoreCase(implProp)) {
             logger.debug("Using legacy watch service (forced by configuration)");
             return new LegacyProjectWatchService(root, gitRepoRoot, globalGitignorePath, listeners);
@@ -128,10 +134,6 @@ public class WatchServiceFactory {
             // macOS benefits from native FSEvents implementation (efficient recursive watching)
             logger.debug("Detected macOS, using native watch service (FSEvents)");
             return createNativeWithFallback(root, gitRepoRoot, globalGitignorePath, listeners);
-        } else if (os.contains("linux")) {
-            // Linux: both use inotify underneath, legacy avoids CPU/update issues in native impl
-            logger.debug("Detected Linux, using legacy watch service");
-            return new LegacyProjectWatchService(root, gitRepoRoot, globalGitignorePath, listeners);
         } else if (os.contains("win")) {
             // Windows: legacy avoids issues in native impl while providing equivalent functionality
             logger.debug("Detected Windows, using legacy watch service");

--- a/app/src/test/java/ai/brokk/WatchServiceFactoryTest.java
+++ b/app/src/test/java/ai/brokk/WatchServiceFactoryTest.java
@@ -25,7 +25,7 @@ class WatchServiceFactoryTest {
 
     @Test
     void testConfigurationForcesNative() throws Exception {
-        var service = WatchServiceFactory.createInternal(tempDir, null, null, List.of(), "native", "linux");
+        var service = WatchServiceFactory.createInternal(tempDir, null, null, List.of(), "native", "mac os x");
 
         assertNotNull(service);
         assertTrue(
@@ -35,12 +35,12 @@ class WatchServiceFactoryTest {
 
     @Test
     void testConfigurationCaseInsensitive() throws Exception {
-        var legacyService = WatchServiceFactory.createInternal(tempDir, null, null, List.of(), "LEGACY", "linux");
+        var legacyService = WatchServiceFactory.createInternal(tempDir, null, null, List.of(), "LEGACY", "mac os x");
         assertTrue(
                 legacyService instanceof LegacyProjectWatchService,
                 "Should handle case-insensitive configuration values");
 
-        var nativeService = WatchServiceFactory.createInternal(tempDir, null, null, List.of(), "NATIVE", "linux");
+        var nativeService = WatchServiceFactory.createInternal(tempDir, null, null, List.of(), "NATIVE", "mac os x");
         assertTrue(
                 nativeService instanceof NativeProjectWatchService,
                 "Should handle case-insensitive configuration values");
@@ -115,7 +115,7 @@ class WatchServiceFactoryTest {
         var listener2 = new TestListener();
 
         var service = WatchServiceFactory.createInternal(
-                tempDir, null, null, List.of(listener1, listener2), "native", "linux");
+                tempDir, null, null, List.of(listener1, listener2), "native", "mac os x");
 
         assertNotNull(service);
         assertTrue(service instanceof NativeProjectWatchService);
@@ -134,7 +134,7 @@ class WatchServiceFactoryTest {
         var gitRepo = tempDir.resolve("repo");
         Files.createDirectories(gitRepo.resolve(".git"));
 
-        var service = WatchServiceFactory.createInternal(gitRepo, gitRepo, null, List.of(), "native", "linux");
+        var service = WatchServiceFactory.createInternal(gitRepo, gitRepo, null, List.of(), "native", "mac os x");
 
         assertNotNull(service);
         assertTrue(service instanceof NativeProjectWatchService);
@@ -182,5 +182,16 @@ class WatchServiceFactoryTest {
                 System.setProperty(propName, previous);
             }
         }
+    }
+
+    @Test
+    void testLinuxAlwaysUsesLegacy() throws Exception {
+        // Linux should always use legacy even when native is explicitly requested
+        var service = WatchServiceFactory.createInternal(tempDir, null, null, List.of(), "native", "linux");
+
+        assertNotNull(service);
+        assertTrue(
+                service instanceof LegacyProjectWatchService,
+                "Linux should always use LegacyProjectWatchService, ignoring 'native' preference");
     }
 }


### PR DESCRIPTION
There isn't a benefit to the native watcher on linux since they both use inotify underneath. On Windows it isn't clear yet if there is a benefit.  Primary benefit is on MacOS because it can use FSEvents with the native implementation.

