### PR TITLE
Brittle/tautological/nullness test detection for Rust & Go

### DIFF
--- a/app/src/main/java/ai/brokk/analyzer/AGENTS.md
+++ b/app/src/main/java/ai/brokk/analyzer/AGENTS.md
@@ -7,6 +7,7 @@
      ```java
      private static final Pattern WILDCARD_IMPORT_PATTERN = Pattern.compile("^from\\s+(.+?)\\s+import\\s+\\*");
      ```
+1. **CST and TSNode over string splicing**: Prefer traversing the concrete syntax tree with `TSNode` (child relationships, `getChildByFieldName`, `getNamedChild`, `getPrevSibling` / `getNextSibling` when appropriate, and helpers like `collectNodesByType`) instead of parsing or classifying code by stitching, normalizing, or scanning raw source text. Reserve `SourceContent.substringFrom(TSNode)` for **leaf** or token-shaped nodes (identifiers, literals, small spans) where the grammar does not expose a finer structure, not as a substitute for structural analysis of expressions or statements.
 
 ### 2. Tree-sitter Query Predicates
 1. **Predicates supported**: Our Tree-sitter Java binding supports query predicates such as `#eq?`, `#any-of?`, `#match?`, and `#is?`.

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/GoTestAssertionSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/GoTestAssertionSmellTest.java
@@ -1,0 +1,116 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class GoTestAssertionSmellTest extends AbstractBrittleTestSuite {
+
+    @Test
+    void meaningfulAssertionLikeBranchDoesNotTriggerNoAssertions() {
+        String code =
+                """
+                package sample
+                import "testing"
+
+                func TestMeaningful(t *testing.T) {
+                    got := "value"
+                    want := "other"
+                    if got != want {
+                        t.Errorf("got %s, want %s", got, want)
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertFalse(hasReason(findings, "no-assertions"));
+    }
+
+    @Test
+    void assertionCountUsesTotalDetectedAssertions() {
+        String code =
+                """
+                package sample
+                import "testing"
+
+                func TestMixed(t *testing.T) {
+                    got := "value"
+                    want := "other"
+                    if true == true {
+                        t.Errorf("tautology")
+                    }
+                    if got != want {
+                        t.Errorf("got %s, want %s", got, want)
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        var constantEquality = findings.stream()
+                .filter(f -> f.reasons().contains("constant-equality"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(constantEquality, "Expected constant-equality smell");
+        assertEquals(2, constantEquality.assertionCount(), "assertionCount should include non-smelly assertions");
+    }
+
+    @Test
+    void shallowOnlyNotEmittedWhenMixedWithMeaningfulAssertion() {
+        String code =
+                """
+                package sample
+                import "testing"
+
+                func TestMixedShallowAndMeaningful(t *testing.T) {
+                    var got *int
+                    want := "expected"
+                    actual := "actual"
+                    if got == nil {
+                        t.Errorf("got nil")
+                    }
+                    if actual != want {
+                        t.Errorf("want %s, got %s", want, actual)
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "nullness-only"));
+        assertFalse(hasReason(findings, "shallow-assertions-only"));
+    }
+
+    @Test
+    void emitsNoAssertionsWhenNoAssertionLikeBranchesExist() {
+        String code =
+                """
+                package sample
+                import "testing"
+
+                func TestNoAssertionLikeBranch(t *testing.T) {
+                    value := 42
+                    _ = value
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "no-assertions"));
+    }
+
+    @Override
+    protected String defaultTestPath() {
+        return "pkg/sample_test.go";
+    }
+
+    @Override
+    protected List<IAnalyzer.TestAssertionSmell> analyze(
+            String source, String path, IAnalyzer.TestAssertionWeights weights) {
+        try (var testProject = InlineTestProjectCreator.code(source, path).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), path);
+            return analyzer.findTestAssertionSmells(file, weights);
+        }
+    }
+}

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/RustTestAssertionSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/RustTestAssertionSmellTest.java
@@ -1,0 +1,121 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class RustTestAssertionSmellTest extends AbstractBrittleTestSuite {
+
+    @Test
+    void assertionCountUsesTotalRecognizedAssertionMacros() {
+        String literal = "a".repeat(defaultWeights().largeLiteralLengthThreshold());
+        String code =
+                """
+                #[test]
+                fn mixed_assertions() {
+                    let expected = String::from("expected");
+                    let actual = String::from("actual");
+                    assert_eq!("%s", actual);
+                    assert_eq!(actual, expected);
+                }
+                """
+                        .formatted(literal);
+        var findings = analyze(code);
+        var overspecified = findings.stream()
+                .filter(f -> f.reasons().contains("overspecified-literal"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(overspecified, "Expected overspecified-literal smell");
+        assertEquals(2, overspecified.assertionCount(), "assertionCount should include non-smelly assertions");
+    }
+
+    @Test
+    void meaningfulAssertionDoesNotTriggerNoAssertions() {
+        String code =
+                """
+                #[test]
+                fn meaningful_assert() {
+                    let expected = String::from("x");
+                    let actual = String::from("x");
+                    assert_eq!(actual, expected);
+                }
+                """;
+        var findings = analyze(code);
+        assertFalse(hasReason(findings, "no-assertions"));
+    }
+
+    @Test
+    void shallowOnlyNotEmittedWhenMixedWithMeaningfulMacro() {
+        String literal = "a".repeat(defaultWeights().largeLiteralLengthThreshold());
+        String code =
+                """
+                #[test]
+                fn mixed_shallow_and_meaningful() {
+                    let expected = String::from("x");
+                    let actual = String::from("y");
+                    assert_eq!("%s", actual);
+                    assert_eq!(actual, expected);
+                }
+                """
+                        .formatted(literal);
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "overspecified-literal"));
+        assertFalse(hasReason(findings, "shallow-assertions-only"));
+    }
+
+    @Test
+    void cfgTestAloneDoesNotMarkHelperFunctionAsTest() {
+        String code =
+                """
+                #[cfg(test)]
+                mod tests {
+                    fn helper_like_test_name() {
+                        assert_eq!(1, 1);
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    void directTestAttributeEnablesSmellDetection() {
+        String literal = "a".repeat(defaultWeights().largeLiteralLengthThreshold());
+        String code =
+                """
+                #[test]
+                fn constant_assertion() {
+                    assert_eq!("%s", actual());
+                }
+
+                fn actual() -> String {
+                    String::from("x")
+                }
+                """;
+        code = code.formatted(literal);
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "overspecified-literal"));
+    }
+
+    @Override
+    protected String defaultTestPath() {
+        return "src/lib.rs";
+    }
+
+    @Override
+    protected List<IAnalyzer.TestAssertionSmell> analyze(
+            String source, String path, IAnalyzer.TestAssertionWeights weights) {
+        try (var testProject = InlineTestProjectCreator.code(source, path).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), path);
+            return analyzer.findTestAssertionSmells(file, weights);
+        }
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -1353,6 +1353,8 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
         }
     }
 
+    private record GoTestFunction(TSNode function, String testParamName) {}
+
     private record GoAssertionAnalysis(
             int assertionCount,
             int shallowAssertionCount,
@@ -1382,21 +1384,21 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
 
     private List<TestAssertionSmell> detectTestAssertionSmells(
             ProjectFile file, TSNode root, SourceContent sourceContent, TestAssertionWeights weights) {
-        List<TSNode> testFunctions = testFunctionsOf(root, sourceContent);
+        List<GoTestFunction> testFunctions = testFunctionsOf(root, sourceContent);
         if (testFunctions.isEmpty()) {
             return List.of();
         }
 
         var candidates = new ArrayList<TestSmellCandidate>();
-        for (TSNode testFn : testFunctions) {
-            var analysis = analyzeGoAssertions(testFn, sourceContent, weights);
+        for (GoTestFunction testFn : testFunctions) {
+            var analysis = analyzeGoAssertions(testFn.function(), testFn.testParamName(), sourceContent, weights);
             var signals = analysis.smells();
             int assertionCount = analysis.assertionCount();
 
             String enclosing = enclosingCodeUnit(
                             file,
-                            testFn.getStartPoint().getRow(),
-                            testFn.getEndPoint().getRow())
+                            testFn.function().getStartPoint().getRow(),
+                            testFn.function().getEndPoint().getRow())
                     .map(CodeUnit::fqName)
                     .orElse(file.toString());
 
@@ -1408,8 +1410,8 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                         weights.noAssertionWeight(),
                         0,
                         List.of(TEST_ASSERTION_KIND_NO_ASSERTIONS),
-                        sourceContent.substringFrom(testFn));
-                candidates.add(new TestSmellCandidate(smell, testFn.getStartByte()));
+                        sourceContent.substringFrom(testFn.function()));
+                candidates.add(new TestSmellCandidate(smell, testFn.function().getStartByte()));
                 continue;
             }
 
@@ -1439,8 +1441,9 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                             score,
                             assertionCount,
                             List.of(TEST_ASSERTION_KIND_SHALLOW_ONLY),
-                            sourceContent.substringFrom(testFn));
-                    candidates.add(new TestSmellCandidate(smell, testFn.getStartByte()));
+                            sourceContent.substringFrom(testFn.function()));
+                    candidates.add(
+                            new TestSmellCandidate(smell, testFn.function().getStartByte()));
                 }
             }
         }
@@ -1460,12 +1463,12 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
         return Math.max(0, weights.meaningfulAssertionCredit()) * creditable;
     }
 
-    private List<TSNode> testFunctionsOf(TSNode root, SourceContent sourceContent) {
+    private List<GoTestFunction> testFunctionsOf(TSNode root, SourceContent sourceContent) {
         // Reuse the same semantic criteria as containsTestMarkers(), but return the matching function nodes.
         return withCachedQuery(
                 QueryType.DEFINITIONS,
                 query -> {
-                    List<TSNode> out = new ArrayList<>();
+                    List<GoTestFunction> out = new ArrayList<>();
                     try (TSQueryCursor cursor = new TSQueryCursor()) {
                         cursor.exec(query, root, sourceContent.text());
                         TSQueryMatch match = new TSQueryMatch();
@@ -1518,20 +1521,26 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
 
                             int totalIdentifierCount = 0;
                             TSNode firstParamDecl = null;
+                            String testParamName = null;
                             for (TSNode child : paramsNode.getNamedChildren()) {
                                 if (PARAMETER_DECLARATION.equals(child.getType())) {
                                     if (firstParamDecl == null) {
                                         firstParamDecl = child;
                                     }
                                     for (TSNode n : child.getNamedChildren()) {
-                                        if ("identifier".equals(n.getType())) {
+                                        if (IDENTIFIER.equals(n.getType())) {
                                             totalIdentifierCount++;
+                                            if (testParamName == null) {
+                                                testParamName = sourceContent
+                                                        .substringFrom(n)
+                                                        .trim();
+                                            }
                                         }
                                     }
                                 }
                             }
 
-                            if (firstParamDecl == null || totalIdentifierCount != 1) {
+                            if (firstParamDecl == null || totalIdentifierCount != 1 || testParamName == null) {
                                 continue;
                             }
 
@@ -1555,7 +1564,7 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                             String typeText =
                                     sourceContent.substringFrom(typeNode).trim();
                             if (TESTING_T.equals(typeText) || POINTER_TESTING_T.equals(typeText)) {
-                                out.add(functionNode);
+                                out.add(new GoTestFunction(functionNode, testParamName));
                             }
                         }
                     }
@@ -1565,7 +1574,7 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
     }
 
     private GoAssertionAnalysis analyzeGoAssertions(
-            TSNode testFn, SourceContent sourceContent, TestAssertionWeights weights) {
+            TSNode testFn, String testParamName, SourceContent sourceContent, TestAssertionWeights weights) {
         var ifStatements = new ArrayList<TSNode>();
         collectNodesByType(testFn, Set.of(IF_STATEMENT), ifStatements);
         if (ifStatements.isEmpty()) {
@@ -1581,8 +1590,7 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
             collectNodesByType(ifStmt, Set.of(CALL_EXPRESSION), errorCalls);
             boolean hasErrorCall = false;
             for (TSNode call : errorCalls) {
-                String callText = sourceContent.substringFrom(call).strip();
-                if (callText.contains("t.Errorf") || callText.contains("t.Fatalf")) {
+                if (isTestFailureCall(call, testParamName, sourceContent)) {
                     hasErrorCall = true;
                     break;
                 }
@@ -1624,6 +1632,27 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
 
         return new GoAssertionAnalysis(
                 assertionCount, shallowAssertionCount, meaningfulAssertionCount, List.copyOf(signals));
+    }
+
+    private static boolean isTestFailureCall(TSNode call, String testParamName, SourceContent sourceContent) {
+        TSNode functionExpr = call.getChildByFieldName("function");
+        if (functionExpr == null || !SELECTOR_EXPRESSION.equals(functionExpr.getType())) {
+            return false;
+        }
+
+        TSNode receiver = functionExpr.getChildByFieldName("operand");
+        TSNode field = functionExpr.getChildByFieldName("field");
+        if (receiver == null || field == null) {
+            return false;
+        }
+
+        String receiverName = sourceContent.substringFrom(receiver).trim();
+        if (!testParamName.equals(receiverName)) {
+            return false;
+        }
+
+        String methodName = sourceContent.substringFrom(field).trim();
+        return "Errorf".equals(methodName) || "Fatalf".equals(methodName);
     }
 
     private @Nullable AssertionSignal classifyGoAssertionFromConditionAndMessage(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -11,6 +11,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1335,6 +1336,490 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
         String lastToken =
                 lastSpace == -1 ? prefix : prefix.substring(lastSpace).trim();
         return "_".equals(lastToken);
+    }
+
+    private record AssertionSignal(
+            String kind,
+            int score,
+            boolean shallow,
+            boolean meaningful,
+            int startByte,
+            List<String> reasons,
+            String excerpt) {}
+
+    private record TestSmellCandidate(TestAssertionSmell smell, int startByte) {
+        int score() {
+            return smell.score();
+        }
+    }
+
+    @Override
+    public List<TestAssertionSmell> findTestAssertionSmells(ProjectFile file, TestAssertionWeights weights) {
+        checkStale("findTestAssertionSmells");
+        if (!containsTests(file)) {
+            return List.of();
+        }
+
+        TestAssertionWeights resolvedWeights = weights != null ? weights : TestAssertionWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file, source -> detectTestAssertionSmells(file, root, source, resolvedWeights), List.of());
+                },
+                List.of());
+    }
+
+    private List<TestAssertionSmell> detectTestAssertionSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, TestAssertionWeights weights) {
+        List<TSNode> testFunctions = testFunctionsOf(root, sourceContent);
+        if (testFunctions.isEmpty()) {
+            return List.of();
+        }
+
+        var candidates = new ArrayList<TestSmellCandidate>();
+        for (TSNode testFn : testFunctions) {
+            var signals = detectGoAssertionSignals(testFn, sourceContent, weights);
+            int assertionCount = signals.size();
+
+            String enclosing = enclosingCodeUnit(
+                            file,
+                            testFn.getStartPoint().getRow(),
+                            testFn.getEndPoint().getRow())
+                    .map(CodeUnit::fqName)
+                    .orElse(file.toString());
+
+            if (assertionCount == 0) {
+                var smell = new TestAssertionSmell(
+                        file,
+                        enclosing,
+                        TEST_ASSERTION_KIND_NO_ASSERTIONS,
+                        weights.noAssertionWeight(),
+                        0,
+                        List.of(TEST_ASSERTION_KIND_NO_ASSERTIONS),
+                        sourceContent.substringFrom(testFn));
+                candidates.add(new TestSmellCandidate(smell, testFn.getStartByte()));
+                continue;
+            }
+
+            for (AssertionSignal signal : signals) {
+                if (signal.score() <= 0) continue;
+                candidates.add(new TestSmellCandidate(
+                        new TestAssertionSmell(
+                                file,
+                                enclosing,
+                                signal.kind(),
+                                signal.score(),
+                                assertionCount,
+                                List.copyOf(signal.reasons()),
+                                signal.excerpt()),
+                        signal.startByte()));
+            }
+
+            boolean allShallow = signals.stream().allMatch(AssertionSignal::shallow);
+            if (allShallow) {
+                int score = weights.shallowAssertionOnlyWeight()
+                        - meaningfulAssertionCredit(signals, weights, AssertionSignal::meaningful);
+                if (score > 0) {
+                    var smell = new TestAssertionSmell(
+                            file,
+                            enclosing,
+                            TEST_ASSERTION_KIND_SHALLOW_ONLY,
+                            score,
+                            assertionCount,
+                            List.of(TEST_ASSERTION_KIND_SHALLOW_ONLY),
+                            sourceContent.substringFrom(testFn));
+                    candidates.add(new TestSmellCandidate(smell, testFn.getStartByte()));
+                }
+            }
+        }
+
+        return candidates.stream()
+                .sorted(Comparator.comparingInt(TestSmellCandidate::score)
+                        .reversed()
+                        .thenComparing(c -> c.smell().file().toString())
+                        .thenComparing(c -> c.smell().enclosingFqName())
+                        .thenComparingInt(TestSmellCandidate::startByte))
+                .map(TestSmellCandidate::smell)
+                .toList();
+    }
+
+    private static int meaningfulAssertionCredit(
+            List<AssertionSignal> assertions,
+            TestAssertionWeights weights,
+            java.util.function.Predicate<AssertionSignal> predicate) {
+        long count = assertions.stream().filter(predicate).count();
+        int creditable = Math.min((int) count, Math.max(0, weights.meaningfulAssertionCreditCap()));
+        return Math.max(0, weights.meaningfulAssertionCredit()) * creditable;
+    }
+
+    private List<TSNode> testFunctionsOf(TSNode root, SourceContent sourceContent) {
+        // Reuse the same semantic criteria as containsTestMarkers(), but return the matching function nodes.
+        return withCachedQuery(
+                QueryType.DEFINITIONS,
+                query -> {
+                    List<TSNode> out = new ArrayList<>();
+                    try (TSQueryCursor cursor = new TSQueryCursor()) {
+                        cursor.exec(query, root, sourceContent.text());
+                        TSQueryMatch match = new TSQueryMatch();
+
+                        while (cursor.nextMatch(match)) {
+                            boolean sawTestMarker = false;
+                            TSNode nameNode = null;
+                            TSNode paramsNode = null;
+                            TSNode functionNode = null;
+
+                            for (TSQueryCapture capture : match.getCaptures()) {
+                                String captureName = query.getCaptureNameForId(capture.getIndex());
+                                TSNode node = capture.getNode();
+                                if (node == null) {
+                                    continue;
+                                }
+
+                                switch (captureName) {
+                                    case TEST_MARKER -> {
+                                        sawTestMarker = true;
+                                        functionNode = node;
+                                    }
+                                    case CAPTURE_TEST_CANDIDATE_NAME -> nameNode = node;
+                                    case CAPTURE_TEST_CANDIDATE_PARAMS -> paramsNode = node;
+                                }
+
+                                if (sawTestMarker && nameNode != null && paramsNode != null) {
+                                    break;
+                                }
+                            }
+
+                            if (!sawTestMarker || nameNode == null || paramsNode == null || functionNode == null) {
+                                continue;
+                            }
+
+                            String funcName =
+                                    sourceContent.substringFrom(nameNode).trim();
+                            if (!funcName.startsWith(TEST_FUNCTION_PREFIX)) {
+                                continue;
+                            }
+
+                            TSNode parent = nameNode.getParent();
+                            if (parent != null) {
+                                TSNode typeParams =
+                                        parent.getChildByFieldName(GO_SYNTAX_PROFILE.typeParametersFieldName());
+                                if (typeParams != null) {
+                                    continue;
+                                }
+                            }
+
+                            int totalIdentifierCount = 0;
+                            TSNode firstParamDecl = null;
+                            for (TSNode child : paramsNode.getNamedChildren()) {
+                                if (PARAMETER_DECLARATION.equals(child.getType())) {
+                                    if (firstParamDecl == null) {
+                                        firstParamDecl = child;
+                                    }
+                                    for (TSNode n : child.getNamedChildren()) {
+                                        if ("identifier".equals(n.getType())) {
+                                            totalIdentifierCount++;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (firstParamDecl == null || totalIdentifierCount != 1) {
+                                continue;
+                            }
+
+                            TSNode typeNode = firstParamDecl.getChildByFieldName(FIELD_TYPE);
+                            if (typeNode == null) {
+                                for (TSNode child : firstParamDecl.getNamedChildren()) {
+                                    String type = child.getType();
+                                    if (POINTER_TYPE.equals(type)
+                                            || QUALIFIED_TYPE.equals(type)
+                                            || TYPE_IDENTIFIER.equals(type)) {
+                                        typeNode = child;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (typeNode == null) {
+                                continue;
+                            }
+
+                            String typeText =
+                                    sourceContent.substringFrom(typeNode).trim();
+                            if (TESTING_T.equals(typeText) || POINTER_TESTING_T.equals(typeText)) {
+                                out.add(functionNode);
+                            }
+                        }
+                    }
+                    return out;
+                },
+                List.of());
+    }
+
+    private List<AssertionSignal> detectGoAssertionSignals(
+            TSNode testFn, SourceContent sourceContent, TestAssertionWeights weights) {
+        var ifStatements = new ArrayList<TSNode>();
+        collectNodesByType(testFn, Set.of(IF_STATEMENT), ifStatements);
+        if (ifStatements.isEmpty()) {
+            return List.of();
+        }
+
+        var signals = new ArrayList<AssertionSignal>();
+        for (TSNode ifStmt : ifStatements) {
+            var errorCalls = new ArrayList<TSNode>();
+            collectNodesByType(ifStmt, Set.of(CALL_EXPRESSION), errorCalls);
+            boolean hasErrorCall = false;
+            for (TSNode call : errorCalls) {
+                String callText = sourceContent.substringFrom(call).strip();
+                if (callText.contains("t.Errorf") || callText.contains("t.Fatalf")) {
+                    hasErrorCall = true;
+                    break;
+                }
+            }
+            if (!hasErrorCall) {
+                continue;
+            }
+
+            TSNode condition = ifStmt.getChildByFieldName("condition");
+            if (condition == null) {
+                var condCandidates = new ArrayList<TSNode>();
+                collectNodesByType(ifStmt, Set.of(BINARY_EXPRESSION, EXPRESSION), condCandidates);
+                if (condCandidates.isEmpty()) {
+                    continue;
+                }
+                condition = condCandidates.getFirst();
+            }
+
+            var signal = classifyGoAssertionFromConditionAndMessage(ifStmt, condition, sourceContent, weights);
+            if (signal != null && signal.score() > 0) {
+                signals.add(signal);
+            }
+        }
+
+        return signals;
+    }
+
+    private @Nullable AssertionSignal classifyGoAssertionFromConditionAndMessage(
+            TSNode ifStmt, TSNode condition, SourceContent sourceContent, TestAssertionWeights weights) {
+        int score = 0;
+        boolean shallow = false;
+        boolean meaningful = true;
+        String kind = "";
+        var reasons = new ArrayList<String>();
+
+        TSNode left = condition.getChildByFieldName("left");
+        TSNode right = condition.getChildByFieldName("right");
+        if (left == null || right == null) {
+            var exprs = new ArrayList<TSNode>();
+            collectNodesByType(condition, Set.of(EXPRESSION), exprs);
+            if (exprs.size() >= 2) {
+                left = exprs.getFirst();
+                right = exprs.get(1);
+            }
+        }
+        if (left == null || right == null) {
+            // Can't classify reliably.
+            return null;
+        }
+
+        boolean leftNil = isGoNilExpr(left);
+        boolean rightNil = isGoNilExpr(right);
+        boolean leftConst = isGoConstantExpr(left);
+        boolean rightConst = isGoConstantExpr(right);
+
+        if (leftConst && rightConst) {
+            score += weights.constantEqualityWeight();
+            kind = TEST_ASSERTION_KIND_CONSTANT_EQUALITY;
+            reasons.add(TEST_ASSERTION_KIND_CONSTANT_EQUALITY);
+            meaningful = false;
+        } else if (sameGoExpr(left, right, sourceContent)) {
+            score += weights.tautologicalAssertionWeight();
+            kind = TEST_ASSERTION_KIND_SELF_COMPARISON;
+            reasons.add(TEST_ASSERTION_KIND_SELF_COMPARISON);
+            meaningful = false;
+        } else if (leftNil || rightNil) {
+            score += weights.nullnessOnlyWeight();
+            kind = TEST_ASSERTION_KIND_NULLNESS_ONLY;
+            reasons.add(TEST_ASSERTION_KIND_NULLNESS_ONLY);
+            shallow = true;
+            meaningful = false;
+        }
+
+        boolean overspecified =
+                containsLargeGoStringLiteral(ifStmt, sourceContent, weights.largeLiteralLengthThreshold());
+        if (overspecified) {
+            score += weights.overspecifiedLiteralWeight();
+            kind = TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL;
+            reasons.add(TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL);
+            meaningful = false;
+            shallow = false;
+        }
+
+        if (score <= 0) {
+            return null;
+        }
+
+        return new AssertionSignal(
+                kind,
+                score,
+                shallow,
+                meaningful,
+                ifStmt.getStartByte(),
+                List.copyOf(reasons),
+                sourceContent.substringFrom(ifStmt));
+    }
+
+    private static boolean isGoNilExpr(TSNode expr) {
+        // Tree-sitter represents the `nil` keyword as its own named node type: "nil".
+        if (NIL_LITERAL.equals(expr.getType())) {
+            return true;
+        }
+        // Be defensive: nil may be wrapped in parens or other expression nodes.
+        return hasDescendantOfType(expr, NIL_LITERAL);
+    }
+
+    private static boolean isGoConstantExpr(TSNode expr) {
+        // nil/true/false are represented as dedicated named node types in the Go grammar.
+        if (NIL_LITERAL.equals(expr.getType())
+                || TRUE_LITERAL.equals(expr.getType())
+                || FALSE_LITERAL.equals(expr.getType())) {
+            return true;
+        }
+        return hasDescendantOfType(expr, NIL_LITERAL)
+                || hasDescendantOfType(expr, TRUE_LITERAL)
+                || hasDescendantOfType(expr, FALSE_LITERAL)
+                || hasDescendantOfType(expr, STRING_LITERAL)
+                || hasDescendantOfType(expr, INTEGER_LITERAL)
+                || hasDescendantOfType(expr, FLOAT_LITERAL)
+                || hasDescendantOfType(expr, BOOLEAN_LITERAL);
+    }
+
+    private static boolean sameGoExpr(TSNode left, TSNode right, SourceContent sourceContent) {
+        TSNode l = unwrapGoParenthesized(left);
+        TSNode r = unwrapGoParenthesized(right);
+        if (l == null || r == null) return false;
+        String lType = l.getType();
+        String rType = r.getType();
+        if (lType == null || rType == null || !lType.equals(rType)) return false;
+
+        String type = lType;
+        if (type.equals(IDENTIFIER) || type.equals(SELECTOR_EXPRESSION)) {
+            // Compare CST shape for common cases (including chained selectors).
+            return sameGoSelectorOrIdentifier(l, r, sourceContent);
+        }
+
+        if (type.equals(CALL_EXPRESSION)) {
+            return sameGoCallExpr(l, r, sourceContent);
+        }
+
+        if (type.equals(BINARY_EXPRESSION)) {
+            return sameGoBinaryExpr(l, r, sourceContent);
+        }
+
+        // Conservative fallback: trimmed CST text.
+        return sourceContent
+                .substringFrom(l)
+                .strip()
+                .equals(sourceContent.substringFrom(r).strip());
+    }
+
+    private static TSNode unwrapGoParenthesized(TSNode n) {
+        TSNode current = n;
+        // Parentheses may wrap expressions; unwrap up to 2 layers.
+        for (int i = 0; i < 2; i++) {
+            if (current == null) return n;
+            if (!PARENTHESIZED_EXPRESSION.equals(current.getType())) break;
+            if (current.getNamedChildCount() == 0) break;
+            TSNode child = current.getNamedChild(0);
+            if (child == null) break;
+            current = child;
+        }
+        return current;
+    }
+
+    private static boolean sameGoSelectorOrIdentifier(TSNode left, TSNode right, SourceContent sourceContent) {
+        // selector_expression has fields `operand` and `field`.
+        String leftType = left.getType();
+        String rightType = right.getType();
+        if (SELECTOR_EXPRESSION.equals(leftType) && SELECTOR_EXPRESSION.equals(rightType)) {
+            TSNode lOperand = left.getChildByFieldName("operand");
+            TSNode lField = left.getChildByFieldName("field");
+            TSNode rOperand = right.getChildByFieldName("operand");
+            TSNode rField = right.getChildByFieldName("field");
+            if (lOperand == null || lField == null || rOperand == null || rField == null) {
+                return false;
+            }
+            return sameGoExpr(lOperand, rOperand, sourceContent) && sameGoExpr(lField, rField, sourceContent);
+        }
+
+        // identifier (or leaf selectors) fallback to exact token text.
+        return sourceContent
+                .substringFrom(left)
+                .strip()
+                .equals(sourceContent.substringFrom(right).strip());
+    }
+
+    private static boolean sameGoCallExpr(TSNode left, TSNode right, SourceContent sourceContent) {
+        TSNode lFunc = left.getChildByFieldName("function");
+        TSNode rFunc = right.getChildByFieldName("function");
+        TSNode lArgsNode = left.getChildByFieldName("arguments");
+        TSNode rArgsNode = right.getChildByFieldName("arguments");
+        if (lFunc == null || rFunc == null || lArgsNode == null || rArgsNode == null) return false;
+
+        if (!sameGoExpr(lFunc, rFunc, sourceContent)) return false;
+
+        // Compare arguments by their top-level named children.
+        int lCount = lArgsNode.getNamedChildCount();
+        int rCount = rArgsNode.getNamedChildCount();
+        if (lCount != rCount) return false;
+        for (int i = 0; i < lCount; i++) {
+            TSNode lArg = lArgsNode.getNamedChild(i);
+            TSNode rArg = rArgsNode.getNamedChild(i);
+            if (lArg == null || rArg == null) return false;
+            if (!sameGoExpr(lArg, rArg, sourceContent)) return false;
+        }
+        return true;
+    }
+
+    private static boolean sameGoBinaryExpr(TSNode left, TSNode right, SourceContent sourceContent) {
+        TSNode lLeft = left.getChildByFieldName("left");
+        TSNode lRight = left.getChildByFieldName("right");
+        TSNode rLeft = right.getChildByFieldName("left");
+        TSNode rRight = right.getChildByFieldName("right");
+        if (lLeft == null || lRight == null || rLeft == null || rRight == null) return false;
+        if (!sameGoExpr(lLeft, rLeft, sourceContent)) return false;
+        if (!sameGoExpr(lRight, rRight, sourceContent)) return false;
+
+        return firstUnnamedChildType(left).equals(firstUnnamedChildType(right));
+    }
+
+    private static String firstUnnamedChildType(TSNode node) {
+        int childCount = node.getChildCount();
+        for (int i = 0; i < childCount; i++) {
+            TSNode child = node.getChild(i);
+            if (child == null) continue;
+            if (!child.isNamed()) {
+                String t = child.getType();
+                return t == null ? "" : t;
+            }
+        }
+        return "";
+    }
+
+    private static boolean containsLargeGoStringLiteral(TSNode root, SourceContent sourceContent, int threshold) {
+        var lits = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(STRING_LITERAL), lits);
+        for (TSNode lit : lits) {
+            if (sourceContent.substringFrom(lit).length() >= threshold) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -1353,6 +1353,12 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
         }
     }
 
+    private record GoAssertionAnalysis(
+            int assertionCount,
+            int shallowAssertionCount,
+            int meaningfulAssertionCount,
+            List<AssertionSignal> smells) {}
+
     @Override
     public List<TestAssertionSmell> findTestAssertionSmells(ProjectFile file, TestAssertionWeights weights) {
         checkStale("findTestAssertionSmells");
@@ -1383,8 +1389,9 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
 
         var candidates = new ArrayList<TestSmellCandidate>();
         for (TSNode testFn : testFunctions) {
-            var signals = detectGoAssertionSignals(testFn, sourceContent, weights);
-            int assertionCount = signals.size();
+            var analysis = analyzeGoAssertions(testFn, sourceContent, weights);
+            var signals = analysis.smells();
+            int assertionCount = analysis.assertionCount();
 
             String enclosing = enclosingCodeUnit(
                             file,
@@ -1420,10 +1427,10 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                         signal.startByte()));
             }
 
-            boolean allShallow = signals.stream().allMatch(AssertionSignal::shallow);
+            boolean allShallow = analysis.shallowAssertionCount() == assertionCount;
             if (allShallow) {
                 int score = weights.shallowAssertionOnlyWeight()
-                        - meaningfulAssertionCredit(signals, weights, AssertionSignal::meaningful);
+                        - meaningfulAssertionCredit(analysis.meaningfulAssertionCount(), weights);
                 if (score > 0) {
                     var smell = new TestAssertionSmell(
                             file,
@@ -1448,12 +1455,8 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                 .toList();
     }
 
-    private static int meaningfulAssertionCredit(
-            List<AssertionSignal> assertions,
-            TestAssertionWeights weights,
-            java.util.function.Predicate<AssertionSignal> predicate) {
-        long count = assertions.stream().filter(predicate).count();
-        int creditable = Math.min((int) count, Math.max(0, weights.meaningfulAssertionCreditCap()));
+    private static int meaningfulAssertionCredit(int meaningfulAssertionCount, TestAssertionWeights weights) {
+        int creditable = Math.min(meaningfulAssertionCount, Math.max(0, weights.meaningfulAssertionCreditCap()));
         return Math.max(0, weights.meaningfulAssertionCredit()) * creditable;
     }
 
@@ -1561,15 +1564,18 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                 List.of());
     }
 
-    private List<AssertionSignal> detectGoAssertionSignals(
+    private GoAssertionAnalysis analyzeGoAssertions(
             TSNode testFn, SourceContent sourceContent, TestAssertionWeights weights) {
         var ifStatements = new ArrayList<TSNode>();
         collectNodesByType(testFn, Set.of(IF_STATEMENT), ifStatements);
         if (ifStatements.isEmpty()) {
-            return List.of();
+            return new GoAssertionAnalysis(0, 0, 0, List.of());
         }
 
         var signals = new ArrayList<AssertionSignal>();
+        int assertionCount = 0;
+        int shallowAssertionCount = 0;
+        int meaningfulAssertionCount = 0;
         for (TSNode ifStmt : ifStatements) {
             var errorCalls = new ArrayList<TSNode>();
             collectNodesByType(ifStmt, Set.of(CALL_EXPRESSION), errorCalls);
@@ -1584,24 +1590,40 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
             if (!hasErrorCall) {
                 continue;
             }
+            assertionCount++;
 
             TSNode condition = ifStmt.getChildByFieldName("condition");
             if (condition == null) {
                 var condCandidates = new ArrayList<TSNode>();
                 collectNodesByType(ifStmt, Set.of(BINARY_EXPRESSION, EXPRESSION), condCandidates);
                 if (condCandidates.isEmpty()) {
+                    // If we detect an assertion-shaped branch but cannot parse condition shape, treat it as non-shallow
+                    // and meaningful to avoid false "no assertions"/"all shallow" outcomes.
+                    meaningfulAssertionCount++;
                     continue;
                 }
                 condition = condCandidates.getFirst();
             }
 
             var signal = classifyGoAssertionFromConditionAndMessage(ifStmt, condition, sourceContent, weights);
+            if (signal != null) {
+                if (signal.shallow()) {
+                    shallowAssertionCount++;
+                }
+                if (signal.meaningful()) {
+                    meaningfulAssertionCount++;
+                }
+            } else {
+                // No smell classification => still a real assertion check.
+                meaningfulAssertionCount++;
+            }
             if (signal != null && signal.score() > 0) {
                 signals.add(signal);
             }
         }
 
-        return signals;
+        return new GoAssertionAnalysis(
+                assertionCount, shallowAssertionCount, meaningfulAssertionCount, List.copyOf(signals));
     }
 
     private @Nullable AssertionSignal classifyGoAssertionFromConditionAndMessage(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -728,12 +728,10 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         var functions = new ArrayList<TSNode>();
         collectNodesByType(root, Set.of(FUNCTION_ITEM), functions);
         var testFunctions = rustFunctionsWithDirectTestAttribute(root, sourceContent);
-        boolean fallbackAllFunctionsAsTests =
-                testFunctions.isEmpty() && sourceContent.text().contains(TEST_ATTRIBUTE_MARKER);
 
         var candidates = new ArrayList<TestSmellCandidate>();
         for (TSNode function : functions) {
-            if (!fallbackAllFunctionsAsTests && !testFunctions.contains(function)) {
+            if (!testFunctions.contains(function)) {
                 continue;
             }
 

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -39,6 +39,12 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         }
     }
 
+    private record RustAssertionAnalysis(
+            int assertionCount,
+            int shallowAssertionCount,
+            int meaningfulAssertionCount,
+            List<AssertionSignal> smells) {}
+
     @Override
     public Optional<String> extractCallReceiver(String reference) {
         return ClassNameExtractor.extractForRust(reference);
@@ -721,17 +727,19 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
             ProjectFile file, TSNode root, SourceContent sourceContent, TestAssertionWeights weights) {
         var functions = new ArrayList<TSNode>();
         collectNodesByType(root, Set.of(FUNCTION_ITEM), functions);
-
-        var testAttrNodes = testAttributeItems(root, sourceContent);
+        var testFunctions = rustFunctionsWithDirectTestAttribute(root, sourceContent);
+        boolean fallbackAllFunctionsAsTests =
+                testFunctions.isEmpty() && sourceContent.text().contains(TEST_ATTRIBUTE_MARKER);
 
         var candidates = new ArrayList<TestSmellCandidate>();
         for (TSNode function : functions) {
-            if (!isRustTestFunction(function, testAttrNodes)) {
+            if (!fallbackAllFunctionsAsTests && !testFunctions.contains(function)) {
                 continue;
             }
 
-            var signals = detectRustAssertionSignals(function, sourceContent, weights);
-            int assertionCount = signals.size();
+            var analysis = analyzeRustAssertions(function, sourceContent, weights);
+            var signals = analysis.smells();
+            int assertionCount = analysis.assertionCount();
 
             String enclosing = enclosingCodeUnit(
                             file,
@@ -767,10 +775,10 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
                         signal.startByte()));
             }
 
-            boolean allShallow = signals.stream().allMatch(AssertionSignal::shallow);
+            boolean allShallow = analysis.shallowAssertionCount() == assertionCount;
             if (allShallow) {
                 int score = weights.shallowAssertionOnlyWeight()
-                        - meaningfulAssertionCredit(signals, weights, AssertionSignal::meaningful);
+                        - meaningfulAssertionCredit(analysis.meaningfulAssertionCount(), weights);
                 if (score > 0) {
                     var smell = new TestAssertionSmell(
                             file,
@@ -795,22 +803,21 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
                 .toList();
     }
 
-    private static int meaningfulAssertionCredit(
-            List<AssertionSignal> assertions,
-            TestAssertionWeights weights,
-            java.util.function.Predicate<AssertionSignal> predicate) {
-        long count = assertions.stream().filter(predicate).count();
-        int creditable = Math.min((int) count, Math.max(0, weights.meaningfulAssertionCreditCap()));
+    private static int meaningfulAssertionCredit(int meaningfulAssertionCount, TestAssertionWeights weights) {
+        int creditable = Math.min(meaningfulAssertionCount, Math.max(0, weights.meaningfulAssertionCreditCap()));
         return Math.max(0, weights.meaningfulAssertionCredit()) * creditable;
     }
 
-    private List<AssertionSignal> detectRustAssertionSignals(
+    private RustAssertionAnalysis analyzeRustAssertions(
             TSNode testFn, SourceContent sourceContent, TestAssertionWeights weights) {
         var macros = new ArrayList<TSNode>();
         collectNodesByType(testFn, Set.of(MACRO_INVOCATION), macros);
-        if (macros.isEmpty()) return List.of();
+        if (macros.isEmpty()) return new RustAssertionAnalysis(0, 0, 0, List.of());
 
         var signals = new ArrayList<AssertionSignal>();
+        int assertionCount = 0;
+        int shallowAssertionCount = 0;
+        int meaningfulAssertionCount = 0;
         for (TSNode macro : macros) {
             String macroText = sourceContent.substringFrom(macro).stripLeading();
             if (!(macroText.contains("assert!")
@@ -819,9 +826,20 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
                     || macroText.contains("assert_matches!"))) {
                 continue;
             }
+            assertionCount++;
 
             if (macroText.contains("assert_eq!") || macroText.contains("assert_ne!")) {
                 var signal = classifyRustEqLikeMacro(macro, sourceContent, weights);
+                if (signal != null) {
+                    if (signal.shallow()) {
+                        shallowAssertionCount++;
+                    }
+                    if (signal.meaningful()) {
+                        meaningfulAssertionCount++;
+                    }
+                } else {
+                    meaningfulAssertionCount++;
+                }
                 if (signal != null && signal.score() > 0) {
                     signals.add(signal);
                 }
@@ -830,6 +848,16 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
 
             if (macroText.contains("assert_matches!")) {
                 var signal = classifyRustMatchesMacro(macro, sourceContent, weights);
+                if (signal != null) {
+                    if (signal.shallow()) {
+                        shallowAssertionCount++;
+                    }
+                    if (signal.meaningful()) {
+                        meaningfulAssertionCount++;
+                    }
+                } else {
+                    meaningfulAssertionCount++;
+                }
                 if (signal != null && signal.score() > 0) {
                     signals.add(signal);
                 }
@@ -838,6 +866,16 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
 
             if (macroText.contains("assert!")) {
                 var signal = classifyRustAssertMacro(macro, sourceContent, weights);
+                if (signal != null) {
+                    if (signal.shallow()) {
+                        shallowAssertionCount++;
+                    }
+                    if (signal.meaningful()) {
+                        meaningfulAssertionCount++;
+                    }
+                } else {
+                    meaningfulAssertionCount++;
+                }
                 if (signal != null && signal.score() > 0) {
                     signals.add(signal);
                 }
@@ -845,13 +883,17 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         }
 
         signals.sort(Comparator.comparingInt(AssertionSignal::startByte));
-        return signals;
+        return new RustAssertionAnalysis(
+                assertionCount, shallowAssertionCount, meaningfulAssertionCount, List.copyOf(signals));
     }
 
     private @Nullable AssertionSignal classifyRustEqLikeMacro(
             TSNode macro, SourceContent sourceContent, TestAssertionWeights weights) {
-        var exprs = new ArrayList<TSNode>();
+        List<TSNode> exprs = new ArrayList<>();
         collectNodesByType(macro, Set.of(EXPRESSION), exprs);
+        if (exprs.size() < 2) {
+            exprs = rustMacroArgumentNodes(macro);
+        }
         if (exprs.size() < 2) {
             return null;
         }
@@ -912,8 +954,11 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
 
     private @Nullable AssertionSignal classifyRustAssertMacro(
             TSNode macro, SourceContent sourceContent, TestAssertionWeights weights) {
-        var exprs = new ArrayList<TSNode>();
+        List<TSNode> exprs = new ArrayList<>();
         collectNodesByType(macro, Set.of(EXPRESSION), exprs);
+        if (exprs.isEmpty()) {
+            exprs = rustMacroArgumentNodes(macro);
+        }
         if (exprs.isEmpty()) return null;
         TSNode condition = exprs.getFirst();
 
@@ -978,6 +1023,42 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
                 sourceContent.substringFrom(macro));
     }
 
+    private static List<TSNode> rustMacroArgumentNodes(TSNode macro) {
+        var args = new ArrayList<TSNode>();
+        TSNode tokenTree = null;
+
+        int childCount = macro.getChildCount();
+        for (int i = 0; i < childCount; i++) {
+            TSNode child = macro.getChild(i);
+            if (child != null && TOKEN_TREE.equals(child.getType())) {
+                tokenTree = child;
+                break;
+            }
+        }
+        if (tokenTree == null) {
+            var tokenTrees = new ArrayList<TSNode>();
+            collectNodesByType(macro, Set.of(TOKEN_TREE), tokenTrees);
+            if (!tokenTrees.isEmpty()) {
+                tokenTree = tokenTrees.getFirst();
+            }
+        }
+        if (tokenTree == null) {
+            return args;
+        }
+
+        int namedCount = tokenTree.getNamedChildCount();
+        for (int i = 0; i < namedCount; i++) {
+            TSNode child = tokenTree.getNamedChild(i);
+            if (child == null) continue;
+            String type = child.getType();
+            if (type == null) continue;
+            // Keep argument-like nodes; ignore punctuation-like wrappers if present.
+            if (ATTRIBUTE_ITEM.equals(type)) continue;
+            args.add(child);
+        }
+        return args;
+    }
+
     private static boolean containsLargeRustStringLiteral(TSNode root, SourceContent sourceContent, int threshold) {
         var stringLits = new ArrayList<TSNode>();
         collectNodesByType(root, Set.of(STRING_LITERAL), stringLits);
@@ -990,18 +1071,35 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         return false;
     }
 
-    private static boolean isRustTestFunction(TSNode function, List<TSNode> testAttrNodes) {
-        int fnStartRow = function.getStartPoint().getRow();
-        int fnStartByte = function.getStartByte();
-        for (TSNode attr : testAttrNodes) {
-            if (attr.getEndByte() <= fnStartByte) {
-                int rowDelta = fnStartRow - attr.getEndPoint().getRow();
-                if (rowDelta >= 0 && rowDelta <= 25 && fnStartByte - attr.getEndByte() <= 20000) {
-                    return true;
+    private Set<TSNode> rustFunctionsWithDirectTestAttribute(TSNode root, SourceContent sourceContent) {
+        var testFunctions = new HashSet<TSNode>();
+        for (TSNode attrItem : testAttributeItems(root, sourceContent)) {
+            if (!isRustTestAttributeItem(attrItem, sourceContent)) {
+                continue;
+            }
+
+            // Shape 1: attribute_item is nested under the function_item.
+            TSNode parent = attrItem.getParent();
+            if (parent != null && FUNCTION_ITEM.equals(parent.getType())) {
+                testFunctions.add(parent);
+                continue;
+            }
+
+            // Shape 2: attribute_item is a sibling immediately preceding the function_item.
+            TSNode next = attrItem.getNextSibling();
+            while (next != null) {
+                String nextType = next.getType();
+                if (ATTRIBUTE_ITEM.equals(nextType)) {
+                    next = next.getNextSibling();
+                    continue;
                 }
+                if (FUNCTION_ITEM.equals(nextType)) {
+                    testFunctions.add(next);
+                }
+                break;
             }
         }
-        return false;
+        return testFunctions;
     }
 
     private static boolean isRustNoneExpr(TSNode expr, SourceContent sourceContent) {
@@ -1083,10 +1181,7 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
 
                                 TSNode attrItemNode = capture.getNode();
                                 if (attrItemNode == null) continue;
-                                String content = sourceContent.substringFrom(attrItemNode);
-                                // Rust attributes look like #[test] or #[cfg(test)]
-                                if (content.contains(TEST_ATTRIBUTE_MARKER)
-                                        || content.contains(CFG_TEST_ATTRIBUTE_MARKER)) {
+                                if (isRustTestContextAttributeItem(attrItemNode, sourceContent)) {
                                     attrs.add(attrItemNode);
                                 }
                             }
@@ -1095,6 +1190,39 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
                     return attrs;
                 },
                 List.of());
+    }
+
+    private static boolean isRustTestAttributeItem(TSNode attrItemNode, SourceContent sourceContent) {
+        var ids = rustAttributeIdentifiers(attrItemNode, sourceContent);
+        // `#[test]` parses to identifier list containing `test` (typically as the first identifier).
+        return !ids.isEmpty() && "test".equals(ids.getFirst());
+    }
+
+    private static boolean isRustTestContextAttributeItem(TSNode attrItemNode, SourceContent sourceContent) {
+        var ids = rustAttributeIdentifiers(attrItemNode, sourceContent);
+        if (ids.isEmpty()) {
+            return false;
+        }
+        // test context is either:
+        //  - `#[test]` (first identifier is test), or
+        //  - `#[cfg(test)]` (first identifier cfg and one nested identifier test).
+        if ("test".equals(ids.getFirst())) {
+            return true;
+        }
+        return "cfg".equals(ids.getFirst()) && ids.stream().anyMatch("test"::equals);
+    }
+
+    private static List<String> rustAttributeIdentifiers(TSNode attrItemNode, SourceContent sourceContent) {
+        var idNodes = new ArrayList<TSNode>();
+        collectNodesByType(attrItemNode, Set.of(IDENTIFIER), idNodes);
+        if (idNodes.isEmpty()) {
+            return List.of();
+        }
+        var ids = new ArrayList<String>(idNodes.size());
+        for (TSNode idNode : idNodes) {
+            ids.add(sourceContent.substringFrom(idNode).strip());
+        }
+        return ids;
     }
 
     private static boolean sameRustExpr(TSNode left, TSNode right, SourceContent sourceContent) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -817,16 +817,16 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         int shallowAssertionCount = 0;
         int meaningfulAssertionCount = 0;
         for (TSNode macro : macros) {
-            String macroText = sourceContent.substringFrom(macro).stripLeading();
-            if (!(macroText.contains("assert!")
-                    || macroText.contains("assert_eq!")
-                    || macroText.contains("assert_ne!")
-                    || macroText.contains("assert_matches!"))) {
+            String macroName = rustMacroName(macro, sourceContent);
+            if (!(ASSERT_MACRO_NAME.equals(macroName)
+                    || ASSERT_EQ_MACRO_NAME.equals(macroName)
+                    || ASSERT_NE_MACRO_NAME.equals(macroName)
+                    || ASSERT_MATCHES_MACRO_NAME.equals(macroName))) {
                 continue;
             }
             assertionCount++;
 
-            if (macroText.contains("assert_eq!") || macroText.contains("assert_ne!")) {
+            if (ASSERT_EQ_MACRO_NAME.equals(macroName) || ASSERT_NE_MACRO_NAME.equals(macroName)) {
                 var signal = classifyRustEqLikeMacro(macro, sourceContent, weights);
                 if (signal != null) {
                     if (signal.shallow()) {
@@ -844,7 +844,7 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
                 continue;
             }
 
-            if (macroText.contains("assert_matches!")) {
+            if (ASSERT_MATCHES_MACRO_NAME.equals(macroName)) {
                 var signal = classifyRustMatchesMacro(macro, sourceContent, weights);
                 if (signal != null) {
                     if (signal.shallow()) {
@@ -862,7 +862,7 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
                 continue;
             }
 
-            if (macroText.contains("assert!")) {
+            if (ASSERT_MACRO_NAME.equals(macroName)) {
                 var signal = classifyRustAssertMacro(macro, sourceContent, weights);
                 if (signal != null) {
                     if (signal.shallow()) {
@@ -883,6 +883,37 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         signals.sort(Comparator.comparingInt(AssertionSignal::startByte));
         return new RustAssertionAnalysis(
                 assertionCount, shallowAssertionCount, meaningfulAssertionCount, List.copyOf(signals));
+    }
+
+    private static final String ASSERT_MACRO_NAME = "assert";
+    private static final String ASSERT_EQ_MACRO_NAME = "assert_eq";
+    private static final String ASSERT_NE_MACRO_NAME = "assert_ne";
+    private static final String ASSERT_MATCHES_MACRO_NAME = "assert_matches";
+
+    private static String rustMacroName(TSNode macro, SourceContent sourceContent) {
+        int tokenTreeStart = Integer.MAX_VALUE;
+        var tokenTrees = new ArrayList<TSNode>();
+        collectNodesByType(macro, Set.of(TOKEN_TREE), tokenTrees);
+        if (!tokenTrees.isEmpty()) {
+            tokenTreeStart = tokenTrees.getFirst().getStartByte();
+        }
+
+        var ids = new ArrayList<TSNode>();
+        collectNodesByType(macro, Set.of(IDENTIFIER), ids);
+
+        TSNode best = null;
+        for (TSNode id : ids) {
+            if (id.getStartByte() >= tokenTreeStart) {
+                continue;
+            }
+            if (best == null || id.getStartByte() > best.getStartByte()) {
+                best = id;
+            }
+        }
+        if (best == null) {
+            return "";
+        }
+        return sourceContent.substringFrom(best).trim();
     }
 
     private @Nullable AssertionSignal classifyRustEqLikeMacro(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -6,7 +6,9 @@ import ai.brokk.analyzer.cache.AnalyzerCache;
 import ai.brokk.project.ICoreProject;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -21,6 +23,21 @@ import org.treesitter.*;
 
 public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisProvider {
     private static final Logger log = LoggerFactory.getLogger(RustAnalyzer.class);
+
+    private record AssertionSignal(
+            String kind,
+            int score,
+            boolean shallow,
+            boolean meaningful,
+            int startByte,
+            List<String> reasons,
+            String excerpt) {}
+
+    private record TestSmellCandidate(TestAssertionSmell smell, int startByte) {
+        int score() {
+            return smell.score();
+        }
+    }
 
     @Override
     public Optional<String> extractCallReceiver(String reference) {
@@ -680,35 +697,492 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
     }
 
     @Override
-    protected boolean containsTestMarkers(TSTree tree, SourceContent sourceContent) {
-        TSNode root = tree.getRootNode();
-        if (root == null) return false;
+    public List<TestAssertionSmell> findTestAssertionSmells(ProjectFile file, TestAssertionWeights weights) {
+        checkStale("findTestAssertionSmells");
+        if (!containsTests(file)) {
+            return List.of();
+        }
+
+        TestAssertionWeights resolvedWeights = weights != null ? weights : TestAssertionWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file, source -> detectTestAssertionSmells(file, root, source, resolvedWeights), List.of());
+                },
+                List.of());
+    }
+
+    private List<TestAssertionSmell> detectTestAssertionSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, TestAssertionWeights weights) {
+        var functions = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(FUNCTION_ITEM), functions);
+
+        var testAttrNodes = testAttributeItems(root, sourceContent);
+
+        var candidates = new ArrayList<TestSmellCandidate>();
+        for (TSNode function : functions) {
+            if (!isRustTestFunction(function, testAttrNodes)) {
+                continue;
+            }
+
+            var signals = detectRustAssertionSignals(function, sourceContent, weights);
+            int assertionCount = signals.size();
+
+            String enclosing = enclosingCodeUnit(
+                            file,
+                            function.getStartPoint().getRow(),
+                            function.getEndPoint().getRow())
+                    .map(CodeUnit::fqName)
+                    .orElse(file.toString());
+
+            if (assertionCount == 0) {
+                var smell = new TestAssertionSmell(
+                        file,
+                        enclosing,
+                        TEST_ASSERTION_KIND_NO_ASSERTIONS,
+                        weights.noAssertionWeight(),
+                        0,
+                        List.of(TEST_ASSERTION_KIND_NO_ASSERTIONS),
+                        sourceContent.substringFrom(function));
+                candidates.add(new TestSmellCandidate(smell, function.getStartByte()));
+                continue;
+            }
+
+            for (AssertionSignal signal : signals) {
+                if (signal.score() <= 0) continue;
+                candidates.add(new TestSmellCandidate(
+                        new TestAssertionSmell(
+                                file,
+                                enclosing,
+                                signal.kind(),
+                                signal.score(),
+                                assertionCount,
+                                List.copyOf(signal.reasons()),
+                                signal.excerpt()),
+                        signal.startByte()));
+            }
+
+            boolean allShallow = signals.stream().allMatch(AssertionSignal::shallow);
+            if (allShallow) {
+                int score = weights.shallowAssertionOnlyWeight()
+                        - meaningfulAssertionCredit(signals, weights, AssertionSignal::meaningful);
+                if (score > 0) {
+                    var smell = new TestAssertionSmell(
+                            file,
+                            enclosing,
+                            TEST_ASSERTION_KIND_SHALLOW_ONLY,
+                            score,
+                            assertionCount,
+                            List.of(TEST_ASSERTION_KIND_SHALLOW_ONLY),
+                            sourceContent.substringFrom(function));
+                    candidates.add(new TestSmellCandidate(smell, function.getStartByte()));
+                }
+            }
+        }
+
+        return candidates.stream()
+                .sorted(Comparator.comparingInt(TestSmellCandidate::score)
+                        .reversed()
+                        .thenComparing(c -> c.smell().file().toString())
+                        .thenComparing(c -> c.smell().enclosingFqName())
+                        .thenComparingInt(TestSmellCandidate::startByte))
+                .map(TestSmellCandidate::smell)
+                .toList();
+    }
+
+    private static int meaningfulAssertionCredit(
+            List<AssertionSignal> assertions,
+            TestAssertionWeights weights,
+            java.util.function.Predicate<AssertionSignal> predicate) {
+        long count = assertions.stream().filter(predicate).count();
+        int creditable = Math.min((int) count, Math.max(0, weights.meaningfulAssertionCreditCap()));
+        return Math.max(0, weights.meaningfulAssertionCredit()) * creditable;
+    }
+
+    private List<AssertionSignal> detectRustAssertionSignals(
+            TSNode testFn, SourceContent sourceContent, TestAssertionWeights weights) {
+        var macros = new ArrayList<TSNode>();
+        collectNodesByType(testFn, Set.of(MACRO_INVOCATION), macros);
+        if (macros.isEmpty()) return List.of();
+
+        var signals = new ArrayList<AssertionSignal>();
+        for (TSNode macro : macros) {
+            String macroText = sourceContent.substringFrom(macro).stripLeading();
+            if (!(macroText.contains("assert!")
+                    || macroText.contains("assert_eq!")
+                    || macroText.contains("assert_ne!")
+                    || macroText.contains("assert_matches!"))) {
+                continue;
+            }
+
+            if (macroText.contains("assert_eq!") || macroText.contains("assert_ne!")) {
+                var signal = classifyRustEqLikeMacro(macro, sourceContent, weights);
+                if (signal != null && signal.score() > 0) {
+                    signals.add(signal);
+                }
+                continue;
+            }
+
+            if (macroText.contains("assert_matches!")) {
+                var signal = classifyRustMatchesMacro(macro, sourceContent, weights);
+                if (signal != null && signal.score() > 0) {
+                    signals.add(signal);
+                }
+                continue;
+            }
+
+            if (macroText.contains("assert!")) {
+                var signal = classifyRustAssertMacro(macro, sourceContent, weights);
+                if (signal != null && signal.score() > 0) {
+                    signals.add(signal);
+                }
+            }
+        }
+
+        signals.sort(Comparator.comparingInt(AssertionSignal::startByte));
+        return signals;
+    }
+
+    private @Nullable AssertionSignal classifyRustEqLikeMacro(
+            TSNode macro, SourceContent sourceContent, TestAssertionWeights weights) {
+        var exprs = new ArrayList<TSNode>();
+        collectNodesByType(macro, Set.of(EXPRESSION), exprs);
+        if (exprs.size() < 2) {
+            return null;
+        }
+        TSNode left = exprs.getFirst();
+        TSNode right = exprs.get(1);
+
+        int score = 0;
+        boolean shallow = false;
+        boolean meaningful = true;
+        String kind = "";
+        var reasons = new ArrayList<String>();
+
+        boolean leftIsNone = isRustNoneExpr(left, sourceContent);
+        boolean rightIsNone = isRustNoneExpr(right, sourceContent);
+        boolean leftConst = isRustConstantExpr(left, sourceContent);
+        boolean rightConst = isRustConstantExpr(right, sourceContent);
+
+        if (leftConst && rightConst) {
+            score += weights.constantEqualityWeight();
+            reasons.add(TEST_ASSERTION_KIND_CONSTANT_EQUALITY);
+            kind = TEST_ASSERTION_KIND_CONSTANT_EQUALITY;
+            meaningful = false;
+        } else if (sameRustExpr(left, right, sourceContent)) {
+            score += weights.tautologicalAssertionWeight();
+            reasons.add(TEST_ASSERTION_KIND_SELF_COMPARISON);
+            kind = TEST_ASSERTION_KIND_SELF_COMPARISON;
+            meaningful = false;
+        } else if (leftIsNone || rightIsNone) {
+            score += weights.nullnessOnlyWeight();
+            reasons.add(TEST_ASSERTION_KIND_NULLNESS_ONLY);
+            kind = TEST_ASSERTION_KIND_NULLNESS_ONLY;
+            shallow = true;
+            meaningful = false;
+        }
+
+        boolean overspecified =
+                containsLargeRustStringLiteral(macro, sourceContent, weights.largeLiteralLengthThreshold());
+        if (overspecified) {
+            score += weights.overspecifiedLiteralWeight();
+            reasons.add(TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL);
+            kind = TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL;
+            meaningful = false;
+        }
+
+        if (score <= 0) {
+            return null;
+        }
+
+        return new AssertionSignal(
+                kind,
+                score,
+                shallow,
+                meaningful,
+                macro.getStartByte(),
+                List.copyOf(reasons),
+                sourceContent.substringFrom(macro));
+    }
+
+    private @Nullable AssertionSignal classifyRustAssertMacro(
+            TSNode macro, SourceContent sourceContent, TestAssertionWeights weights) {
+        var exprs = new ArrayList<TSNode>();
+        collectNodesByType(macro, Set.of(EXPRESSION), exprs);
+        if (exprs.isEmpty()) return null;
+        TSNode condition = exprs.getFirst();
+
+        int score = 0;
+        boolean shallow = false;
+        boolean meaningful = true;
+        String kind = "";
+        var reasons = new ArrayList<String>();
+
+        String condText = sourceContent.substringFrom(condition).strip();
+        if ("true".equals(condText) || "false".equals(condText)) {
+            score += weights.constantTruthWeight();
+            reasons.add(TEST_ASSERTION_KIND_CONSTANT_TRUTH);
+            kind = TEST_ASSERTION_KIND_CONSTANT_TRUTH;
+            meaningful = false;
+        } else if (isRustNoneExpr(condition, sourceContent)
+                || isRustIsNoneMethodCall(condition, sourceContent)
+                || isRustNoneEqualityOrInequality(condition, sourceContent)) {
+            score += weights.nullnessOnlyWeight();
+            reasons.add(TEST_ASSERTION_KIND_NULLNESS_ONLY);
+            kind = TEST_ASSERTION_KIND_NULLNESS_ONLY;
+            shallow = true;
+            meaningful = false;
+        }
+
+        boolean overspecified =
+                containsLargeRustStringLiteral(macro, sourceContent, weights.largeLiteralLengthThreshold());
+        if (overspecified) {
+            score += weights.overspecifiedLiteralWeight();
+            reasons.add(TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL);
+            kind = TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL;
+            meaningful = false;
+        }
+
+        if (score <= 0) {
+            return null;
+        }
+
+        return new AssertionSignal(
+                kind,
+                score,
+                shallow,
+                meaningful,
+                macro.getStartByte(),
+                List.copyOf(reasons),
+                sourceContent.substringFrom(macro));
+    }
+
+    private @Nullable AssertionSignal classifyRustMatchesMacro(
+            TSNode macro, SourceContent sourceContent, TestAssertionWeights weights) {
+        boolean overspecified =
+                containsLargeRustStringLiteral(macro, sourceContent, weights.largeLiteralLengthThreshold());
+        if (!overspecified) return null;
+
+        return new AssertionSignal(
+                TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL,
+                weights.overspecifiedLiteralWeight(),
+                false,
+                false,
+                macro.getStartByte(),
+                List.of(TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL),
+                sourceContent.substringFrom(macro));
+    }
+
+    private static boolean containsLargeRustStringLiteral(TSNode root, SourceContent sourceContent, int threshold) {
+        var stringLits = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(STRING_LITERAL), stringLits);
+        if (stringLits.isEmpty()) return false;
+        for (TSNode lit : stringLits) {
+            if (sourceContent.substringFrom(lit).length() >= threshold) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isRustTestFunction(TSNode function, List<TSNode> testAttrNodes) {
+        int fnStartRow = function.getStartPoint().getRow();
+        int fnStartByte = function.getStartByte();
+        for (TSNode attr : testAttrNodes) {
+            if (attr.getEndByte() <= fnStartByte) {
+                int rowDelta = fnStartRow - attr.getEndPoint().getRow();
+                if (rowDelta >= 0 && rowDelta <= 25 && fnStartByte - attr.getEndByte() <= 20000) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isRustNoneExpr(TSNode expr, SourceContent sourceContent) {
+        return "None".equals(sourceContent.substringFrom(expr).strip());
+    }
+
+    private static boolean isRustIsNoneMethodCall(TSNode expr, SourceContent sourceContent) {
+        var calls = new ArrayList<TSNode>();
+        collectNodesByType(expr, Set.of(CALL_EXPRESSION), calls);
+        if (calls.isEmpty()) return false;
+
+        for (TSNode call : calls) {
+            var fieldExprs = new ArrayList<TSNode>();
+            collectNodesByType(call, Set.of(FIELD_EXPRESSION), fieldExprs);
+            if (fieldExprs.isEmpty()) continue;
+
+            for (TSNode fieldExpr : fieldExprs) {
+                var idNodes = new ArrayList<TSNode>();
+                collectNodesByType(fieldExpr, Set.of(IDENTIFIER), idNodes);
+                for (TSNode id : idNodes) {
+                    if ("is_none".equals(sourceContent.substringFrom(id).strip())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isRustNoneEqualityOrInequality(TSNode expr, SourceContent sourceContent) {
+        var bins = new ArrayList<TSNode>();
+        collectNodesByType(expr, Set.of(BINARY_EXPRESSION), bins);
+        if (bins.isEmpty()) return false;
+
+        for (TSNode bin : bins) {
+            TSNode left = bin.getChildByFieldName("left");
+            TSNode right = bin.getChildByFieldName("right");
+            if (left == null || right == null) continue;
+
+            String op = firstUnnamedChildType(bin);
+            boolean leftIsNone = isRustNoneExpr(left, sourceContent);
+            boolean rightIsNone = isRustNoneExpr(right, sourceContent);
+            if (("==".equals(op) && (leftIsNone || rightIsNone)) || ("!=".equals(op) && (leftIsNone || rightIsNone))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isRustConstantExpr(TSNode expr, SourceContent sourceContent) {
+        // `true`/`false` are represented by the named `boolean_literal` node in the Rust grammar.
+        // `None` is an identifier (so we still need text-based matching).
+        if (hasDescendantOfType(expr, BOOLEAN_LITERAL)) {
+            return true;
+        }
+        if (isRustNoneExpr(expr, sourceContent)) {
+            return true;
+        }
+        return hasDescendantOfType(expr, STRING_LITERAL)
+                || hasDescendantOfType(expr, CHAR_LITERAL)
+                || hasDescendantOfType(expr, INTEGER_LITERAL)
+                || hasDescendantOfType(expr, FLOAT_LITERAL)
+                || hasDescendantOfType(expr, BOOLEAN_LITERAL);
+    }
+
+    private List<TSNode> testAttributeItems(TSNode root, SourceContent sourceContent) {
+        if (root == null) return List.of();
         return withCachedQuery(
                 QueryType.DEFINITIONS,
                 query -> {
+                    var attrs = new ArrayList<TSNode>();
                     try (TSQueryCursor cursor = new TSQueryCursor()) {
                         cursor.exec(query, root, sourceContent.text());
-
                         TSQueryMatch match = new TSQueryMatch();
                         while (cursor.nextMatch(match)) {
                             for (TSQueryCapture capture : match.getCaptures()) {
                                 String captureName = query.getCaptureNameForId(capture.getIndex());
-                                if (TEST_MARKER.equals(captureName)) {
-                                    // The capture is now directly on the attribute_item node
-                                    TSNode attrItemNode = capture.getNode();
-                                    if (attrItemNode != null) {
-                                        String content = sourceContent.substringFrom(attrItemNode);
-                                        // Rust attributes look like #[test] or #[cfg(test)]
-                                        if (content.contains("#[test]") || content.contains("#[cfg(test)]")) {
-                                            return true;
-                                        }
-                                    }
+                                if (!TEST_MARKER.equals(captureName)) continue;
+
+                                TSNode attrItemNode = capture.getNode();
+                                if (attrItemNode == null) continue;
+                                String content = sourceContent.substringFrom(attrItemNode);
+                                // Rust attributes look like #[test] or #[cfg(test)]
+                                if (content.contains(TEST_ATTRIBUTE_MARKER)
+                                        || content.contains(CFG_TEST_ATTRIBUTE_MARKER)) {
+                                    attrs.add(attrItemNode);
                                 }
                             }
                         }
                     }
-                    return false;
+                    return attrs;
                 },
-                false);
+                List.of());
+    }
+
+    private static boolean sameRustExpr(TSNode left, TSNode right, SourceContent sourceContent) {
+        TSNode l = unwrapRustParenthesized(left);
+        TSNode r = unwrapRustParenthesized(right);
+
+        if (l == null || r == null) return false;
+        String lType = l.getType();
+        String rType = r.getType();
+        if (lType == null || rType == null || !lType.equals(rType)) return false;
+
+        String type = lType;
+        // For the most common leaf nodes, compare the exact CST text (trimmed), not whitespace-normalized strings.
+        if (type.equals("identifier") || type.equals("scoped_identifier")) {
+            return sourceContent
+                    .substringFrom(l)
+                    .strip()
+                    .equals(sourceContent.substringFrom(r).strip());
+        }
+        if (type.equals(BOOLEAN_LITERAL)
+                || type.equals(CHAR_LITERAL)
+                || type.equals(STRING_LITERAL)
+                || type.equals(INTEGER_LITERAL)
+                || type.equals(FLOAT_LITERAL)) {
+            return sourceContent
+                    .substringFrom(l)
+                    .strip()
+                    .equals(sourceContent.substringFrom(r).strip());
+        }
+
+        if (type.equals("binary_expression")) {
+            return sameRustBinaryExpr(l, r, sourceContent);
+        }
+
+        // Conservative fallback: compare CST text for the whole expression.
+        return sourceContent
+                .substringFrom(l)
+                .strip()
+                .equals(sourceContent.substringFrom(r).strip());
+    }
+
+    private static TSNode unwrapRustParenthesized(TSNode n) {
+        TSNode current = n;
+        // Be defensive: unwrap up to 2 layers of `parenthesized_expression`.
+        for (int i = 0; i < 2; i++) {
+            if (current == null) return n;
+            if (!"parenthesized_expression".equals(current.getType())) break;
+            if (current.getNamedChildCount() == 0) break;
+            TSNode child = current.getNamedChild(0);
+            if (child == null) break;
+            current = child;
+        }
+        return current;
+    }
+
+    private static boolean sameRustBinaryExpr(TSNode left, TSNode right, SourceContent sourceContent) {
+        TSNode lLeft = left.getChildByFieldName("left");
+        TSNode lRight = left.getChildByFieldName("right");
+        TSNode rLeft = right.getChildByFieldName("left");
+        TSNode rRight = right.getChildByFieldName("right");
+        if (lLeft == null || lRight == null || rLeft == null || rRight == null) {
+            return false;
+        }
+
+        if (!sameRustExpr(lLeft, rLeft, sourceContent)) return false;
+        if (!sameRustExpr(lRight, rRight, sourceContent)) return false;
+
+        // `operator` is typically an unnamed child token (e.g. "==" or "!=").
+        return firstUnnamedChildType(left).equals(firstUnnamedChildType(right));
+    }
+
+    private static String firstUnnamedChildType(TSNode node) {
+        int childCount = node.getChildCount();
+        for (int i = 0; i < childCount; i++) {
+            TSNode child = node.getChild(i);
+            if (child == null) continue;
+            if (!child.isNamed()) {
+                String t = child.getType();
+                return t == null ? "" : t;
+            }
+        }
+        return "";
+    }
+
+    @Override
+    protected boolean containsTestMarkers(TSTree tree, SourceContent sourceContent) {
+        TSNode root = tree.getRootNode();
+        if (root == null) return false;
+        return !testAttributeItems(root, sourceContent).isEmpty();
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/go/GoTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/go/GoTreeSitterNodeTypes.java
@@ -11,6 +11,17 @@ public final class GoTreeSitterNodeTypes {
     public static final String METHOD_DECLARATION = CommonTreeSitterNodeTypes.METHOD_DECLARATION;
 
     // ===== GO-SPECIFIC TYPES =====
+    // Control flow / expression nodes (used for assertion heuristics)
+    public static final String IF_STATEMENT = "if_statement";
+    public static final String EXPRESSION = "expression";
+    public static final String BINARY_EXPRESSION = "binary_expression";
+    public static final String CALL_EXPRESSION = "call_expression";
+
+    // Common expression leaf nodes (used for tautology checks)
+    public static final String IDENTIFIER = "identifier";
+    public static final String SELECTOR_EXPRESSION = "selector_expression";
+    public static final String PARENTHESIZED_EXPRESSION = "parenthesized_expression";
+
     // Type definitions
     public static final String STRUCT_TYPE = "struct_type";
     public static final String INTERFACE_TYPE = "interface_type";
@@ -42,6 +53,26 @@ public final class GoTreeSitterNodeTypes {
     public static final String POINTER_TYPE = "pointer_type";
     public static final String QUALIFIED_TYPE = "qualified_type";
     public static final String TYPE_IDENTIFIER = "type_identifier";
+
+    // Literals (best-effort node type names)
+    public static final String STRING_LITERAL = "string_literal";
+    public static final String CHAR_LITERAL = "char_literal";
+    public static final String INTEGER_LITERAL = "integer_literal";
+    public static final String FLOAT_LITERAL = "float_literal";
+    public static final String BOOLEAN_LITERAL = "boolean_literal";
+    public static final String NIL_LITERAL = "nil";
+    public static final String TRUE_LITERAL = "true";
+    public static final String FALSE_LITERAL = "false";
+
+    // ===== Test assertion smell labels (shared string values) =====
+    // These are semantic labels used in IAnalyzer.TestAssertionSmell.
+    public static final String TEST_ASSERTION_KIND_NO_ASSERTIONS = "no-assertions";
+    public static final String TEST_ASSERTION_KIND_CONSTANT_TRUTH = "constant-truth";
+    public static final String TEST_ASSERTION_KIND_CONSTANT_EQUALITY = "constant-equality";
+    public static final String TEST_ASSERTION_KIND_SELF_COMPARISON = "self-comparison";
+    public static final String TEST_ASSERTION_KIND_NULLNESS_ONLY = "nullness-only";
+    public static final String TEST_ASSERTION_KIND_SHALLOW_ONLY = "shallow-assertions-only";
+    public static final String TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL = "overspecified-literal";
 
     public static final String TEST_FUNCTION_PREFIX = "Test";
     public static final String TESTING_T = "testing.T";

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/rust/RustTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/rust/RustTreeSitterNodeTypes.java
@@ -47,5 +47,39 @@ public final class RustTreeSitterNodeTypes {
     // ===== QUERY CAPTURE NAMES =====
     public static final String TEST_MARKER = "test_marker";
 
+    // ===== Test attribute marker strings (best-effort) =====
+    // Used when filtering attribute_item text for `#[test]` and `#[cfg(test)]`.
+    public static final String TEST_ATTRIBUTE_MARKER = "#[test]";
+    public static final String CFG_TEST_ATTRIBUTE_MARKER = "#[cfg(test)]";
+
+    // ===== Assertion / Macro CST nodes (best-effort node type names) =====
+    // Rust macros like assert_eq!, assert!, assert_matches!
+    public static final String MACRO_INVOCATION = "macro_invocation";
+    public static final String TOKEN_TREE = "token_tree";
+
+    // Common expression nodes (used for argument inspection)
+    public static final String EXPRESSION = "expression";
+    public static final String CALL_EXPRESSION = "call_expression";
+    public static final String BINARY_EXPRESSION = "binary_expression";
+    public static final String FIELD_EXPRESSION = "field_expression";
+    public static final String IDENTIFIER = "identifier";
+
+    // Literal nodes (used for constant/overspecified-literal detection)
+    public static final String STRING_LITERAL = "string_literal";
+    public static final String CHAR_LITERAL = "char_literal";
+    public static final String INTEGER_LITERAL = "integer_literal";
+    public static final String FLOAT_LITERAL = "float_literal";
+    public static final String BOOLEAN_LITERAL = "boolean_literal";
+
+    // ===== Test assertion smell labels (shared string values) =====
+    // These are semantic labels used in IAnalyzer.TestAssertionSmell.
+    public static final String TEST_ASSERTION_KIND_NO_ASSERTIONS = "no-assertions";
+    public static final String TEST_ASSERTION_KIND_CONSTANT_TRUTH = "constant-truth";
+    public static final String TEST_ASSERTION_KIND_CONSTANT_EQUALITY = "constant-equality";
+    public static final String TEST_ASSERTION_KIND_SELF_COMPARISON = "self-comparison";
+    public static final String TEST_ASSERTION_KIND_NULLNESS_ONLY = "nullness-only";
+    public static final String TEST_ASSERTION_KIND_SHALLOW_ONLY = "shallow-assertions-only";
+    public static final String TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL = "overspecified-literal";
+
     private RustTreeSitterNodeTypes() {}
 }


### PR DESCRIPTION
## Summary
- implement low-quality test assertion smell detection for Go and Rust analyzers.
- replace string-based tautology/nullness checks with CST-node traversal helpers.
- centralize Go/Rust node-type and test-marker constants in language-specific TreeSitter node type classes.

## Test plan
- ./gradlew :brokk-shared:compileJava

Made with [Cursor](https://cursor.com)