### PR TITLE
Add Go and Rust exception smell detection

### DIFF
--- a/app/src/test/java/ai/brokk/analyzer/code_quality/GoExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/GoExceptionHandlingSmellTest.java
@@ -119,4 +119,3 @@ public class GoExceptionHandlingSmellTest {
         }
     }
 }
-

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/GoExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/GoExceptionHandlingSmellTest.java
@@ -1,0 +1,122 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class GoExceptionHandlingSmellTest {
+
+    @Test
+    void flagsEmptyRecoverHandler() {
+        String code =
+                """
+                package main
+
+                func work() {}
+
+                func run() {
+                    defer func() {
+                        if r := recover(); r != nil {
+                        }
+                    }()
+                    work()
+                }
+                """;
+        var findings = analyze(code);
+        assertFalse(findings.isEmpty());
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().stream().anyMatch(r -> r.startsWith("generic-catch:"))));
+    }
+
+    @Test
+    void flagsCommentOnlyRecoverHandler() {
+        String code =
+                """
+                package main
+
+                func run() {
+                    defer func() {
+                        if r := recover(); r != nil {
+                            // ignore
+                        }
+                    }()
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("comment-only-body")));
+    }
+
+    @Test
+    void flagsLogOnlyRecoverHandler() {
+        String code =
+                """
+                package main
+
+                import "log"
+
+                func run() {
+                    defer func() {
+                        if r := recover(); r != nil {
+                            log.Printf("bad: %v", r)
+                        }
+                    }()
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("log-only-body")));
+    }
+
+    @Test
+    void meaningfulRecoverHandlerWithRethrowIsMitigated() {
+        String code =
+                """
+                package main
+
+                import "log"
+
+                func run() {
+                    defer func() {
+                        if r := recover(); r != nil {
+                            x := 1
+                            y := 2
+                            z := x + y
+                            log.Printf("bad: %v %d", r, z)
+                            panic(r)
+                        }
+                    }()
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.isEmpty(), "Expected meaningful handler to be mitigated by body credit");
+    }
+
+    @Test
+    void flagsEmptyErrNotNilHandler() {
+        String code =
+                """
+                package main
+
+                func run() {
+                    var err error
+                    if err != nil {
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+    }
+
+    private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
+        try (var testProject = InlineTestProjectCreator.code(source, "main.go").build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), "main.go");
+            return analyzer.findExceptionHandlingSmells(file, IAnalyzer.ExceptionSmellWeights.defaults());
+        }
+    }
+}
+

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java
@@ -86,11 +86,11 @@ public class RustExceptionHandlingSmellTest {
     }
 
     private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
-        try (var testProject = InlineTestProjectCreator.code(source, "src/lib.rs").build()) {
+        try (var testProject =
+                InlineTestProjectCreator.code(source, "src/lib.rs").build()) {
             IAnalyzer analyzer = testProject.getAnalyzer();
             ProjectFile file = new ProjectFile(testProject.getRoot(), "src/lib.rs");
             return analyzer.findExceptionHandlingSmells(file, IAnalyzer.ExceptionSmellWeights.defaults());
         }
     }
 }
-

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java
@@ -1,0 +1,96 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class RustExceptionHandlingSmellTest {
+
+    @Test
+    void flagsEmptyCatchUnwindErrArm() {
+        String code =
+                """
+                use std::panic;
+
+                pub fn work() {}
+
+                pub fn run() {
+                    let res = panic::catch_unwind(|| {
+                        work();
+                    });
+                    match res {
+                        Ok(_) => (),
+                        Err(_) => {
+                        }
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertFalse(findings.isEmpty());
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+    }
+
+    @Test
+    void flagsCommentOnlyErrArm() {
+        String code =
+                """
+                pub fn run() {
+                    let res: Result<(), ()> = Err(());
+                    match res {
+                        Ok(_) => (),
+                        Err(_) => {
+                            /* ignore */
+                        }
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("comment-only-body")));
+    }
+
+    @Test
+    void flagsLogOnlyErrArm() {
+        String code =
+                """
+                pub fn run() {
+                    let res: Result<(), ()> = Err(());
+                    match res {
+                        Ok(_) => (),
+                        Err(_) => {
+                            eprintln!(\"bad\");
+                        }
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("log-only-body")));
+    }
+
+    @Test
+    void flagsEmptyIfLetErrHandler() {
+        String code =
+                """
+                pub fn run() {
+                    let res: Result<(), ()> = Err(());
+                    if let Err(_) = res {
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+    }
+
+    private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
+        try (var testProject = InlineTestProjectCreator.code(source, "src/lib.rs").build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), "src/lib.rs");
+            return analyzer.findExceptionHandlingSmells(file, IAnalyzer.ExceptionSmellWeights.defaults());
+        }
+    }
+}
+

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java
@@ -108,6 +108,37 @@ public class RustExceptionHandlingSmellTest {
                 "Expected the flagged handler to be the empty nested if-let body, not the outer if body");
     }
 
+    @Test
+    void doesNotAnalyzeNestedMatchArmsUnderOuterMatchContext() {
+        String code =
+                """
+                pub fn run() {
+                    let outer: Result<(), ()> = Ok(());
+                    let inner: Result<(), ()> = Err(());
+                    match outer {
+                        Ok(_) => {
+                            match inner {
+                                Ok(_) => (),
+                                Err(_) => {
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            let a = 1;
+                            let b = 2;
+                            let c = a + b;
+                            let d = c + 1;
+                            let e = d + 1;
+                            let _ = e;
+                        }
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.size() == 1, "Expected only the inner match Err arm to be flagged");
+        assertTrue(findings.getFirst().reasons().contains("empty-body"));
+    }
+
     private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
         try (var testProject =
                 InlineTestProjectCreator.code(source, "src/lib.rs").build()) {

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java
@@ -85,6 +85,29 @@ public class RustExceptionHandlingSmellTest {
         assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
     }
 
+    @Test
+    void doesNotMisattributeNestedIfLetErrToOuterIf() {
+        String code =
+                """
+                pub fn run() {
+                    let res: Result<(), ()> = Err(());
+                    if true {
+                        let x = 1;
+                        if let Err(_) = res {
+                        }
+                        let y = x + 1;
+                        let _ = y;
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+        assertTrue(findings.size() == 1, "Expected only the nested if-let to be flagged");
+        assertTrue(
+                findings.getFirst().bodyStatementCount() == 0,
+                "Expected the flagged handler to be the empty nested if-let body, not the outer if body");
+    }
+
     private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
         try (var testProject =
                 InlineTestProjectCreator.code(source, "src/lib.rs").build()) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -10,8 +10,8 @@ import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1567,28 +1567,22 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
         }
 
         return analyzeHandlerBody(
-                file,
-                consequence,
-                sourceContent,
-                weights,
-                weights.genericExceptionWeight(),
-                "generic-catch:error");
+                file, consequence, sourceContent, weights, weights.genericExceptionWeight(), "generic-catch:error");
     }
 
-    private static boolean conditionLooksLikeErrNotNil(
-            TSNode ifNode, TSNode consequence, SourceContent sourceContent) {
-            // Keep this AST-guided: look for a binary expression "err != nil" that appears before the consequence block.
-            var binaries = new ArrayList<TSNode>();
-            collectNodesByType(ifNode, Set.of(BINARY_EXPRESSION), binaries);
-            for (TSNode binary : binaries) {
-                if (binary.getStartByte() >= consequence.getStartByte()) {
-                    continue;
-                }
+    private static boolean conditionLooksLikeErrNotNil(TSNode ifNode, TSNode consequence, SourceContent sourceContent) {
+        // Keep this AST-guided: look for a binary expression "err != nil" that appears before the consequence block.
+        var binaries = new ArrayList<TSNode>();
+        collectNodesByType(ifNode, Set.of(BINARY_EXPRESSION), binaries);
+        for (TSNode binary : binaries) {
+            if (binary.getStartByte() >= consequence.getStartByte()) {
+                continue;
+            }
             TSNode left = binary.getChildByFieldName("left");
             TSNode right = binary.getChildByFieldName("right");
-                if (left == null || right == null) {
-                    continue;
-                }
+            if (left == null || right == null) {
+                continue;
+            }
             if (!IDENTIFIER.equals(left.getType()) || !NIL.equals(right.getType())) {
                 continue;
             }
@@ -1655,9 +1649,16 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                         bodyNode.getEndPoint().getRow())
                 .map(CodeUnit::fqName)
                 .orElse(file.toString());
-        String excerpt = compactExcerpt(sourceContent.substringFrom(bodyNode.getParent() != null ? bodyNode.getParent() : bodyNode));
+        String excerpt = compactExcerpt(
+                sourceContent.substringFrom(bodyNode.getParent() != null ? bodyNode.getParent() : bodyNode));
         var smell = new ExceptionHandlingSmell(
-                file, enclosing, baseReason.replace("generic-catch:", ""), score, bodyStatements, List.copyOf(reasons), excerpt);
+                file,
+                enclosing,
+                baseReason.replace("generic-catch:", ""),
+                score,
+                bodyStatements,
+                List.copyOf(reasons),
+                excerpt);
         return Optional.of(new SmellCandidate(smell, bodyNode.getStartByte()));
     }
 

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -10,12 +10,14 @@ import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -42,6 +44,11 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
 
     // Pattern to strip Go comments (line comments // and block comments /* */)
     private static final Pattern GO_COMMENT_PATTERN = Pattern.compile("//[^\r\n]*|/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/");
+
+    private static final Set<String> COMMENT_NODE_TYPES = Set.of(COMMENT);
+    private static final Set<String> GO_LOG_RECEIVER_NAMES = Set.of("log", "logger", "zap", "slog", "fmt");
+    private static final Set<String> GO_LOG_METHOD_NAMES =
+            Set.of("print", "printf", "println", "debug", "info", "warn", "warning", "error", "fatal", "panic");
 
     private static final LanguageSyntaxProfile GO_SYNTAX_PROFILE = new LanguageSyntaxProfile(
             Set.of(TYPE_SPEC, TYPE_ALIAS), // classLikeNodeTypes
@@ -1444,5 +1451,321 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                     return false;
                 },
                 false);
+    }
+
+    @Override
+    public List<ExceptionHandlingSmell> findExceptionHandlingSmells(ProjectFile file, ExceptionSmellWeights weights) {
+        checkStale("findExceptionHandlingSmells");
+        ExceptionSmellWeights resolvedWeights = weights != null ? weights : ExceptionSmellWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file,
+                            source -> detectExceptionHandlingSmells(file, root, source, resolvedWeights),
+                            List.of());
+                },
+                List.of());
+    }
+
+    private List<ExceptionHandlingSmell> detectExceptionHandlingSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        var findings = new ArrayList<SmellCandidate>();
+
+        var defers = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(DEFER_STATEMENT), defers);
+        for (TSNode defer : defers) {
+            analyzeDeferRecoverHandler(file, defer, sourceContent, weights).ifPresent(findings::add);
+        }
+
+        var ifs = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(IF_STATEMENT), ifs);
+        for (TSNode ifNode : ifs) {
+            analyzeErrNotNilHandler(file, ifNode, sourceContent, weights).ifPresent(findings::add);
+        }
+
+        return findings.stream()
+                .sorted(Comparator.comparingInt(SmellCandidate::score)
+                        .reversed()
+                        .thenComparing(c -> c.smell().file().toString())
+                        .thenComparing(c -> c.smell().enclosingFqName())
+                        .thenComparingInt(SmellCandidate::startByte))
+                .map(SmellCandidate::smell)
+                .toList();
+    }
+
+    private Optional<SmellCandidate> analyzeDeferRecoverHandler(
+            ProjectFile file, TSNode deferNode, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        TSNode functionLiteral = findFirstNamedDescendant(deferNode, FUNCTION_LITERAL);
+        if (functionLiteral == null) {
+            return Optional.empty();
+        }
+        TSNode body = functionLiteral.getChildByFieldName("body");
+        if (body == null) {
+            body = findFirstNamedDescendant(functionLiteral, BLOCK);
+        }
+        if (body == null) {
+            return Optional.empty();
+        }
+
+        // Find `if ... recover() ... { handler }` patterns inside the deferred function.
+        var ifs = new ArrayList<TSNode>();
+        collectNodesByType(body, Set.of(IF_STATEMENT), ifs);
+        for (TSNode ifNode : ifs) {
+            TSNode consequence = ifNode.getChildByFieldName("consequence");
+            if (consequence == null) {
+                consequence = findFirstNamedDescendant(ifNode, BLOCK);
+            }
+            if (consequence == null) {
+                continue;
+            }
+            if (!ifConditionContainsRecoverCall(ifNode, consequence, sourceContent)) {
+                continue;
+            }
+            return analyzeHandlerBody(
+                    file,
+                    consequence,
+                    sourceContent,
+                    weights,
+                    weights.genericThrowableWeight(),
+                    "generic-catch:recover()");
+        }
+        return Optional.empty();
+    }
+
+    private static boolean ifConditionContainsRecoverCall(
+            TSNode ifNode, TSNode consequence, SourceContent sourceContent) {
+        var calls = new ArrayList<TSNode>();
+        collectNodesByType(ifNode, Set.of(CALL_EXPRESSION), calls);
+        for (TSNode call : calls) {
+            if (call.getStartByte() >= consequence.getStartByte()) {
+                continue;
+            }
+            String callee = callExpressionCalleeName(call, sourceContent);
+            if ("recover".equals(callee)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Optional<SmellCandidate> analyzeErrNotNilHandler(
+            ProjectFile file, TSNode ifNode, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        TSNode consequence = ifNode.getChildByFieldName("consequence");
+        if (consequence == null) {
+            consequence = findFirstNamedDescendant(ifNode, BLOCK);
+        }
+        if (consequence == null) {
+            return Optional.empty();
+        }
+        if (!conditionLooksLikeErrNotNil(ifNode, consequence, sourceContent)) {
+            return Optional.empty();
+        }
+
+        return analyzeHandlerBody(
+                file,
+                consequence,
+                sourceContent,
+                weights,
+                weights.genericExceptionWeight(),
+                "generic-catch:error");
+    }
+
+    private static boolean conditionLooksLikeErrNotNil(
+            TSNode ifNode, TSNode consequence, SourceContent sourceContent) {
+            // Keep this AST-guided: look for a binary expression "err != nil" that appears before the consequence block.
+            var binaries = new ArrayList<TSNode>();
+            collectNodesByType(ifNode, Set.of(BINARY_EXPRESSION), binaries);
+            for (TSNode binary : binaries) {
+                if (binary.getStartByte() >= consequence.getStartByte()) {
+                    continue;
+                }
+            TSNode left = binary.getChildByFieldName("left");
+            TSNode right = binary.getChildByFieldName("right");
+                if (left == null || right == null) {
+                    continue;
+                }
+            if (!IDENTIFIER.equals(left.getType()) || !NIL.equals(right.getType())) {
+                continue;
+            }
+            if (!"err".equals(sourceContent.substringFrom(left).strip())) {
+                continue;
+            }
+            // Tree-sitter-go doesn't expose operator as a named node; validate via the binary expression text.
+            if (sourceContent.substringFrom(binary).contains("!=")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Optional<SmellCandidate> analyzeHandlerBody(
+            ProjectFile file,
+            TSNode bodyNode,
+            SourceContent sourceContent,
+            ExceptionSmellWeights weights,
+            int baseScore,
+            String baseReason) {
+        int bodyStatements = countHandlerStatements(bodyNode);
+        String bodyText = sourceContent.substringFrom(bodyNode);
+        boolean hasAnyComment = bodyText.contains("//") || bodyText.contains("/*");
+        boolean emptyBody = bodyStatements == 0 && !hasAnyComment;
+        boolean commentOnlyBody = bodyStatements == 0 && hasAnyComment;
+        boolean smallBody = bodyStatements <= weights.smallBodyMaxStatements();
+        boolean rethrowPresent = hasCallToIdent(bodyNode, "panic", sourceContent);
+        boolean logOnly = bodyStatements == 1 && isLikelyLogOnlyBody(bodyNode, sourceContent) && !rethrowPresent;
+
+        int score = baseScore;
+        var reasons = new ArrayList<String>();
+        reasons.add(baseReason);
+        if (emptyBody) {
+            score += weights.emptyBodyWeight();
+            reasons.add("empty-body");
+        }
+        if (commentOnlyBody) {
+            score += weights.commentOnlyBodyWeight();
+            reasons.add("comment-only-body");
+        }
+        if (smallBody) {
+            score += weights.smallBodyWeight();
+            reasons.add("small-body:" + bodyStatements);
+        }
+        if (logOnly) {
+            score += weights.logOnlyWeight();
+            reasons.add("log-only-body");
+        }
+
+        int creditStatements = Math.min(bodyStatements, Math.max(0, weights.meaningfulBodyStatementThreshold()));
+        int bodyCredit = Math.max(0, weights.meaningfulBodyCreditPerStatement()) * creditStatements;
+        if (bodyCredit > 0) {
+            score -= bodyCredit;
+            reasons.add("meaningful-body-credit:" + bodyCredit);
+        }
+        if (score <= 0) {
+            return Optional.empty();
+        }
+
+        String enclosing = enclosingCodeUnit(
+                        file,
+                        bodyNode.getStartPoint().getRow(),
+                        bodyNode.getEndPoint().getRow())
+                .map(CodeUnit::fqName)
+                .orElse(file.toString());
+        String excerpt = compactExcerpt(sourceContent.substringFrom(bodyNode.getParent() != null ? bodyNode.getParent() : bodyNode));
+        var smell = new ExceptionHandlingSmell(
+                file, enclosing, baseReason.replace("generic-catch:", ""), score, bodyStatements, List.copyOf(reasons), excerpt);
+        return Optional.of(new SmellCandidate(smell, bodyNode.getStartByte()));
+    }
+
+    private static int countHandlerStatements(TSNode bodyNode) {
+        TSNode list = firstNamedChildOfType(bodyNode, STATEMENT_LIST);
+        TSNode container = list != null ? list : bodyNode;
+        int expressions = 0;
+        for (int i = 0; i < container.getNamedChildCount(); i++) {
+            TSNode child = container.getNamedChild(i);
+            if (child == null) {
+                continue;
+            }
+            if (COMMENT.equals(child.getType())) {
+                continue;
+            }
+            expressions++;
+        }
+        return expressions;
+    }
+
+    private static boolean hasCallToIdent(TSNode root, String targetName, SourceContent sourceContent) {
+        var calls = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(CALL_EXPRESSION), calls);
+        return calls.stream().anyMatch(call -> targetName.equals(callExpressionCalleeName(call, sourceContent)));
+    }
+
+    private static String callExpressionCalleeName(TSNode call, SourceContent sourceContent) {
+        TSNode fn = call.getChildByFieldName("function");
+        if (fn == null && call.getNamedChildCount() > 0) {
+            fn = call.getNamedChild(0);
+        }
+        if (fn == null) {
+            return "";
+        }
+        if (IDENTIFIER.equals(fn.getType())) {
+            return sourceContent.substringFrom(fn).strip();
+        }
+        if (!SELECTOR_EXPRESSION.equals(fn.getType())) {
+            return "";
+        }
+        TSNode field = fn.getChildByFieldName("field");
+        if (field != null) {
+            return sourceContent.substringFrom(field).strip();
+        }
+        // Fallback: last identifier within selector expression
+        TSNode ident = findFirstNamedDescendant(fn, IDENTIFIER);
+        return ident == null ? "" : sourceContent.substringFrom(ident).strip();
+    }
+
+    private static boolean isLikelyLogOnlyBody(TSNode bodyNode, SourceContent sourceContent) {
+        TSNode list = firstNamedChildOfType(bodyNode, STATEMENT_LIST);
+        TSNode container = list != null ? list : bodyNode;
+        TSNode statement = firstNonCommentNamedChild(container, COMMENT_NODE_TYPES);
+        if (statement == null || !EXPRESSION_STATEMENT.equals(statement.getType())) {
+            return false;
+        }
+        TSNode call = findFirstNamedDescendant(statement, CALL_EXPRESSION);
+        if (call == null) {
+            return false;
+        }
+        TSNode fn = call.getChildByFieldName("function");
+        if (fn == null) {
+            fn = call.getNamedChildCount() > 0 ? call.getNamedChild(0) : null;
+        }
+        if (fn == null) {
+            return false;
+        }
+        if (IDENTIFIER.equals(fn.getType())) {
+            String bare = sourceContent.substringFrom(fn).strip().toLowerCase(Locale.ROOT);
+            return GO_LOG_METHOD_NAMES.contains(bare);
+        }
+        if (!SELECTOR_EXPRESSION.equals(fn.getType())) {
+            return false;
+        }
+        TSNode receiver = fn.getChildByFieldName("operand");
+        TSNode method = fn.getChildByFieldName("field");
+        if (receiver == null || method == null) {
+            return false;
+        }
+        String receiverText = sourceContent.substringFrom(receiver).strip().toLowerCase(Locale.ROOT);
+        String methodText = sourceContent.substringFrom(method).strip().toLowerCase(Locale.ROOT);
+        boolean receiverLike = GO_LOG_RECEIVER_NAMES.contains(receiverText)
+                || GO_LOG_RECEIVER_NAMES.stream().anyMatch(name -> receiverText.endsWith("." + name));
+        boolean methodLike = GO_LOG_METHOD_NAMES.contains(methodText);
+        return receiverLike && methodLike;
+    }
+
+    private static @Nullable TSNode firstNamedChildOfType(TSNode node, String type) {
+        for (int i = 0; i < node.getNamedChildCount(); i++) {
+            TSNode child = node.getNamedChild(i);
+            if (child != null && type.equals(child.getType())) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private static String compactExcerpt(String text) {
+        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        if (compact.length() <= 180) {
+            return compact;
+        }
+        return compact.substring(0, 180) + "...";
+    }
+
+    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
+        int score() {
+            return smell.score();
+        }
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -798,8 +798,10 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
 
     private Optional<SmellCandidate> analyzeIfLetErrHandler(
             ProjectFile file, TSNode ifExpr, SourceContent sourceContent, ExceptionSmellWeights weights) {
-        TSNode letCond = findFirstNamedDescendant(ifExpr, LET_CONDITION);
-        if (letCond == null || !patternContainsErr(letCond, sourceContent)) {
+        // Only inspect this `if`'s condition; do not search the whole subtree (which would
+        // incorrectly attribute nested `if let Err(...)` conditions to an outer `if`).
+        TSNode condition = ifExpr.getChildByFieldName("condition");
+        if (condition == null || !patternContainsErr(condition, sourceContent)) {
             return Optional.empty();
         }
         TSNode consequence = ifExpr.getChildByFieldName("consequence");

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -764,6 +764,9 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         var arms = new ArrayList<TSNode>();
         collectNodesByType(matchExpr, Set.of(MATCH_ARM), arms);
         for (TSNode arm : arms) {
+            if (!belongsToMatchExpression(arm, matchExpr)) {
+                continue;
+            }
             TSNode pattern = arm.getChildByFieldName("pattern");
             if (pattern == null && arm.getNamedChildCount() > 0) {
                 pattern = arm.getNamedChild(0);
@@ -783,6 +786,17 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
             analyzeRustHandlerBody(file, body, sourceContent, weights, base, baseReason)
                     .ifPresent(out::add);
         }
+    }
+
+    private static boolean belongsToMatchExpression(TSNode arm, TSNode matchExpr) {
+        TSNode parent = arm.getParent();
+        while (parent != null && !MATCH_EXPRESSION.equals(parent.getType())) {
+            parent = parent.getParent();
+        }
+        if (parent == null) {
+            return false;
+        }
+        return parent.getStartByte() == matchExpr.getStartByte() && parent.getEndByte() == matchExpr.getEndByte();
     }
 
     private static boolean matchContainsCatchUnwindCall(TSNode matchExpr, SourceContent sourceContent) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -8,9 +8,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -759,7 +759,8 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
             }
             int base = isCatchUnwind ? weights.genericThrowableWeight() : weights.genericExceptionWeight();
             String baseReason = isCatchUnwind ? "generic-catch:catch_unwind" : "generic-catch:Err";
-            analyzeRustHandlerBody(file, body, sourceContent, weights, base, baseReason).ifPresent(out::add);
+            analyzeRustHandlerBody(file, body, sourceContent, weights, base, baseReason)
+                    .ifPresent(out::add);
         }
     }
 
@@ -788,12 +789,7 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
             return Optional.empty();
         }
         return analyzeRustHandlerBody(
-                file,
-                consequence,
-                sourceContent,
-                weights,
-                weights.genericExceptionWeight(),
-                "generic-catch:Err");
+                file, consequence, sourceContent, weights, weights.genericExceptionWeight(), "generic-catch:Err");
     }
 
     private Optional<SmellCandidate> analyzeRustHandlerBody(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -6,6 +6,10 @@ import ai.brokk.analyzer.cache.AnalyzerCache;
 import ai.brokk.project.ICoreProject;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -21,6 +25,10 @@ import org.treesitter.*;
 
 public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisProvider {
     private static final Logger log = LoggerFactory.getLogger(RustAnalyzer.class);
+
+    private static final Set<String> COMMENT_NODE_TYPES = Set.of(LINE_COMMENT, BLOCK_COMMENT);
+    private static final Set<String> RUST_LOG_MACRO_NAMES = Set.of("trace", "debug", "info", "warn", "error");
+    private static final Set<String> RUST_PRINT_MACRO_NAMES = Set.of("println", "eprintln");
 
     @Override
     public Optional<String> extractCallReceiver(String reference) {
@@ -676,6 +684,308 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
             // The rawSnippet in ImportInfo should be a clean standalone "use ...;" statement for the specific leaf.
             String standaloneSnippet = "use " + resolvedPath + (alias != null ? " as " + alias : "") + ";";
             localImportInfos.add(new ImportInfo(standaloneSnippet, isWildcard, identifier, alias));
+        }
+    }
+
+    @Override
+    public List<ExceptionHandlingSmell> findExceptionHandlingSmells(ProjectFile file, ExceptionSmellWeights weights) {
+        checkStale("findExceptionHandlingSmells");
+        ExceptionSmellWeights resolvedWeights = weights != null ? weights : ExceptionSmellWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file,
+                            source -> detectExceptionHandlingSmells(file, root, source, resolvedWeights),
+                            List.of());
+                },
+                List.of());
+    }
+
+    private List<ExceptionHandlingSmell> detectExceptionHandlingSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        var findings = new ArrayList<SmellCandidate>();
+
+        var matches = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(MATCH_EXPRESSION), matches);
+        for (TSNode matchExpr : matches) {
+            analyzeMatchHandlers(file, matchExpr, sourceContent, weights, findings);
+        }
+
+        var ifs = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(IF_EXPRESSION), ifs);
+        for (TSNode ifExpr : ifs) {
+            analyzeIfLetErrHandler(file, ifExpr, sourceContent, weights).ifPresent(findings::add);
+        }
+
+        return findings.stream()
+                .sorted(Comparator.comparingInt(SmellCandidate::score)
+                        .reversed()
+                        .thenComparing(c -> c.smell().file().toString())
+                        .thenComparing(c -> c.smell().enclosingFqName())
+                        .thenComparingInt(SmellCandidate::startByte))
+                .map(SmellCandidate::smell)
+                .toList();
+    }
+
+    private void analyzeMatchHandlers(
+            ProjectFile file,
+            TSNode matchExpr,
+            SourceContent sourceContent,
+            ExceptionSmellWeights weights,
+            List<SmellCandidate> out) {
+        boolean isCatchUnwind = matchContainsCatchUnwindCall(matchExpr, sourceContent);
+
+        var arms = new ArrayList<TSNode>();
+        collectNodesByType(matchExpr, Set.of(MATCH_ARM), arms);
+        for (TSNode arm : arms) {
+            TSNode pattern = arm.getChildByFieldName("pattern");
+            if (pattern == null && arm.getNamedChildCount() > 0) {
+                pattern = arm.getNamedChild(0);
+            }
+            if (pattern == null || !patternContainsErr(pattern, sourceContent)) {
+                continue;
+            }
+            TSNode body = arm.getChildByFieldName("value");
+            if (body == null && arm.getNamedChildCount() > 0) {
+                body = arm.getNamedChild(arm.getNamedChildCount() - 1);
+            }
+            if (body == null) {
+                continue;
+            }
+            int base = isCatchUnwind ? weights.genericThrowableWeight() : weights.genericExceptionWeight();
+            String baseReason = isCatchUnwind ? "generic-catch:catch_unwind" : "generic-catch:Err";
+            analyzeRustHandlerBody(file, body, sourceContent, weights, base, baseReason).ifPresent(out::add);
+        }
+    }
+
+    private static boolean matchContainsCatchUnwindCall(TSNode matchExpr, SourceContent sourceContent) {
+        var calls = new ArrayList<TSNode>();
+        collectNodesByType(matchExpr, Set.of(CALL_EXPRESSION), calls);
+        for (TSNode call : calls) {
+            if ("catch_unwind".equals(rustCallCalleeLastIdent(call, sourceContent))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Optional<SmellCandidate> analyzeIfLetErrHandler(
+            ProjectFile file, TSNode ifExpr, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        TSNode letCond = findFirstNamedDescendant(ifExpr, LET_CONDITION);
+        if (letCond == null || !patternContainsErr(letCond, sourceContent)) {
+            return Optional.empty();
+        }
+        TSNode consequence = ifExpr.getChildByFieldName("consequence");
+        if (consequence == null) {
+            consequence = findFirstNamedDescendant(ifExpr, BLOCK);
+        }
+        if (consequence == null) {
+            return Optional.empty();
+        }
+        return analyzeRustHandlerBody(
+                file,
+                consequence,
+                sourceContent,
+                weights,
+                weights.genericExceptionWeight(),
+                "generic-catch:Err");
+    }
+
+    private Optional<SmellCandidate> analyzeRustHandlerBody(
+            ProjectFile file,
+            TSNode handlerNode,
+            SourceContent sourceContent,
+            ExceptionSmellWeights weights,
+            int baseScore,
+            String baseReason) {
+        TSNode block = BLOCK.equals(handlerNode.getType()) ? handlerNode : null;
+        int bodyStatements = block != null ? countHandlerStatements(block) : 1;
+        String bodyText = sourceContent.substringFrom(handlerNode);
+        boolean hasAnyComment = bodyText.contains("//") || bodyText.contains("/*");
+        boolean emptyBody = block != null && bodyStatements == 0 && !hasAnyComment;
+        boolean commentOnlyBody = block != null && bodyStatements == 0 && hasAnyComment;
+        boolean smallBody = bodyStatements <= weights.smallBodyMaxStatements();
+        boolean rethrowPresent = hasPanicLike(handlerNode, sourceContent);
+        boolean logOnly = bodyStatements == 1 && isLikelyLogOnlyRust(handlerNode, sourceContent) && !rethrowPresent;
+
+        int score = baseScore;
+        var reasons = new ArrayList<String>();
+        reasons.add(baseReason);
+        if (emptyBody) {
+            score += weights.emptyBodyWeight();
+            reasons.add("empty-body");
+        }
+        if (commentOnlyBody) {
+            score += weights.commentOnlyBodyWeight();
+            reasons.add("comment-only-body");
+        }
+        if (smallBody) {
+            score += weights.smallBodyWeight();
+            reasons.add("small-body:" + bodyStatements);
+        }
+        if (logOnly) {
+            score += weights.logOnlyWeight();
+            reasons.add("log-only-body");
+        }
+
+        int creditStatements = Math.min(bodyStatements, Math.max(0, weights.meaningfulBodyStatementThreshold()));
+        int bodyCredit = Math.max(0, weights.meaningfulBodyCreditPerStatement()) * creditStatements;
+        if (bodyCredit > 0) {
+            score -= bodyCredit;
+            reasons.add("meaningful-body-credit:" + bodyCredit);
+        }
+        if (score <= 0) {
+            return Optional.empty();
+        }
+
+        String enclosing = enclosingCodeUnit(
+                        file,
+                        handlerNode.getStartPoint().getRow(),
+                        handlerNode.getEndPoint().getRow())
+                .map(CodeUnit::fqName)
+                .orElse(file.toString());
+        var smell = new ExceptionHandlingSmell(
+                file,
+                enclosing,
+                baseReason.replace("generic-catch:", ""),
+                score,
+                bodyStatements,
+                List.copyOf(reasons),
+                compactExcerpt(sourceContent.substringFrom(handlerNode)));
+        return Optional.of(new SmellCandidate(smell, handlerNode.getStartByte()));
+    }
+
+    private static boolean patternContainsErr(TSNode patternNode, SourceContent sourceContent) {
+        Deque<TSNode> stack = new ArrayDeque<>();
+        stack.push(patternNode);
+        while (!stack.isEmpty()) {
+            TSNode node = stack.pop();
+            if (node == null) {
+                continue;
+            }
+            if (IDENTIFIER.equals(node.getType())
+                    && "Err".equals(sourceContent.substringFrom(node).strip())) {
+                return true;
+            }
+            for (int i = 0; i < node.getNamedChildCount(); i++) {
+                TSNode child = node.getNamedChild(i);
+                if (child != null) {
+                    stack.push(child);
+                }
+            }
+        }
+        return false;
+    }
+
+    private static int countHandlerStatements(TSNode block) {
+        int expressions = 0;
+        for (int i = 0; i < block.getNamedChildCount(); i++) {
+            TSNode child = block.getNamedChild(i);
+            if (child == null) {
+                continue;
+            }
+            if (COMMENT_NODE_TYPES.contains(child.getType())) {
+                continue;
+            }
+            expressions++;
+        }
+        return expressions;
+    }
+
+    private static boolean hasPanicLike(TSNode root, SourceContent sourceContent) {
+        var macros = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(MACRO_INVOCATION), macros);
+        for (TSNode macro : macros) {
+            if ("panic".equals(rustMacroLastIdent(macro, sourceContent))) {
+                return true;
+            }
+        }
+        var calls = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(CALL_EXPRESSION), calls);
+        for (TSNode call : calls) {
+            if ("resume_unwind".equals(rustCallCalleeLastIdent(call, sourceContent))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isLikelyLogOnlyRust(TSNode handlerNode, SourceContent sourceContent) {
+        TSNode node = handlerNode;
+        if (BLOCK.equals(handlerNode.getType())) {
+            node = firstNonCommentNamedChild(handlerNode, COMMENT_NODE_TYPES);
+            if (node == null) {
+                return false;
+            }
+        }
+        TSNode macro = findFirstNamedDescendant(node, MACRO_INVOCATION);
+        if (macro == null) {
+            return false;
+        }
+        String lastIdent = rustMacroLastIdent(macro, sourceContent).toLowerCase(Locale.ROOT);
+        return RUST_LOG_MACRO_NAMES.contains(lastIdent) || RUST_PRINT_MACRO_NAMES.contains(lastIdent);
+    }
+
+    private static String rustMacroLastIdent(TSNode macroInvocation, SourceContent sourceContent) {
+        TSNode path = macroInvocation.getNamedChildCount() > 0 ? macroInvocation.getNamedChild(0) : null;
+        if (path == null) {
+            path = findFirstNamedDescendant(macroInvocation, PATH);
+        }
+        if (path == null) {
+            path = findFirstNamedDescendant(macroInvocation, SCOPED_IDENTIFIER);
+        }
+        if (path == null) {
+            path = findFirstNamedDescendant(macroInvocation, IDENTIFIER);
+        }
+        return path == null ? "" : lastIdentifierIn(path, sourceContent);
+    }
+
+    private static String rustCallCalleeLastIdent(TSNode call, SourceContent sourceContent) {
+        TSNode function = call.getChildByFieldName("function");
+        if (function == null && call.getNamedChildCount() > 0) {
+            function = call.getNamedChild(0);
+        }
+        return function == null ? "" : lastIdentifierIn(function, sourceContent);
+    }
+
+    private static String lastIdentifierIn(TSNode node, SourceContent sourceContent) {
+        String last = "";
+        try (var cursor = new TSTreeCursor(node)) {
+            while (true) {
+                TSNode current = cursor.currentNode();
+                if (current == null) {
+                    break;
+                }
+                if (IDENTIFIER.equals(current.getType())) {
+                    String text = sourceContent.substringFrom(current).strip();
+                    if (!text.isEmpty()) {
+                        last = text;
+                    }
+                }
+                if (!gotoNextDepthFirst(cursor, current.isNamed())) {
+                    break;
+                }
+            }
+        }
+        return last;
+    }
+
+    private static String compactExcerpt(String text) {
+        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        if (compact.length() <= 180) {
+            return compact;
+        }
+        return compact.substring(0, 180) + "...";
+    }
+
+    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
+        int score() {
+            return smell.score();
         }
     }
 

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/go/GoTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/go/GoTreeSitterNodeTypes.java
@@ -47,6 +47,25 @@ public final class GoTreeSitterNodeTypes {
     public static final String TESTING_T = "testing.T";
     public static final String POINTER_TESTING_T = "*testing.T";
 
+    // ===== STATEMENTS / EXPRESSIONS (for code quality traversal) =====
+    public static final String DEFER_STATEMENT = "defer_statement";
+    public static final String IF_STATEMENT = "if_statement";
+    public static final String BLOCK = "block";
+    public static final String STATEMENT_LIST = "statement_list";
+    public static final String RETURN_STATEMENT = "return_statement";
+
+    public static final String CALL_EXPRESSION = "call_expression";
+    // tree-sitter-go uses "func_literal" for anonymous functions.
+    public static final String FUNCTION_LITERAL = "func_literal";
+    public static final String EXPRESSION_STATEMENT = "expression_statement";
+    public static final String SELECTOR_EXPRESSION = "selector_expression";
+    public static final String IDENTIFIER = "identifier";
+    public static final String BINARY_EXPRESSION = "binary_expression";
+    public static final String NIL = "nil";
+
+    // Tree-sitter-go uses a single "comment" node type for both line and block comments.
+    public static final String COMMENT = "comment";
+
     private GoTreeSitterNodeTypes() {
         // Utility class - no instantiation
     }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/rust/RustTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/rust/RustTreeSitterNodeTypes.java
@@ -44,6 +44,21 @@ public final class RustTreeSitterNodeTypes {
 
     public static final String IMPORT_DECLARATION = "use_declaration";
 
+    // ===== STATEMENTS / EXPRESSIONS (for code quality traversal) =====
+    public static final String CALL_EXPRESSION = "call_expression";
+    public static final String MATCH_EXPRESSION = "match_expression";
+    public static final String MATCH_ARM = "match_arm";
+    public static final String IF_EXPRESSION = "if_expression";
+    public static final String LET_CONDITION = "let_condition";
+    public static final String BLOCK = "block";
+    public static final String EXPRESSION_STATEMENT = "expression_statement";
+    public static final String MACRO_INVOCATION = "macro_invocation";
+    public static final String PATH = "path";
+    public static final String SCOPED_IDENTIFIER = "scoped_identifier";
+    public static final String IDENTIFIER = "identifier";
+    public static final String LINE_COMMENT = "line_comment";
+    public static final String BLOCK_COMMENT = "block_comment";
+
     // ===== QUERY CAPTURE NAMES =====
     public static final String TEST_MARKER = "test_marker";
 


### PR DESCRIPTION
### Summary
- Add `findExceptionHandlingSmells(...)` support for Go and Rust analyzers using Tree-sitter AST traversal.
- Detect Go `recover()` handlers and `if err != nil` blocks, plus Rust `catch_unwind`, `match Err(_)`, and `if let Err(_)` handlers.
- Add JUnit coverage for the new Go and Rust heuristics.

**Key Changes**:
- Extended Go and Rust Tree-sitter node type constants to support handler traversal and classification.
- Implemented AST-based smell scoring, including empty/comment-only/small/log-only handlers and meaningful-body credit.
- Added rethrow-aware suppression for log-only handlers and covered the new behavior with focused unit tests.

**Touch Points**:
- `brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/go/GoTreeSitterNodeTypes.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/rust/RustTreeSitterNodeTypes.java`
- `app/src/test/java/ai/brokk/analyzer/code_quality/GoExceptionHandlingSmellTest.java`
- `app/src/test/java/ai/brokk/analyzer/code_quality/RustExceptionHandlingSmellTest.java`

**Testing**:
- Ran `./gradlew :app:test --tests ai.brokk.analyzer.code_quality.GoExceptionHandlingSmellTest --tests ai.brokk.analyzer.code_quality.RustExceptionHandlingSmellTest`