### PR TITLE
fix(search agent): don't record initial pruning exchange in the sessi…

### DIFF
--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -823,10 +823,6 @@ public class SearchAgent {
             return;
         }
 
-        // Record the turn
-        sessionMessages.add(new UserMessage("Review the current workspace. If relevant, prune irrelevant fragments."));
-        sessionMessages.add(result.aiMessage());
-
         // Execute tool requests (one shot; we're not responding back with results)
         var ai = ToolRegistry.removeDuplicateToolRequests(result.aiMessage());
         for (var req : ai.toolExecutionRequests()) {


### PR DESCRIPTION
…onMessages

Recording the exchange:
1.) Put a tool call with arguments (tokens) that are deemed *irrelevant* to the task at hand 
2.) Left in sessionMessages a Tool Call with no result message, which Anthropic deems as a bad request. Now that we're not emulating tool calls this breaks.