### PR TITLE
Optimize ProjectTree refresh with parallel preloading and generation tracking

### DIFF
--- a/app/src/main/java/ai/brokk/gui/ProjectTree.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectTree.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -808,6 +809,89 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         }
     }
 
+    /**
+     * Recursively populates a tree node from preloaded directory data.
+     * Directories with preloaded children are populated and marked as loaded;
+     * directories without preloaded data get a "Loading..." placeholder for lazy loading.
+     */
+    private void populateFromPreloadedData(
+            DefaultMutableTreeNode node, File dir, Map<File, List<ProjectTreeNode>> preCreatedNodes) {
+        List<ProjectTreeNode> children = preCreatedNodes.get(dir);
+        if (children == null) {
+            node.add(new DefaultMutableTreeNode(LOADING_PLACEHOLDER));
+            return;
+        }
+
+        for (ProjectTreeNode childPtn : children) {
+            var childNode = new DefaultMutableTreeNode(childPtn);
+
+            if (childPtn.isDirectory()) {
+                if (preCreatedNodes.containsKey(childPtn.getFile())) {
+                    populateFromPreloadedData(childNode, childPtn.getFile(), preCreatedNodes);
+                    childPtn.markLoaded();
+                } else {
+                    childNode.add(new DefaultMutableTreeNode(LOADING_PLACEHOLDER));
+                }
+            }
+
+            node.add(childNode);
+        }
+    }
+
+    /**
+     * Finds a node by relative path in an already-populated tree, without loading or expanding.
+     */
+    private @Nullable DefaultMutableTreeNode findNodeInPopulatedTree(DefaultMutableTreeNode root, Path relativePath) {
+        var current = root;
+        for (int i = 0; i < relativePath.getNameCount(); i++) {
+            String targetName = relativePath.getName(i).toString();
+            DefaultMutableTreeNode found = null;
+            Enumeration<?> children = current.children();
+            while (children.hasMoreElements()) {
+                var child = (DefaultMutableTreeNode) children.nextElement();
+                if (child.getUserObject() instanceof ProjectTreeNode ptn
+                        && ptn.getFile().getName().equals(targetName)) {
+                    found = child;
+                    break;
+                }
+            }
+            if (found == null) return null;
+            current = found;
+        }
+        return current;
+    }
+
+    /**
+     * Walks expanded subtrees and auto-expands single-child directory chains.
+     * Called after restoring expansion state on an already-populated tree.
+     */
+    private void expandSingleChildChainsInPopulatedTree(DefaultMutableTreeNode node) {
+        if (!(node.getUserObject() instanceof ProjectTreeNode ptn) || !ptn.isDirectory()) return;
+
+        TreePath nodePath = new TreePath(node.getPath());
+        boolean nodeIsExpanded = isExpanded(nodePath) || node.getParent() == null;
+        if (!nodeIsExpanded) return;
+
+        if (node.getChildCount() == 1) {
+            var child = (DefaultMutableTreeNode) node.getFirstChild();
+            if (child.getUserObject() instanceof ProjectTreeNode childPtn
+                    && childPtn.isDirectory()
+                    && childPtn.isChildrenLoaded()) {
+                TreePath childPath = new TreePath(child.getPath());
+                if (!isExpanded(childPath)) {
+                    expandPath(childPath);
+                }
+                expandSingleChildChainsInPopulatedTree(child);
+            }
+        } else {
+            for (int i = 0; i < node.getChildCount(); i++) {
+                if (node.getChildAt(i) instanceof DefaultMutableTreeNode child) {
+                    expandSingleChildChainsInPopulatedTree(child);
+                }
+            }
+        }
+    }
+
     private void invalidateAllChildrenRecursively(DefaultMutableTreeNode node) {
         if (node.getUserObject() instanceof ProjectTreeNode ptn && ptn.isDirectory()) {
             ptn.resetLoadState(); // Mark as not loaded
@@ -984,15 +1068,8 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
 
     private void performRefreshInternal() {
         int thisGeneration = refreshGeneration.incrementAndGet();
-        int previousActive = activeRefreshId;
-        activeRefreshId = thisGeneration;
-        if (previousActive >= 0) {
-            logger.info(">>> REFRESH START id={} (SUPERSEDING stale id={})", thisGeneration, previousActive);
-        } else {
-            logger.info(">>> REFRESH START id={}", thisGeneration);
-        }
 
-        pendingRefreshWhenShown = false; // Clear flag when actually refreshing
+        pendingRefreshWhenShown = false;
         isRefreshing = true;
 
         var root = (DefaultMutableTreeNode) getModel().getRoot();
@@ -1004,107 +1081,168 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
             collectExpandedDirectoryPathsRecursive(root, previouslyExpandedDirPaths);
         }
 
-        // Invalidate all loaded children data
-        if (root != null && root.getUserObject() instanceof ProjectTreeNode ptn) {
-            ptn.resetLoadState();
-        }
         if (root == null) {
             isRefreshing = false;
             return;
         }
 
-        invalidateAllChildrenRecursively(root);
-        root.removeAllChildren();
-        root.add(new DefaultMutableTreeNode(LOADING_PLACEHOLDER));
-        logger.info("nodeStructureChanged: root cleared (refresh id={})", thisGeneration);
-        ((DefaultTreeModel) getModel()).nodeStructureChanged(root);
+        Path projectRoot = project.getRoot();
 
-        // Load root children async, then restore expansions and selections.
-        // Each async stage checks refreshGeneration to bail out if a newer refresh has started.
+        // Collect all directories that need preloading:
+        // root + all directories along expanded paths + parent directories of selected files
+        Set<File> initialDirs = new LinkedHashSet<>();
+        initialDirs.add(projectRoot.toFile());
+        for (Path expandedPath : previouslyExpandedDirPaths) {
+            for (int i = 1; i <= expandedPath.getNameCount(); i++) {
+                initialDirs.add(projectRoot.resolve(expandedPath.subpath(0, i)).toFile());
+            }
+        }
+        for (ProjectFile pf : previouslySelectedFiles) {
+            Path rel = pf.getRelPath();
+            for (int i = 1; i < rel.getNameCount(); i++) {
+                initialDirs.add(projectRoot.resolve(rel.subpath(0, i)).toFile());
+            }
+        }
+
+        var sortedExpandedPaths = previouslyExpandedDirPaths.stream()
+                .sorted(Comparator.comparingInt(Path::getNameCount))
+                .toList();
+
         final var rootRef = root;
-        loadChildrenForNodeAsync(root)
-                .thenCompose(ignored -> {
-                    if (refreshGeneration.get() != thisGeneration) {
-                        logger.info("--- REFRESH ABANDONED id={} (superseded)", thisGeneration);
-                        return CompletableFuture.<Void>completedFuture(null);
-                    }
-                    // Restore expanded directories - process sequentially by depth to avoid race conditions.
-                    // Shorter paths (parents) must be expanded before longer paths (children) that depend on them.
-                    // Note: empty paths are filtered at the source in collectExpandedDirectoryPathsRecursive
-                    var sortedPaths = previouslyExpandedDirPaths.stream()
-                            .sorted(Comparator.comparingInt(Path::getNameCount))
-                            .toList();
 
-                    CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
-                    for (Path expandedDirPath : sortedPaths) {
-                        final Path pathForLambda = expandedDirPath;
-                        chain = chain.thenCompose(v -> {
-                            if (refreshGeneration.get() != thisGeneration) {
-                                return CompletableFuture.<Void>completedFuture(null);
-                            }
-                            return findAndExpandNodeAsync(rootRef, pathForLambda, 0)
-                                    .thenAccept(nodeToExpand -> {
-                                        if (refreshGeneration.get() != thisGeneration) return;
-                                        if (nodeToExpand != null) {
-                                            SwingUtilities.invokeLater(() -> {
-                                                if (refreshGeneration.get() != thisGeneration) return;
-                                                TreePath pathToExpand = new TreePath(nodeToExpand.getPath());
-                                                if (!isExpanded(pathToExpand)) {
-                                                    expandPath(pathToExpand);
-                                                }
-                                            });
-                                        } else {
-                                            logger.trace("Could not find previously expanded directory: {}", pathForLambda);
+        // Preload all directory contents in parallel off EDT, following single-child chains.
+        // Then rebuild the tree in a single EDT pass to avoid flash and per-node repaints.
+        LoggingFuture.supplyAsync(
+                        () -> {
+                            Map<File, List<File>> allDirContents = new ConcurrentHashMap<>();
+                            Set<File> dirsToLoad = new LinkedHashSet<>(initialDirs);
+
+                            // Iteratively load directories, following single-child chains
+                            while (!dirsToLoad.isEmpty()) {
+                                var futures = dirsToLoad.stream()
+                                        .filter(File::isDirectory)
+                                        .filter(dir -> !allDirContents.containsKey(dir))
+                                        .map(dir -> CompletableFuture.runAsync(
+                                                () -> {
+                                                    File[] children = dir.listFiles();
+                                                    if (children != null) {
+                                                        Arrays.sort(children, (f1, f2) -> {
+                                                            boolean f1IsDir = f1.isDirectory();
+                                                            boolean f2IsDir = f2.isDirectory();
+                                                            if (f1IsDir && !f2IsDir) return -1;
+                                                            if (!f1IsDir && f2IsDir) return 1;
+                                                            return f1.getName().compareToIgnoreCase(f2.getName());
+                                                        });
+                                                        allDirContents.put(dir, Arrays.asList(children));
+                                                    } else {
+                                                        allDirContents.put(dir, List.of());
+                                                    }
+                                                },
+                                                IO_EXECUTOR))
+                                        .toArray(CompletableFuture[]::new);
+                                CompletableFuture.allOf(futures).join();
+
+                                // Follow single-child directory chains for correct collapsed display names
+                                Set<File> nextBatch = new LinkedHashSet<>();
+                                for (File dir : dirsToLoad) {
+                                    List<File> children = allDirContents.get(dir);
+                                    if (children != null
+                                            && children.size() == 1
+                                            && children.get(0).isDirectory()) {
+                                        File singleChild = children.get(0);
+                                        if (!allDirContents.containsKey(singleChild)) {
+                                            nextBatch.add(singleChild);
                                         }
-                                    });
-                        });
-                    }
-                    return chain;
-                })
-                .thenCompose(ignored -> {
+                                    }
+                                }
+                                dirsToLoad = nextBatch;
+                            }
+
+                            // Pre-create nodes and warm coloring caches off EDT
+                            Map<File, List<ProjectTreeNode>> preCreatedNodes = new ConcurrentHashMap<>();
+                            for (var entry : allDirContents.entrySet()) {
+                                var nodes = new ArrayList<ProjectTreeNode>();
+                                for (File child : entry.getValue()) {
+                                    var ptn = new ProjectTreeNode(child, false);
+                                    ptn.isExcluded();
+                                    ptn.isGitignored();
+                                    ptn.isTracked();
+                                    nodes.add(ptn);
+                                }
+                                preCreatedNodes.put(entry.getKey(), nodes);
+                            }
+
+                            return preCreatedNodes;
+                        },
+                        IO_EXECUTOR)
+                .thenAccept(preCreatedNodes -> SwingUtilities.invokeLater(() -> {
                     if (refreshGeneration.get() != thisGeneration) {
-                        return CompletableFuture.<Void>completedFuture(null);
+                        isRefreshing = false;
+                        return;
                     }
+
+                    // Rebuild tree in one pass — no intermediate "Loading..." flash
+                    invalidateAllChildrenRecursively(rootRef);
+                    rootRef.removeAllChildren();
+                    populateFromPreloadedData(rootRef, projectRoot.toFile(), preCreatedNodes);
+                    if (rootRef.getUserObject() instanceof ProjectTreeNode rootPtn) {
+                        rootPtn.markLoaded();
+                    }
+
+                    // Single model change notification instead of per-node nodeStructureChanged
+                    ((DefaultTreeModel) getModel()).nodeStructureChanged(rootRef);
+
+                    // Expand previously expanded paths. Children are already populated and marked
+                    // loaded, so treeWillExpand -> loadChildrenForNodeAsync is a no-op (CAS guard).
+                    for (Path expandedPath : sortedExpandedPaths) {
+                        var node = findNodeInPopulatedTree(rootRef, expandedPath);
+                        if (node != null) {
+                            TreePath treePath = new TreePath(node.getPath());
+                            if (!isExpanded(treePath)) {
+                                expandPath(treePath);
+                            }
+                        } else {
+                            logger.trace("Could not find previously expanded directory: {}", expandedPath);
+                        }
+                    }
+
+                    // Auto-expand single-child directory chains from expanded nodes
+                    expandSingleChildChainsInPopulatedTree(rootRef);
+
                     // Restore selections
-                    if (previouslySelectedFiles.isEmpty()) {
-                        return CompletableFuture.completedFuture(null);
+                    if (!previouslySelectedFiles.isEmpty()) {
+                        var pathsToSelect = new ArrayList<TreePath>();
+                        for (ProjectFile pf : previouslySelectedFiles) {
+                            if (!pf.exists()) continue;
+                            var node = findNodeInPopulatedTree(rootRef, pf.getRelPath());
+                            if (node != null) {
+                                pathsToSelect.add(new TreePath(node.getPath()));
+                            } else {
+                                logger.trace("Could not find previously selected file: {}", pf.getRelPath());
+                            }
+                        }
+                        if (!pathsToSelect.isEmpty()) {
+                            setSelectionPaths(pathsToSelect.toArray(new TreePath[0]));
+                            TreePath leadPath = getLeadSelectionPath();
+                            if (leadPath != null) {
+                                scrollPathToVisible(leadPath);
+                            } else {
+                                scrollPathToVisible(pathsToSelect.getFirst());
+                            }
+                        }
                     }
-                    var selectionFutures = previouslySelectedFiles.stream()
-                            .filter(ProjectFile::exists)
-                            .map(pf -> findAndExpandNodeAsync(rootRef, pf.getRelPath(), 0))
-                            .toArray(CompletableFuture[]::new);
-                    return CompletableFuture.allOf(selectionFutures).thenAccept(v -> {
-                        SwingUtilities.invokeLater(() -> {
-                            if (refreshGeneration.get() != thisGeneration) {
-                                logger.info("--- REFRESH ABANDONED id={} at selection restore (superseded)", thisGeneration);
-                                return;
-                            }
-                            var pathsToSelect = new ArrayList<TreePath>();
-                            for (ProjectFile pf : previouslySelectedFiles) {
-                                if (!pf.exists()) continue;
-                                var nodeToSelect = findAndExpandNode(rootRef, pf.getRelPath(), 0);
-                                if (nodeToSelect != null) {
-                                    pathsToSelect.add(new TreePath(nodeToSelect.getPath()));
-                                } else {
-                                    logger.trace("Could not find previously selected file: {}", pf.getRelPath());
-                                }
-                            }
-                            if (!pathsToSelect.isEmpty()) {
-                                setSelectionPaths(pathsToSelect.toArray(new TreePath[0]));
-                                TreePath leadPath = getLeadSelectionPath();
-                                if (leadPath != null) {
-                                    scrollPathToVisible(leadPath);
-                                } else {
-                                    scrollPathToVisible(pathsToSelect.getFirst());
-                                }
-                            }
-                            logger.info("<<< REFRESH END id={}", thisGeneration);
-                            activeRefreshId = -1;
-                            logger.trace("ProjectTree refresh complete.");
-                        });
+
+                    isRefreshing = false;
+                    logger.trace("ProjectTree refresh complete.");
+                }))
+                .exceptionally(ex -> {
+                    logger.error("Error during parallel refresh", ex);
+                    SwingUtilities.invokeLater(() -> {
+                        isRefreshing = false;
+                        chrome.toolError("Failed to refresh project tree: " + ex.getMessage());
                     });
-                })
-                .whenComplete((result, ex) -> SwingUtilities.invokeLater(() -> isRefreshing = false));
+                    return null;
+                });
     }
 
     /**

--- a/app/src/main/java/ai/brokk/gui/ProjectTree.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectTree.java
@@ -65,6 +65,9 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     private static final String LOADING_PLACEHOLDER = "Loading...";
     private static final ExecutorService IO_EXECUTOR = ExecutorsUtil.newFixedThreadExecutor("ProjectTree-IO-", 4);
 
+    // INSTRUMENTATION - remove after profiling
+    private volatile int activeRefreshId = -1;
+
     /** Generation counter for refresh operations; incremented at the start of each refresh
      * so that async continuations from a stale refresh can detect they've been superseded. */
     private final AtomicInteger refreshGeneration = new AtomicInteger(0);
@@ -648,15 +651,21 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         // Atomically try to start loading - avoids all race conditions
         var result = new CompletableFuture<Void>();
         if (!treeNode.tryStartLoading(result)) {
-            // Someone else is loading or already loaded - return their future
+            logger.info(
+                    "loadChildren: {} (CAS=false, already loaded/loading)",
+                    treeNode.getFile().getName());
             var existing = treeNode.getLoadFuture();
             return existing != null ? existing : CompletableFuture.completedFuture(null);
         }
+        logger.info("loadChildren: {} (CAS=true, loading)", treeNode.getFile().getName());
 
         // We won the race - proceed with loading
         // Ensure there's a visible "Loading..." placeholder while background work runs.
         if (node.getChildCount() == 0) {
             node.add(new DefaultMutableTreeNode(LOADING_PLACEHOLDER));
+            logger.info(
+                    "nodeStructureChanged: placeholder for {}",
+                    treeNode.getFile().getName());
             ((DefaultTreeModel) getModel()).nodeStructureChanged(node);
         }
 
@@ -731,6 +740,11 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                                 node.add(childNode);
                             }
 
+                            logger.info(
+                                    "nodeStructureChanged: children loaded for {}",
+                                    ((ProjectTreeNode) node.getUserObject())
+                                            .getFile()
+                                            .getName());
                             ((DefaultTreeModel) getModel()).nodeStructureChanged(node);
 
                             // Attempt to auto-expand single-directory chains as before.
@@ -780,6 +794,8 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                             && onlyChild.getFirstChild() instanceof DefaultMutableTreeNode
                             && LOADING_PLACEHOLDER.equals(
                                     ((DefaultMutableTreeNode) onlyChild.getFirstChild()).getUserObject())) {
+                        logger.info(
+                                "expandSingleDir: {}", childTreeNode.getFile().getName());
                         expandPath(childPath); // This will trigger the TreeWillExpandListener.
                         // The listener calls loadChildrenForNode.
                         // loadChildrenForNode calls this method again, forming the recursive chain.
@@ -827,6 +843,10 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         if (isRestoringExpansion) {
             return;
         }
+        logger.info(
+                "scheduleExpansionSave (isRestoringExpansion={}, activeRefreshId={})",
+                isRestoringExpansion,
+                activeRefreshId);
         if (expansionSaveTimer != null) {
             expansionSaveTimer.stop();
         }
@@ -921,6 +941,11 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                     batch.getFiles().size());
         }
 
+        logger.info(
+                "onFilesChanged: scheduling refresh (overflow={}, gitignoreChanged={}, fileCount={})",
+                batch.isOverflowed(),
+                batch.isUntrackedGitignoreChanged(),
+                batch.getFiles().size());
         scheduleRefresh();
     }
 
@@ -956,6 +981,13 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
 
     private void performRefreshInternal() {
         int thisGeneration = refreshGeneration.incrementAndGet();
+        int previousActive = activeRefreshId;
+        activeRefreshId = thisGeneration;
+        if (previousActive >= 0) {
+            logger.info(">>> REFRESH START id={} (SUPERSEDING stale id={})", thisGeneration, previousActive);
+        } else {
+            logger.info(">>> REFRESH START id={}", thisGeneration);
+        }
 
         pendingRefreshWhenShown = false; // Clear flag when actually refreshing
 
@@ -979,6 +1011,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         invalidateAllChildrenRecursively(root);
         root.removeAllChildren();
         root.add(new DefaultMutableTreeNode(LOADING_PLACEHOLDER));
+        logger.info("nodeStructureChanged: root cleared (refresh id={})", thisGeneration);
         ((DefaultTreeModel) getModel()).nodeStructureChanged(root);
 
         // Load root children async, then restore expansions and selections.
@@ -987,7 +1020,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         loadChildrenForNodeAsync(root)
                 .thenCompose(ignored -> {
                     if (refreshGeneration.get() != thisGeneration) {
-                        logger.debug("Refresh superseded after root load (generation {})", thisGeneration);
+                        logger.info("--- REFRESH ABANDONED id={} (superseded)", thisGeneration);
                         return CompletableFuture.<Void>completedFuture(null);
                     }
                     // Restore expanded directories - process sequentially by depth to avoid race conditions.
@@ -1037,7 +1070,10 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                             .toArray(CompletableFuture[]::new);
                     return CompletableFuture.allOf(selectionFutures).thenAccept(v -> {
                         SwingUtilities.invokeLater(() -> {
-                            if (refreshGeneration.get() != thisGeneration) return;
+                            if (refreshGeneration.get() != thisGeneration) {
+                                logger.info("--- REFRESH ABANDONED id={} at selection restore (superseded)", thisGeneration);
+                                return;
+                            }
                             var pathsToSelect = new ArrayList<TreePath>();
                             for (ProjectFile pf : previouslySelectedFiles) {
                                 if (!pf.exists()) continue;
@@ -1057,6 +1093,8 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                                     scrollPathToVisible(pathsToSelect.getFirst());
                                 }
                             }
+                            logger.info("<<< REFRESH END id={}", thisGeneration);
+                            activeRefreshId = -1;
                             logger.trace("ProjectTree refresh complete.");
                         });
                     });

--- a/app/src/main/java/ai/brokk/gui/ProjectTree.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectTree.java
@@ -94,6 +94,9 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     /** Flag to track if a refresh should occur when component becomes visible */
     private volatile boolean pendingRefreshWhenShown = false;
 
+    /** Flag to suppress expansion saves during performRefreshInternal's restoration phase */
+    private volatile boolean isRefreshing = false;
+
     public ProjectTree(IProject project, ContextManager contextManager, Chrome chrome) {
         this.project = project;
         this.contextManager = contextManager;
@@ -840,7 +843,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     }
 
     private void scheduleExpansionSave() {
-        if (isRestoringExpansion) {
+        if (isRestoringExpansion || isRefreshing) {
             return;
         }
         logger.info(
@@ -990,6 +993,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         }
 
         pendingRefreshWhenShown = false; // Clear flag when actually refreshing
+        isRefreshing = true;
 
         var root = (DefaultMutableTreeNode) getModel().getRoot();
 
@@ -1005,6 +1009,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
             ptn.resetLoadState();
         }
         if (root == null) {
+            isRefreshing = false;
             return;
         }
 
@@ -1098,7 +1103,8 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                             logger.trace("ProjectTree refresh complete.");
                         });
                     });
-                });
+                })
+                .whenComplete((result, ex) -> SwingUtilities.invokeLater(() -> isRefreshing = false));
     }
 
     /**

--- a/app/src/main/java/ai/brokk/gui/ProjectTree.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectTree.java
@@ -21,7 +21,6 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
-import java.awt.event.HierarchyEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -89,9 +88,6 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     /** Flag to track if a refresh was requested during expansion restoration */
     private volatile boolean pendingRefreshDuringRestore = false;
 
-    /** Flag to track if a refresh should occur when component becomes visible */
-    private volatile boolean pendingRefreshWhenShown = false;
-
     /** Flag to suppress expansion saves during performRefreshInternal's restoration phase */
     private volatile boolean isRefreshing = false;
 
@@ -103,17 +99,6 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
 
         initializeTree();
         setupTreeBehavior(); // Includes mouse listeners and keyboard bindings now
-
-        // Defer tree refreshes when component is not visible
-        addHierarchyListener(e -> {
-            if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0) {
-                if (isShowing() && pendingRefreshWhenShown) {
-                    logger.trace("Component now visible, executing deferred refresh");
-                    pendingRefreshWhenShown = false;
-                    performRefreshInternal();
-                }
-            }
-        });
     }
 
     private void initializeTree() {
@@ -927,8 +912,8 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         if (isRestoringExpansion || isRefreshing) {
             return;
         }
-        logger.trace("scheduleExpansionSave (isRestoringExpansion={}, isRefreshing={})",
-                     isRestoringExpansion, isRefreshing);
+        logger.trace(
+                "scheduleExpansionSave (isRestoringExpansion={}, isRefreshing={})", isRestoringExpansion, isRefreshing);
         if (expansionSaveTimer != null) {
             expansionSaveTimer.stop();
         }
@@ -1053,11 +1038,6 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     }
 
     private void performRefresh() {
-        if (!isShowing()) {
-            logger.trace("Tree not visible, deferring refresh");
-            pendingRefreshWhenShown = true;
-            return;
-        }
         performRefreshInternal();
     }
 
@@ -1065,7 +1045,6 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         int thisGeneration = refreshGeneration.incrementAndGet();
 
         logger.trace("Refresh start (generation {})", thisGeneration);
-        pendingRefreshWhenShown = false;
         isRefreshing = true;
 
         var root = (DefaultMutableTreeNode) getModel().getRoot();

--- a/app/src/main/java/ai/brokk/gui/ProjectTree.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectTree.java
@@ -1160,7 +1160,6 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                 .thenAccept(preCreatedNodes -> SwingUtilities.invokeLater(() -> {
                     if (refreshGeneration.get() != thisGeneration) {
                         logger.trace("Refresh superseded (generation {})", thisGeneration);
-                        isRefreshing = false;
                         return;
                     }
 
@@ -1221,8 +1220,15 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                 .exceptionally(ex -> {
                     logger.error("Error during parallel refresh", ex);
                     SwingUtilities.invokeLater(() -> {
-                        isRefreshing = false;
-                        chrome.toolError("Failed to refresh project tree: " + ex.getMessage());
+                        if (refreshGeneration.get() == thisGeneration) {
+                            isRefreshing = false;
+                            chrome.toolError("Failed to refresh project tree: " + ex.getMessage());
+                        } else {
+                            logger.trace(
+                                    "Ignoring error from superseded refresh (generation {}): {}",
+                                    thisGeneration,
+                                    ex.getMessage());
+                        }
                     });
                     return null;
                 });

--- a/app/src/main/java/ai/brokk/gui/ProjectTree.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectTree.java
@@ -964,15 +964,16 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                     }));
         }
 
-        // Clear the flag when restoration completes and process any pending refresh
-        chain.whenComplete((result, ex) -> {
+        // Clear the flag when restoration completes and process any pending refresh.
+        // Must run on EDT to avoid races with scheduleRefresh reading these flags.
+        chain.whenComplete((result, ex) -> SwingUtilities.invokeLater(() -> {
             isRestoringExpansion = false;
             if (pendingRefreshDuringRestore) {
                 logger.trace("Expansion restoration complete, processing pending refresh");
                 pendingRefreshDuringRestore = false;
                 scheduleRefresh();
             }
-        });
+        }));
     }
 
     @Override
@@ -1093,11 +1094,13 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                             Set<File> dirsToLoad = new LinkedHashSet<>(initialDirs);
 
                             // Iteratively load directories, following single-child chains
-                            while (!dirsToLoad.isEmpty()) {
+                            // (depth-limited to guard against symlink cycles)
+                            int chainDepth = 0;
+                            while (!dirsToLoad.isEmpty() && chainDepth < 20) {
                                 var futures = dirsToLoad.stream()
                                         .filter(File::isDirectory)
                                         .filter(dir -> !allDirContents.containsKey(dir))
-                                        .map(dir -> CompletableFuture.runAsync(
+                                        .map(dir -> LoggingFuture.runAsync(
                                                 () -> {
                                                     File[] children = dir.listFiles();
                                                     if (children != null) {
@@ -1115,7 +1118,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                                                 },
                                                 IO_EXECUTOR))
                                         .toArray(CompletableFuture[]::new);
-                                CompletableFuture.allOf(futures).join();
+                                LoggingFuture.allOf(futures).join();
 
                                 // Follow single-child directory chains for correct collapsed display names
                                 Set<File> nextBatch = new LinkedHashSet<>();
@@ -1131,6 +1134,10 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                                     }
                                 }
                                 dirsToLoad = nextBatch;
+                                chainDepth++;
+                            }
+                            if (chainDepth >= 20) {
+                                logger.warn("Single-child directory chain depth limit reached during refresh preload");
                             }
 
                             // Pre-create nodes and warm coloring caches off EDT
@@ -1261,7 +1268,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                             // Read all directory contents in parallel
                             Map<File, List<File>> dirContents = new ConcurrentHashMap<>();
                             var futures = dirsToLoad.stream()
-                                    .map(dir -> CompletableFuture.runAsync(
+                                    .map(dir -> LoggingFuture.runAsync(
                                             () -> {
                                                 File[] children = dir.listFiles();
                                                 if (children != null) {
@@ -1279,7 +1286,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                                             },
                                             IO_EXECUTOR))
                                     .toArray(CompletableFuture[]::new);
-                            CompletableFuture.allOf(futures).join();
+                            LoggingFuture.allOf(futures).join();
                             return dirContents;
                         },
                         IO_EXECUTOR)
@@ -1911,15 +1918,20 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
             var name = new StringBuilder(file.getName());
             var current = node;
 
-            // Follow single-child directory chains
-            while (current.getChildCount() == 1) {
+            // Follow single-child directory chains (depth-limited to guard against symlink cycles)
+            int chainDepth = 0;
+            while (current.getChildCount() == 1 && chainDepth < 20) {
                 var child = (DefaultMutableTreeNode) current.getFirstChild();
                 if (child.getUserObject() instanceof ProjectTreeNode childNode && childNode.isDirectory()) {
                     name.append("/").append(childNode.getFile().getName());
                     current = child;
+                    chainDepth++;
                 } else {
                     break;
                 }
+            }
+            if (chainDepth >= 20) {
+                logger.warn("Single-child directory chain depth limit reached at {}", file.getAbsolutePath());
             }
             return name.toString();
         }

--- a/app/src/main/java/ai/brokk/gui/ProjectTree.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectTree.java
@@ -66,9 +66,6 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     private static final String LOADING_PLACEHOLDER = "Loading...";
     private static final ExecutorService IO_EXECUTOR = ExecutorsUtil.newFixedThreadExecutor("ProjectTree-IO-", 4);
 
-    // INSTRUMENTATION - remove after profiling
-    private volatile int activeRefreshId = -1;
-
     /** Generation counter for refresh operations; incremented at the start of each refresh
      * so that async continuations from a stale refresh can detect they've been superseded. */
     private final AtomicInteger refreshGeneration = new AtomicInteger(0);
@@ -655,19 +652,19 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         // Atomically try to start loading - avoids all race conditions
         var result = new CompletableFuture<Void>();
         if (!treeNode.tryStartLoading(result)) {
-            logger.info(
+            logger.trace(
                     "loadChildren: {} (CAS=false, already loaded/loading)",
                     treeNode.getFile().getName());
             var existing = treeNode.getLoadFuture();
             return existing != null ? existing : CompletableFuture.completedFuture(null);
         }
-        logger.info("loadChildren: {} (CAS=true, loading)", treeNode.getFile().getName());
+        logger.trace("loadChildren: {} (CAS=true, loading)", treeNode.getFile().getName());
 
         // We won the race - proceed with loading
         // Ensure there's a visible "Loading..." placeholder while background work runs.
         if (node.getChildCount() == 0) {
             node.add(new DefaultMutableTreeNode(LOADING_PLACEHOLDER));
-            logger.info(
+            logger.trace(
                     "nodeStructureChanged: placeholder for {}",
                     treeNode.getFile().getName());
             ((DefaultTreeModel) getModel()).nodeStructureChanged(node);
@@ -744,7 +741,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                                 node.add(childNode);
                             }
 
-                            logger.info(
+                            logger.trace(
                                     "nodeStructureChanged: children loaded for {}",
                                     ((ProjectTreeNode) node.getUserObject())
                                             .getFile()
@@ -798,7 +795,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                             && onlyChild.getFirstChild() instanceof DefaultMutableTreeNode
                             && LOADING_PLACEHOLDER.equals(
                                     ((DefaultMutableTreeNode) onlyChild.getFirstChild()).getUserObject())) {
-                        logger.info(
+                        logger.trace(
                                 "expandSingleDir: {}", childTreeNode.getFile().getName());
                         expandPath(childPath); // This will trigger the TreeWillExpandListener.
                         // The listener calls loadChildrenForNode.
@@ -930,10 +927,8 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         if (isRestoringExpansion || isRefreshing) {
             return;
         }
-        logger.info(
-                "scheduleExpansionSave (isRestoringExpansion={}, activeRefreshId={})",
-                isRestoringExpansion,
-                activeRefreshId);
+        logger.trace("scheduleExpansionSave (isRestoringExpansion={}, isRefreshing={})",
+                     isRestoringExpansion, isRefreshing);
         if (expansionSaveTimer != null) {
             expansionSaveTimer.stop();
         }
@@ -1028,7 +1023,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                     batch.getFiles().size());
         }
 
-        logger.info(
+        logger.trace(
                 "onFilesChanged: scheduling refresh (overflow={}, gitignoreChanged={}, fileCount={})",
                 batch.isOverflowed(),
                 batch.isUntrackedGitignoreChanged(),
@@ -1069,6 +1064,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     private void performRefreshInternal() {
         int thisGeneration = refreshGeneration.incrementAndGet();
 
+        logger.trace("Refresh start (generation {})", thisGeneration);
         pendingRefreshWhenShown = false;
         isRefreshing = true;
 
@@ -1177,6 +1173,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                         IO_EXECUTOR)
                 .thenAccept(preCreatedNodes -> SwingUtilities.invokeLater(() -> {
                     if (refreshGeneration.get() != thisGeneration) {
+                        logger.trace("Refresh superseded (generation {})", thisGeneration);
                         isRefreshing = false;
                         return;
                     }

--- a/app/src/main/java/ai/brokk/gui/ProjectTree.java
+++ b/app/src/main/java/ai/brokk/gui/ProjectTree.java
@@ -44,6 +44,7 @@ import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.swing.*;
@@ -63,6 +64,10 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     private static final Logger logger = LogManager.getLogger(ProjectTree.class);
     private static final String LOADING_PLACEHOLDER = "Loading...";
     private static final ExecutorService IO_EXECUTOR = ExecutorsUtil.newFixedThreadExecutor("ProjectTree-IO-", 4);
+
+    /** Generation counter for refresh operations; incremented at the start of each refresh
+     * so that async continuations from a stale refresh can detect they've been superseded. */
+    private final AtomicInteger refreshGeneration = new AtomicInteger(0);
 
     private final IProject project;
     private final ContextManager contextManager;
@@ -950,6 +955,8 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
     }
 
     private void performRefreshInternal() {
+        int thisGeneration = refreshGeneration.incrementAndGet();
+
         pendingRefreshWhenShown = false; // Clear flag when actually refreshing
 
         var root = (DefaultMutableTreeNode) getModel().getRoot();
@@ -974,10 +981,15 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
         root.add(new DefaultMutableTreeNode(LOADING_PLACEHOLDER));
         ((DefaultTreeModel) getModel()).nodeStructureChanged(root);
 
-        // Load root children async, then restore expansions and selections
+        // Load root children async, then restore expansions and selections.
+        // Each async stage checks refreshGeneration to bail out if a newer refresh has started.
         final var rootRef = root;
         loadChildrenForNodeAsync(root)
                 .thenCompose(ignored -> {
+                    if (refreshGeneration.get() != thisGeneration) {
+                        logger.debug("Refresh superseded after root load (generation {})", thisGeneration);
+                        return CompletableFuture.<Void>completedFuture(null);
+                    }
                     // Restore expanded directories - process sequentially by depth to avoid race conditions.
                     // Shorter paths (parents) must be expanded before longer paths (children) that depend on them.
                     // Note: empty paths are filtered at the source in collectExpandedDirectoryPathsRecursive
@@ -988,23 +1000,33 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                     CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
                     for (Path expandedDirPath : sortedPaths) {
                         final Path pathForLambda = expandedDirPath;
-                        chain = chain.thenCompose(v -> findAndExpandNodeAsync(rootRef, pathForLambda, 0)
-                                .thenAccept(nodeToExpand -> {
-                                    if (nodeToExpand != null) {
-                                        SwingUtilities.invokeLater(() -> {
-                                            TreePath pathToExpand = new TreePath(nodeToExpand.getPath());
-                                            if (!isExpanded(pathToExpand)) {
-                                                expandPath(pathToExpand);
-                                            }
-                                        });
-                                    } else {
-                                        logger.trace("Could not find previously expanded directory: {}", pathForLambda);
-                                    }
-                                }));
+                        chain = chain.thenCompose(v -> {
+                            if (refreshGeneration.get() != thisGeneration) {
+                                return CompletableFuture.<Void>completedFuture(null);
+                            }
+                            return findAndExpandNodeAsync(rootRef, pathForLambda, 0)
+                                    .thenAccept(nodeToExpand -> {
+                                        if (refreshGeneration.get() != thisGeneration) return;
+                                        if (nodeToExpand != null) {
+                                            SwingUtilities.invokeLater(() -> {
+                                                if (refreshGeneration.get() != thisGeneration) return;
+                                                TreePath pathToExpand = new TreePath(nodeToExpand.getPath());
+                                                if (!isExpanded(pathToExpand)) {
+                                                    expandPath(pathToExpand);
+                                                }
+                                            });
+                                        } else {
+                                            logger.trace("Could not find previously expanded directory: {}", pathForLambda);
+                                        }
+                                    });
+                        });
                     }
                     return chain;
                 })
                 .thenCompose(ignored -> {
+                    if (refreshGeneration.get() != thisGeneration) {
+                        return CompletableFuture.<Void>completedFuture(null);
+                    }
                     // Restore selections
                     if (previouslySelectedFiles.isEmpty()) {
                         return CompletableFuture.completedFuture(null);
@@ -1015,6 +1037,7 @@ public class ProjectTree extends JTree implements AbstractWatchService.Listener 
                             .toArray(CompletableFuture[]::new);
                     return CompletableFuture.allOf(selectionFutures).thenAccept(v -> {
                         SwingUtilities.invokeLater(() -> {
+                            if (refreshGeneration.get() != thisGeneration) return;
                             var pathsToSelect = new ArrayList<TreePath>();
                             for (ProjectFile pf : previouslySelectedFiles) {
                                 if (!pf.exists()) continue;

--- a/app/src/main/resources/log4j2.xml
+++ b/app/src/main/resources/log4j2.xml
@@ -41,9 +41,6 @@
     <Logger name="io.methvin.watcher" level="warn" additivity="false">
       <AppenderRef ref="RollingFileLogger"/>
     </Logger>
-    <Logger name="ai.brokk.gui.ProjectTree" level="trace" additivity="false">
-      <AppenderRef ref="RollingFileLogger"/>
-    </Logger>
     <Logger name="com.github.difflib" level="error" additivity="false">
       <AppenderRef ref="RollingFileLogger"/>
     </Logger>

--- a/app/src/main/resources/log4j2.xml
+++ b/app/src/main/resources/log4j2.xml
@@ -41,6 +41,9 @@
     <Logger name="io.methvin.watcher" level="warn" additivity="false">
       <AppenderRef ref="RollingFileLogger"/>
     </Logger>
+    <Logger name="ai.brokk.gui.ProjectTree" level="trace" additivity="false">
+      <AppenderRef ref="RollingFileLogger"/>
+    </Logger>
     <Logger name="com.github.difflib" level="error" additivity="false">
       <AppenderRef ref="RollingFileLogger"/>
     </Logger>


### PR DESCRIPTION
This PR significantly optimizes the `ProjectTree` refresh logic by shifting expensive directory traversals and node creation tasks from the Event Dispatch Thread (EDT) to background IO executors. 

Key improvements include:
- **Parallel Preloading**: Collects directory contents and warms coloring caches (Git/exclusion status) in parallel before rebuilding the tree.
- **Atomic Refresh Generations**: Introduced an `AtomicInteger` counter to ensure that stale asynchronous refresh results are discarded if a newer refresh has already started.
- **Flicker Reduction**: Rebuilds the tree tructure in a single pass on the EDT, eliminating the "Loading..." placeholder flash previously seen during full refreshes.
- **Efficient State Restoration**: Replaces slow recursive async lookups with a fast synchronous lookup in the pre-populated tree to restore expansion and selection states.

Closes #2680