### PR TITLE
Add PHP exception handling smell detection

### DIFF
--- a/app/src/test/java/ai/brokk/analyzer/code_quality/PhpExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/PhpExceptionHandlingSmellTest.java
@@ -20,7 +20,7 @@ public class PhpExceptionHandlingSmellTest {
                 function run(): void {
                     try {
                         work();
-                    } catch (\\Exception $e) {
+                    } catch (\\exception $e) {
                     }
                 }
 
@@ -29,6 +29,7 @@ public class PhpExceptionHandlingSmellTest {
         var findings = analyze(code);
         assertFalse(findings.isEmpty());
         assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("generic-catch:Exception")));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/PhpExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/PhpExceptionHandlingSmellTest.java
@@ -1,0 +1,134 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PhpExceptionHandlingSmellTest {
+
+    @Test
+    void flagsEmptyCatchBody() {
+        String code =
+                """
+                <?php
+                function run(): void {
+                    try {
+                        work();
+                    } catch (\\Exception $e) {
+                    }
+                }
+
+                function work(): void {}
+                """;
+        var findings = analyze(code);
+        assertFalse(findings.isEmpty());
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+    }
+
+    @Test
+    void flagsCommentOnlyCatchBody() {
+        String code =
+                """
+                <?php
+                function run(): void {
+                    try {
+                        work();
+                    } catch (\\Exception $e) {
+                        /* ignore during cleanup */
+                    }
+                }
+
+                function work(): void {}
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("comment-only-body")));
+    }
+
+    @Test
+    void flagsGenericTinyCatchBody() {
+        String code =
+                """
+                <?php
+                function run(): void {
+                    try {
+                        work();
+                    } catch (\\Throwable $e) {
+                        metrics();
+                    }
+                }
+
+                function work(): void {}
+                function metrics(): void {}
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("generic-catch:Throwable")));
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().stream().anyMatch(r -> r.startsWith("small-body:"))));
+    }
+
+    @Test
+    void substantialRethrowHandlingDoesNotFlagWithDefaultWeights() {
+        String code =
+                """
+                <?php
+                function run(): void {
+                    try {
+                        work();
+                    } catch (\\Exception $e) {
+                        $code = status_code($e);
+                        $msg = "failure " . $code;
+                        audit($msg);
+                        notify_ops($msg);
+                        throw new \\RuntimeException($msg, 0, $e);
+                    }
+                }
+
+                function status_code(\\Exception $e): int { return 500; }
+                function audit(string $msg): void {}
+                function notify_ops(string $msg): void {}
+                function work(): void {}
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.isEmpty(), "Expected meaningful handler to be mitigated by body credit");
+    }
+
+    @Test
+    void weightTuningCanPromoteOrSuppressFindings() {
+        String code =
+                """
+                <?php
+                function run($logger): void {
+                    try {
+                        work();
+                    } catch (\\RuntimeException $e) {
+                        $logger->warn("bad", $e);
+                    }
+                }
+
+                function work(): void {}
+                """;
+        var defaults = analyze(code);
+        var tunedWeights = new IAnalyzer.ExceptionSmellWeights(0, 0, 0, 0, 0, 0, 0, 5, 6, 2);
+        var tuned = analyze(code, tunedWeights);
+        assertFalse(defaults.isEmpty(), "Default heuristics should flag log-only tiny handler");
+        assertEquals(0, tuned.size(), "Higher body credit should suppress the same finding");
+    }
+
+    private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
+        return analyze(source, IAnalyzer.ExceptionSmellWeights.defaults());
+    }
+
+    private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source, IAnalyzer.ExceptionSmellWeights weights) {
+        try (var testProject =
+                InlineTestProjectCreator.code(source, "pkg/Test.php").build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), "pkg/Test.php");
+            return analyzer.findExceptionHandlingSmells(file, weights);
+        }
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
@@ -6,6 +6,7 @@ import ai.brokk.analyzer.cache.AnalyzerCache;
 import ai.brokk.analyzer.cache.PhpAnalyzerCache;
 import ai.brokk.project.ICoreProject;
 import java.util.*;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.Nullable;
 import org.treesitter.*;
 
@@ -222,6 +223,235 @@ public final class PhpAnalyzer extends TreeSitterAnalyzer {
     @Override
     protected String getLanguageSpecificIndent() {
         return "  ";
+    }
+
+    @Override
+    public List<ExceptionHandlingSmell> findExceptionHandlingSmells(ProjectFile file, ExceptionSmellWeights weights) {
+        checkStale("findExceptionHandlingSmells");
+        ExceptionSmellWeights resolvedWeights = weights != null ? weights : ExceptionSmellWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file,
+                            source -> detectExceptionHandlingSmells(file, root, source, resolvedWeights),
+                            List.of());
+                },
+                List.of());
+    }
+
+    private static final Set<String> PHP_COMMENT_NODE_TYPES = Set.of(COMMENT);
+    private static final Pattern PHP_LOG_ONLY_PATTERN = Pattern.compile(
+            "(?i)(?:\\$this\\s*->\\s*(?:logger|log)|\\$(?:logger|log))\\s*->\\s*(?:error|warn|warning|info|debug|trace)\\b"
+                    + "|\\bLog\\s*::\\s*(?:error|warn|warning|info|debug|trace)\\b"
+                    + "|\\berror_log\\s*\\(");
+
+    private List<ExceptionHandlingSmell> detectExceptionHandlingSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        var findings = new ArrayList<SmellCandidate>();
+        collectCatchSmells(file, root, sourceContent, weights, findings);
+        return findings.stream()
+                .sorted(Comparator.comparingInt(SmellCandidate::score)
+                        .reversed()
+                        .thenComparing(c -> c.smell().file().toString())
+                        .thenComparing(c -> c.smell().enclosingFqName())
+                        .thenComparingInt(SmellCandidate::startByte))
+                .map(SmellCandidate::smell)
+                .toList();
+    }
+
+    private void collectCatchSmells(
+            ProjectFile file,
+            TSNode node,
+            SourceContent sourceContent,
+            ExceptionSmellWeights weights,
+            List<SmellCandidate> out) {
+        if (node == null) {
+            return;
+        }
+        if (CATCH_CLAUSE.equals(node.getType())) {
+            analyzeCatchClause(file, node, sourceContent, weights).ifPresent(out::add);
+        }
+        for (int i = 0; i < node.getChildCount(); i++) {
+            TSNode child = node.getChild(i);
+            if (child != null) {
+                collectCatchSmells(file, child, sourceContent, weights, out);
+            }
+        }
+    }
+
+    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
+        int score() {
+            return smell.score();
+        }
+    }
+
+    private Optional<SmellCandidate> analyzeCatchClause(
+            ProjectFile file, TSNode catchClause, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        TSNode bodyNode = catchClause.getChildByFieldName("body");
+        if (bodyNode == null) {
+            bodyNode = firstNamedChildOfType(catchClause, COMPOUND_STATEMENT);
+        }
+        if (bodyNode == null) {
+            return Optional.empty();
+        }
+
+        int bodyStatements = countBodyStatements(bodyNode);
+        boolean hasAnyComment = hasDescendantOfType(bodyNode, COMMENT);
+        boolean emptyBody = bodyStatements == 0 && !hasAnyComment;
+        boolean commentOnlyBody = bodyStatements == 0 && hasAnyComment;
+        boolean smallBody = bodyStatements <= weights.smallBodyMaxStatements();
+        boolean throwPresent = hasDescendantOfType(bodyNode, THROW_STATEMENT);
+        boolean logOnly = bodyStatements == 1 && isLikelyLogOnlyBody(bodyNode, sourceContent) && !throwPresent;
+
+        String catchType = extractCatchType(catchClause, sourceContent);
+        List<String> normalizedTypes = normalizeCatchTypesForScoring(catchType);
+
+        int score = 0;
+        var reasons = new ArrayList<String>();
+        if (normalizedTypes.contains("Throwable")) {
+            score += weights.genericThrowableWeight();
+            reasons.add("generic-catch:Throwable");
+        } else if (normalizedTypes.contains("Exception")) {
+            score += weights.genericExceptionWeight();
+            reasons.add("generic-catch:Exception");
+        } else if (normalizedTypes.contains("RuntimeException")) {
+            score += weights.genericRuntimeExceptionWeight();
+            reasons.add("generic-catch:RuntimeException");
+        }
+        if (emptyBody) {
+            score += weights.emptyBodyWeight();
+            reasons.add("empty-body");
+        }
+        if (commentOnlyBody) {
+            score += weights.commentOnlyBodyWeight();
+            reasons.add("comment-only-body");
+        }
+        if (smallBody) {
+            score += weights.smallBodyWeight();
+            reasons.add("small-body:" + bodyStatements);
+        }
+        if (logOnly) {
+            score += weights.logOnlyWeight();
+            reasons.add("log-only-body");
+        }
+
+        int creditStatements = Math.min(bodyStatements, Math.max(0, weights.meaningfulBodyStatementThreshold()));
+        int bodyCredit = Math.max(0, weights.meaningfulBodyCreditPerStatement()) * creditStatements;
+        if (bodyCredit > 0) {
+            score -= bodyCredit;
+            reasons.add("meaningful-body-credit:" + bodyCredit);
+        }
+        if (score <= 0) {
+            return Optional.empty();
+        }
+
+        String enclosing = enclosingCodeUnit(
+                        file,
+                        catchClause.getStartPoint().getRow(),
+                        catchClause.getEndPoint().getRow())
+                .map(CodeUnit::fqName)
+                .orElse(file.toString());
+        var smell = new ExceptionHandlingSmell(
+                file,
+                enclosing,
+                catchType,
+                score,
+                bodyStatements,
+                List.copyOf(reasons),
+                compactCatchExcerpt(sourceContent.substringFrom(catchClause)));
+        return Optional.of(new SmellCandidate(smell, catchClause.getStartByte()));
+    }
+
+    private static int countBodyStatements(TSNode bodyNode) {
+        int statements = 0;
+        for (int i = 0; i < bodyNode.getNamedChildCount(); i++) {
+            TSNode child = bodyNode.getNamedChild(i);
+            if (child == null) {
+                continue;
+            }
+            if (PHP_COMMENT_NODE_TYPES.contains(child.getType())) {
+                continue;
+            }
+            statements++;
+        }
+        return statements;
+    }
+
+    private static boolean isLikelyLogOnlyBody(TSNode bodyNode, SourceContent sourceContent) {
+        TSNode statement = firstNonCommentNamedChild(bodyNode, PHP_COMMENT_NODE_TYPES);
+        if (statement == null) {
+            return false;
+        }
+        String text = sourceContent.substringFrom(statement).strip();
+        if (text.isEmpty()) {
+            return false;
+        }
+        return PHP_LOG_ONLY_PATTERN.matcher(text).find();
+    }
+
+    private static String extractCatchType(TSNode catchClause, SourceContent sourceContent) {
+        TSNode typeNode = catchClause.getChildByFieldName("type");
+        if (typeNode != null) {
+            String type = sourceContent.substringFrom(typeNode).strip();
+            if (!type.isEmpty()) {
+                return type.replaceAll("\\s+", " ");
+            }
+        }
+
+        for (int i = 0; i < catchClause.getNamedChildCount(); i++) {
+            TSNode child = catchClause.getNamedChild(i);
+            if (child == null) {
+                continue;
+            }
+            String type = Objects.toString(child.getType(), "");
+            if (COMPOUND_STATEMENT.equals(type) || VARIABLE_NAME.equals(type) || COMMENT.equals(type)) {
+                continue;
+            }
+            String text = sourceContent.substringFrom(child).strip();
+            if (!text.isEmpty()) {
+                return text.replaceAll("\\s+", " ");
+            }
+        }
+
+        return "<unknown>";
+    }
+
+    private static List<String> normalizeCatchTypesForScoring(String catchType) {
+        if (catchType.isBlank() || "<unknown>".equals(catchType)) {
+            return List.of();
+        }
+        return Arrays.stream(catchType.split("\\|"))
+                .map(String::strip)
+                .filter(s -> !s.isEmpty())
+                .map(s -> s.startsWith("\\") ? s.substring(1) : s)
+                .map(s -> {
+                    int lastSep = s.lastIndexOf('\\');
+                    return lastSep >= 0 ? s.substring(lastSep + 1) : s;
+                })
+                .toList();
+    }
+
+    private static String compactCatchExcerpt(String text) {
+        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        if (compact.length() <= 180) {
+            return compact;
+        }
+        return compact.substring(0, 180) + "...";
+    }
+
+    private static @Nullable TSNode firstNamedChildOfType(TSNode node, String type) {
+        for (int i = 0; i < node.getNamedChildCount(); i++) {
+            TSNode child = node.getNamedChild(i);
+            if (child != null && type.equals(child.getType())) {
+                return child;
+            }
+        }
+        return null;
     }
 
     private String extractModifiers(TSNode methodNode, SourceContent sourceContent) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
@@ -313,13 +313,13 @@ public final class PhpAnalyzer extends TreeSitterAnalyzer {
 
         int score = 0;
         var reasons = new ArrayList<String>();
-        if (normalizedTypes.contains("Throwable")) {
+        if (normalizedTypes.contains("throwable")) {
             score += weights.genericThrowableWeight();
             reasons.add("generic-catch:Throwable");
-        } else if (normalizedTypes.contains("Exception")) {
+        } else if (normalizedTypes.contains("exception")) {
             score += weights.genericExceptionWeight();
             reasons.add("generic-catch:Exception");
-        } else if (normalizedTypes.contains("RuntimeException")) {
+        } else if (normalizedTypes.contains("runtimeexception")) {
             score += weights.genericRuntimeExceptionWeight();
             reasons.add("generic-catch:RuntimeException");
         }
@@ -433,6 +433,7 @@ public final class PhpAnalyzer extends TreeSitterAnalyzer {
                     int lastSep = s.lastIndexOf('\\');
                     return lastSep >= 0 ? s.substring(lastSep + 1) : s;
                 })
+                .map(s -> s.toLowerCase(Locale.ROOT))
                 .toList();
     }
 

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/php/PhpTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/php/PhpTreeSitterNodeTypes.java
@@ -20,6 +20,11 @@ public final class PhpTreeSitterNodeTypes {
     // Statements
     public static final String DECLARE_STATEMENT = "declare_statement";
     public static final String COMPOUND_STATEMENT = "compound_statement";
+    public static final String TRY_STATEMENT = "try_statement";
+    public static final String CATCH_CLAUSE = "catch_clause";
+    public static final String THROW_STATEMENT = "throw_statement";
+    public static final String EXPRESSION_STATEMENT = "expression_statement";
+    public static final String VARIABLE_NAME = "variable_name";
 
     // Class-like declarations
     public static final String TRAIT_DECLARATION = "trait_declaration";


### PR DESCRIPTION
## Summary
- Add `reportExceptionHandlingSmells` support for PHP via `PhpAnalyzer`.
- Traverse PHP catch clauses with Tree-sitter and score empty, generic, small, log-only, and well-handled catches consistently with other analyzers.
- Add PHP analyzer coverage in `PhpExceptionHandlingSmellTest`.

## Testing
- `./gradlew :app:test --tests '*PhpExceptionHandlingSmellTest'`
- `./gradlew fix tidy`