### PR TITLE
Split background workloads on ContextManager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,11 @@ This repository contains multiple subprojects with different languages and stand
 
 ## Null Safety
 
-1. **Null Away**: This project is built with Null Away: fields, parameter, and return values are non-null by default. 
-Annotate exceptions to this rule with @Nullable (imported from org.jetbrains.annotations). Use requireNonNull 
+1. **Null Away**: This project is built with Null Away: fields, parameter, and return values are non-null by default.
+Annotate exceptions to this rule with @Nullable (imported from org.jetbrains.annotations). Use requireNonNull
 (static import from java.util.Objects) when the static type is @Nullable but our code path expects it to be non-null.
-Less often, it is useful to use castNonNull (static import from org.checkerframework.checker.nullness.util.NullnessUtil) 
-when we can prove a value is not null but the compiler doesn't realize it, e.g. accessing get(true) in a Map 
+Less often, it is useful to use castNonNull (static import from org.checkerframework.checker.nullness.util.NullnessUtil)
+when we can prove a value is not null but the compiler doesn't realize it, e.g. accessing get(true) in a Map
 returned by Collectors.partitioningBy. You do not need either requireNonNull or castNonNull when a field, parameter,
 or return value is not annotated @Nullable.
 1. **RedundantNullCheck**: Try to resolve `RedundantNullCheck` warnings by either removing the redundant null check or by annotating the reported variable or method with @Nullable (imported from org.jetbrains.annotations). Do NOT suppress the `RedundantNullCheck` warnings.
@@ -73,7 +73,11 @@ with try/catch is unnecessary and futile; don't do that.
    then use a normal CompletableFuture, but in this case you must be VERY careful that you don't leave exceptions silently ignored.
    Deal with any log-and-ignore subpaths with GlobalExceptionHandler.handle(Throwable) instead of logging manually.
 3. Avoid SwingWorker in favor of virtual threads using ExecutorsUtil.newVirtualThreadExecutor, or LoggingFuture.supplyAsync.
-4. ContextManager.submitBackgroundTask is for tasks that run long enough to be noticeable by the user. For shorter
-   tasks use LoggingFuture.supplyAsync / LoggingFuture.supplyVirtualAsync, depending on whether the task expects to be cpu- or i/o-bound.
+4. For tasks that run long enough to be noticeable by the user, use one of two tracked-task executors:
+   - `submitBackgroundTask` — reserved for analyzer callbacks, test execution, and build operations.
+   - `submitMaintenanceTask` — for everything else (I/O, network, LLM calls, dependency imports, git operations, UI bookkeeping).
+   Both have identical signatures and status-tracking behavior; the split prevents maintenance work from competing
+   with critical-path analyzer/build operations for threads.
+   For shorter tasks use LoggingFuture.supplyAsync / LoggingFuture.supplyVirtualAsync, depending on whether the task expects to be cpu- or i/o-bound.
 5. Use ai.brokk.concurrent.AtomicWrites.save(Path, XXX) for writing to disk, where XXX may be a byte[], a String,
    or a lambda that takes an OutputStream parameter.

--- a/app/src/main/interruptions.md
+++ b/app/src/main/interruptions.md
@@ -35,11 +35,12 @@ Logging and error reporting for these executors is centralized via `LoggingExecu
 
 - Use `ContextManager.beginTask` to open a TaskScope, then append one or more `TaskResult`s. Close (or try-with-resources) to commit exactly one history entry:
   - Changed files are made editable before the history entry is pushed.
-  - If canceled before any AI output, nothing is pushed to the history stack.  
+  - If canceled before any AI output, nothing is pushed to the history stack.
 
 ### Background tasks
 
-- Submit non-user work with `ContextManager.submitBackgroundTask(...)`.
+- Submit analyzer/test/build work with `ContextManager.submitBackgroundTask(...)`.
+- Submit all other non-user work with `ContextManager.submitMaintenanceTask(...)`.
 - Background tasks are not targeted by the Stop button and can ignore InterruptedException (won't happen, it's just noise in the code).
 - Prefer `getAnalyzerUninterrupted()` in background code; reserve `getAnalyzer()` (interruptible) for cancelable user actions.
 

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -161,8 +161,8 @@ public class ContextManager implements IContextManager, AutoCloseable {
 
     // Short bookkeeping tasks only (balance checks, session ops, history cleanup, service reload)
     private final LoggingExecutorService maintenanceTasks = createLoggingExecutorService(new ThreadPoolExecutor(
-            2,
-            2,
+            4,
+            4,
             60L,
             TimeUnit.SECONDS,
             new LinkedBlockingQueue<>(),
@@ -2067,7 +2067,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * Returns a CompletableFuture for the style guide content.
      */
     public CompletableFuture<String> ensureGuidesAsync() {
-        return submitBackgroundTask("Loading project guides", () -> {
+        return submitMaintenanceTask("Loading project guides", () -> {
             // Handle style guide off EDT
             String existingStyleGuide = project.getStyleGuide();
             if (!existingStyleGuide.isEmpty()) {
@@ -2222,7 +2222,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * Returns a CompletableFuture for the regenerated style guide content.
      */
     public CompletableFuture<String> regenerateStyleGuideAsync() {
-        return submitBackgroundTask("Regenerating style guide", () -> {
+        return submitMaintenanceTask("Regenerating style guide", () -> {
             if (!project.hasGit()) {
                 logger.info("No Git repository found, skipping style guide regeneration.");
                 styleGenerationSkipped = true;

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -1883,10 +1883,10 @@ public class ContextManager implements IContextManager, AutoCloseable {
         });
     }
 
-    @Override
-    public <T> CompletableFuture<T> submitBackgroundTask(String taskDescription, Callable<T> task) {
+    private <T> CompletableFuture<T> submitTrackedTask(
+            LoggingExecutorService executor, String taskDescription, Callable<T> task) {
         taskDescriptions.put(task, taskDescription);
-        return backgroundTasks.submit(() -> {
+        return executor.submit(() -> {
             try {
                 io.backgroundOutput(taskDescription);
                 return task.call();
@@ -1909,6 +1909,11 @@ public class ContextManager implements IContextManager, AutoCloseable {
                 });
             }
         });
+    }
+
+    @Override
+    public <T> CompletableFuture<T> submitBackgroundTask(String taskDescription, Callable<T> task) {
+        return submitTrackedTask(backgroundTasks, taskDescription, task);
     }
 
     /**

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -159,6 +159,15 @@ public class ContextManager implements IContextManager, AutoCloseable {
     private final LoggingExecutorService historyCompressionExecutor =
             ExecutorsUtil.newFixedThreadExecutor("HistoryCompress-", 5);
 
+    // Lightweight maintenance tasks (balance checks, session ops, style guides, etc.)
+    private final LoggingExecutorService maintenanceTasks = createLoggingExecutorService(new ThreadPoolExecutor(
+            2,
+            2,
+            60L,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            ExecutorsUtil.createNamedThreadFactory("MaintenanceTask")));
+
     private final LoggingExecutorService syncExecutor = createLoggingExecutorService(
             Executors.newSingleThreadExecutor(ExecutorsUtil.createNamedThreadFactory("SessionSync")));
 

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -1391,6 +1391,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         var syncExecutorFuture = syncExecutor.shutdownAndAwait(awaitMillis, "syncExecutor");
         var contextActionFuture = contextActionExecutor.shutdownAndAwait(awaitMillis, "contextActionExecutor");
         var backgroundFuture = backgroundTasks.shutdownAndAwait(awaitMillis, "backgroundTasks");
+        var maintenanceFuture = maintenanceTasks.shutdownAndAwait(awaitMillis, "maintenanceTasks");
         var userActionsFuture = userActions.shutdownAndAwait(awaitMillis);
         var historyCompressionFuture =
                 historyCompressionExecutor.shutdownAndAwait(awaitMillis, "historyCompressionExecutor");
@@ -1398,6 +1399,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         return CompletableFuture.allOf(
                         contextActionFuture,
                         backgroundFuture,
+                        maintenanceFuture,
                         userActionsFuture,
                         syncExecutorFuture,
                         historyCompressionFuture)

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -223,6 +223,11 @@ public class ContextManager implements IContextManager, AutoCloseable {
     }
 
     @Override
+    public ExecutorService getMaintenanceTasks() {
+        return maintenanceTasks;
+    }
+
+    @Override
     public void addContextListener(ContextListener listener) {
         contextListeners.add(listener);
     }

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -352,7 +352,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
 
     private CompletableFuture<Void> migrateToSessionsV3IfNeeded() {
         if (project instanceof MainProject mainProject && !mainProject.isMigrationsToSessionsV3Complete()) {
-            return submitBackgroundTask("Quarantine unreadable sessions", () -> {
+            return submitMaintenanceTask("Quarantine unreadable sessions", () -> {
                 var sessionManager = project.getSessionManager();
 
                 // Scan .zip files directly and quarantine unreadable ones; exercise history loading to trigger
@@ -439,7 +439,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
                 && !project.getRemoteProjectName().isBlank();
 
         // Load saved context history or create a new one
-        CompletableFuture<Void> contextTask = submitBackgroundTask("Loading saved context", () -> {
+        CompletableFuture<Void> contextTask = submitMaintenanceTask("Loading saved context", () -> {
             try {
                 initializeCurrentSessionAndHistory(false);
             } finally {
@@ -625,7 +625,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @param changedFiles Set of files that changed (may be empty for backward compatibility)
      */
     void handleTrackedFileChange(Set<ProjectFile> changedFiles) {
-        submitBackgroundTask("Update for FS changes", () -> {
+        submitMaintenanceTask("Update for FS changes", () -> {
             // Invalidate caches
             project.getRepo().invalidateCaches();
             project.invalidateAllFiles();
@@ -667,7 +667,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
 
     /** Submits a background task to clean up old LLM session history directories. */
     private void cleanupOldHistoryAsync() {
-        submitBackgroundTask("Cleaning up LLM history", this::cleanupOldHistory);
+        submitMaintenanceTask("Cleaning up LLM history", this::cleanupOldHistory);
     }
 
     /**
@@ -1855,7 +1855,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @return A CompletableFuture that will return the description string.
      */
     public CompletableFuture<String> submitSummarizePastedImage(Image pastedImage) {
-        return submitBackgroundTask("Summarizing pasted image", () -> {
+        return submitMaintenanceTask("Summarizing pasted image", () -> {
             try {
                 // Convert AWT Image to LangChain4j Image (requires Base64 encoding)
                 var l4jImage = ImageUtil.toL4JImage(pastedImage);
@@ -1951,7 +1951,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         }
 
         // No details found, run the BuildAgent asynchronously
-        buildAgentFuture = submitBackgroundTask("Inferring build details", () -> {
+        buildAgentFuture = submitMaintenanceTask("Inferring build details", () -> {
             io.showNotification(IConsoleIO.NotificationRole.INFO, "Inferring project build details");
 
             // Check if task was cancelled before starting
@@ -2005,7 +2005,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
     public void reloadService() {
         if (isReloadingService.compareAndSet(false, true)) {
             // Run reinit in the background so callers don't block; notify UI listeners when finished.
-            submitBackgroundTask("Reloading service", () -> {
+            submitMaintenanceTask("Reloading service", () -> {
                 try {
                     serviceProvider.reinit(project);
                     // Notify registered listeners on the EDT so they can safely update Swing UI.
@@ -2075,7 +2075,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * Returns a CompletableFuture for the style guide content.
      */
     public CompletableFuture<String> ensureGuidesAsync() {
-        return submitBackgroundTask("Loading project guides", () -> {
+        return submitMaintenanceTask("Loading project guides", () -> {
             // Handle style guide off EDT
             String existingStyleGuide = project.getStyleGuide();
             if (!existingStyleGuide.isEmpty()) {
@@ -2230,7 +2230,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * Returns a CompletableFuture for the regenerated style guide content.
      */
     public CompletableFuture<String> regenerateStyleGuideAsync() {
-        return submitBackgroundTask("Regenerating style guide", () -> {
+        return submitMaintenanceTask("Regenerating style guide", () -> {
             if (!project.hasGit()) {
                 logger.info("No Git repository found, skipping style guide regeneration.");
                 styleGenerationSkipped = true;
@@ -2675,7 +2675,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @return A CompletableFuture representing the completion of the session rename task
      */
     public CompletableFuture<Void> renameSessionAsync(UUID sessionId, Future<String> newNameFuture) {
-        return submitBackgroundTask("Renaming session", () -> {
+        return submitMaintenanceTask("Renaming session", () -> {
             try {
                 String newName = newNameFuture.get(Context.CONTEXT_ACTION_SUMMARY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                 project.getSessionManager().renameSession(sessionId, newName);
@@ -2848,7 +2848,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
             return; // Only relevant when using the Brokk proxy
         }
 
-        submitBackgroundTask("Balance Check", () -> {
+        submitMaintenanceTask("Balance Check", () -> {
             try {
                 float balance = serviceProvider.get().getUserBalance();
                 logger.debug("Checked balance: ${}", String.format("%.2f", balance));

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -159,7 +159,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
     private final LoggingExecutorService historyCompressionExecutor =
             ExecutorsUtil.newFixedThreadExecutor("HistoryCompress-", 5);
 
-    // Short bookkeeping tasks only (balance checks, session ops, history cleanup, service reload)
+    // All non-analyzer, non-test, non-build tracked tasks (I/O, network, LLM, git ops, UI bookkeeping)
     private final LoggingExecutorService maintenanceTasks = createLoggingExecutorService(new ThreadPoolExecutor(
             4,
             4,

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -159,7 +159,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
     private final LoggingExecutorService historyCompressionExecutor =
             ExecutorsUtil.newFixedThreadExecutor("HistoryCompress-", 5);
 
-    // Lightweight maintenance tasks (balance checks, session ops, style guides, etc.)
+    // Short bookkeeping tasks only (balance checks, session ops, history cleanup, service reload)
     private final LoggingExecutorService maintenanceTasks = createLoggingExecutorService(new ThreadPoolExecutor(
             2,
             2,
@@ -1859,7 +1859,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @return A CompletableFuture that will return the description string.
      */
     public CompletableFuture<String> submitSummarizePastedImage(Image pastedImage) {
-        return submitMaintenanceTask("Summarizing pasted image", () -> {
+        return submitBackgroundTask("Summarizing pasted image", () -> {
             try {
                 // Convert AWT Image to LangChain4j Image (requires Base64 encoding)
                 var l4jImage = ImageUtil.toL4JImage(pastedImage);
@@ -1955,7 +1955,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         }
 
         // No details found, run the BuildAgent asynchronously
-        buildAgentFuture = submitMaintenanceTask("Inferring build details", () -> {
+        buildAgentFuture = submitBackgroundTask("Inferring build details", () -> {
             io.showNotification(IConsoleIO.NotificationRole.INFO, "Inferring project build details");
 
             // Check if task was cancelled before starting
@@ -2079,7 +2079,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * Returns a CompletableFuture for the style guide content.
      */
     public CompletableFuture<String> ensureGuidesAsync() {
-        return submitMaintenanceTask("Loading project guides", () -> {
+        return submitBackgroundTask("Loading project guides", () -> {
             // Handle style guide off EDT
             String existingStyleGuide = project.getStyleGuide();
             if (!existingStyleGuide.isEmpty()) {
@@ -2234,7 +2234,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * Returns a CompletableFuture for the regenerated style guide content.
      */
     public CompletableFuture<String> regenerateStyleGuideAsync() {
-        return submitMaintenanceTask("Regenerating style guide", () -> {
+        return submitBackgroundTask("Regenerating style guide", () -> {
             if (!project.hasGit()) {
                 logger.info("No Git repository found, skipping style guide regeneration.");
                 styleGenerationSkipped = true;

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -217,18 +217,6 @@ public class ContextManager implements IContextManager, AutoCloseable {
     @SuppressWarnings("NullAway.Init")
     private AbstractWatchService watchService;
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public ExecutorService getBackgroundTasks() {
-        return backgroundTasks;
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public ExecutorService getMaintenanceTasks() {
-        return maintenanceTasks;
-    }
-
     @Override
     public void addContextListener(ContextListener listener) {
         contextListeners.add(listener);

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -217,11 +217,13 @@ public class ContextManager implements IContextManager, AutoCloseable {
     @SuppressWarnings("NullAway.Init")
     private AbstractWatchService watchService;
 
+    @SuppressWarnings("deprecation")
     @Override
     public ExecutorService getBackgroundTasks() {
         return backgroundTasks;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public ExecutorService getMaintenanceTasks() {
         return maintenanceTasks;

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -292,7 +292,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         this.userActions = new UserActionManager(this.io);
 
         // Begin monitoring for excessive memory usage
-        this.lowMemoryWatcherManager = new LowMemoryWatcherManager(this.backgroundTasks);
+        this.lowMemoryWatcherManager = new LowMemoryWatcherManager(this.maintenanceTasks);
         this.lowMemoryWatcherManager.registerWithStrongReference(
                 () -> LowMemoryWatcherManager.LowMemoryWarningManager.alertUser(this.io),
                 LowMemoryWatcher.LowMemoryWatcherType.ONLY_AFTER_GC);
@@ -615,7 +615,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @param changedFiles Set of files that changed (may be empty for backward compatibility)
      */
     void handleTrackedFileChange(Set<ProjectFile> changedFiles) {
-        submitBackgroundTask("Update for FS changes", () -> {
+        submitMaintenanceTask("Update for FS changes", () -> {
             // Invalidate caches
             project.getRepo().invalidateCaches();
             project.invalidateAllFiles();
@@ -1847,7 +1847,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @return A CompletableFuture that will return the description string.
      */
     public CompletableFuture<String> submitSummarizePastedImage(Image pastedImage) {
-        return submitBackgroundTask("Summarizing pasted image", () -> {
+        return submitMaintenanceTask("Summarizing pasted image", () -> {
             try {
                 // Convert AWT Image to LangChain4j Image (requires Base64 encoding)
                 var l4jImage = ImageUtil.toL4JImage(pastedImage);
@@ -1943,7 +1943,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
         }
 
         // No details found, run the BuildAgent asynchronously
-        buildAgentFuture = submitBackgroundTask("Inferring build details", () -> {
+        buildAgentFuture = submitMaintenanceTask("Inferring build details", () -> {
             io.showNotification(IConsoleIO.NotificationRole.INFO, "Inferring project build details");
 
             // Check if task was cancelled before starting
@@ -2465,7 +2465,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      */
     public CompletableFuture<ContextHistory> loadSessionHistoryAsync(UUID sessionId) {
         return LoggingFuture.supplyAsync(
-                () -> project.getSessionManager().loadHistory(sessionId, this), backgroundTasks);
+                () -> project.getSessionManager().loadHistory(sessionId, this), maintenanceTasks);
     }
 
     /**

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -627,7 +627,7 @@ public class ContextManager implements IContextManager, AutoCloseable {
      * @param changedFiles Set of files that changed (may be empty for backward compatibility)
      */
     void handleTrackedFileChange(Set<ProjectFile> changedFiles) {
-        submitMaintenanceTask("Update for FS changes", () -> {
+        submitBackgroundTask("Update for FS changes", () -> {
             // Invalidate caches
             project.getRepo().invalidateCaches();
             project.invalidateAllFiles();

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -1916,6 +1916,11 @@ public class ContextManager implements IContextManager, AutoCloseable {
         return submitTrackedTask(backgroundTasks, taskDescription, task);
     }
 
+    @Override
+    public <T> CompletableFuture<T> submitMaintenanceTask(String taskDescription, Callable<T> task) {
+        return submitTrackedTask(maintenanceTasks, taskDescription, task);
+    }
+
     /**
      * Ensures build details are loaded or inferred using BuildAgent if necessary. Runs asynchronously in the
      * background.

--- a/app/src/main/java/ai/brokk/IContextManager.java
+++ b/app/src/main/java/ai/brokk/IContextManager.java
@@ -152,10 +152,20 @@ public interface IContextManager {
         default void onLiveDependenciesChanged() {}
     }
 
+    /**
+     * @deprecated Use {@link #submitBackgroundTask(String, Callable)} or
+     *             {@link #submitBackgroundTask(String, Runnable)} instead of accessing the executor directly.
+     */
+    @Deprecated
     default ExecutorService getBackgroundTasks() {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * @deprecated Use {@link #submitMaintenanceTask(String, Callable)} or
+     *             {@link #submitMaintenanceTask(String, Runnable)} instead of accessing the executor directly.
+     */
+    @Deprecated
     default ExecutorService getMaintenanceTasks() {
         return getBackgroundTasks();
     }

--- a/app/src/main/java/ai/brokk/IContextManager.java
+++ b/app/src/main/java/ai/brokk/IContextManager.java
@@ -156,6 +156,10 @@ public interface IContextManager {
         throw new UnsupportedOperationException();
     }
 
+    default ExecutorService getMaintenanceTasks() {
+        return getBackgroundTasks();
+    }
+
     /**
      * Returns the live, unfrozen context that we can edit.
      *

--- a/app/src/main/java/ai/brokk/IContextManager.java
+++ b/app/src/main/java/ai/brokk/IContextManager.java
@@ -32,7 +32,6 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -150,24 +149,6 @@ public interface IContextManager {
 
         /** Called when live dependencies are added or removed. */
         default void onLiveDependenciesChanged() {}
-    }
-
-    /**
-     * @deprecated Use {@link #submitBackgroundTask(String, Callable)} or
-     *             {@link #submitBackgroundTask(String, Runnable)} instead of accessing the executor directly.
-     */
-    @Deprecated
-    default ExecutorService getBackgroundTasks() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * @deprecated Use {@link #submitMaintenanceTask(String, Callable)} or
-     *             {@link #submitMaintenanceTask(String, Runnable)} instead of accessing the executor directly.
-     */
-    @Deprecated
-    default ExecutorService getMaintenanceTasks() {
-        return getBackgroundTasks();
     }
 
     /**

--- a/app/src/main/java/ai/brokk/IContextManager.java
+++ b/app/src/main/java/ai/brokk/IContextManager.java
@@ -268,6 +268,21 @@ public interface IContextManager {
         });
     }
 
+    default <T> CompletableFuture<T> submitMaintenanceTask(String taskDescription, Callable<T> task) {
+        try {
+            return CompletableFuture.completedFuture(task.call());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    default CompletableFuture<Void> submitMaintenanceTask(String taskDescription, Runnable task) {
+        return submitMaintenanceTask(taskDescription, () -> {
+            task.run();
+            return null;
+        });
+    }
+
     default Set<ProjectFile> getTestFiles() {
         Set<ProjectFile> allFiles = getRepo().getTrackedFiles();
         var analyzer = getAnalyzerWrapper().getNonBlocking();

--- a/app/src/main/java/ai/brokk/agents/MergeAgent.java
+++ b/app/src/main/java/ai/brokk/agents/MergeAgent.java
@@ -197,10 +197,10 @@ public class MergeAgent {
                 "Submitting background tasks for commit explanations. Ours: {} commits, Theirs: {} commits.",
                 annotations.ourCommits().size(),
                 annotations.theirCommits().size());
-        Future<String> oursFuture = cm.submitBackgroundTask("Explain relevant OUR commits", () -> {
+        Future<String> oursFuture = cm.submitMaintenanceTask("Explain relevant OUR commits", () -> {
             return buildCommitExplanations("Our relevant commits", annotations.ourCommits());
         });
-        Future<String> theirsFuture = cm.submitBackgroundTask("Explain relevant THEIR commits", () -> {
+        Future<String> theirsFuture = cm.submitMaintenanceTask("Explain relevant THEIR commits", () -> {
             return buildCommitExplanations("Their relevant commits", annotations.theirCommits());
         });
 

--- a/app/src/main/java/ai/brokk/analyzer/JavaLanguage.java
+++ b/app/src/main/java/ai/brokk/analyzer/JavaLanguage.java
@@ -121,7 +121,7 @@ public class JavaLanguage implements JvmLanguage {
         Decompiler.decompileJar(
                 chrome,
                 pkg.sourcePath(),
-                chrome.getContextManager()::submitBackgroundTask,
+                chrome.getContextManager()::submitMaintenanceTask,
                 () -> SwingUtilities.invokeLater(() -> {
                     if (lifecycle != null) lifecycle.dependencyImportFinished(depName);
                 }));

--- a/app/src/main/java/ai/brokk/analyzer/NodeJsDependencyHelper.java
+++ b/app/src/main/java/ai/brokk/analyzer/NodeJsDependencyHelper.java
@@ -147,7 +147,7 @@ public final class NodeJsDependencyHelper {
             SwingUtilities.invokeLater(() -> currentListener.dependencyImportStarted(pkg.displayName()));
         }
 
-        chrome.getContextManager().submitBackgroundTask("Copying NPM package: " + pkg.displayName(), () -> {
+        chrome.getContextManager().submitMaintenanceTask("Copying NPM package: " + pkg.displayName(), () -> {
             try {
                 Files.createDirectories(requireNonNull(targetRoot.getParent()));
                 if (Files.exists(targetRoot)) {

--- a/app/src/main/java/ai/brokk/analyzer/PythonLanguage.java
+++ b/app/src/main/java/ai/brokk/analyzer/PythonLanguage.java
@@ -230,7 +230,7 @@ public class PythonLanguage implements Language {
             SwingUtilities.invokeLater(() -> currentListener.dependencyImportStarted(pkg.displayName()));
         }
 
-        chrome.getContextManager().submitBackgroundTask("Copying Python package: " + pkg.displayName(), () -> {
+        chrome.getContextManager().submitMaintenanceTask("Copying Python package: " + pkg.displayName(), () -> {
             try {
                 Files.createDirectories(targetRoot.getParent());
                 if (Files.exists(targetRoot)) {

--- a/app/src/main/java/ai/brokk/analyzer/RustLanguage.java
+++ b/app/src/main/java/ai/brokk/analyzer/RustLanguage.java
@@ -202,7 +202,7 @@ public class RustLanguage implements Language {
             SwingUtilities.invokeLater(() -> currentListener.dependencyImportStarted(pkg.displayName()));
         }
 
-        chrome.getContextManager().submitBackgroundTask("Copying Rust crate: " + pkg.displayName(), () -> {
+        chrome.getContextManager().submitMaintenanceTask("Copying Rust crate: " + pkg.displayName(), () -> {
             try {
                 Files.createDirectories(targetRoot.getParent());
                 if (Files.exists(targetRoot)) {

--- a/app/src/main/java/ai/brokk/context/DiffService.java
+++ b/app/src/main/java/ai/brokk/context/DiffService.java
@@ -94,7 +94,7 @@ public final class DiffService {
                     .map(ContextHistory.GitState::commitHash)
                     .orElse("HEAD");
             return LoggingFuture.supplyAsync(
-                    () -> diff(k.curr(), castNonNull(k.prev()), revision), cm.getBackgroundTasks());
+                    () -> diff(k.curr(), castNonNull(k.prev()), revision), cm.getMaintenanceTasks());
         });
     }
 

--- a/app/src/main/java/ai/brokk/context/DiffService.java
+++ b/app/src/main/java/ai/brokk/context/DiffService.java
@@ -6,7 +6,6 @@ import ai.brokk.ExceptionReporter;
 import ai.brokk.IContextManager;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.concurrent.ComputedValue;
-import ai.brokk.concurrent.LoggingFuture;
 import ai.brokk.git.CommitInfo;
 import ai.brokk.git.GitRepo;
 import ai.brokk.git.GitRepoData.FileDiff;
@@ -93,8 +92,7 @@ public final class DiffService {
             var revision = history.getGitState(k.prev().id())
                     .map(ContextHistory.GitState::commitHash)
                     .orElse("HEAD");
-            return LoggingFuture.supplyAsync(
-                    () -> diff(k.curr(), castNonNull(k.prev()), revision), cm.getMaintenanceTasks());
+            return cm.submitMaintenanceTask("Computing diff", () -> diff(k.curr(), castNonNull(k.prev()), revision));
         });
     }
 

--- a/app/src/main/java/ai/brokk/context/DiffService.java
+++ b/app/src/main/java/ai/brokk/context/DiffService.java
@@ -92,7 +92,7 @@ public final class DiffService {
             var revision = history.getGitState(k.prev().id())
                     .map(ContextHistory.GitState::commitHash)
                     .orElse("HEAD");
-            return cm.submitBackgroundTask("Computing diff", () -> diff(k.curr(), castNonNull(k.prev()), revision));
+            return cm.submitMaintenanceTask("Computing diff", () -> diff(k.curr(), castNonNull(k.prev()), revision));
         });
     }
 

--- a/app/src/main/java/ai/brokk/context/DiffService.java
+++ b/app/src/main/java/ai/brokk/context/DiffService.java
@@ -92,7 +92,7 @@ public final class DiffService {
             var revision = history.getGitState(k.prev().id())
                     .map(ContextHistory.GitState::commitHash)
                     .orElse("HEAD");
-            return cm.submitMaintenanceTask("Computing diff", () -> diff(k.curr(), castNonNull(k.prev()), revision));
+            return cm.submitBackgroundTask("Computing diff", () -> diff(k.curr(), castNonNull(k.prev()), revision));
         });
     }
 

--- a/app/src/main/java/ai/brokk/difftool/ui/BrokkDiffPanel.java
+++ b/app/src/main/java/ai/brokk/difftool/ui/BrokkDiffPanel.java
@@ -1009,7 +1009,7 @@ public class BrokkDiffPanel extends JPanel
             }
         }
 
-        contextManager.submitBackgroundTask("Capture diffs", () -> {
+        contextManager.submitMaintenanceTask("Capture diffs", () -> {
             var combinedBuilder = new StringBuilder();
             var filesForFragment = new LinkedHashSet<ProjectFile>();
             String primaryDisplayName = null;
@@ -1083,7 +1083,7 @@ public class BrokkDiffPanel extends JPanel
             var fragment = new ContextFragments.StringFragment(
                     contextManager, combinedBuilder.toString(), description, syntaxStyle, filesForFragment);
 
-            contextManager.submitBackgroundTask("Add fragments to context", () -> {
+            contextManager.submitMaintenanceTask("Add fragments to context", () -> {
                 contextManager.addFragments(fragment);
                 contextManager
                         .getIo()

--- a/app/src/main/java/ai/brokk/difftool/ui/DiffDisplayCore.java
+++ b/app/src/main/java/ai/brokk/difftool/ui/DiffDisplayCore.java
@@ -209,7 +209,7 @@ public class DiffDisplayCore {
     private void createAsync(
             int index, FileComparisonInfo expectedInfo, int targetLine, ReviewParser.DiffSide targetSide) {
         int generation = updateGeneration.get();
-        contextManager.submitBackgroundTask("Computing diff: " + expectedInfo.getDisplayName(), () -> {
+        contextManager.submitMaintenanceTask("Computing diff: " + expectedInfo.getDisplayName(), () -> {
             // Expensive I/O and CPU work (diffing) happens here on a virtual thread
             var diffNode = FileComparisonHelper.createDiffNode(
                     expectedInfo.leftSource(), expectedInfo.rightSource(), contextManager, isMultipleCommitsContext);

--- a/app/src/main/java/ai/brokk/gui/Chrome.java
+++ b/app/src/main/java/ai/brokk/gui/Chrome.java
@@ -250,7 +250,7 @@ public class Chrome
 
         if (getProject().hasGit()) {
             // Initial refreshes are now done in the background
-            contextManager.submitBackgroundTask("Loading project state", () -> {
+            contextManager.submitMaintenanceTask("Loading project state", () -> {
                 updateGitRepo();
                 projectFilesPanel.requestUpdate();
                 return null;
@@ -1865,7 +1865,7 @@ public class Chrome
      * Shows the git configuration dialog with editable commit message.
      */
     private void showGitConfigDialog() {
-        contextManager.submitBackgroundTask("Checking .gitignore", () -> {
+        contextManager.submitMaintenanceTask("Checking .gitignore", () -> {
             if (!getProject().isGitIgnoreSet()) {
                 SwingUtilities.invokeLater(() -> {
                     var dialog = new GitConfigCommitDialog(frame, this, contextManager, getProject());
@@ -2464,7 +2464,7 @@ public class Chrome
      */
     public void refreshGitAsync(@Nullable String branchName) {
         if (SwingUtilities.isEventDispatchThread()) {
-            contextManager.submitBackgroundTask("Refreshing Git", () -> {
+            contextManager.submitMaintenanceTask("Refreshing Git", () -> {
                 refreshGit(branchName);
                 return null;
             });

--- a/app/src/main/java/ai/brokk/gui/CommitDialog.java
+++ b/app/src/main/java/ai/brokk/gui/CommitDialog.java
@@ -242,7 +242,7 @@ public class CommitDialog extends BaseThemedDialog {
         commitMessageArea.setEnabled(false);
         regenerateButton.setEnabled(false);
 
-        contextManager.submitBackgroundTask("Committing changes", () -> {
+        contextManager.submitMaintenanceTask("Committing changes", () -> {
             try {
                 GitWorkflow.CommitResult result = workflowService.commit(filesToCommit, msg);
                 var repo = (GitRepo) chrome.contextManager.getRepo();

--- a/app/src/main/java/ai/brokk/gui/GitConfigCommitDialog.java
+++ b/app/src/main/java/ai/brokk/gui/GitConfigCommitDialog.java
@@ -128,7 +128,7 @@ public class GitConfigCommitDialog extends JDialog {
         noButton.setEnabled(false);
         commitMessageArea.setEnabled(false);
 
-        contextManager.submitBackgroundTask("Setting up .gitignore and committing", () -> {
+        contextManager.submitMaintenanceTask("Setting up .gitignore and committing", () -> {
             var result = GitIgnoreConfigurator.setupGitIgnoreAndStageFiles(project, chrome);
 
             if (result.errorMessage().isPresent()) {

--- a/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
@@ -1829,7 +1829,7 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
             return;
         }
 
-        contextManager.submitBackgroundTask("Compute diff window entries", () -> {
+        contextManager.submitMaintenanceTask("Compute diff window entries", () -> {
             // Build a multi-file BrokkDiffPanel like showFileHistoryDiff, but with our per-file old/new buffers
             var prevOfCtx = contextManager.getContextHistory().previousOf(ctx);
             String actionDesc = ctx.getAction(prevOfCtx).renderNowOr(Context.SUMMARIZING);
@@ -1848,7 +1848,7 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
 
             var diffPairFutures = new ArrayList<CompletableFuture<BufferedSourcePair>>();
             for (var de : diffs) {
-                var task = contextManager.submitBackgroundTask("Compute diff window entry for:" + de, () -> {
+                var task = contextManager.submitMaintenanceTask("Compute diff window entry for:" + de, () -> {
                     String pathDisplay;
                     var files = de.fragment().sourceFiles().join();
                     if (!files.isEmpty()) {

--- a/app/src/main/java/ai/brokk/gui/MergeDialogPanel.java
+++ b/app/src/main/java/ai/brokk/gui/MergeDialogPanel.java
@@ -345,7 +345,7 @@ public class MergeDialogPanel extends BaseThemedDialog {
             return;
         }
 
-        contextManager.submitBackgroundTask("Checking merge conflicts", () -> {
+        contextManager.submitMaintenanceTask("Checking merge conflicts", () -> {
             String conflictResultString;
             try {
                 if (selectedTargetBranch.equals(sourceBranch)) {

--- a/app/src/main/java/ai/brokk/gui/ReviewDetailPanel.java
+++ b/app/src/main/java/ai/brokk/gui/ReviewDetailPanel.java
@@ -259,7 +259,7 @@ public class ReviewDetailPanel extends JPanel implements ThemeAware {
             JPopupMenu menu = new JPopupMenu();
             JMenuItem editItem = new JMenuItem("Edit + Enqueue");
             editItem.addActionListener(e -> {
-                contextManager.getBackgroundTasks().submit(() -> {
+                contextManager.getMaintenanceTasks().submit(() -> {
                     String edited =
                             showEditDialog((Chrome) contextManager.getIo(), "Edit Recommendation", recommendation);
                     if (edited != null && !edited.isBlank()) {

--- a/app/src/main/java/ai/brokk/gui/ReviewDetailPanel.java
+++ b/app/src/main/java/ai/brokk/gui/ReviewDetailPanel.java
@@ -259,7 +259,7 @@ public class ReviewDetailPanel extends JPanel implements ThemeAware {
             JPopupMenu menu = new JPopupMenu();
             JMenuItem editItem = new JMenuItem("Edit + Enqueue");
             editItem.addActionListener(e -> {
-                contextManager.getMaintenanceTasks().submit(() -> {
+                contextManager.submitMaintenanceTask("Editing recommendation", () -> {
                     String edited =
                             showEditDialog((Chrome) contextManager.getIo(), "Edit Recommendation", recommendation);
                     if (edited != null && !edited.isBlank()) {

--- a/app/src/main/java/ai/brokk/gui/RightPanel.java
+++ b/app/src/main/java/ai/brokk/gui/RightPanel.java
@@ -274,7 +274,7 @@ public class RightPanel extends JPanel implements ThemeAware {
         var sessionManager = contextManager.getProject().getSessionManager();
         for (var s : sessions) {
             var sessionId = s.id();
-            contextManager.getMaintenanceTasks().submit(() -> {
+            contextManager.submitMaintenanceTask("Loading session stats for " + s.name(), () -> {
                 var stats = sessionManager.countSessionStats(sessionId);
                 taskCounts.put(sessionId, stats.tasks());
                 SwingUtilities.invokeLater(list::repaint);

--- a/app/src/main/java/ai/brokk/gui/RightPanel.java
+++ b/app/src/main/java/ai/brokk/gui/RightPanel.java
@@ -274,7 +274,7 @@ public class RightPanel extends JPanel implements ThemeAware {
         var sessionManager = contextManager.getProject().getSessionManager();
         for (var s : sessions) {
             var sessionId = s.id();
-            contextManager.getBackgroundTasks().submit(() -> {
+            contextManager.getMaintenanceTasks().submit(() -> {
                 var stats = sessionManager.countSessionStats(sessionId);
                 taskCounts.put(sessionId, stats.tasks());
                 SwingUtilities.invokeLater(list::repaint);

--- a/app/src/main/java/ai/brokk/gui/VoiceInputButton.java
+++ b/app/src/main/java/ai/brokk/gui/VoiceInputButton.java
@@ -363,7 +363,7 @@ public class VoiceInputButton extends JButton {
         }
 
         // We do the STT in the background so as not to block the UI
-        contextManager.submitBackgroundTask("Transcribing Audio", () -> {
+        contextManager.submitMaintenanceTask("Transcribing Audio", () -> {
             IConsoleIO iConsoleIO1 = contextManager.getIo();
             iConsoleIO1.showNotification(NotificationRole.INFO, "Transcribing audio");
             try {

--- a/app/src/main/java/ai/brokk/gui/WorkspaceChip.java
+++ b/app/src/main/java/ai/brokk/gui/WorkspaceChip.java
@@ -646,7 +646,7 @@ public class WorkspaceChip extends JPanel {
                     .map(f -> (ContextFragments.SummaryFragment) f)
                     .toList();
             contextManager
-                    .submitBackgroundTask(
+                    .submitMaintenanceTask(
                             "Aggregating summaries",
                             () -> ContextFragments.SummaryFragment.combinedText(fragmentsToProcess))
                     .thenAccept(combinedText -> SwingUtilities.invokeLater(() -> {
@@ -825,7 +825,7 @@ public class WorkspaceChip extends JPanel {
                             .distinct()
                             .toList();
             contextManager
-                    .submitBackgroundTask(
+                    .submitMaintenanceTask(
                             "Compute AGENTS.md",
                             () -> ProjectGuideResolver.resolve(candidateFiles, contextManager.getProject()))
                     .thenAccept(content -> SwingUtilities.invokeLater(() -> {

--- a/app/src/main/java/ai/brokk/gui/dependencies/DependencyUpdateHelper.java
+++ b/app/src/main/java/ai/brokk/gui/dependencies/DependencyUpdateHelper.java
@@ -128,7 +128,7 @@ public final class DependencyUpdateHelper {
                 String.format("Updating %s dependency '%s' in the background...", dependencyKindLabel, depName));
 
         var future =
-                cm.submitBackgroundTask(String.format("Update %s dependency %s", dependencyKindLabel, depName), () -> {
+                cm.submitMaintenanceTask(String.format("Update %s dependency %s", dependencyKindLabel, depName), () -> {
                     var analyzer = cm.getAnalyzerWrapper();
                     analyzer.pause();
                     try {
@@ -196,7 +196,7 @@ public final class DependencyUpdateHelper {
         var project = chrome.getProject();
         var cm = chrome.getContextManager();
 
-        var future = cm.submitBackgroundTask("Auto-update local dependencies", () -> {
+        var future = cm.submitMaintenanceTask("Auto-update local dependencies", () -> {
             var analyzer = cm.getAnalyzerWrapper();
             analyzer.pause();
             try {
@@ -259,7 +259,7 @@ public final class DependencyUpdateHelper {
         var project = chrome.getProject();
         var cm = chrome.getContextManager();
 
-        var future = cm.submitBackgroundTask("Auto-update Git dependencies", () -> {
+        var future = cm.submitMaintenanceTask("Auto-update Git dependencies", () -> {
             var analyzer = cm.getAnalyzerWrapper();
             analyzer.pause();
             try {

--- a/app/src/main/java/ai/brokk/gui/dialogs/BlitzForgeDialog.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/BlitzForgeDialog.java
@@ -973,7 +973,7 @@ public class BlitzForgeDialog extends BaseThemedDialog {
         }
 
         // Run heavy work off the EDT using the background executor.
-        cm.getMaintenanceTasks().submit(() -> {
+        cm.submitMaintenanceTask("Estimating cost", () -> {
             double cost;
             boolean hadError = false;
             try {
@@ -1101,7 +1101,7 @@ public class BlitzForgeDialog extends BaseThemedDialog {
         int generation = tokenWarningGeneration.incrementAndGet();
 
         // Run heavy work off the EDT using the background executor.
-        cm.getMaintenanceTasks().submit(() -> {
+        cm.submitMaintenanceTask("Checking token limits", () -> {
             long workspaceTokens = 0L;
             long historyTokens = 0L;
             boolean hadError = false;

--- a/app/src/main/java/ai/brokk/gui/dialogs/BlitzForgeDialog.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/BlitzForgeDialog.java
@@ -852,7 +852,7 @@ public class BlitzForgeDialog extends BaseThemedDialog {
 
             // Offload expensive file enumeration and filtering to background thread
             var cm = chrome.getContextManager();
-            cm.submitBackgroundTask("Enumerate project files", () -> {
+            cm.submitMaintenanceTask("Enumerate project files", () -> {
                         var files = chrome.getProject().getRepo().getTrackedFiles().stream()
                                 .filter(ProjectFile::isText);
                         var filtered = ALL_LANGUAGES_OPTION.equals(langSel)
@@ -1036,7 +1036,7 @@ public class BlitzForgeDialog extends BaseThemedDialog {
 
     private void fetchUserBalance() {
         var cm = chrome.getContextManager();
-        cm.submitBackgroundTask("Fetch balance", () -> cm.getService().getUserBalance())
+        cm.submitMaintenanceTask("Fetch balance", () -> cm.getService().getUserBalance())
                 .thenAccept(balance -> userBalance = balance);
     }
 
@@ -1249,7 +1249,7 @@ public class BlitzForgeDialog extends BaseThemedDialog {
             return;
         }
         var cm = chrome.getContextManager();
-        cm.submitBackgroundTask("Attach files", () -> fragments.stream()
+        cm.submitMaintenanceTask("Attach files", () -> fragments.stream()
                         .flatMap(frag -> frag.referencedFiles().join().stream())
                         .collect(Collectors.toCollection(ArrayList::new)))
                 .thenAccept(flist -> SwingUtil.runOnEdt(() -> addProjectFilesToTable(flist)));

--- a/app/src/main/java/ai/brokk/gui/dialogs/BlitzForgeDialog.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/BlitzForgeDialog.java
@@ -973,7 +973,7 @@ public class BlitzForgeDialog extends BaseThemedDialog {
         }
 
         // Run heavy work off the EDT using the background executor.
-        cm.getBackgroundTasks().submit(() -> {
+        cm.getMaintenanceTasks().submit(() -> {
             double cost;
             boolean hadError = false;
             try {
@@ -1101,7 +1101,7 @@ public class BlitzForgeDialog extends BaseThemedDialog {
         int generation = tokenWarningGeneration.incrementAndGet();
 
         // Run heavy work off the EDT using the background executor.
-        cm.getBackgroundTasks().submit(() -> {
+        cm.getMaintenanceTasks().submit(() -> {
             long workspaceTokens = 0L;
             long historyTokens = 0L;
             boolean hadError = false;

--- a/app/src/main/java/ai/brokk/gui/dialogs/CreatePullRequestDialog.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/CreatePullRequestDialog.java
@@ -345,7 +345,7 @@ public class CreatePullRequestDialog extends BaseThemedDialog {
             return;
         }
 
-        contextManager.submitBackgroundTask("Fetching commits for " + contextName, () -> {
+        contextManager.submitMaintenanceTask("Fetching commits for " + contextName, () -> {
             try {
                 var repo = contextManager.getProject().getRepo();
                 if (!(repo instanceof GitRepo gitRepo)) {
@@ -779,7 +779,7 @@ public class CreatePullRequestDialog extends BaseThemedDialog {
             return;
         }
 
-        contextManager.submitBackgroundTask("Finding overlapping sessions", () -> {
+        contextManager.submitMaintenanceTask("Finding overlapping sessions", () -> {
             List<UUID> sessionIds = ReviewScope.findOverlappingSessions(contextManager, commits);
             var sessionInfos = new ArrayList<SessionManager.SessionInfo>();
             var taskCounts = new HashMap<UUID, Integer>();

--- a/app/src/main/java/ai/brokk/gui/dialogs/ImportDependencyDialog.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/ImportDependencyDialog.java
@@ -435,7 +435,7 @@ public class ImportDependencyDialog {
 
             requireNonNull(validateGitRepoButton).setEnabled(false);
 
-            chrome.getContextManager().submitBackgroundTask("Loading branches and tags", () -> {
+            chrome.getContextManager().submitMaintenanceTask("Loading branches and tags", () -> {
                 try {
                     String normalizedUrl = url;
                     if (!normalizedUrl.endsWith(".git")) {
@@ -535,7 +535,7 @@ public class ImportDependencyDialog {
             dialog.dispose();
             bringDependenciesDialogToFront();
 
-            chrome.getContextManager().submitBackgroundTask("Copying directory: " + sourcePath.getFileName(), () -> {
+            chrome.getContextManager().submitMaintenanceTask("Copying directory: " + sourcePath.getFileName(), () -> {
                 try {
                     Files.createDirectories(dependenciesRoot);
                     if (Files.exists(targetPath)) {
@@ -606,7 +606,7 @@ public class ImportDependencyDialog {
             dialog.dispose();
             bringDependenciesDialogToFront();
 
-            chrome.getContextManager().submitBackgroundTask("Cloning repository: " + repoUrl, () -> {
+            chrome.getContextManager().submitMaintenanceTask("Cloning repository: " + repoUrl, () -> {
                 try {
                     Files.createDirectories(dependenciesRoot);
 

--- a/app/src/main/java/ai/brokk/gui/dialogs/ImportLanguagePanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/ImportLanguagePanel.java
@@ -189,7 +189,7 @@ public class ImportLanguagePanel extends JPanel {
     }
 
     private void loadPackages() {
-        chrome.getContextManager().submitBackgroundTask("Discovering " + language.name() + " dependencies", () -> {
+        chrome.getContextManager().submitMaintenanceTask("Discovering " + language.name() + " dependencies", () -> {
             try {
                 var pkgs = language.listDependencyPackages(chrome.getProject());
                 SwingUtilities.invokeLater(() -> populate(pkgs));

--- a/app/src/main/java/ai/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/PreviewTextPanel.java
@@ -187,7 +187,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware, EditorFontSi
             SwingUtilities.invokeLater(() -> requireNonNull(attachButton).setIcon(Icons.ATTACH_FILE));
             var finalAttachButton = attachButton; // Final reference for lambda
 
-            cm.submitBackgroundTask("Determining files in the current context", () -> {
+            cm.submitMaintenanceTask("Determining files in the current context", () -> {
                 var files = cm.getFilesInContext();
 
                 SwingUtilities.invokeLater(() -> {
@@ -329,7 +329,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware, EditorFontSi
 
         // Fetch declarations in the background if it's a project file
         if (file != null) {
-            fileDeclarations = cm.submitBackgroundTask("Fetch Declarations", () -> {
+            fileDeclarations = cm.submitMaintenanceTask("Fetch Declarations", () -> {
                 var analyzer = cm.getAnalyzerUninterrupted();
                 return analyzer.isEmpty() ? Collections.emptySet() : analyzer.getDeclarations(file);
             });
@@ -634,7 +634,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware, EditorFontSi
                         sourceItem.addActionListener(
                                 action -> SourceCaptureUtil.captureSourceForCodeUnit(codeUnit, cm));
                         if (constructorSourceItem != null) {
-                            constructorSourceItem.addActionListener(action -> cm.submitBackgroundTask(
+                            constructorSourceItem.addActionListener(action -> cm.submitMaintenanceTask(
                                     "Capture Source",
                                     () -> SourceCaptureUtil.captureSourceForCodeUnit(constructorCu, cm)));
                         }
@@ -667,10 +667,10 @@ public class PreviewTextPanel extends JPanel implements ThemeAware, EditorFontSi
                     }
 
                     if (usagesAvailable) {
-                        usageItem.addActionListener(action -> cm.submitBackgroundTask(
+                        usageItem.addActionListener(action -> cm.submitMaintenanceTask(
                                 "Capture Usages", () -> cm.usageForIdentifier(codeUnit.fqName(), true)));
                         if (constructorUsageItem != null) {
-                            constructorUsageItem.addActionListener(action -> cm.submitBackgroundTask(
+                            constructorUsageItem.addActionListener(action -> cm.submitMaintenanceTask(
                                     "Capture Usages",
                                     () -> cm.usageForIdentifier(codeUnit.fqName() + "." + identifier, true)));
                         }
@@ -772,7 +772,7 @@ public class PreviewTextPanel extends JPanel implements ThemeAware, EditorFontSi
         // Only try to get symbols if we have a file and its corresponding fragment is a PathFragment
         if (file != null) {
             // Submit the task to fetch symbols in the background
-            symbolsFuture = cm.submitBackgroundTask("Fetch File Symbols", () -> {
+            symbolsFuture = cm.submitMaintenanceTask("Fetch File Symbols", () -> {
                 var analyzer = cm.getAnalyzerUninterrupted();
                 return analyzer.getSymbols(analyzer.getDeclarations(file));
             });

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -1212,7 +1212,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         this.balanceField.setText("Loading...");
         var contextManager = chrome.getContextManager();
         var models = contextManager.getService();
-        contextManager.submitBackgroundTask("Refreshing user balance", () -> {
+        contextManager.submitMaintenanceTask("Refreshing user balance", () -> {
             try {
                 float balance = models.getUserBalance();
                 SwingUtilities.invokeLater(() -> this.balanceField.setText(String.format("$%.2f", balance)));
@@ -2301,7 +2301,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
             return;
         }
 
-        chrome.getContextManager().submitBackgroundTask("Disconnecting OpenAI", () -> {
+        chrome.getContextManager().submitMaintenanceTask("Disconnecting OpenAI", () -> {
             String error = Service.disconnectCodexOauth();
             SwingUtilities.invokeLater(() -> {
                 if (error == null) {

--- a/app/src/main/java/ai/brokk/gui/git/GitCommitBrowserPanel.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitCommitBrowserPanel.java
@@ -1158,7 +1158,7 @@ public class GitCommitBrowserPanel extends JPanel implements SettingsChangeListe
             return;
         }
 
-        contextManager.submitBackgroundTask("Fetching changes for commits", () -> {
+        contextManager.submitMaintenanceTask("Fetching changes for commits", () -> {
             var allChangedFiles = commits.stream()
                     .flatMap((ICommitInfo ci) -> safeChangedFiles(getRepo(), ci))
                     .collect(Collectors.toSet());
@@ -1281,7 +1281,7 @@ public class GitCommitBrowserPanel extends JPanel implements SettingsChangeListe
     }
 
     private void loadStashesInPanel() {
-        contextManager.submitBackgroundTask("Fetching stashes", () -> {
+        contextManager.submitMaintenanceTask("Fetching stashes", () -> {
             try {
                 var stashes = getRepo().listStashes();
                 setCommits(stashes, Collections.emptySet(), false, false, STASHES_VIRTUAL_BRANCH);
@@ -1298,7 +1298,7 @@ public class GitCommitBrowserPanel extends JPanel implements SettingsChangeListe
     }
 
     private void loadCommitsForBranchInPanel(String branchName) {
-        contextManager.submitBackgroundTask("Fetching commits and state for " + branchName, () -> {
+        contextManager.submitMaintenanceTask("Fetching commits and state for " + branchName, () -> {
             try {
                 var commits = getRepo().listCommitsDetailed(branchName);
                 // branchName here is guaranteed not to be STASHES_VIRTUAL_BRANCH or starting with "Search:"
@@ -1367,7 +1367,7 @@ public class GitCommitBrowserPanel extends JPanel implements SettingsChangeListe
     }
 
     private void searchCommitsInPanel(String query) {
-        contextManager.submitBackgroundTask("Searching commits for: " + query, () -> {
+        contextManager.submitMaintenanceTask("Searching commits for: " + query, () -> {
             try {
                 var searchResults = getRepo().searchCommits(query);
                 // For search results, unpushed status and push/pull buttons are less relevant,

--- a/app/src/main/java/ai/brokk/gui/git/GitHistoryTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitHistoryTab.java
@@ -134,7 +134,7 @@ public class GitHistoryTab extends JPanel {
             viewDiffItem.setEnabled(single);
             viewInLogItem.setEnabled(single);
 
-            contextManager.submitBackgroundTask("Determining files in context", () -> {
+            contextManager.submitMaintenanceTask("Determining files in context", () -> {
                 var files = contextManager.getFilesInContext(); // blocking
                 SwingUtilities.invokeLater(() -> {
                     if (single) {
@@ -208,7 +208,7 @@ public class GitHistoryTab extends JPanel {
     }
 
     private void loadFileHistory() {
-        contextManager.submitBackgroundTask("Loading file history: " + file, () -> {
+        contextManager.submitMaintenanceTask("Loading file history: " + file, () -> {
             try {
                 var history = getRepo().getFileHistoryWithPaths(file);
                 SwingUtilities.invokeLater(() -> {

--- a/app/src/main/java/ai/brokk/gui/git/GitIssuesTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitIssuesTab.java
@@ -156,7 +156,7 @@ public class GitIssuesTab extends JPanel implements SettingsChangeListener, Them
         this.currentDescriptionFuture = null;
 
         // Load dynamic statuses after issueService and statusFilter are initialized
-        var future = contextManager.submitBackgroundTask("Load Available Issue Statuses", () -> {
+        var future = contextManager.submitMaintenanceTask("Load Available Issue Statuses", () -> {
             List<String> fetchedStatuses = null;
             try {
                 // Ensure issueService is available
@@ -816,7 +816,7 @@ public class GitIssuesTab extends JPanel implements SettingsChangeListener, Them
         issueBodyTextPane.setText(
                 "<html><body><p><i>Loading description for " + header.id() + "...</i></p></body></html>");
 
-        var future = contextManager.submitBackgroundTask("Fetching/Rendering Issue Details for " + header.id(), () -> {
+        var future = contextManager.submitMaintenanceTask("Fetching/Rendering Issue Details for " + header.id(), () -> {
             try {
                 IssueDetails details = issueService.loadDetails(header.id());
                 String htmlBody = details.htmlBody();
@@ -888,7 +888,7 @@ public class GitIssuesTab extends JPanel implements SettingsChangeListener, Them
             issueTableModel.setRowCount(0);
         });
 
-        currentSearchFuture = contextManager.submitBackgroundTask("Fetching GitHub Issues", () -> {
+        currentSearchFuture = contextManager.submitMaintenanceTask("Fetching GitHub Issues", () -> {
             try {
                 // Read filter values
                 final String currentSearchQuery = searchBox.getText().strip();
@@ -1062,7 +1062,7 @@ public class GitIssuesTab extends JPanel implements SettingsChangeListener, Them
         loadMoreButton.setEnabled(false);
         searchBox.setLoading(true, "Loading more issues...");
 
-        var future = contextManager.submitBackgroundTask("Loading more issues", () -> {
+        var future = contextManager.submitMaintenanceTask("Loading more issues", () -> {
             try {
                 var result =
                         StreamingPaginationHelper.loadPrebatchedBatch(iterator, StreamingPaginationHelper.BATCH_SIZE);
@@ -1353,7 +1353,7 @@ public class GitIssuesTab extends JPanel implements SettingsChangeListener, Them
         }
         IssueHeader header = displayedIssues.get(selectedRow);
 
-        var future = contextManager.submitBackgroundTask("Fetching issue details for copy: " + header.id(), () -> {
+        var future = contextManager.submitMaintenanceTask("Fetching issue details for copy: " + header.id(), () -> {
             try {
                 IssueDetails details = issueService.loadDetails(header.id());
                 String body = details.markdownBody();

--- a/app/src/main/java/ai/brokk/gui/git/GitLogTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitLogTab.java
@@ -305,7 +305,7 @@ public class GitLogTab extends JPanel implements ThemeAware {
             // Immediate visual feedback
             fetchButton.setLoading(true, "Fetching…");
 
-            contextManager.submitBackgroundTask("Fetching all remotes", () -> {
+            contextManager.submitMaintenanceTask("Fetching all remotes", () -> {
                 try {
                     var pm = new IoProgressMonitor(contextManager.getIo());
                     // network call
@@ -323,7 +323,7 @@ public class GitLogTab extends JPanel implements ThemeAware {
                         requestUpdate(); // local rescan
                     });
                 }
-                return null; // submitBackgroundTask expects a Callable result
+                return null; // submitMaintenanceTask expects a Callable result
             });
         });
 
@@ -369,7 +369,7 @@ public class GitLogTab extends JPanel implements ThemeAware {
                 // Then check/fetch in background and refresh if updates found
                 var ref = RemoteBranchRef.parse(branchName);
                 if (ref != null) {
-                    contextManager.submitBackgroundTask("Checking " + branchName, () -> {
+                    contextManager.submitMaintenanceTask("Checking " + branchName, () -> {
                         try {
                             if (getRepo().remote().branchNeedsFetch(ref.remoteName(), ref.branchName())) {
                                 logger.info(
@@ -668,7 +668,7 @@ public class GitLogTab extends JPanel implements ThemeAware {
                 },
                 "");
 
-        contextManager.submitBackgroundTask("Fetching git branches", () -> {
+        contextManager.submitMaintenanceTask("Fetching git branches", () -> {
             try {
                 String currentGitBranch = getRepo().getCurrentBranch(); // Get current branch from Git
                 List<String> localBranches = getRepo().listLocalBranches();
@@ -795,7 +795,7 @@ public class GitLogTab extends JPanel implements ThemeAware {
 
     /** Update commits list for the given branch and highlights unpushed commits if applicable. */
     private void updateCommitsForBranch(String branchName) {
-        contextManager.submitBackgroundTask("Fetching commits for " + branchName, () -> {
+        contextManager.submitMaintenanceTask("Fetching commits for " + branchName, () -> {
             try {
                 List<CommitInfo> commits;
                 Set<String> unpushedCommitIds = new HashSet<>();
@@ -1353,7 +1353,7 @@ public class GitLogTab extends JPanel implements ThemeAware {
 
     /** Selects the current branch in the branch table. Called after PR checkout to highlight the new branch. */
     public void selectCurrentBranch() {
-        contextManager.submitBackgroundTask("Finding current branch", () -> {
+        contextManager.submitMaintenanceTask("Finding current branch", () -> {
             try {
                 var currentBranch = getRepo().getCurrentBranch();
                 SwingUtilities.invokeLater(() -> {

--- a/app/src/main/java/ai/brokk/gui/git/GitPullRequestsTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitPullRequestsTab.java
@@ -1398,7 +1398,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
         }
 
         activeCiFetcher = new CiStatusFetcherWorker(prsRequiringCiFetch);
-        contextManager.getBackgroundTasks().submit(activeCiFetcher);
+        contextManager.getMaintenanceTasks().submit(activeCiFetcher);
     }
 
     private class PrFilesFetcherWorker extends ExceptionAwareSwingWorker<Map<Integer, List<String>>, Void> {
@@ -2067,7 +2067,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
                 }
             }
         };
-        contextManager.getBackgroundTasks().submit(activePrFilesFetcher);
+        contextManager.getMaintenanceTasks().submit(activePrFilesFetcher);
     }
 
     /**

--- a/app/src/main/java/ai/brokk/gui/git/GitPullRequestsTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitPullRequestsTab.java
@@ -1398,7 +1398,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
         }
 
         activeCiFetcher = new CiStatusFetcherWorker(prsRequiringCiFetch);
-        contextManager.getMaintenanceTasks().submit(activeCiFetcher);
+        contextManager.submitMaintenanceTask("Fetching CI status", activeCiFetcher);
     }
 
     private class PrFilesFetcherWorker extends ExceptionAwareSwingWorker<Map<Integer, List<String>>, Void> {
@@ -2067,7 +2067,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
                 }
             }
         };
-        contextManager.getMaintenanceTasks().submit(activePrFilesFetcher);
+        contextManager.submitMaintenanceTask("Fetching PR files", activePrFilesFetcher);
     }
 
     /**

--- a/app/src/main/java/ai/brokk/gui/git/GitPullRequestsTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitPullRequestsTab.java
@@ -495,7 +495,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
                     viewPrDiffButton.setEnabled(singlePrSelected);
                     updatePrTableContextMenuState();
 
-                    this.contextManager.submitBackgroundTask("Updating PR #" + prNumber + " local status", () -> {
+                    this.contextManager.submitMaintenanceTask("Updating PR #" + prNumber + " local status", () -> {
                         SwingUtilities.invokeLater(() -> {
                             int currentRow = prTable.getSelectedRow();
                             if (currentRow != -1
@@ -803,7 +803,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
                     }
 
                     if (!futuresToCancelAndAwait.isEmpty()) {
-                        contextManager.submitBackgroundTask("Finalizing cancellations and refreshing PR data", () -> {
+                        contextManager.submitMaintenanceTask("Finalizing cancellations and refreshing PR data", () -> {
                             for (Future<?> f : futuresToCancelAndAwait) {
                                 try {
                                     f.get();
@@ -844,7 +844,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
                     }
 
                     if (!futuresToCancelAndAwait.isEmpty()) {
-                        contextManager.submitBackgroundTask("Finalizing cancellations and refreshing PR data", () -> {
+                        contextManager.submitMaintenanceTask("Finalizing cancellations and refreshing PR data", () -> {
                             for (Future<?> f : futuresToCancelAndAwait) {
                                 try {
                                     f.get();
@@ -1017,7 +1017,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
         labelChoices.clear();
         assigneeChoices.clear();
 
-        var future = contextManager.submitBackgroundTask("Fetching GitHub Pull Requests", () -> {
+        var future = contextManager.submitMaintenanceTask("Fetching GitHub Pull Requests", () -> {
             try {
                 var project = contextManager.getProject();
                 GitHubAuth auth = GitHubAuth.getOrCreateInstance(project);
@@ -1108,7 +1108,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
         loadMoreButton.setEnabled(false);
         refreshPrButton.setToolTipText("Loading more PRs...");
 
-        var future = contextManager.submitBackgroundTask("Loading more PRs", () -> {
+        var future = contextManager.submitMaintenanceTask("Loading more PRs", () -> {
             try {
                 var result = StreamingPaginationHelper.loadBatch(iterator, StreamingPaginationHelper.BATCH_SIZE);
 
@@ -1635,7 +1635,7 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
         prCommitsTableModel.setRowCount(0);
         prCommitsTableModel.addRow(new Object[] {"Loading commits..."});
 
-        var future = contextManager.submitBackgroundTask("Fetching commits for PR #" + prNumber, () -> {
+        var future = contextManager.submitMaintenanceTask("Fetching commits for PR #" + prNumber, () -> {
             List<ICommitInfo> newCommitList = new ArrayList<>();
             try {
                 var project = contextManager.getProject();

--- a/app/src/main/java/ai/brokk/gui/git/GitPullRequestsTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitPullRequestsTab.java
@@ -12,7 +12,6 @@ import ai.brokk.git.ICommitInfo;
 import ai.brokk.git.IGitRepo.ModificationType;
 import ai.brokk.gui.Chrome;
 import ai.brokk.gui.Constants;
-import ai.brokk.gui.ExceptionAwareSwingWorker;
 import ai.brokk.gui.FilterBox;
 import ai.brokk.gui.PrTitleFormatter;
 import ai.brokk.gui.components.GitHubTokenMissingPanel;
@@ -45,8 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -136,10 +135,10 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
     private boolean isShowingError = false;
 
     @Nullable
-    private SwingWorker<Map<Integer, String>, Void> activeCiFetcher;
+    private CompletableFuture<Map<Integer, String>> activeCiFetcher;
 
     @Nullable
-    private SwingWorker<Map<Integer, List<String>>, Void> activePrFilesFetcher;
+    private CompletableFuture<Map<Integer, List<String>>> activePrFilesFetcher;
 
     // Store default options for static filters to easily reset them
     private static final List<String> STATUS_FILTER_OPTIONS = List.of("Open", "Closed"); // "All" is null selection
@@ -1307,81 +1306,34 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
         fetchCiStatusesForDisplayedPrs();
     }
 
-    private class CiStatusFetcherWorker extends ExceptionAwareSwingWorker<Map<Integer, String>, Void> {
-        private final List<GHPullRequest> prsToFetch;
-
-        public CiStatusFetcherWorker(List<GHPullRequest> prsToFetch) {
-            super(chrome);
-            this.prsToFetch = prsToFetch;
-        }
-
-        @Override
-        protected Map<Integer, String> doInBackground() {
-            Map<Integer, String> fetchedStatuses = new HashMap<>();
-            for (GHPullRequest prToFetch : prsToFetch) {
-                if (isCancelled()) {
-                    break;
-                }
-                try {
-                    if (prToFetch.isMerged()) { // This can throw IOException
-                        fetchedStatuses.put(prToFetch.getNumber(), "Merged");
-                    } else {
-                        String status = getCiStatus(prToFetch); // This can throw IOException
-                        fetchedStatuses.put(prToFetch.getNumber(), status);
-                    }
-                } catch (IOException e) {
-                    logger.warn(
-                            "Failed to get status (merged/CI) for PR #{} due to IOException: {}",
-                            prToFetch.getNumber(),
-                            e);
-                    fetchedStatuses.put(prToFetch.getNumber(), "Err");
-                }
+    private Map<Integer, String> fetchCiStatuses(List<GHPullRequest> prsToFetch) {
+        Map<Integer, String> fetchedStatuses = new HashMap<>();
+        for (var prToFetch : prsToFetch) {
+            if (Thread.currentThread().isInterrupted()) {
+                break;
             }
-            return fetchedStatuses;
-        }
-
-        @Override
-        protected void done() {
-            if (isCancelled()) {
-                logger.debug("CI status fetch worker cancelled.");
-                return;
-            }
-            // Centralized exception handling
-            super.done();
-
-            Map<Integer, String> newStatuses;
             try {
-                newStatuses = get();
-            } catch (InterruptedException | ExecutionException ignored) {
-                // Already handled by ExceptionAwareSwingWorker.done()
-                return;
-            }
-
-            ciStatusCache.putAll(newStatuses);
-
-            // Update the table model with new CI statuses
-            for (int i = 0; i < prTableModel.getRowCount(); i++) {
-                Object prNumCellObj = prTableModel.getValueAt(i, PR_COL_NUMBER);
-                if (prNumCellObj instanceof String prNumCell && prNumCell.startsWith("#")) {
-                    try {
-                        int prNumberInTable = Integer.parseInt(prNumCell.substring(1));
-                        if (newStatuses.containsKey(prNumberInTable)) {
-                            prTableModel.setValueAt(newStatuses.get(prNumberInTable), i, PR_COL_STATUS);
-                        }
-                    } catch (NumberFormatException nfe) {
-                        logger.trace("Skipping Status update for non-PR row in table: {}", prNumCell);
-                    }
+                if (prToFetch.isMerged()) {
+                    fetchedStatuses.put(prToFetch.getNumber(), "Merged");
+                } else {
+                    var status = getCiStatus(prToFetch);
+                    fetchedStatuses.put(prToFetch.getNumber(), status);
                 }
+            } catch (IOException e) {
+                logger.warn(
+                        "Failed to get status (merged/CI) for PR #{} due to IOException: {}", prToFetch.getNumber(), e);
+                fetchedStatuses.put(prToFetch.getNumber(), "Err");
             }
         }
+        return fetchedStatuses;
     }
 
     private void fetchCiStatusesForDisplayedPrs() {
         assert SwingUtilities.isEventDispatchThread();
 
         List<GHPullRequest> prsRequiringCiFetch = new ArrayList<>();
-        for (GHPullRequest pr : displayedPrs) {
-            String currentStatusInCache = ciStatusCache.get(pr.getNumber());
+        for (var pr : displayedPrs) {
+            var currentStatusInCache = ciStatusCache.get(pr.getNumber());
             if (currentStatusInCache == null
                     || "?".equals(currentStatusInCache)
                     || "...".equals(currentStatusInCache)
@@ -1397,143 +1349,116 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
             activeCiFetcher.cancel(true);
         }
 
-        activeCiFetcher = new CiStatusFetcherWorker(prsRequiringCiFetch);
-        contextManager.submitMaintenanceTask("Fetching CI status", activeCiFetcher);
-    }
-
-    private class PrFilesFetcherWorker extends ExceptionAwareSwingWorker<Map<Integer, List<String>>, Void> {
-        private final List<GHPullRequest> prsToFetchFilesFor;
-        private final IProject project;
-
-        public PrFilesFetcherWorker(List<GHPullRequest> prsToFetchFilesFor, IProject project) {
-            super(chrome);
-            this.prsToFetchFilesFor = prsToFetchFilesFor;
-            this.project = project;
-        }
-
-        @Override
-        protected Map<Integer, List<String>> doInBackground() {
-            Map<Integer, List<String>> fetchedFilesMap = new HashMap<>();
-            var repo = getRepo();
-
-            for (GHPullRequest pr : prsToFetchFilesFor) {
-                if (isCancelled()) break;
-                try {
-                    String headSha = pr.getHead().getSha();
-                    String baseSha = pr.getBase().getSha();
-                    int prNumber = pr.getNumber();
-                    boolean headLocallyAvailable;
-                    boolean baseLocallyAvailable;
-
-                    GitHubAuth auth;
+        activeCiFetcher =
+                contextManager.submitMaintenanceTask("Fetching CI status", () -> fetchCiStatuses(prsRequiringCiFetch));
+        activeCiFetcher.thenAccept(newStatuses -> SwingUtilities.invokeLater(() -> {
+            ciStatusCache.putAll(newStatuses);
+            for (int i = 0; i < prTableModel.getRowCount(); i++) {
+                var prNumCellObj = prTableModel.getValueAt(i, PR_COL_NUMBER);
+                if (prNumCellObj instanceof String prNumCell && prNumCell.startsWith("#")) {
                     try {
-                        auth = GitHubAuth.getOrCreateInstance(this.project);
-                    } catch (IOException e) {
-                        logger.warn(
-                                "Failed to get GitHubAuth instance in PrFilesFetcherWorker for PR #{}: {}",
-                                prNumber,
-                                e.getMessage(),
-                                e);
-                        throw new RuntimeException(
-                                "Failed to initialize GitHubAuth for PR #" + prNumber + ": " + e.getMessage(), e);
-                    }
-
-                    // Ensure head SHA is available
-                    String headFetchRefSpec =
-                            String.format("+refs/pull/%d/head:refs/remotes/origin/pr/%d/head", prNumber, prNumber);
-                    headLocallyAvailable = GitHostUtil.ensureShaIsLocal(repo, headSha, headFetchRefSpec, "origin");
-
-                    if (!headLocallyAvailable) {
-                        // If direct PR head fetch fails, try fetching the source branch if it's from origin
-                        if (pr.getHead()
-                                .getRepository()
-                                .getFullName()
-                                .equals(auth.getOwner() + "/" + auth.getRepoName())) {
-                            String headBranchName = pr.getHead()
-                                    .getRef(); // e.g., "feature/my-branch" or "refs/heads/feature/my-branch"
-                            if (headBranchName.startsWith("refs/heads/"))
-                                headBranchName = headBranchName.substring("refs/heads/".length());
-                            String headBranchFetchRefSpec = String.format(
-                                    "+refs/heads/%s:refs/remotes/origin/%s", headBranchName, headBranchName);
-                            headLocallyAvailable =
-                                    GitHostUtil.ensureShaIsLocal(repo, headSha, headBranchFetchRefSpec, "origin");
-                        } else {
-                            logger.warn(
-                                    "PR #{} head {} is from a fork. Initial fetch failed and advanced fork fetching not yet implemented in PrFilesFetcherWorker.",
-                                    prNumber,
-                                    repo.shortHash(headSha));
-                            // headLocallyAvailable remains the result of the first ensureShaIsLocal attempt
+                        int prNumberInTable = Integer.parseInt(prNumCell.substring(1));
+                        if (newStatuses.containsKey(prNumberInTable)) {
+                            prTableModel.setValueAt(newStatuses.get(prNumberInTable), i, PR_COL_STATUS);
                         }
+                    } catch (NumberFormatException nfe) {
+                        logger.trace("Skipping Status update for non-PR row in table: {}", prNumCell);
                     }
-
-                    // Ensure base SHA is available
-                    String baseBranchName = pr.getBase().getRef(); // e.g. "main"
-                    String baseFetchRefSpec =
-                            String.format("+refs/heads/%s:refs/remotes/origin/%s", baseBranchName, baseBranchName);
-                    baseLocallyAvailable = GitHostUtil.ensureShaIsLocal(repo, baseSha, baseFetchRefSpec, "origin");
-
-                    if (headLocallyAvailable && baseLocallyAvailable) {
-                        List<String> changedFiles;
-                        try {
-                            // Always use the PR's base SHA for diffing, which represents the exact
-                            // commit the PR was created from. This ensures we only show files that
-                            // actually changed in the PR, not additional changes in the target branch.
-                            String mergeBase = repo.getMergeBase(headSha, baseSha);
-
-                            if (mergeBase != null) {
-                                changedFiles = repo.listFilesChangedBetweenCommits(mergeBase, headSha).stream()
-                                        .map(mf -> mf.file().toString())
-                                        .collect(Collectors.toList());
-                            } else {
-                                // Fallback to direct diff if merge base calculation fails
-                                changedFiles = repo.listFilesChangedBetweenCommits(baseSha, headSha).stream()
-                                        .map(mf -> mf.file().toString())
-                                        .collect(Collectors.toList());
-                            }
-                        } catch (Exception e) {
-                            logger.warn(
-                                    "Error calculating changed files for PR #{}, using fallback diff: {}",
-                                    prNumber,
-                                    e.getMessage());
-                            changedFiles = repo.listFilesChangedBetweenCommits(baseSha, headSha).stream()
-                                    .map(mf -> mf.file().toString())
-                                    .collect(Collectors.toList());
-                        }
-                        fetchedFilesMap.put(prNumber, changedFiles);
-                    } else {
-                        String missingShasMsg = "";
-                        if (!headLocallyAvailable) missingShasMsg += "head (" + repo.shortHash(headSha) + ")";
-                        if (!baseLocallyAvailable) {
-                            if (!missingShasMsg.isEmpty()) missingShasMsg += " and ";
-                            missingShasMsg += "base (" + repo.shortHash(baseSha) + ")";
-                        }
-                        logger.warn(
-                                "Could not make {} SHA(s) for PR #{} fully available locally to list files.",
-                                missingShasMsg,
-                                prNumber);
-                        fetchedFilesMap.put(
-                                prNumber,
-                                List.of(
-                                        "Error: Could not make required SHAs locally available. Ensure refs are fetched."));
-                    }
-                } catch (Exception e) {
-                    logger.error("Error fetching or processing files for PR #{}", pr.getNumber(), e);
-                    fetchedFilesMap.put(pr.getNumber(), List.of("Error fetching files: " + e.getMessage()));
                 }
             }
-            return fetchedFilesMap;
-        }
+        }));
+    }
 
-        @Override
-        protected void done() {
-            if (isCancelled()) {
-                logger.debug("PR files fetcher worker cancelled.");
-                return;
+    private Map<Integer, List<String>> fetchPrFiles(List<GHPullRequest> prsToFetchFilesFor, IProject project) {
+        Map<Integer, List<String>> fetchedFilesMap = new HashMap<>();
+        var repo = getRepo();
+
+        for (var pr : prsToFetchFilesFor) {
+            if (Thread.currentThread().isInterrupted()) break;
+            try {
+                var headSha = pr.getHead().getSha();
+                var baseSha = pr.getBase().getSha();
+                int prNumber = pr.getNumber();
+                boolean headLocallyAvailable;
+                boolean baseLocallyAvailable;
+
+                GitHubAuth auth;
+                try {
+                    auth = GitHubAuth.getOrCreateInstance(project);
+                } catch (IOException e) {
+                    logger.warn("Failed to get GitHubAuth instance for PR #{}: {}", prNumber, e.getMessage(), e);
+                    throw new RuntimeException(
+                            "Failed to initialize GitHubAuth for PR #" + prNumber + ": " + e.getMessage(), e);
+                }
+
+                // Ensure head SHA is available
+                var headFetchRefSpec =
+                        String.format("+refs/pull/%d/head:refs/remotes/origin/pr/%d/head", prNumber, prNumber);
+                headLocallyAvailable = GitHostUtil.ensureShaIsLocal(repo, headSha, headFetchRefSpec, "origin");
+
+                if (!headLocallyAvailable) {
+                    // If direct PR head fetch fails, try fetching the source branch if it's from origin
+                    if (pr.getHead().getRepository().getFullName().equals(auth.getOwner() + "/" + auth.getRepoName())) {
+                        var headBranchName = pr.getHead().getRef();
+                        if (headBranchName.startsWith("refs/heads/"))
+                            headBranchName = headBranchName.substring("refs/heads/".length());
+                        var headBranchFetchRefSpec =
+                                String.format("+refs/heads/%s:refs/remotes/origin/%s", headBranchName, headBranchName);
+                        headLocallyAvailable =
+                                GitHostUtil.ensureShaIsLocal(repo, headSha, headBranchFetchRefSpec, "origin");
+                    } else {
+                        logger.warn(
+                                "PR #{} head {} is from a fork. Initial fetch failed and advanced fork fetching not yet implemented.",
+                                prNumber,
+                                repo.shortHash(headSha));
+                    }
+                }
+
+                // Ensure base SHA is available
+                var baseBranchName = pr.getBase().getRef();
+                var baseFetchRefSpec =
+                        String.format("+refs/heads/%s:refs/remotes/origin/%s", baseBranchName, baseBranchName);
+                baseLocallyAvailable = GitHostUtil.ensureShaIsLocal(repo, baseSha, baseFetchRefSpec, "origin");
+
+                if (headLocallyAvailable && baseLocallyAvailable) {
+                    List<String> changedFiles;
+                    try {
+                        var mergeBase = repo.getMergeBase(headSha, baseSha);
+                        var diffBase = (mergeBase != null) ? mergeBase : baseSha;
+                        changedFiles = repo.listFilesChangedBetweenCommits(diffBase, headSha).stream()
+                                .map(mf -> mf.file().toString())
+                                .collect(Collectors.toList());
+                    } catch (Exception e) {
+                        logger.warn(
+                                "Error calculating changed files for PR #{}, using fallback diff: {}",
+                                prNumber,
+                                e.getMessage());
+                        changedFiles = repo.listFilesChangedBetweenCommits(baseSha, headSha).stream()
+                                .map(mf -> mf.file().toString())
+                                .collect(Collectors.toList());
+                    }
+                    fetchedFilesMap.put(prNumber, changedFiles);
+                } else {
+                    var missingShasMsg = "";
+                    if (!headLocallyAvailable) missingShasMsg += "head (" + repo.shortHash(headSha) + ")";
+                    if (!baseLocallyAvailable) {
+                        if (!missingShasMsg.isEmpty()) missingShasMsg += " and ";
+                        missingShasMsg += "base (" + repo.shortHash(baseSha) + ")";
+                    }
+                    logger.warn(
+                            "Could not make {} SHA(s) for PR #{} fully available locally to list files.",
+                            missingShasMsg,
+                            prNumber);
+                    fetchedFilesMap.put(
+                            prNumber,
+                            List.of("Error: Could not make required SHAs locally available. Ensure refs are fetched."));
+                }
+            } catch (Exception e) {
+                logger.error("Error fetching or processing files for PR #{}", pr.getNumber(), e);
+                fetchedFilesMap.put(pr.getNumber(), List.of("Error fetching files: " + e.getMessage()));
             }
-
-            // Centralized exception handling
-            super.done();
         }
+        return fetchedFilesMap;
     }
 
     @Nullable
@@ -2028,46 +1953,34 @@ public class GitPullRequestsTab extends JPanel implements SettingsChangeListener
             activePrFilesFetcher.cancel(true);
         }
 
-        activePrFilesFetcher = new PrFilesFetcherWorker(List.of(pr), contextManager.getProject()) {
-            @Override
-            protected void done() {
-                if (isCancelled()) {
-                    logger.debug("PR files fetcher worker cancelled.");
-                    return;
-                }
-                try {
-                    Map<Integer, List<String>> newFilesData = get();
-                    // Update the files table directly for the fetched PR
-                    List<String> files = newFilesData.get(pr.getNumber());
-                    SwingUtilities.invokeLater(() -> {
-                        // Only update if this PR is still selected
-                        int selectedRow = prTable.getSelectedRow();
-                        if (selectedRow >= 0
-                                && selectedRow < displayedPrs.size()
-                                && displayedPrs.get(selectedRow).getNumber() == pr.getNumber()) {
-                            prFilesTableModel.setRowCount(0);
-                            if (files == null || files.isEmpty()) {
-                                prFilesTableModel.addRow(new Object[] {"No files changed in this PR"});
+        var project = contextManager.getProject();
+        activePrFilesFetcher =
+                contextManager.submitMaintenanceTask("Fetching PR files", () -> fetchPrFiles(List.of(pr), project));
+        activePrFilesFetcher.thenAccept(newFilesData -> {
+            var files = newFilesData.get(pr.getNumber());
+            SwingUtilities.invokeLater(() -> {
+                // Only update if this PR is still selected
+                int selectedRow = prTable.getSelectedRow();
+                if (selectedRow >= 0
+                        && selectedRow < displayedPrs.size()
+                        && displayedPrs.get(selectedRow).getNumber() == pr.getNumber()) {
+                    prFilesTableModel.setRowCount(0);
+                    if (files == null || files.isEmpty()) {
+                        prFilesTableModel.addRow(new Object[] {"No files changed in this PR"});
+                    } else {
+                        for (var file : files) {
+                            if (file.startsWith("Error:")) {
+                                prFilesTableModel.addRow(new Object[] {file});
                             } else {
-                                for (String file : files) {
-                                    if (file.startsWith("Error:")) {
-                                        prFilesTableModel.addRow(new Object[] {file});
-                                    } else {
-                                        // Format as "<file name> - full file path"
-                                        String fileName = file.substring(file.lastIndexOf('/') + 1);
-                                        String displayText = fileName + " - " + file;
-                                        prFilesTableModel.addRow(new Object[] {displayText});
-                                    }
-                                }
+                                var fileName = file.substring(file.lastIndexOf('/') + 1);
+                                var displayText = fileName + " - " + file;
+                                prFilesTableModel.addRow(new Object[] {displayText});
                             }
                         }
-                    });
-                } catch (InterruptedException | ExecutionException e) {
-                    throw new RuntimeException(e);
+                    }
                 }
-            }
-        };
-        contextManager.submitMaintenanceTask("Fetching PR files", activePrFilesFetcher);
+            });
+        });
     }
 
     /**

--- a/app/src/main/java/ai/brokk/gui/git/GitWorktreeTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitWorktreeTab.java
@@ -430,7 +430,7 @@ public class GitWorktreeTab extends JPanel {
 
                     int choice = dialogFuture.get();
                     if (choice == JOptionPane.YES_OPTION) {
-                        contextManager.submitBackgroundTask("Pruning stale worktrees", () -> {
+                        contextManager.submitMaintenanceTask("Pruning stale worktrees", () -> {
                             try {
                                 gitRepo.worktrees().pruneWorktrees();
                                 chrome.showNotification(

--- a/app/src/main/java/ai/brokk/gui/menu/ContextMenuBuilder.java
+++ b/app/src/main/java/ai/brokk/gui/menu/ContextMenuBuilder.java
@@ -412,7 +412,7 @@ public class ContextMenuBuilder {
         logger.info("Open in preview for symbol: {}", context.symbolName());
 
         var symbolName = context.symbolName();
-        context.contextManager().submitBackgroundTask("Open in preview for " + symbolName, () -> {
+        context.contextManager().submitMaintenanceTask("Open in preview for " + symbolName, () -> {
             var definition = findSymbolDefinition(context);
             definition.ifPresent(codeUnit -> openPreview(codeUnit, context));
         });
@@ -422,7 +422,7 @@ public class ContextMenuBuilder {
         logger.info("Open in project tree for symbol: {}", context.symbolName());
 
         var symbolName = context.symbolName();
-        context.contextManager().submitBackgroundTask("Open in project tree for " + symbolName, () -> {
+        context.contextManager().submitMaintenanceTask("Open in project tree for " + symbolName, () -> {
             var definition = findSymbolDefinition(context);
             if (definition.isPresent()) {
                 var projectFile = definition.get().source();
@@ -484,7 +484,7 @@ public class ContextMenuBuilder {
     private void openPreview(CodeUnit symbol, SymbolMenuContext context) {
         logger.debug("Opening symbol in preview: {} in file: {}", symbol.fqName(), symbol.source());
 
-        context.contextManager().submitBackgroundTask("Open preview for " + symbol.fqName(), () -> {
+        context.contextManager().submitMaintenanceTask("Open preview for " + symbol.fqName(), () -> {
             SwingUtilities.invokeLater(() -> {
                 // Try to get the symbol's source range to position the preview
                 var analyzer = context.contextManager().getAnalyzerWrapper().getNonBlocking();
@@ -585,7 +585,7 @@ public class ContextMenuBuilder {
         }
 
         var fqn = context.fqn() != null ? context.fqn() : context.symbolName();
-        context.contextManager().submitBackgroundTask("Capture Source Code", () -> {
+        context.contextManager().submitMaintenanceTask("Capture Source Code", () -> {
             var definition = findSymbolDefinition(context);
             if (definition.isPresent()) {
                 SourceCaptureUtil.captureSourceForCodeUnit(definition.get(), context.contextManager());
@@ -617,7 +617,7 @@ public class ContextMenuBuilder {
         }
 
         var taskLabel = FileManagerUtil.fileManagerActionLabel();
-        context.contextManager().submitBackgroundTask(taskLabel, () -> {
+        context.contextManager().submitMaintenanceTask(taskLabel, () -> {
             try {
                 FileManagerUtil.revealPath(target);
             } catch (IOException | UnsupportedOperationException ex) {

--- a/app/src/main/java/ai/brokk/gui/mop/webview/MOPBridge.java
+++ b/app/src/main/java/ai/brokk/gui/mop/webview/MOPBridge.java
@@ -434,7 +434,7 @@ public final class MOPBridge {
         }
 
         // Use Chrome's background task system instead of raw ai.brokk.concurrent.LoggingFuture.supplyAsync()
-        contextManager.submitBackgroundTask("Symbol lookup for " + symbolNames.size() + " symbols", () -> {
+        contextManager.submitMaintenanceTask("Symbol lookup for " + symbolNames.size() + " symbols", () -> {
             // Assert background task is not running on EDT
             assert !SwingUtilities.isEventDispatchThread() : "Background task running on EDT";
 
@@ -518,7 +518,7 @@ public final class MOPBridge {
         }
 
         // Use Chrome's background task system for file path lookup
-        contextManager.submitBackgroundTask("File path lookup for " + filePaths.size() + " paths", () -> {
+        contextManager.submitMaintenanceTask("File path lookup for " + filePaths.size() + " paths", () -> {
             // Assert background task is not running on EDT
             assert !SwingUtilities.isEventDispatchThread() : "Background task running on EDT";
 

--- a/app/src/main/java/ai/brokk/gui/terminal/TerminalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/terminal/TerminalPanel.java
@@ -276,7 +276,7 @@ public class TerminalPanel extends JPanel implements ThemeAware {
                 final var p1 = selStart;
                 final var p2 = selEnd;
                 future = c.getContextManager()
-                        .submitBackgroundTask(
+                        .submitMaintenanceTask(
                                 "Capturing terminal selection", () -> finalDisplay.getSelectionText(p1, p2));
             } else {
                 if (displayPanel == null) {
@@ -287,7 +287,7 @@ public class TerminalPanel extends JPanel implements ThemeAware {
 
                 final var finalDisplay = displayPanel;
                 future = c.getContextManager()
-                        .submitBackgroundTask("Capturing terminal buffer", finalDisplay::getFullBufferText);
+                        .submitMaintenanceTask("Capturing terminal buffer", finalDisplay::getFullBufferText);
             }
 
             future.thenAcceptAsync(this::submitCapturedContent, SwingUtilities::invokeLater)

--- a/app/src/main/java/ai/brokk/gui/util/FileDropHandlerFactory.java
+++ b/app/src/main/java/ai/brokk/gui/util/FileDropHandlerFactory.java
@@ -202,11 +202,11 @@ public final class FileDropHandlerFactory {
                             };
 
                             // Prefer ContextManager.submitContextTask when available for correct task scoping;
-                            // otherwise fall back to the generic submitBackgroundTask.
+                            // otherwise fall back to the generic submitMaintenanceTask.
                             if (cm instanceof ContextManager cmConcrete) {
                                 cmConcrete.submitContextTask(additionTask);
                             } else {
-                                cm.submitBackgroundTask("Add dropped files", additionTask);
+                                cm.submitMaintenanceTask("Add dropped files", additionTask);
                             }
                         } else if (decision == ContextSizeGuard.Decision.CANCELLED) {
                             io.showNotification(IConsoleIO.NotificationRole.INFO, "File addition cancelled");

--- a/app/src/main/java/ai/brokk/gui/util/GitDiffUiUtil.java
+++ b/app/src/main/java/ai/brokk/gui/util/GitDiffUiUtil.java
@@ -177,7 +177,7 @@ public interface GitDiffUiUtil {
         var dialogTitle = "Diff: " + file.getFileName() + " (" + shortCommitId + ")";
         var parentCommitId = commitId + "^";
 
-        cm.submitBackgroundTask("Loading history diff for " + file.getFileName(), () -> {
+        cm.submitMaintenanceTask("Loading history diff for " + file.getFileName(), () -> {
             try {
                 var parentContent = repo.getFileContent(parentCommitId, file);
                 var commitContent = repo.getFileContent(commitId, file);
@@ -202,7 +202,7 @@ public interface GitDiffUiUtil {
     static void viewFileAtRevision(ContextManager cm, Chrome chrome, String commitId, String filePath) {
         var repo = cm.getProject().getRepo();
 
-        cm.submitBackgroundTask("View file at revision", () -> {
+        cm.submitMaintenanceTask("View file at revision", () -> {
             var file = new ProjectFile(cm.getRoot(), filePath);
             try {
                 final String content = repo.getFileContent(commitId, file);
@@ -368,7 +368,7 @@ public interface GitDiffUiUtil {
         var repo = cm.getProject().getRepo();
         var file = new ProjectFile(cm.getRoot(), filePath);
 
-        cm.submitBackgroundTask("Loading compare-with-local for " + file.getFileName(), () -> {
+        cm.submitMaintenanceTask("Loading compare-with-local for " + file.getFileName(), () -> {
             // Figure out the base commit ID and title components
             String baseCommitId;
             String baseCommitTitle;
@@ -456,7 +456,7 @@ public interface GitDiffUiUtil {
     static void openCommitDiffPanel(ContextManager cm, Chrome chrome, ICommitInfo commitInfo) {
         var repo = (GitRepo) cm.getProject().getRepo();
 
-        cm.submitBackgroundTask("Opening diff for commit " + ((GitRepo) repo).shortHash(commitInfo.id()), () -> {
+        cm.submitMaintenanceTask("Opening diff for commit " + ((GitRepo) repo).shortHash(commitInfo.id()), () -> {
             try {
                 var files = CommitInfo.changedFiles(repo, commitInfo.id());
                 if (files.isEmpty()) {
@@ -498,7 +498,7 @@ public interface GitDiffUiUtil {
     static void openCommitDiffPanel(ContextManager cm, Chrome chrome, ICommitInfo commitInfo, String targetFileName) {
         var repo = (GitRepo) cm.getProject().getRepo();
 
-        cm.submitBackgroundTask("Opening diff for commit " + ((GitRepo) repo).shortHash(commitInfo.id()), () -> {
+        cm.submitMaintenanceTask("Opening diff for commit " + ((GitRepo) repo).shortHash(commitInfo.id()), () -> {
             try {
                 var files = CommitInfo.changedFiles(repo, commitInfo.id());
                 if (files.isEmpty()) {
@@ -554,7 +554,7 @@ public interface GitDiffUiUtil {
     }
 
     static void compareCommitToLocal(ContextManager contextManager, Chrome chrome, ICommitInfo commitInfo) {
-        contextManager.submitBackgroundTask("Comparing commit to local", () -> {
+        contextManager.submitMaintenanceTask("Comparing commit to local", () -> {
             var repo = (GitRepo) contextManager.getProject().getRepo();
             try {
                 var changedFiles = CommitInfo.changedFiles(repo, commitInfo.id());
@@ -777,7 +777,7 @@ public interface GitDiffUiUtil {
     static void openPrDiffPanel(ContextManager contextManager, Chrome chrome, GHPullRequest pr, String targetFileName) {
         String targetFilePath = extractFilePathFromDisplay(targetFileName);
 
-        contextManager.submitBackgroundTask("Opening PR diff", () -> {
+        contextManager.submitMaintenanceTask("Opening PR diff", () -> {
             try {
                 var repo = (GitRepo) contextManager.getProject().getRepo();
 

--- a/app/src/main/java/ai/brokk/gui/util/SourceCaptureUtil.java
+++ b/app/src/main/java/ai/brokk/gui/util/SourceCaptureUtil.java
@@ -21,7 +21,7 @@ public class SourceCaptureUtil {
      * @param contextManager The context manager to submit the task to
      */
     public static void captureSourceForCodeUnit(CodeUnit codeUnit, ContextManager contextManager) {
-        contextManager.submitBackgroundTask("Capture Source Code", () -> {
+        contextManager.submitMaintenanceTask("Capture Source Code", () -> {
             try {
                 var analyzer = contextManager.getAnalyzer();
                 contextManager.sourceCodeForCodeUnit(analyzer, codeUnit);

--- a/app/src/main/java/ai/brokk/util/BuildTools.java
+++ b/app/src/main/java/ai/brokk/util/BuildTools.java
@@ -108,7 +108,7 @@ public class BuildTools {
     }
 
     public static CompletableFuture<@Nullable String> determineVerificationCommandAsync(ContextManager cm) {
-        return cm.submitBackgroundTask(
+        return cm.submitMaintenanceTask(
                 "Determine build verification command", () -> determineVerificationCommand(cm.liveContext()));
     }
 

--- a/app/src/test/java/ai/brokk/testutil/TestContextManager.java
+++ b/app/src/test/java/ai/brokk/testutil/TestContextManager.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.Nullable;
@@ -200,13 +198,6 @@ public final class TestContextManager implements IContextManager {
             throws InterruptedException {
         return new ai.brokk.TaskResult(
                 liveContext(), new ai.brokk.TaskResult.StopDetails(ai.brokk.TaskResult.StopReason.SUCCESS));
-    }
-
-    private final ExecutorService backgroundTasks = Executors.newCachedThreadPool();
-
-    @Override
-    public ExecutorService getBackgroundTasks() {
-        return backgroundTasks;
     }
 
     @Override

--- a/errorprone-checks/src/main/java/ai/brokk/errorprone/BlockingOperationChecker.java
+++ b/errorprone-checks/src/main/java/ai/brokk/errorprone/BlockingOperationChecker.java
@@ -45,7 +45,7 @@ public final class BlockingOperationChecker extends BugChecker implements BugChe
      * to match any implementing class. For final classes (like LoggingFuture), a direct FQCN match is used.
      */
     private static final Map<String, List<String>> SAFE_BACKGROUND_CONTEXTS = Map.of(
-            "ai.brokk.IContextManager", List.of("submitBackgroundTask"),
+            "ai.brokk.IContextManager", List.of("submitBackgroundTask", "submitMaintenanceTask"),
             "ai.brokk.concurrent.LoggingFuture", List.of("supplyAsync", "supplyCallableAsync"));
 
     private static boolean hasDirectAnnotation(Symbol sym, String fqcn) {


### PR DESCRIPTION
This PR introduces a dedicated `maintenanceTasks` executor in `ContextManager` to separate lightweight bookkeeping and I/O tasks from heavy analyzer or build operations.

Key changes include:
- Added `submitMaintenanceTask` to `IContextManager` and `ContextManager`.
- Migrated most of background tasks—including Git operations, dependency imports, session management, and UI-driven lookups—from the general `backgroundTasks` executor to the new maintenance executor.
- Updated documentation in `AGENTS.md` and `interruptions.md` to define when to use each executor.
- Updated the `BlockingOperationChecker` error-prone rule to recognize the new maintenance submission method as a safe background context.

Addresses the request at #3079

What's still on the background executor:

* Code Intelligence pre-build
* Code Intelligence post-build (2 sites)
* Code Intelligence ready
* Update for Git changes (analyzer callback)
* Update for FS changes (analyzer callback)
* Update for dependency changes (analyzer callback) |
* Running tests
* Startup warmup build
