### PR TITLE
Fix secret-scan path separators across platforms

### DIFF
--- a/app/src/main/java/ai/brokk/git/GitSecretScanner.java
+++ b/app/src/main/java/ai/brokk/git/GitSecretScanner.java
@@ -389,7 +389,10 @@ public class GitSecretScanner {
             if (!absolutePath.startsWith(projectRoot)) {
                 return Optional.empty();
             }
-            return Optional.of(projectRoot.relativize(absolutePath).toString());
+            // JGit returns '/'-separated paths, but Path#toString uses OS-specific separators.
+            // Normalize to '/' so scan reports (and tests) are stable across platforms.
+            String rel = projectRoot.relativize(absolutePath).toString();
+            return Optional.of(rel.replace('\\', '/'));
         } catch (IllegalArgumentException e) {
             logger.debug("Skipping unmappable git path {}: {}", gitPath, e.getMessage());
             return Optional.empty();

--- a/app/src/main/java/ai/brokk/git/GitSecretScanner.java
+++ b/app/src/main/java/ai/brokk/git/GitSecretScanner.java
@@ -4,6 +4,7 @@ import ai.brokk.analyzer.BrokkFile;
 import ai.brokk.concurrent.ExecutorsUtil;
 import ai.brokk.concurrent.LoggingExecutorService;
 import ai.brokk.concurrent.LoggingFuture;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -389,10 +390,12 @@ public class GitSecretScanner {
             if (!absolutePath.startsWith(projectRoot)) {
                 return Optional.empty();
             }
-            // JGit returns '/'-separated paths, but Path#toString uses OS-specific separators.
-            // Normalize to '/' so scan reports (and tests) are stable across platforms.
             String rel = projectRoot.relativize(absolutePath).toString();
-            return Optional.of(rel.replace('\\', '/'));
+            // Normalize Windows separators to '/', but don't rewrite legitimate backslashes on POSIX.
+            if (File.separatorChar == '\\') {
+                rel = rel.replace('\\', '/');
+            }
+            return Optional.of(rel);
         } catch (IllegalArgumentException e) {
             logger.debug("Skipping unmappable git path {}: {}", gitPath, e.getMessage());
             return Optional.empty();


### PR DESCRIPTION
Ensure path separators are POSIX style