### PR TITLE
fix: Sessions lost after opening project in older brokk

### DIFF
--- a/app/src/main/java/ai/brokk/SessionManager.java
+++ b/app/src/main/java/ai/brokk/SessionManager.java
@@ -13,6 +13,7 @@ import ai.brokk.util.SerialByKeyExecutor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.github.f4b6a3.uuid.UuidCreator;
+import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
@@ -42,9 +43,15 @@ import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.Nullable;
 
 public class SessionManager implements AutoCloseable {
+    private static final String SESSIONS_FORMAT_VERSION = "4.0";
+
     /** Record representing session metadata for the sessions management system. */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record SessionInfo(UUID id, String name, long created, long modified) {
+    public record SessionInfo(UUID id, String name, long created, long modified, @Nullable String version) {
+
+        public SessionInfo(UUID id, String name, long created, long modified) {
+            this(id, name, created, modified, SESSIONS_FORMAT_VERSION);
+        }
 
         @JsonIgnore
         public boolean isSessionModified() {
@@ -104,7 +111,9 @@ public class SessionManager implements AutoCloseable {
             try (var stream = Files.list(sessionsDir)) {
                 stream.filter(path -> path.toString().endsWith(".zip"))
                         .forEach(zipPath -> readSessionInfoFromZip(zipPath).ifPresent(sessionInfo -> {
-                            sessions.put(sessionInfo.id(), sessionInfo);
+                            if (isVersionSupported(sessionInfo.version())) {
+                                sessions.put(sessionInfo.id(), sessionInfo);
+                            }
                         }));
             }
         } catch (IOException e) {
@@ -151,7 +160,8 @@ public class SessionManager implements AutoCloseable {
     public void renameSession(UUID sessionId, String newName) {
         SessionInfo oldInfo = sessionsCache.get(sessionId);
         if (oldInfo != null) {
-            var updatedInfo = new SessionInfo(oldInfo.id(), newName, oldInfo.created(), System.currentTimeMillis());
+            var updatedInfo = new SessionInfo(
+                    oldInfo.id(), newName, oldInfo.created(), System.currentTimeMillis(), oldInfo.version());
             sessionsCache.put(sessionId, updatedInfo);
             sessionExecutorByKey.submit(sessionId.toString(), () -> {
                 try {
@@ -265,6 +275,9 @@ public class SessionManager implements AutoCloseable {
                     moveSessionToUnreadable(sessionId);
                     quarantinedIds.add(sessionId);
                     moved++;
+                    continue;
+                }
+                if (!isVersionSupported(info.get().version())) {
                     continue;
                 }
 
@@ -413,7 +426,11 @@ public class SessionManager implements AutoCloseable {
         if (currentInfo != null) {
             if (!isSessionEmpty(currentInfo, contextHistory)) {
                 infoToSave = new SessionInfo(
-                        currentInfo.id(), currentInfo.name(), currentInfo.created(), System.currentTimeMillis());
+                        currentInfo.id(),
+                        currentInfo.name(),
+                        currentInfo.created(),
+                        System.currentTimeMillis(),
+                        currentInfo.version());
                 sessionsCache.put(sessionId, infoToSave); // Update cache before async task
             } // else, session info is not modified, we are just adding an empty initial context (e.g. welcome message)
             // to the session
@@ -729,6 +746,35 @@ public class SessionManager implements AutoCloseable {
 
     public Path getSessionsDir() {
         return sessionsDir;
+    }
+
+    private static boolean isVersionSupported(@Nullable String version) {
+        if (version == null) {
+            return true;
+        }
+        try {
+            return compareVersions(version, SESSIONS_FORMAT_VERSION) <= 0;
+        } catch (NumberFormatException e) {
+            logger.warn("Cannot parse session format version '{}'", version);
+            return false;
+        }
+    }
+
+    static int compareVersions(String v1, String v2) throws NumberFormatException {
+        List<String> parts1 = Splitter.on('.').splitToList(v1);
+        List<String> parts2 = Splitter.on('.').splitToList(v2);
+        int length = Math.max(parts1.size(), parts2.size());
+        for (int i = 0; i < length; i++) {
+            int p1 = i < parts1.size() ? Integer.parseInt(parts1.get(i)) : 0;
+            int p2 = i < parts2.size() ? Integer.parseInt(parts2.get(i)) : 0;
+            if (p1 < p2) {
+                return -1;
+            }
+            if (p1 > p2) {
+                return 1;
+            }
+        }
+        return 0;
     }
 
     @Override

--- a/app/src/test/java/ai/brokk/SessionManagerTest.java
+++ b/app/src/test/java/ai/brokk/SessionManagerTest.java
@@ -13,16 +13,20 @@ import ai.brokk.project.MainProject;
 import ai.brokk.testutil.NoOpConsoleIO;
 import ai.brokk.testutil.TestContextManager;
 import ai.brokk.util.Messages;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.message.ChatMessage;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -477,5 +481,88 @@ public class SessionManagerTest {
         assertEquals(0, count, "Non-existent session should return 0");
 
         project.close();
+    }
+
+    @Test
+    void testLoadSessionSkippingUnsupportedVersion() throws Exception {
+        Path sessionsDir = tempDir.resolve(".brokk").resolve("sessions");
+        Files.createDirectories(sessionsDir);
+        ObjectMapper mapper = new ObjectMapper();
+
+        // 1. Create a legacy session (version = null)
+        UUID legacyId = UUID.randomUUID();
+        SessionInfo legacyInfo = new SessionInfo(
+                legacyId, "Legacy Session", System.currentTimeMillis(), System.currentTimeMillis(), null);
+        createSessionZip(sessionsDir, legacyInfo, mapper);
+
+        // 2. Create a future session (version = "99.0")
+        UUID futureId = UUID.randomUUID();
+        SessionInfo futureInfo = new SessionInfo(
+                futureId, "Future Session", System.currentTimeMillis(), System.currentTimeMillis(), "99.0");
+        createSessionZip(sessionsDir, futureInfo, mapper);
+
+        // 3. Create a supported session (version = current)
+        UUID currentId = UUID.randomUUID();
+        SessionInfo currentInfo =
+                new SessionInfo(currentId, "Current Session", System.currentTimeMillis(), System.currentTimeMillis());
+        createSessionZip(sessionsDir, currentInfo, mapper);
+
+        // Initialize SessionManager (loads sessions from disk)
+        MainProject project = new MainProject(tempDir);
+        var sessionManager = project.getSessionManager();
+        List<SessionInfo> sessions = sessionManager.listSessions();
+
+        Set<UUID> loadedIds = sessions.stream().map(SessionInfo::id).collect(Collectors.toSet());
+
+        assertTrue(loadedIds.contains(legacyId), "Should load legacy session (null version)");
+        assertTrue(loadedIds.contains(currentId), "Should load current version session");
+        assertFalse(loadedIds.contains(futureId), "Should NOT load future version session");
+
+        // Verify file existence
+        assertTrue(
+                Files.exists(sessionsDir.resolve(futureId.toString() + ".zip")),
+                "Future session zip should still exist on disk");
+
+        project.close();
+    }
+
+    @Test
+    void testCompareVersions() {
+        // Equal versions
+        assertEquals(0, SessionManager.compareVersions("1.0", "1.0"));
+        assertEquals(0, SessionManager.compareVersions("2.3.4", "2.3.4"));
+
+        // Ordering
+        assertEquals(-1, SessionManager.compareVersions("1.0", "1.1"));
+        assertEquals(1, SessionManager.compareVersions("1.1", "1.0"));
+
+        assertEquals(-1, SessionManager.compareVersions("1.9", "1.10"));
+        assertEquals(1, SessionManager.compareVersions("1.10", "1.9"));
+
+        assertEquals(-1, SessionManager.compareVersions("1.0", "2.0"));
+        assertEquals(1, SessionManager.compareVersions("2.0", "1.0"));
+
+        // Different number of components
+        assertEquals(0, SessionManager.compareVersions("1.0", "1.0.0"));
+        assertEquals(0, SessionManager.compareVersions("1.0.0", "1.0"));
+
+        assertEquals(-1, SessionManager.compareVersions("1.0", "1.0.1"));
+        assertEquals(1, SessionManager.compareVersions("1.0.1", "1.0"));
+
+        // Single component versions
+        assertEquals(0, SessionManager.compareVersions("4", "4.0"));
+        assertEquals(0, SessionManager.compareVersions("4.0", "4"));
+        assertEquals(-1, SessionManager.compareVersions("4", "4.1"));
+        assertEquals(1, SessionManager.compareVersions("4.1", "4"));
+    }
+
+    private void createSessionZip(Path sessionsDir, SessionInfo info, ObjectMapper mapper) throws IOException {
+        Path zipPath = sessionsDir.resolve(info.id() + ".zip");
+        // Create new zip file
+        try (var fs = FileSystems.newFileSystem(zipPath, Map.of("create", "true"))) {
+            Path manifestPath = fs.getPath("manifest.json");
+            String json = mapper.writeValueAsString(info);
+            Files.writeString(manifestPath, json);
+        }
     }
 }


### PR DESCRIPTION
Closes #2119.

Added sessions format version to manifest, so we just skip loading the versions greater than the currently supported one.

I think it would also be useful when we start thinking about a more structured way to [migrate](https://github.com/BrokkAi/brokk/issues/1212) sessions between the versions.