### PR TITLE
fix: Session drop-down does not accommodate full text height

### DIFF
--- a/app/src/main/java/ai/brokk/gui/components/SplitButton.java
+++ b/app/src/main/java/ai/brokk/gui/components/SplitButton.java
@@ -323,6 +323,7 @@ public class SplitButton extends JComponent {
         // Clear any forced sizes to allow recalculation of natural dimensions
         actionButton.setPreferredSize(null);
         arrowButton.setPreferredSize(null);
+        arrowButton.setMinimumSize(null);
 
         // Use the max height of both buttons so they're visually consistent
         int actionHeight = actionButton.getPreferredSize().height;


### PR DESCRIPTION
Closes #2280.

Before:
<img width="498" height="96" alt="image" src="https://github.com/user-attachments/assets/8d23488d-bcd2-4716-b1e1-b3dff8474971" />

After:
<img width="498" height="96" alt="image" src="https://github.com/user-attachments/assets/55ca5e6a-8707-41d1-9ff4-062acb3623bd" />
