### PR TITLE
docs: Add Claude Code plugin installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ This gives a quick "fitness for this task" indicator so you can choose the best 
   <img src="docs/media/screenshot-bpr-meter.png" alt="In-app BPR meter above the Instructions panel" width="800">
 </p>
 
+## Claude Code Plugin
+
+Brokk is available as a [Claude Code plugin](claude-plugin/README.md) that adds semantic code intelligence -- symbol navigation, cross-reference analysis, and structural code understanding. See the [plugin README](claude-plugin/README.md) for installation instructions.
+
 ## Terminal UI (Python Client)
 
 The `brokk-code/` directory contains the **Python (Textual) terminal UI client**. This is an interactive TUI that launches and manages a **local Java executor** subprocess.

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -1,0 +1,33 @@
+# Brokk Claude Code Plugin
+
+Semantic code intelligence for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) -- symbol navigation, cross-reference analysis, and structural code understanding powered by tree-sitter.
+
+## Install from marketplace
+
+```shell
+/plugin marketplace add BrokkAi/brokk
+/plugin install brokk@brokk-marketplace
+```
+
+## Local testing (from a clone of this repo)
+
+```shell
+claude --plugin-dir ./claude-plugin
+```
+
+## Prerequisites
+
+[uv](https://docs.astral.sh/uv/) must be installed. The plugin runs `uvx brokk mcp-core`, which fetches the `brokk` package from PyPI automatically.
+
+## Skills
+
+The plugin adds the following skills to Claude Code:
+
+| Skill | Description |
+|-------|-------------|
+| Code Navigation | Symbol searching, usage scanning, class skeleton navigation |
+| Code Reading | Reading source code at different detail levels |
+| Codebase Search | Text search, file discovery, directory listing |
+| Git Exploration | Git commit history exploration |
+| Workspace | Workspace activation and management |
+| Structured Data | JSON and XML/HTML querying |


### PR DESCRIPTION
## Summary
- Add `claude-plugin/README.md` with marketplace install commands, prerequisites, and skills table
- Link to it from the root README in a new "Claude Code Plugin" section
- Follows up on #3281 which added the plugin but had no user-facing docs

## Test plan
- [ ] Verify links render correctly on GitHub
- [ ] Verify marketplace install commands match what #3281 implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)