### PR TITLE
Normalize Codex paths on Windows & Ensure Git Tests Don't Sign

### DIFF
--- a/app/src/test/java/ai/brokk/tools/SftServerTest.java
+++ b/app/src/test/java/ai/brokk/tools/SftServerTest.java
@@ -319,9 +319,7 @@ class SftServerTest {
         try (var git = Git.open(root.toFile())) {
             // JGit will sign commits when `commit.gpgsign` is true (from global/user config).
             // These tests don't provide a GPG key, so disable signing for the temporary repo.
-            git.getRepository()
-                    .getConfig()
-                    .setBoolean("commit", null, "gpgsign", false);
+            git.getRepository().getConfig().setBoolean("commit", null, "gpgsign", false);
             git.add().addFilepattern(".").call();
             return git.commit()
                     .setMessage(message)

--- a/app/src/test/java/ai/brokk/tools/SftServerTest.java
+++ b/app/src/test/java/ai/brokk/tools/SftServerTest.java
@@ -317,6 +317,11 @@ class SftServerTest {
 
     private static String commitAll(Path root, String message) throws Exception {
         try (var git = Git.open(root.toFile())) {
+            // JGit will sign commits when `commit.gpgsign` is true (from global/user config).
+            // These tests don't provide a GPG key, so disable signing for the temporary repo.
+            git.getRepository()
+                    .getConfig()
+                    .setBoolean("commit", null, "gpgsign", false);
             git.add().addFilepattern(".").call();
             return git.commit()
                     .setMessage(message)

--- a/brokk-code/brokk_code/__main__.py
+++ b/brokk-code/brokk_code/__main__.py
@@ -1960,7 +1960,9 @@ def _main_dispatch(
         prefetch_commands: list[tuple[str, list[str]]] = []
         try:
             uv_binary = ensure_uv_ready()
-            uvx_command = str(Path(uv_binary).parent / "uvx")
+            # Path/str conversions on Windows produce backslashes, but these values
+            # are written into JSON configs where we want stable POSIX-style paths.
+            uvx_command = str(Path(uv_binary).parent / "uvx").replace("\\", "/")
             jbang_binary: str | None = None
             if args.target != "codex-plugin":
                 jbang_binary = resolve_jbang_binary() if args.verbose else ensure_jbang_ready()

--- a/brokk-code/brokk_code/mcp_config.py
+++ b/brokk-code/brokk_code/mcp_config.py
@@ -914,7 +914,9 @@ def _marketplace_root(marketplace_path: Path) -> Path:
 
 def _relative_marketplace_source_path(*, plugin_path: Path, marketplace_path: Path) -> str:
     marketplace_root = _marketplace_root(marketplace_path)
-    relative_path = os.path.relpath(plugin_path, start=marketplace_root)
+    # `os.path.relpath` returns platform-specific separators. Marketplace JSON
+    # expects stable POSIX-style paths, so normalize to forward slashes.
+    relative_path = os.path.relpath(plugin_path, start=marketplace_root).replace("\\", "/")
     if relative_path.startswith("./") or relative_path.startswith("../"):
         return relative_path
     return f"./{relative_path}"


### PR DESCRIPTION
Normalize Codex marketplace and uvx path strings to use POSIX-style slashes.

This fixes Windows-only test failures.

Made with [Cursor](https://cursor.com)