### PR TITLE
Fix root commit diffing by supporting empty tree references

### DIFF
--- a/app/src/main/java/ai/brokk/git/GitRefs.java
+++ b/app/src/main/java/ai/brokk/git/GitRefs.java
@@ -1,0 +1,16 @@
+package ai.brokk.git;
+
+import org.eclipse.jgit.lib.Constants;
+
+/**
+ * Centralized constants for special Git references used throughout Brokk.
+ */
+public final class GitRefs {
+    private GitRefs() {}
+
+    /** Sentinel value representing the current working tree state (uncommitted/unstaged changes). */
+    public static final String WORKING = "WORKING";
+
+    /** The SHA-1 of the empty tree object, used when diffing root commits. */
+    public static final String EMPTY_TREE = Constants.EMPTY_TREE_ID.getName();
+}

--- a/app/src/main/java/ai/brokk/git/GitRepoData.java
+++ b/app/src/main/java/ai/brokk/git/GitRepoData.java
@@ -159,19 +159,30 @@ public class GitRepoData {
 
     /** Show diff for a specific file between two commits. */
     public String getDiff(ProjectFile file, String oldRev, String newRev) throws GitAPIException {
+        var oldTreeIter = prepareTreeParser(oldRev);
+        if (oldTreeIter == null) {
+            logger.warn("Old commit/tree {} not found. Returning empty diff.", oldRev);
+            return "";
+        }
+
         try (var out = new ByteArrayOutputStream()) {
             var pathFilter = PathFilter.create(repo.toRepoRelativePath(file));
             if ("WORKING".equals(newRev)) {
                 git.diff()
-                        .setOldTree(prepareTreeParser(oldRev))
+                        .setOldTree(oldTreeIter)
                         .setNewTree(null) // Working tree
                         .setPathFilter(pathFilter)
                         .setOutputStream(out)
                         .call();
             } else {
+                var newTreeIter = prepareTreeParser(newRev);
+                if (newTreeIter == null) {
+                    logger.warn("New commit/tree {} not found. Returning empty diff.", newRev);
+                    return "";
+                }
                 git.diff()
-                        .setOldTree(prepareTreeParser(oldRev))
-                        .setNewTree(prepareTreeParser(newRev))
+                        .setOldTree(oldTreeIter)
+                        .setNewTree(newTreeIter)
                         .setPathFilter(pathFilter)
                         .setOutputStream(out)
                         .call();

--- a/app/src/main/java/ai/brokk/git/GitRepoData.java
+++ b/app/src/main/java/ai/brokk/git/GitRepoData.java
@@ -20,7 +20,6 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
-import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
@@ -167,7 +166,7 @@ public class GitRepoData {
 
         try (var out = new ByteArrayOutputStream()) {
             var pathFilter = PathFilter.create(repo.toRepoRelativePath(file));
-            if ("WORKING".equals(newRev)) {
+            if (GitRefs.WORKING.equals(newRev)) {
                 git.diff()
                         .setOldTree(oldTreeIter)
                         .setNewTree(null) // Working tree
@@ -281,7 +280,7 @@ public class GitRepoData {
      * of renames and file status tracking.
      */
     public List<ModifiedFile> listFilesChangedInCommit(String commitId) throws GitAPIException {
-        if ("WORKING".equals(commitId)) {
+        if (GitRefs.WORKING.equals(commitId)) {
             return listFilesChangedBetweenCommits("HEAD", "WORKING");
         }
 
@@ -320,7 +319,7 @@ public class GitRepoData {
         var oldTreeIter = prepareTreeParser(oldRef);
         if (oldTreeIter == null) return List.of();
 
-        if (!"WORKING".equals(newRef)) {
+        if (!GitRefs.WORKING.equals(newRef)) {
             try (var diffFormatter = new DiffFormatter(DisabledOutputStream.INSTANCE)) {
                 diffFormatter.setRepository(repository);
                 diffFormatter.setDetectRenames(true);
@@ -428,7 +427,7 @@ public class GitRepoData {
     }
 
     public String getRefContent(String ref, ProjectFile file) throws GitAPIException {
-        if ("WORKING".equals(ref)) {
+        if (GitRefs.WORKING.equals(ref)) {
             return file.read().orElse("");
         }
         try {
@@ -447,7 +446,7 @@ public class GitRepoData {
         }
 
         // Handle the special empty tree ID (used when diffing root commits)
-        if (Constants.EMPTY_TREE_ID.getName().equals(objectId)) {
+        if (GitRefs.EMPTY_TREE.equals(objectId)) {
             return new EmptyTreeIterator();
         }
 

--- a/app/src/main/java/ai/brokk/git/GitRepoData.java
+++ b/app/src/main/java/ai/brokk/git/GitRepoData.java
@@ -20,9 +20,12 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.eclipse.jgit.treewalk.EmptyTreeIterator;
 import org.eclipse.jgit.treewalk.FileTreeIterator;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
@@ -426,10 +429,15 @@ public class GitRepoData {
     }
 
     /** Prepares an AbstractTreeIterator for the given commit-ish string. */
-    public @Nullable CanonicalTreeParser prepareTreeParser(String objectId) throws GitAPIException {
+    public @Nullable AbstractTreeIterator prepareTreeParser(String objectId) throws GitAPIException {
         if (objectId.isBlank()) {
             logger.warn("prepareTreeParser called with blank ref. Returning null iterator.");
             return null;
+        }
+
+        // Handle the special empty tree ID (used when diffing root commits)
+        if (Constants.EMPTY_TREE_ID.getName().equals(objectId)) {
+            return new EmptyTreeIterator();
         }
 
         var objId = repo.resolveToCommit(objectId);

--- a/app/src/main/java/ai/brokk/tools/GitTools.java
+++ b/app/src/main/java/ai/brokk/tools/GitTools.java
@@ -3,6 +3,7 @@ package ai.brokk.tools;
 import ai.brokk.IContextManager;
 import ai.brokk.Llm;
 import ai.brokk.TaskResult;
+import ai.brokk.git.GitRefs;
 import ai.brokk.git.GitRepo;
 import ai.brokk.prompts.CommitPrompts;
 import ai.brokk.prompts.MergePrompts;
@@ -15,7 +16,6 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.Constants;
 import org.jetbrains.annotations.Nullable;
 
 public class GitTools {
@@ -136,7 +136,7 @@ public class GitTools {
             return repo.getDiff(parentRev, revision);
         } catch (GitAPIException e) {
             // If resolving parent fails, it's likely a root commit or invalid revision
-            return repo.getDiff(Constants.EMPTY_TREE_ID.getName(), revision);
+            return repo.getDiff(GitRefs.EMPTY_TREE, revision);
         }
     }
 }

--- a/app/src/test/java/ai/brokk/git/GitRepoTest.java
+++ b/app/src/test/java/ai/brokk/git/GitRepoTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.RepositoryState;
@@ -2326,6 +2327,73 @@ public class GitRepoTest {
 
         assertEquals("committed", diff.oldText());
         assertEquals("working changes", diff.newText());
+    }
+
+    @Test
+    void testGetDiff_EmptyTreeToFirstCommit() throws Exception {
+        // This tests the fix for diffing against the empty tree (root commit scenario).
+        // When explaining a root commit, GitTools falls back to Constants.EMPTY_TREE_ID.getName()
+        // as the "parent" revision. Previously this would fail because resolveToCommit cannot
+        // resolve a tree ID.
+
+        // The setUp already creates an initial commit with README.md
+        String firstCommitSha = repo.getCurrentCommitId();
+
+        // Diff from empty tree to first commit should show all files as added
+        String diff = repo.getDiff(Constants.EMPTY_TREE_ID.getName(), firstCommitSha);
+
+        assertNotNull(diff, "Diff should not be null");
+        assertFalse(diff.isEmpty(), "Diff should not be empty for a commit that adds files");
+        assertTrue(diff.contains("README.md"), "Diff should mention the added file");
+        assertTrue(diff.contains("+Initial commit file."), "Diff should show the added content");
+    }
+
+    @Test
+    void testGetDiff_EmptyTreeToFirstCommit_MultipleFiles() throws Exception {
+        // Create a fresh repo with multiple files in the first commit
+        Path multiFileRepo = tempDir.resolve("multiFileRepo");
+        Files.createDirectories(multiFileRepo);
+
+        try (Git git = Git.init().setDirectory(multiFileRepo.toFile()).call()) {
+            Files.writeString(multiFileRepo.resolve("file1.txt"), "Content of file 1");
+            Files.writeString(multiFileRepo.resolve("file2.txt"), "Content of file 2");
+            git.add().addFilepattern(".").call();
+            git.commit()
+                    .setMessage("Initial commit with multiple files")
+                    .setAuthor("Test User", "test@example.com")
+                    .setSign(false)
+                    .call();
+        }
+
+        var multiRepo = new GitRepo(multiFileRepo);
+        try {
+            String firstCommitSha = multiRepo.getCurrentCommitId();
+
+            String diff = multiRepo.getDiff(Constants.EMPTY_TREE_ID.getName(), firstCommitSha);
+
+            assertNotNull(diff);
+            assertFalse(diff.isEmpty());
+            assertTrue(diff.contains("file1.txt"), "Diff should include file1.txt");
+            assertTrue(diff.contains("file2.txt"), "Diff should include file2.txt");
+            assertTrue(diff.contains("+Content of file 1"), "Diff should show file1 content as added");
+            assertTrue(diff.contains("+Content of file 2"), "Diff should show file2 content as added");
+        } finally {
+            GitTestCleanupUtil.cleanupGitResources(multiRepo);
+        }
+    }
+
+    @Test
+    void testGetDiff_EmptyTreeWithFileFilter() throws Exception {
+        // Test that single-file diff also works with empty tree
+        String firstCommitSha = repo.getCurrentCommitId();
+        ProjectFile readme = new ProjectFile(projectRoot, "README.md");
+
+        String diff = repo.getDiff(readme, Constants.EMPTY_TREE_ID.getName(), firstCommitSha);
+
+        assertNotNull(diff);
+        assertFalse(diff.isEmpty());
+        assertTrue(diff.contains("README.md"));
+        assertTrue(diff.contains("+Initial commit file."));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/git/GitRepoTest.java
+++ b/app/src/test/java/ai/brokk/git/GitRepoTest.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
-import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.RepositoryState;
@@ -2199,12 +2198,12 @@ public class GitRepoTest {
         assertEquals("", diffHead, "Diff against HEAD should be empty as they are the same commit");
 
         // 4. Diff against WORKING (the special token) should show the filesystem changes
-        String diffWorking = repo.getDiff(initialCommit, "WORKING");
+        String diffWorking = repo.getDiff(initialCommit, GitRefs.WORKING);
         assertTrue(diffWorking.contains("+Modified content"), "Diff against WORKING should show working tree changes");
 
         // 5. Verify single file diff also works with WORKING
         ProjectFile pf = new ProjectFile(projectRoot, "working_test.txt");
-        String fileDiffWorking = repo.getDiff(pf, initialCommit, "WORKING");
+        String fileDiffWorking = repo.getDiff(pf, initialCommit, GitRefs.WORKING);
         assertTrue(fileDiffWorking.contains("+Modified content"), "File diff against WORKING should show changes");
     }
 
@@ -2250,8 +2249,8 @@ public class GitRepoTest {
         Files.writeString(projectRoot.resolve("file1.txt"), "modified content");
         Files.writeString(projectRoot.resolve("file2.txt"), "new content");
 
-        // 3. List changes using "WORKING"
-        var result = repo.listFilesChangedBetweenCommits(initialCommit, "WORKING");
+        // 3. List changes using WORKING
+        var result = repo.listFilesChangedBetweenCommits(initialCommit, GitRefs.WORKING);
 
         var modified = result.stream()
                 .filter(f -> f.file().getFileName().equals("file1.txt"))
@@ -2332,7 +2331,7 @@ public class GitRepoTest {
     @Test
     void testGetDiff_EmptyTreeToFirstCommit() throws Exception {
         // This tests the fix for diffing against the empty tree (root commit scenario).
-        // When explaining a root commit, GitTools falls back to Constants.EMPTY_TREE_ID.getName()
+        // When explaining a root commit, GitTools falls back to GitRefs.EMPTY_TREE
         // as the "parent" revision. Previously this would fail because resolveToCommit cannot
         // resolve a tree ID.
 
@@ -2340,7 +2339,7 @@ public class GitRepoTest {
         String firstCommitSha = repo.getCurrentCommitId();
 
         // Diff from empty tree to first commit should show all files as added
-        String diff = repo.getDiff(Constants.EMPTY_TREE_ID.getName(), firstCommitSha);
+        String diff = repo.getDiff(GitRefs.EMPTY_TREE, firstCommitSha);
 
         assertNotNull(diff, "Diff should not be null");
         assertFalse(diff.isEmpty(), "Diff should not be empty for a commit that adds files");
@@ -2369,7 +2368,7 @@ public class GitRepoTest {
         try {
             String firstCommitSha = multiRepo.getCurrentCommitId();
 
-            String diff = multiRepo.getDiff(Constants.EMPTY_TREE_ID.getName(), firstCommitSha);
+            String diff = multiRepo.getDiff(GitRefs.EMPTY_TREE, firstCommitSha);
 
             assertNotNull(diff);
             assertFalse(diff.isEmpty());
@@ -2388,7 +2387,7 @@ public class GitRepoTest {
         String firstCommitSha = repo.getCurrentCommitId();
         ProjectFile readme = new ProjectFile(projectRoot, "README.md");
 
-        String diff = repo.getDiff(readme, Constants.EMPTY_TREE_ID.getName(), firstCommitSha);
+        String diff = repo.getDiff(readme, GitRefs.EMPTY_TREE, firstCommitSha);
 
         assertNotNull(diff);
         assertFalse(diff.isEmpty());


### PR DESCRIPTION
The primary functional improvement is the fix for diffing root commits. Previously, attempting to diff the first commit against an empty tree would fail because the system tried to resolve the empty tree ID as a commit. The `GitRepoData.prepareTreeParser` method has been updated to return an `EmptyTreeIterator` when the `EMPTY_TREE` reference is encountered. 

This PR also introduces a centralized `GitRefs` utility to manage special Git reference constants like `WORKING` (for uncommitted changes) and `EMPTY_TREE`. 

Closes #2831 #2830

Key changes:
- Created `GitRefs.java` for centralized Git constants.
- Updated `GitRepoData` to handle `EmptyTreeIterator` for root commit diffs.

brokk-session-ids:019c58cf-48e6-7e10-b6e2-58c2c6fe2f76