### PR TITLE
Add C++ exception-handling smell detection

### DIFF
--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -204,7 +204,7 @@ public class CodeQualityTools {
 
     @Tool(
             """
-            Detects suspicious Java catch blocks using weighted heuristics designed for high-recall triage.
+            Detects suspicious exception handlers using weighted heuristics designed for high-recall triage.
             Scores generic catches and tiny/empty handlers, then subtracts credit for richer handling bodies.
             Use minScore, maxFindings, and weight parameters to tune precision/recall.""")
     public String reportExceptionHandlingSmells(

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/CppExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/CppExceptionHandlingSmellTest.java
@@ -1,0 +1,104 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CppExceptionHandlingSmellTest {
+
+    @Test
+    void flagsEmptyCatchBody() {
+        String code =
+                """
+                #include <stdexcept>
+
+                void run() {
+                    try {
+                        throw std::runtime_error("bad");
+                    } catch (...) {
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertFalse(findings.isEmpty());
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().stream().anyMatch(r -> r.startsWith("generic-catch:"))));
+    }
+
+    @Test
+    void flagsCommentOnlyCatchBody() {
+        String code =
+                """
+                #include <exception>
+
+                void run() {
+                    try {
+                        throw 1;
+                    } catch (const std::exception& e) {
+                        /* ignore */
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("comment-only-body")));
+    }
+
+    @Test
+    void flagsLogOnlyCatchBody() {
+        String code =
+                """
+                #include <exception>
+                #include <iostream>
+
+                void run() {
+                    try {
+                        throw 1;
+                    } catch (const std::exception& e) {
+                        std::cerr << "bad";
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("log-only-body")));
+    }
+
+    @Test
+    void meaningfulRethrowDoesNotFlagWithDefaultWeights() {
+        String code =
+                """
+                #include <stdexcept>
+
+                int status() { return 500; }
+                void audit(int code) {}
+                void notifyOps(int code) {}
+
+                void run() {
+                    try {
+                        throw std::runtime_error("bad");
+                    } catch (const std::exception& e) {
+                        int code = status();
+                        audit(code);
+                        notifyOps(code);
+                        throw;
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(
+                findings.isEmpty(), "Expected meaningful handler to be mitigated by body credit; findings=" + findings);
+    }
+
+    private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
+        try (var testProject =
+                InlineTestProjectCreator.code(source, "src/test.cpp").build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), "src/test.cpp");
+            return analyzer.findExceptionHandlingSmells(file, IAnalyzer.ExceptionSmellWeights.defaults());
+        }
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
@@ -389,26 +389,10 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
     }
 
     private static int countBodyStatements(TSNode bodyNode) {
+        // Count "executable" statements in the body, including nested statements, but avoid
+        // inflating counts for wrapper/control statements like "if_statement" that contain the
+        // real recovery logic inside.
         int statements = 0;
-        for (int i = 0; i < bodyNode.getChildCount(); i++) {
-            TSNode child = bodyNode.getChild(i);
-            if (child == null) {
-                continue;
-            }
-            if (!child.isNamed()) {
-                continue;
-            }
-            if (CPP_COMMENT_NODE_TYPES.contains(child.getType())) {
-                continue;
-            }
-            statements++;
-        }
-        if (statements > 0) {
-            return statements;
-        }
-
-        // Fallback: some grammars represent compound bodies with minimal direct named children.
-        // Count only statement-like descendants to avoid overcounting identifiers and literals.
         var stack = new ArrayDeque<TSNode>();
         stack.push(bodyNode);
         while (!stack.isEmpty()) {
@@ -422,7 +406,7 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
                 if (CPP_COMMENT_NODE_TYPES.contains(type)) {
                     continue;
                 }
-                if (isStatementLikeNodeType(type)) {
+                if (isExecutableStatementNodeType(type)) {
                     statements++;
                 }
                 stack.push(child);
@@ -431,9 +415,25 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
         return statements;
     }
 
-    private static boolean isStatementLikeNodeType(String type) {
-        return DECLARATION.equals(type) || type.endsWith("_statement");
+    private static boolean isExecutableStatementNodeType(String type) {
+        if (DECLARATION.equals(type)) {
+            return true;
+        }
+        if (!type.endsWith("_statement")) {
+            return false;
+        }
+        return !CPP_WRAPPER_STATEMENT_TYPES.contains(type);
     }
+
+    private static final Set<String> CPP_WRAPPER_STATEMENT_TYPES = Set.of(
+            COMPOUND_STATEMENT,
+            "if_statement",
+            "for_statement",
+            "while_statement",
+            "do_statement",
+            "switch_statement",
+            "try_statement",
+            "labeled_statement");
 
     private static String extractCatchType(TSNode catchNode, TSNode bodyNode, SourceContent sourceContent) {
         int bodyStart = bodyNode.getStartByte();

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
@@ -117,6 +117,25 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
             "xor",
             "xor_eq");
 
+    private static final String CATCH_CLAUSE = "catch_clause";
+    private static final String COMPOUND_STATEMENT = "compound_statement";
+    private static final String THROW_STATEMENT = "throw_statement";
+    private static final Set<String> CPP_COMMENT_NODE_TYPES = Set.of(CommonTreeSitterNodeTypes.COMMENT);
+    private static final Set<String> LOG_IDENTIFIER_TOKENS = Set.of(
+            "log",
+            "logger",
+            "spdlog",
+            "printf",
+            "fprintf",
+            "perror",
+            "syslog",
+            "cerr",
+            "cout",
+            "clog",
+            "qdebug",
+            "qwarning",
+            "qcritical");
+
     @Override
     public Optional<String> extractCallReceiver(String reference) {
         return ClassNameExtractor.extractForCpp(reference);
@@ -258,6 +277,236 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
      * Factory method to get or create a CodeUnit instance with optional parameter signature.
      * For functions, this is called with an enhanced FQName that includes parameter types for overload distinction.
      */
+    @Override
+    public List<ExceptionHandlingSmell> findExceptionHandlingSmells(ProjectFile file, ExceptionSmellWeights weights) {
+        checkStale("findExceptionHandlingSmells");
+        ExceptionSmellWeights resolvedWeights = weights != null ? weights : ExceptionSmellWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file,
+                            source -> detectExceptionHandlingSmells(file, root, source, resolvedWeights),
+                            List.of());
+                },
+                List.of());
+    }
+
+    private List<ExceptionHandlingSmell> detectExceptionHandlingSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        var catches = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(CATCH_CLAUSE), catches);
+        return catches.stream()
+                .map(catchNode -> analyzeCatchClause(file, catchNode, sourceContent, weights))
+                .flatMap(Optional::stream)
+                .sorted(Comparator.comparingInt(ExceptionHandlingSmell::score)
+                        .reversed()
+                        .thenComparing(f -> f.file().toString())
+                        .thenComparing(ExceptionHandlingSmell::enclosingFqName))
+                .toList();
+    }
+
+    private Optional<ExceptionHandlingSmell> analyzeCatchClause(
+            ProjectFile file, TSNode catchNode, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        TSNode bodyNode = catchNode.getChildByFieldName("body");
+        if (bodyNode == null) {
+            bodyNode = catchNode.getNamedChildren().stream()
+                    .filter(child -> COMPOUND_STATEMENT.equals(child.getType()))
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (bodyNode == null) {
+            return Optional.empty();
+        }
+
+        String catchType = extractCatchType(catchNode, bodyNode, sourceContent);
+        int bodyStatements = countBodyStatements(bodyNode);
+        boolean hasAnyComment = hasDescendantOfType(bodyNode, CommonTreeSitterNodeTypes.COMMENT);
+        boolean emptyBody = bodyStatements == 0 && !hasAnyComment;
+        boolean commentOnlyBody = bodyStatements == 0 && hasAnyComment;
+        boolean smallBody = bodyStatements <= weights.smallBodyMaxStatements();
+        boolean throwPresent = hasDescendantOfType(bodyNode, THROW_STATEMENT);
+        boolean logOnly = bodyStatements == 1 && isLikelyLogOnlyBody(bodyNode, sourceContent) && !throwPresent;
+
+        int score = 0;
+        var reasons = new ArrayList<String>();
+        String normalizedCatch = catchType.toLowerCase(Locale.ROOT);
+        if (normalizedCatch.equals("...") || normalizedCatch.contains("...")) {
+            score += weights.genericThrowableWeight();
+            reasons.add("generic-catch:catch-all");
+        } else if (normalizedCatch.contains("runtime_error")) {
+            score += weights.genericRuntimeExceptionWeight();
+            reasons.add("generic-catch:runtime_error");
+        } else if (normalizedCatch.contains("exception")) {
+            score += weights.genericExceptionWeight();
+            reasons.add("generic-catch:exception");
+        }
+        if (emptyBody) {
+            score += weights.emptyBodyWeight();
+            reasons.add("empty-body");
+        }
+        if (commentOnlyBody) {
+            score += weights.commentOnlyBodyWeight();
+            reasons.add("comment-only-body");
+        }
+        if (smallBody) {
+            score += weights.smallBodyWeight();
+            reasons.add("small-body:" + bodyStatements);
+        }
+        if (logOnly) {
+            score += weights.logOnlyWeight();
+            reasons.add("log-only-body");
+        }
+
+        int creditStatements = Math.min(bodyStatements, Math.max(0, weights.meaningfulBodyStatementThreshold()));
+        int bodyCredit = Math.max(0, weights.meaningfulBodyCreditPerStatement()) * creditStatements;
+        if (bodyCredit > 0) {
+            score -= bodyCredit;
+            reasons.add("meaningful-body-credit:" + bodyCredit);
+        }
+        if (score <= 0) {
+            return Optional.empty();
+        }
+
+        String enclosing = enclosingCodeUnit(
+                        file,
+                        catchNode.getStartPoint().getRow(),
+                        catchNode.getEndPoint().getRow())
+                .map(CodeUnit::fqName)
+                .orElse(file.toString());
+        return Optional.of(new ExceptionHandlingSmell(
+                file,
+                enclosing,
+                catchType,
+                score,
+                bodyStatements,
+                List.copyOf(reasons),
+                compactCatchExcerpt(sourceContent.substringFrom(catchNode))));
+    }
+
+    private static int countBodyStatements(TSNode bodyNode) {
+        int statements = 0;
+        for (int i = 0; i < bodyNode.getChildCount(); i++) {
+            TSNode child = bodyNode.getChild(i);
+            if (child == null) {
+                continue;
+            }
+            if (!child.isNamed()) {
+                continue;
+            }
+            if (CPP_COMMENT_NODE_TYPES.contains(child.getType())) {
+                continue;
+            }
+            statements++;
+        }
+        if (statements > 0) {
+            return statements;
+        }
+
+        // Fallback: some grammars represent compound bodies with minimal direct named children.
+        // Count only statement-like descendants to avoid overcounting identifiers and literals.
+        var stack = new ArrayDeque<TSNode>();
+        stack.push(bodyNode);
+        while (!stack.isEmpty()) {
+            TSNode current = stack.pop();
+            for (int i = 0; i < current.getChildCount(); i++) {
+                TSNode child = current.getChild(i);
+                if (child == null || !child.isNamed()) {
+                    continue;
+                }
+                String type = Objects.toString(child.getType(), "");
+                if (CPP_COMMENT_NODE_TYPES.contains(type)) {
+                    continue;
+                }
+                if (isStatementLikeNodeType(type)) {
+                    statements++;
+                }
+                stack.push(child);
+            }
+        }
+        return statements;
+    }
+
+    private static boolean isStatementLikeNodeType(String type) {
+        return DECLARATION.equals(type) || type.endsWith("_statement");
+    }
+
+    private static String extractCatchType(TSNode catchNode, TSNode bodyNode, SourceContent sourceContent) {
+        int bodyStart = bodyNode.getStartByte();
+        TSNode best = null;
+        var stack = new ArrayDeque<TSNode>();
+        stack.push(catchNode);
+        while (!stack.isEmpty()) {
+            TSNode current = stack.pop();
+            for (int i = 0; i < current.getChildCount(); i++) {
+                TSNode child = current.getChild(i);
+                if (child == null || !child.isNamed()) {
+                    continue;
+                }
+                if (child.getStartByte() >= bodyStart) {
+                    continue;
+                }
+                String type = Objects.toString(child.getType(), "");
+                if (PARAMETER_DECLARATION.equals(type)) {
+                    if (best == null || child.getStartByte() < best.getStartByte()) {
+                        best = child;
+                    }
+                }
+                stack.push(child);
+            }
+        }
+        if (best == null) {
+            return "...";
+        }
+        String text = sourceContent.substringFrom(best).strip();
+        return text.isEmpty() ? "..." : compactWhitespace(text);
+    }
+
+    private static boolean isLikelyLogOnlyBody(TSNode bodyNode, SourceContent sourceContent) {
+        TSNode statement = firstNonCommentNamedChild(bodyNode, CPP_COMMENT_NODE_TYPES);
+        if (statement == null) {
+            return false;
+        }
+        var identifiers = new HashSet<String>();
+        collectIdentifierTokens(statement, sourceContent, identifiers);
+        return identifiers.stream().anyMatch(LOG_IDENTIFIER_TOKENS::contains);
+    }
+
+    private static void collectIdentifierTokens(TSNode node, SourceContent sourceContent, Set<String> out) {
+        if (node == null) {
+            return;
+        }
+        String type = Objects.toString(node.getType(), "");
+        if (IDENTIFIER.equals(type) || FIELD_IDENTIFIER.equals(type)) {
+            String text = sourceContent.substringFrom(node).strip().toLowerCase(Locale.ROOT);
+            if (!text.isEmpty()) {
+                out.add(text);
+            }
+        }
+        for (int i = 0; i < node.getNamedChildCount(); i++) {
+            TSNode child = node.getNamedChild(i);
+            if (child != null) {
+                collectIdentifierTokens(child, sourceContent, out);
+            }
+        }
+    }
+
+    private static String compactCatchExcerpt(String text) {
+        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        if (compact.length() <= 180) {
+            return compact;
+        }
+        return compact.substring(0, 180) + "...";
+    }
+
+    private static String compactWhitespace(String text) {
+        return text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+    }
+
     public CodeUnit createCodeUnit(ProjectFile source, CodeUnitType kind, String packageName, String fqName) {
         return new CodeUnit(source, kind, packageName, fqName);
     }


### PR DESCRIPTION
## Summary
- Add `reportExceptionHandlingSmells` support for C/C++ in `CppAnalyzer`.
- Keep the tool description language-agnostic in `CodeQualityTools`.
- Add C++ coverage for empty, comment-only, log-only, and rethrow handlers.

## Testing
- `./gradlew fix tidy`
- `./gradlew :app:test --tests '*CppExceptionHandlingSmellTest'`
- `./gradlew analyze`