### PR TITLE
Refactor SearchAgent to use ArchitectAgent for code tasks

### DIFF
--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -951,6 +951,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         });
     }
 
+    @Override
     public boolean undoContext() {
         return withFileChangeNotificationsPaused(() -> {
             UndoResult result = contextHistory.undo(1, io, project);

--- a/app/src/main/java/ai/brokk/IContextManager.java
+++ b/app/src/main/java/ai/brokk/IContextManager.java
@@ -35,6 +35,10 @@ import org.jetbrains.annotations.Blocking;
 public interface IContextManager {
     Logger logger = LogManager.getLogger(IContextManager.class);
 
+    default boolean undoContext() {
+        throw new UnsupportedOperationException();
+    }
+
     /** Callback interface for analyzer update events. */
     interface AnalyzerCallback {
         /** Called before each analyzer build begins. */

--- a/app/src/main/java/ai/brokk/agents/ArchitectAgent.java
+++ b/app/src/main/java/ai/brokk/agents/ArchitectAgent.java
@@ -6,6 +6,7 @@ import static org.checkerframework.checker.nullness.util.NullnessUtil.castNonNul
 import ai.brokk.AbstractService.ModelConfig;
 import ai.brokk.ContextManager;
 import ai.brokk.IConsoleIO;
+import ai.brokk.IContextManager;
 import ai.brokk.Llm;
 import ai.brokk.MutedConsoleIO;
 import ai.brokk.TaskResult;
@@ -67,7 +68,7 @@ public class ArchitectAgent {
     // Result of executing a single search request: both the tool execution result and the SearchAgent result
     private record SearchTaskResult(ToolExecutionResult toolResult, TaskResult taskResult) {}
 
-    private final ContextManager cm;
+    private final IContextManager cm;
     private final StreamingChatModel planningModel;
     private final StreamingChatModel codeModel;
     private final String goal;
@@ -96,7 +97,7 @@ public class ArchitectAgent {
      * @param goal      The initial user instruction or goal for the agent.
      */
     public ArchitectAgent(
-            ContextManager contextManager,
+            IContextManager contextManager,
             StreamingChatModel planningModel,
             StreamingChatModel codeModel,
             String goal,

--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -158,7 +158,6 @@ public class SearchAgent {
 
     // State toggles
     private boolean beastMode;
-    private boolean codeAgentJustSucceeded;
 
     /**
      * Primary constructor with explicit IO and ScanConfig.
@@ -193,7 +192,6 @@ public class SearchAgent {
         this.summarizer = cm.getLlm(summarizeModel, "Summarizer: " + goal);
 
         this.beastMode = false;
-        this.codeAgentJustSucceeded = false;
         this.objective = objective;
         this.metrics = "true".equalsIgnoreCase(System.getenv("BRK_COLLECT_METRICS"))
                 ? SearchMetrics.tracking()
@@ -439,13 +437,6 @@ public class SearchAgent {
                         return errorResult(
                                 new TaskResult.StopDetails(TaskResult.StopReason.LLM_ABORTED, "Aborted: " + display),
                                 taskMeta());
-                    } else if (termReq.name().equals("callCodeAgent")) {
-                        if (codeAgentJustSucceeded) {
-                            // code agent already appended output to history, empty messages are skipped by scope.append
-                            return TaskResult.humanResult(
-                                    cm, "CodeAgent finished", List.of(), context, TaskResult.StopReason.SUCCESS);
-                        }
-                        // If CodeAgent did not succeed, continue planning/search loop
                     } else {
                         return createResult(termReq.name(), goal);
                     }
@@ -1228,21 +1219,15 @@ public class SearchAgent {
         // Append first the SearchAgent's result so far; CodeAgent appends its own result
         context = scope.append(createResult("Search: " + goal, goal));
 
+        // Call the agent (actually Architect, not Code, so it can recover if the Context isn't quite complete)
         logger.debug("SearchAgent.callCodeAgent invoked with instructions: {}", instructions);
         io.llmOutput("**Code Agent** engaged: " + instructions, ChatMessageType.AI, true, false);
-        var agent = new CodeAgent(cm, cm.getCodeModel());
-        var opts = new HashSet<CodeAgent.Option>();
-
-        // Keep a snapshot to determine if changes occurred
-        Context contextBefore = context;
-
-        var result = agent.executeWithoutHistory(context, instructions, opts);
+        var agent = new ArchitectAgent(
+                cm, cm.getService().getModel(ModelType.ARCHITECT), cm.getCodeModel(), instructions, scope);
+        var result = agent.execute();
         var stopDetails = result.stopDetails();
         var reason = stopDetails.reason();
-
         context = scope.append(result);
-
-        boolean didChange = !context.getChangedFiles(contextBefore).isEmpty();
 
         if (reason == TaskResult.StopReason.SUCCESS) {
             // housekeeping
@@ -1250,11 +1235,10 @@ public class SearchAgent {
             cm.compressHistory();
             // CodeAgent appended its own result; we don't need to llmOutput anything redundant
             logger.debug("SearchAgent.callCodeAgent finished successfully");
-            codeAgentJustSucceeded = true;
             return "CodeAgent finished with a successful build!";
         }
 
-        // propagate critical failures
+        // handle failure
         if (reason == TaskResult.StopReason.INTERRUPTED) {
             throw new InterruptedException();
         }
@@ -1263,31 +1247,7 @@ public class SearchAgent {
             logger.error("Fatal LLM error during CodeAgent execution: {}", stopDetails.explanation());
             throw new ToolRegistry.FatalLlmException(stopDetails.explanation());
         }
-
-        // Non-success outcomes: continue planning on next loop
-        codeAgentJustSucceeded = false;
-        logger.debug("SearchAgent.callCodeAgent failed with reason {}; continuing planning", reason);
-
-        // Provide actionable guidance; reserve workspace details only for BUILD_ERROR
-        StringBuilder sb = new StringBuilder();
-        if (reason == TaskResult.StopReason.BUILD_ERROR) {
-            sb.append("CodeAgent was not able to get to a clean build. Details are in the Workspace.\n");
-            if (didChange) {
-                sb.append("Changes were made; you can undo with 'undoLastChanges' if they are negative progress.\n");
-            }
-            sb.append(
-                    "Consider retrying with 'deferBuild=true' for multi-step changes, then complete follow-up fixes.\n");
-        } else {
-            sb.append("CodeAgent did not complete successfully.\n");
-            if (didChange) {
-                sb.append("If the changes are not helpful, you can undo with 'undoLastChanges'.\n");
-            }
-            sb.append(
-                    "Try smaller, focused edits with valid SEARCH/REPLACE blocks; add or refresh required files using workspace tools "
-                            + "(e.g., addFilesToWorkspace, addFileSummariesToWorkspace), or use callSearchAgent to locate the correct targets, then retry callCodeAgent.\n");
-        }
-        sb.append("Continuing search and planning.\n");
-        return sb.toString();
+        throw new ToolRegistry.ToolCallException(ToolExecutionResult.Status.FATAL, stopDetails.explanation());
     }
 
     // =======================


### PR DESCRIPTION
This PR improves the integration between `SearchAgent` and the code generation logic by replacing the direct `CodeAgent` call with an `ArchitectAgent` call. This change allows for more robust recovery and planning when `SearchAgent` initiates code modifications.

Additionally, `ArchitectAgent` gets list of changed files upon successful CodeAgent execution to make it easier for the planner to see when the actual changes diverge from the expected.