### PR TITLE
Add C# exception-handling smell support

### DIFF
--- a/app/src/test/java/ai/brokk/analyzer/code_quality/CSharpExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/CSharpExceptionHandlingSmellTest.java
@@ -1,0 +1,127 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CSharpExceptionHandlingSmellTest {
+
+    @Test
+    void emptyCatchExceptionIsFlagged() {
+        var findings = analyze(
+                """
+                using System;
+
+                namespace Example;
+
+                class Test {
+                    void Run() {
+                        try {
+                            Console.WriteLine("hi");
+                        } catch (Exception e) {
+                        }
+                    }
+                }
+                """,
+                "com/example/Test.cs");
+        assertFalse(findings.isEmpty());
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("generic-catch:Exception")));
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+    }
+
+    @Test
+    void catchAllIsFlagged() {
+        var findings = analyze(
+                """
+                using System;
+
+                class Test {
+                    void Run() {
+                        try {
+                            Console.WriteLine("hi");
+                        } catch {
+                        }
+                    }
+                }
+                """,
+                "com/example/Test.cs");
+        assertFalse(findings.isEmpty());
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("generic-catch:Exception")));
+    }
+
+    @Test
+    void logOnlyCatchIsFlagged() {
+        var findings = analyze(
+                """
+                using System;
+
+                class Logger {
+                    public void LogError(Exception e) { }
+                }
+
+                class Test {
+                    private readonly Logger logger = new Logger();
+
+                    void Run() {
+                        try {
+                            Console.WriteLine("hi");
+                        } catch (Exception e) {
+                            logger.LogError(e);
+                        }
+                    }
+                }
+                """,
+                "com/example/Test.cs");
+        assertFalse(findings.isEmpty());
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("log-only-body")));
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("small-body:1")));
+    }
+
+    @Test
+    void bodyCreditCanSuppressTinyHandler() {
+        var code =
+                """
+                using System;
+
+                class Logger {
+                    public void LogError(Exception e) { }
+                }
+
+                class Test {
+                    private readonly Logger logger = new Logger();
+
+                    void Run() {
+                        try {
+                            Console.WriteLine("hi");
+                        } catch (Exception e) {
+                            logger.LogError(e);
+                        }
+                    }
+                }
+                """;
+        var defaults = analyze(code, "com/example/Test.cs", IAnalyzer.ExceptionSmellWeights.defaults());
+        var tunedWeights = new IAnalyzer.ExceptionSmellWeights(0, 0, 0, 0, 0, 0, 0, 5, 6, 2);
+        var tuned = analyze(code, "com/example/Test.cs", tunedWeights);
+        assertFalse(defaults.isEmpty(), "Default heuristics should flag log-only tiny handler");
+        assertEquals(0, tuned.size(), "Higher body credit should suppress the same finding");
+    }
+
+    private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source, String relPath) {
+        return analyze(source, relPath, IAnalyzer.ExceptionSmellWeights.defaults());
+    }
+
+    private List<IAnalyzer.ExceptionHandlingSmell> analyze(
+            String source, String relPath, IAnalyzer.ExceptionSmellWeights weights) {
+        try (var testProject = InlineTestProjectCreator.code(source, relPath).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), relPath);
+            return analyzer.findExceptionHandlingSmells(file, weights);
+        }
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -29,6 +30,21 @@ import org.treesitter.TreeSitterCSharp;
  */
 public final class CSharpAnalyzer extends TreeSitterAnalyzer {
     static final Logger log = LoggerFactory.getLogger(CSharpAnalyzer.class);
+
+    private static final Set<String> CSHARP_COMMENT_NODE_TYPES = Set.of(LINE_COMMENT, BLOCK_COMMENT, COMMENT);
+    private static final Set<String> LOG_RECEIVER_NAMES = Set.of("console", "trace", "debug", "logger", "log");
+    private static final Set<String> LOG_METHOD_NAMES = Set.of(
+            "writeline",
+            "write",
+            "print",
+            "printf",
+            "log",
+            "logtrace",
+            "logdebug",
+            "loginformation",
+            "logwarning",
+            "logerror",
+            "logcritical");
 
     private static final LanguageSyntaxProfile CS_SYNTAX_PROFILE = new LanguageSyntaxProfile(
             Set.of(
@@ -247,6 +263,240 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
     @Override
     protected LanguageSyntaxProfile getLanguageSyntaxProfile() {
         return CS_SYNTAX_PROFILE;
+    }
+
+    @Override
+    public List<ExceptionHandlingSmell> findExceptionHandlingSmells(ProjectFile file, ExceptionSmellWeights weights) {
+        checkStale("findExceptionHandlingSmells");
+        ExceptionSmellWeights resolvedWeights = weights != null ? weights : ExceptionSmellWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file,
+                            source -> detectExceptionHandlingSmells(file, root, source, resolvedWeights),
+                            List.of());
+                },
+                List.of());
+    }
+
+    private List<ExceptionHandlingSmell> detectExceptionHandlingSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        var catches = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(CATCH_CLAUSE), catches);
+        var findings = new ArrayList<SmellCandidate>();
+        for (TSNode catchNode : catches) {
+            analyzeCatchClause(file, catchNode, sourceContent, weights).ifPresent(findings::add);
+        }
+        return findings.stream()
+                .sorted(java.util.Comparator.comparingInt(SmellCandidate::score)
+                        .reversed()
+                        .thenComparing(c -> c.smell().file().toString())
+                        .thenComparing(c -> c.smell().enclosingFqName())
+                        .thenComparingInt(SmellCandidate::startByte))
+                .map(SmellCandidate::smell)
+                .toList();
+    }
+
+    private Optional<SmellCandidate> analyzeCatchClause(
+            ProjectFile file, TSNode catchNode, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        TSNode bodyNode = catchNode.getChildByFieldName("body");
+        if (bodyNode == null) {
+            bodyNode = catchNode.getNamedChildren().stream()
+                    .filter(child -> BLOCK.equals(child.getType()))
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (bodyNode == null) {
+            return Optional.empty();
+        }
+
+        String catchType = extractCatchType(catchNode, sourceContent);
+        if (catchType.isEmpty()) {
+            return Optional.empty();
+        }
+
+        int bodyStatements = countBodyStatements(bodyNode);
+        boolean hasAnyComment = hasAnyComment(bodyNode);
+        boolean emptyBody = bodyStatements == 0 && !hasAnyComment;
+        boolean commentOnlyBody = bodyStatements == 0 && hasAnyComment;
+        boolean smallBody = bodyStatements <= weights.smallBodyMaxStatements();
+        boolean throwPresent =
+                hasDescendantOfType(bodyNode, THROW_STATEMENT) || hasDescendantOfType(bodyNode, THROW_EXPRESSION);
+        boolean logOnly = bodyStatements == 1 && isLikelyLogOnlyBody(bodyNode, sourceContent) && !throwPresent;
+
+        int score = 0;
+        var reasons = new ArrayList<String>();
+        String catchTypeLower = catchType.toLowerCase(Locale.ROOT);
+        if (catchTypeLower.contains("exception")) {
+            score += weights.genericExceptionWeight();
+            reasons.add("generic-catch:Exception");
+        } else if (catchTypeLower.contains("throwable")) {
+            score += weights.genericThrowableWeight();
+            reasons.add("generic-catch:Throwable");
+        }
+        if (emptyBody) {
+            score += weights.emptyBodyWeight();
+            reasons.add("empty-body");
+        }
+        if (commentOnlyBody) {
+            score += weights.commentOnlyBodyWeight();
+            reasons.add("comment-only-body");
+        }
+        if (smallBody) {
+            score += weights.smallBodyWeight();
+            reasons.add("small-body:" + bodyStatements);
+        }
+        if (logOnly) {
+            score += weights.logOnlyWeight();
+            reasons.add("log-only-body");
+        }
+
+        int creditStatements = Math.min(bodyStatements, Math.max(0, weights.meaningfulBodyStatementThreshold()));
+        int bodyCredit = Math.max(0, weights.meaningfulBodyCreditPerStatement()) * creditStatements;
+        if (bodyCredit > 0) {
+            score -= bodyCredit;
+            reasons.add("meaningful-body-credit:" + bodyCredit);
+        }
+
+        if (score <= 0) {
+            return Optional.empty();
+        }
+
+        String enclosing = enclosingCodeUnit(
+                        file,
+                        catchNode.getStartPoint().getRow(),
+                        catchNode.getEndPoint().getRow())
+                .map(CodeUnit::fqName)
+                .orElse(file.toString());
+        String excerpt = compactCatchExcerpt(sourceContent.substringFrom(catchNode));
+        var smell = new ExceptionHandlingSmell(
+                file, enclosing, catchType, score, bodyStatements, List.copyOf(reasons), excerpt);
+        return Optional.of(new SmellCandidate(smell, catchNode.getStartByte()));
+    }
+
+    private static String extractCatchType(TSNode catchNode, SourceContent sourceContent) {
+        var decl = findFirstNamedDescendant(catchNode, CATCH_DECLARATION);
+        if (decl == null) {
+            // C# catch-all: `catch { ... }`
+            return "Exception";
+        }
+        TSNode typeNode = decl.getChildByFieldName("type");
+        if (typeNode != null) {
+            String typeText = sourceContent.substringFrom(typeNode).strip();
+            if (!typeText.isEmpty()) {
+                return typeText;
+            }
+        }
+        TSNode fallback = firstNamedChildOfType(decl, Set.of(QUALIFIED_NAME, GENERIC_NAME, IDENTIFIER_NAME));
+        if (fallback != null) {
+            String typeText = sourceContent.substringFrom(fallback).strip();
+            if (!typeText.isEmpty()) {
+                return typeText;
+            }
+        }
+        return "Exception";
+    }
+
+    private static int countBodyStatements(TSNode bodyNode) {
+        int statements = 0;
+        for (int i = 0; i < bodyNode.getNamedChildCount(); i++) {
+            TSNode child = bodyNode.getNamedChild(i);
+            if (child == null) {
+                continue;
+            }
+            if (CSHARP_COMMENT_NODE_TYPES.contains(child.getType())) {
+                continue;
+            }
+            statements++;
+        }
+        return statements;
+    }
+
+    private static boolean hasAnyComment(TSNode bodyNode) {
+        var comments = new ArrayList<TSNode>();
+        collectNodesByType(bodyNode, CSHARP_COMMENT_NODE_TYPES, comments);
+        return !comments.isEmpty();
+    }
+
+    private static boolean isLikelyLogOnlyBody(TSNode bodyNode, SourceContent sourceContent) {
+        TSNode statement = firstNonCommentNamedChild(bodyNode, CSHARP_COMMENT_NODE_TYPES);
+        if (statement == null || !EXPRESSION_STATEMENT.equals(statement.getType())) {
+            return false;
+        }
+        TSNode invocation = findFirstNamedDescendant(statement, INVOCATION_EXPRESSION);
+        if (invocation == null) {
+            return false;
+        }
+
+        TSNode expression = invocation.getChildByFieldName("expression");
+        if (expression == null) {
+            expression = invocation.getChildByFieldName("function");
+        }
+        if (expression == null) {
+            return false;
+        }
+
+        String receiverText = "";
+        String methodName = "";
+        if (MEMBER_ACCESS_EXPRESSION.equals(expression.getType())) {
+            TSNode receiverNode = expression.getChildByFieldName("expression");
+            TSNode nameNode = expression.getChildByFieldName("name");
+            if (receiverNode != null) {
+                receiverText = sourceContent.substringFrom(receiverNode).strip().toLowerCase(Locale.ROOT);
+            }
+            if (nameNode != null) {
+                methodName = sourceContent.substringFrom(nameNode).strip().toLowerCase(Locale.ROOT);
+            }
+        } else {
+            methodName = sourceContent.substringFrom(expression).strip().toLowerCase(Locale.ROOT);
+        }
+
+        String receiverName = lastDotSegment(receiverText);
+        if (LOG_RECEIVER_NAMES.contains(receiverName)) {
+            return true;
+        }
+        return LOG_METHOD_NAMES.contains(methodName) || methodName.startsWith("log");
+    }
+
+    private static @Nullable TSNode firstNamedChildOfType(TSNode node, Set<String> candidateTypes) {
+        for (int i = 0; i < node.getNamedChildCount(); i++) {
+            TSNode child = node.getNamedChild(i);
+            if (child == null) {
+                continue;
+            }
+            if (candidateTypes.contains(child.getType())) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private static String lastDotSegment(String text) {
+        String cleaned = text.strip();
+        if (cleaned.isEmpty()) {
+            return "";
+        }
+        int lastDot = cleaned.lastIndexOf('.');
+        return (lastDot >= 0 ? cleaned.substring(lastDot + 1) : cleaned).strip();
+    }
+
+    private static String compactCatchExcerpt(String text) {
+        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        if (compact.length() <= 180) {
+            return compact;
+        }
+        return compact.substring(0, 180) + "...";
+    }
+
+    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
+        int score() {
+            return smell.score();
+        }
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
@@ -331,11 +331,11 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
 
         int score = 0;
         var reasons = new ArrayList<String>();
-        String catchTypeLower = catchType.toLowerCase(Locale.ROOT);
-        if (catchTypeLower.contains("exception")) {
+        String normalizedCatchType = normalizeTypeNameForGenericCheck(catchType);
+        if (isGenericExceptionType(normalizedCatchType)) {
             score += weights.genericExceptionWeight();
             reasons.add("generic-catch:Exception");
-        } else if (catchTypeLower.contains("throwable")) {
+        } else if (isGenericThrowableType(normalizedCatchType)) {
             score += weights.genericThrowableWeight();
             reasons.add("generic-catch:Throwable");
         }
@@ -460,7 +460,7 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
         if (LOG_RECEIVER_NAMES.contains(receiverName)) {
             return true;
         }
-        return LOG_METHOD_NAMES.contains(methodName) || methodName.startsWith("log");
+        return LOG_METHOD_NAMES.contains(methodName);
     }
 
     private static @Nullable TSNode firstNamedChildOfType(TSNode node, Set<String> candidateTypes) {
@@ -483,6 +483,22 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
         }
         int lastDot = cleaned.lastIndexOf('.');
         return (lastDot >= 0 ? cleaned.substring(lastDot + 1) : cleaned).strip();
+    }
+
+    private static String normalizeTypeNameForGenericCheck(String typeText) {
+        String cleaned = typeText.strip().toLowerCase(Locale.ROOT);
+        if (cleaned.startsWith("global::")) {
+            cleaned = cleaned.substring("global::".length());
+        }
+        return cleaned;
+    }
+
+    private static boolean isGenericExceptionType(String normalizedTypeName) {
+        return "exception".equals(normalizedTypeName) || "system.exception".equals(normalizedTypeName);
+    }
+
+    private static boolean isGenericThrowableType(String normalizedTypeName) {
+        return "throwable".equals(normalizedTypeName) || "system.throwable".equals(normalizedTypeName);
     }
 
     private static String compactCatchExcerpt(String text) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/csharp/CSharpTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/csharp/CSharpTreeSitterNodeTypes.java
@@ -53,6 +53,24 @@ public final class CSharpTreeSitterNodeTypes {
 
     public static final String TEST_MARKER = "test_marker";
 
+    // Exception handling (try/catch)
+    public static final String CATCH_CLAUSE = "catch_clause";
+    public static final String CATCH_DECLARATION = "catch_declaration";
+    public static final String BLOCK = "block";
+    public static final String THROW_STATEMENT = "throw_statement";
+    public static final String THROW_EXPRESSION = "throw_expression";
+    public static final String EXPRESSION_STATEMENT = "expression_statement";
+    public static final String INVOCATION_EXPRESSION = "invocation_expression";
+    public static final String MEMBER_ACCESS_EXPRESSION = "member_access_expression";
+    public static final String IDENTIFIER_NAME = "identifier_name";
+    public static final String QUALIFIED_NAME = "qualified_name";
+    public static final String GENERIC_NAME = "generic_name";
+
+    // Comments (Tree-sitter grammars vary; include common aliases)
+    public static final String LINE_COMMENT = CommonTreeSitterNodeTypes.LINE_COMMENT;
+    public static final String BLOCK_COMMENT = CommonTreeSitterNodeTypes.BLOCK_COMMENT;
+    public static final String COMMENT = CommonTreeSitterNodeTypes.COMMENT;
+
     public static final String EQUALS_VALUE_CLAUSE = "equals_value_clause";
     public static final String PARENTHESIZED_EXPRESSION = "parenthesized_expression";
     public static final String LITERAL = "literal";


### PR DESCRIPTION
## Summary
- Add `reportExceptionHandlingSmells` support for C# by implementing exception-handling smell detection in `CSharpAnalyzer`.
- Use Tree-sitter node traversal for C# catch clauses, comment detection, and log-only heuristics.
- Add C# unit coverage for empty catches, catch-all handlers, log-only handlers, and body-credit suppression.

## Testing
- `./gradlew :app:test --tests ai.brokk.analyzer.code_quality.CSharpExceptionHandlingSmellTest`
- `./gradlew fix tidy`