### PR TITLE
Add Scala exception handling smell support

### DIFF
--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -204,7 +204,7 @@ public class CodeQualityTools {
 
     @Tool(
             """
-            Detects suspicious Java catch blocks using weighted heuristics designed for high-recall triage.
+            Detects suspicious exception handlers using weighted heuristics designed for high-recall triage.
             Scores generic catches and tiny/empty handlers, then subtracts credit for richer handling bodies.
             Use minScore, maxFindings, and weight parameters to tune precision/recall.""")
     public String reportExceptionHandlingSmells(

--- a/app/src/test/java/ai/brokk/analyzer/code_quality/ScalaExceptionHandlingSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/ScalaExceptionHandlingSmellTest.java
@@ -1,0 +1,115 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ScalaExceptionHandlingSmellTest {
+
+    @Test
+    void flagsNoOpCatchBody() {
+        String code =
+                """
+                package com.example
+                class Test {
+                  def run(): Unit = {
+                    try {
+                      work()
+                    } catch {
+                      case e: Exception => ()
+                    }
+                  }
+                  def work(): Unit = {}
+                }
+                """;
+        var findings = analyze(code);
+        assertFalse(findings.isEmpty());
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("empty-body")));
+    }
+
+    @Test
+    void flagsCommentOnlyCatchBody() {
+        String code =
+                """
+                package com.example
+                class Test {
+                  def run(): Unit = {
+                    try {
+                      work()
+                    } catch {
+                      case _: Exception =>
+                        // ignore during cleanup
+                        ()
+                    }
+                  }
+                  def work(): Unit = {}
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("comment-only-body")));
+    }
+
+    @Test
+    void flagsGenericTinyCatchBody() {
+        String code =
+                """
+                package com.example
+                class Test {
+                  def run(): Unit = {
+                    try {
+                      work()
+                    } catch {
+                      case t: Throwable => metrics()
+                    }
+                  }
+                  def work(): Unit = {}
+                  def metrics(): Unit = {}
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.catchType().contains("Throwable")));
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().stream().anyMatch(r -> r.startsWith("small-body:"))));
+    }
+
+    @Test
+    void substantialRethrowHandlingDoesNotFlagWithDefaultWeights() {
+        String code =
+                """
+                package com.example
+                class Test {
+                  def run(): Unit = {
+                    try {
+                      work()
+                    } catch {
+                      case e: Exception =>
+                        val code = statusCode(e)
+                        val message = "failure " + code
+                        audit(message)
+                        notifyOps(message)
+                        throw new IllegalStateException(message, e)
+                    }
+                  }
+                  def statusCode(e: Exception): Int = 500
+                  def audit(msg: String): Unit = {}
+                  def notifyOps(msg: String): Unit = {}
+                  def work(): Unit = {}
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.isEmpty(), "Expected meaningful handler to be mitigated by body credit");
+    }
+
+    private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
+        try (var testProject =
+                InlineTestProjectCreator.code(source, "com/example/Test.scala").build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), "com/example/Test.scala");
+            return analyzer.findExceptionHandlingSmells(file, IAnalyzer.ExceptionSmellWeights.defaults());
+        }
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/ScalaAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/ScalaAnalyzer.java
@@ -92,7 +92,7 @@ public class ScalaAnalyzer extends TreeSitterAnalyzer implements JvmBasedAnalyze
 
         var findings = new ArrayList<ExceptionHandlingSmell>();
         for (TSNode tryNode : tryNodes) {
-            TSNode catchClause = findFirstNamedDescendant(tryNode, CATCH_CLAUSE);
+            TSNode catchClause = immediateCatchClause(tryNode);
             if (catchClause == null) {
                 continue;
             }
@@ -107,6 +107,22 @@ public class ScalaAnalyzer extends TreeSitterAnalyzer implements JvmBasedAnalyze
                         .thenComparing(f -> f.file().toString())
                         .thenComparing(ExceptionHandlingSmell::enclosingFqName))
                 .toList();
+    }
+
+    private static @Nullable TSNode immediateCatchClause(TSNode tryExpression) {
+        // Avoid descendant search: nested try/catch inside the try-body should not be attributed to this
+        // try_expression.
+        TSNode byField = tryExpression.getChildByFieldName("catch");
+        if (byField != null && CATCH_CLAUSE.equals(byField.getType())) {
+            return byField;
+        }
+        for (int i = 0; i < tryExpression.getNamedChildCount(); i++) {
+            TSNode child = tryExpression.getNamedChild(i);
+            if (child != null && CATCH_CLAUSE.equals(child.getType())) {
+                return child;
+            }
+        }
+        return null;
     }
 
     private Optional<ExceptionHandlingSmell> analyzeCaseClause(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/ScalaAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/ScalaAnalyzer.java
@@ -4,7 +4,10 @@ import static ai.brokk.analyzer.scala.ScalaTreeSitterNodeTypes.*;
 
 import ai.brokk.analyzer.cache.AnalyzerCache;
 import ai.brokk.project.ICoreProject;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -18,6 +21,8 @@ import org.treesitter.TSTree;
 import org.treesitter.TreeSitterScala;
 
 public class ScalaAnalyzer extends TreeSitterAnalyzer implements JvmBasedAnalyzer {
+    private static final Set<String> LOG_RECEIVER_BASE_NAMES = Set.of("log", "logger");
+    private static final Set<String> LOG_METHOD_NAMES = Set.of("warn", "info", "error", "debug", "trace");
 
     public ScalaAnalyzer(ICoreProject project) {
         this(project, ProgressListener.NOOP);
@@ -59,6 +64,310 @@ public class ScalaAnalyzer extends TreeSitterAnalyzer implements JvmBasedAnalyze
     @Override
     protected LanguageSyntaxProfile getLanguageSyntaxProfile() {
         return SCALA_SYNTAX_PROFILE;
+    }
+
+    @Override
+    public List<ExceptionHandlingSmell> findExceptionHandlingSmells(ProjectFile file, ExceptionSmellWeights weights) {
+        checkStale("findExceptionHandlingSmells");
+        ExceptionSmellWeights resolvedWeights = weights != null ? weights : ExceptionSmellWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file,
+                            source -> detectExceptionHandlingSmells(file, root, source, resolvedWeights),
+                            List.of());
+                },
+                List.of());
+    }
+
+    private List<ExceptionHandlingSmell> detectExceptionHandlingSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        var tryNodes = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(TRY_EXPRESSION), tryNodes);
+
+        var findings = new ArrayList<ExceptionHandlingSmell>();
+        for (TSNode tryNode : tryNodes) {
+            TSNode catchClause = findFirstNamedDescendant(tryNode, CATCH_CLAUSE);
+            if (catchClause == null) {
+                continue;
+            }
+            for (TSNode caseClause : topLevelCaseClauses(catchClause)) {
+                analyzeCaseClause(file, caseClause, sourceContent, weights).ifPresent(findings::add);
+            }
+        }
+
+        return findings.stream()
+                .sorted(Comparator.comparingInt(ExceptionHandlingSmell::score)
+                        .reversed()
+                        .thenComparing(f -> f.file().toString())
+                        .thenComparing(ExceptionHandlingSmell::enclosingFqName))
+                .toList();
+    }
+
+    private Optional<ExceptionHandlingSmell> analyzeCaseClause(
+            ProjectFile file, TSNode caseClause, SourceContent sourceContent, ExceptionSmellWeights weights) {
+        List<TSNode> handlerNodes = caseClauseHandlerNodes(caseClause);
+        if (handlerNodes.isEmpty()) {
+            return Optional.empty();
+        }
+        String catchType = extractCatchType(caseClause, sourceContent);
+        boolean hasAnyComment = hasDescendantOfAnyType(caseClause, Set.of(COMMENT, LINE_COMMENT, BLOCK_COMMENT));
+        boolean throwPresent = handlerNodes.stream()
+                .anyMatch(n -> THROW_EXPRESSION.equals(n.getType()) || hasDescendantOfType(n, THROW_EXPRESSION));
+        int bodyStatements = countMeaningfulHandlerStatements(handlerNodes, sourceContent);
+
+        boolean emptyBody = bodyStatements == 0 && !hasAnyComment;
+        boolean commentOnlyBody = bodyStatements == 0 && hasAnyComment;
+        boolean smallBody = bodyStatements <= weights.smallBodyMaxStatements();
+        boolean logOnly = bodyStatements == 1 && isLikelyLogOnlyBody(handlerNodes, sourceContent) && !throwPresent;
+
+        int score = 0;
+        var reasons = new ArrayList<String>();
+        if (catchType.contains("Throwable")) {
+            score += weights.genericThrowableWeight();
+            reasons.add("generic-catch:Throwable");
+        } else if (catchType.contains("Exception")) {
+            if (catchType.contains("RuntimeException")) {
+                score += weights.genericRuntimeExceptionWeight();
+                reasons.add("generic-catch:RuntimeException");
+            } else {
+                score += weights.genericExceptionWeight();
+                reasons.add("generic-catch:Exception");
+            }
+        }
+        if (emptyBody) {
+            score += weights.emptyBodyWeight();
+            reasons.add("empty-body");
+        }
+        if (commentOnlyBody) {
+            score += weights.commentOnlyBodyWeight();
+            reasons.add("comment-only-body");
+        }
+        if (smallBody) {
+            score += weights.smallBodyWeight();
+            reasons.add("small-body:" + bodyStatements);
+        }
+        if (logOnly) {
+            score += weights.logOnlyWeight();
+            reasons.add("log-only-body");
+        }
+
+        int creditStatements = Math.min(bodyStatements, Math.max(0, weights.meaningfulBodyStatementThreshold()));
+        int bodyCredit = Math.max(0, weights.meaningfulBodyCreditPerStatement()) * creditStatements;
+        if (bodyCredit > 0) {
+            score -= bodyCredit;
+            reasons.add("meaningful-body-credit:" + bodyCredit);
+        }
+
+        if (score <= 0) {
+            return Optional.empty();
+        }
+
+        String enclosing = enclosingCodeUnit(
+                        file,
+                        caseClause.getStartPoint().getRow(),
+                        caseClause.getEndPoint().getRow())
+                .map(CodeUnit::fqName)
+                .orElse(file.toString());
+        String excerpt = compactExcerpt(sourceContent.substringFrom(caseClause));
+        return Optional.of(new ExceptionHandlingSmell(
+                file, enclosing, catchType, score, bodyStatements, List.copyOf(reasons), excerpt));
+    }
+
+    private static List<TSNode> caseClauseHandlerNodes(TSNode caseClause) {
+        var named = new ArrayList<TSNode>();
+        for (int i = 0; i < caseClause.getNamedChildCount(); i++) {
+            TSNode child = caseClause.getNamedChild(i);
+            if (child != null) {
+                named.add(child);
+            }
+        }
+        int start = 0;
+        while (start < named.size()) {
+            String type = named.get(start).getType();
+            if (TYPED_PATTERN.equals(type) || GUARD.equals(type)) {
+                start++;
+                continue;
+            }
+            break;
+        }
+        if (start >= named.size()) {
+            return List.of();
+        }
+        return named.subList(start, named.size());
+    }
+
+    private static List<TSNode> topLevelCaseClauses(TSNode catchClause) {
+        // We want only the case clauses that are part of the catch, not nested matches in the bodies.
+        var cases = new ArrayList<TSNode>();
+        var stack = new ArrayList<TSNode>();
+        stack.add(catchClause);
+        while (!stack.isEmpty()) {
+            TSNode node = stack.removeLast();
+            if (node == null) {
+                continue;
+            }
+            String type = node.getType();
+            if (CASE_CLAUSE.equals(type)) {
+                cases.add(node);
+                continue;
+            }
+            for (int i = node.getNamedChildCount() - 1; i >= 0; i--) {
+                TSNode child = node.getNamedChild(i);
+                if (child != null) {
+                    stack.add(child);
+                }
+            }
+        }
+        return cases;
+    }
+
+    private static boolean hasDescendantOfAnyType(TSNode root, Set<String> types) {
+        for (String type : types) {
+            if (findFirstNamedDescendant(root, type) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String extractCatchType(TSNode caseClause, SourceContent sourceContent) {
+        TSNode patternNode = caseClause.getChildByFieldName("pattern");
+        if (patternNode == null) {
+            // Fall back to the clause itself; this should still be useful in the markdown output.
+            return sourceContent.substringFrom(caseClause).strip();
+        }
+        TSNode typedPattern = findFirstNamedDescendant(patternNode, TYPED_PATTERN);
+        if (typedPattern == null) {
+            return sourceContent.substringFrom(patternNode).strip();
+        }
+        TSNode typeNode = typedPattern.getChildByFieldName("type");
+        if (typeNode == null) {
+            return sourceContent.substringFrom(typedPattern).strip();
+        }
+        return sourceContent.substringFrom(typeNode).strip();
+    }
+
+    private static int countMeaningfulHandlerStatements(List<TSNode> handlerNodes, SourceContent sourceContent) {
+        int statements = 0;
+        for (TSNode node : handlerNodes) {
+            if (node == null) {
+                continue;
+            }
+            String type = node.getType();
+            if (type == null) {
+                continue;
+            }
+            if (COMMENT.equals(type) || LINE_COMMENT.equals(type) || BLOCK_COMMENT.equals(type)) {
+                continue;
+            }
+            if (UNIT.equals(type)) {
+                continue;
+            }
+            if (SPAN.equals(type) || BLOCK.equals(type) || INDENTED_BLOCK.equals(type)) {
+                statements += countTopLevelSpanElements(node);
+                continue;
+            }
+            String text = sourceContent.substringFrom(node).strip();
+            if (text.equals("()") || text.equals("{}")) {
+                continue;
+            }
+            statements++;
+        }
+        return statements;
+    }
+
+    private static int countTopLevelSpanElements(TSNode node) {
+        var elements = new ArrayList<TSNode>();
+        collectTopLevelSpanElements(node, elements);
+        int statements = 0;
+        for (TSNode element : elements) {
+            String elementType = element.getType();
+            if (elementType == null) {
+                continue;
+            }
+            if (UNIT.equals(elementType)) {
+                continue;
+            }
+            if (COMMENT.equals(elementType) || LINE_COMMENT.equals(elementType) || BLOCK_COMMENT.equals(elementType)) {
+                continue;
+            }
+            statements++;
+        }
+        return statements;
+    }
+
+    private static void collectTopLevelSpanElements(TSNode node, List<TSNode> out) {
+        for (int i = 0; i < node.getNamedChildCount(); i++) {
+            TSNode child = node.getNamedChild(i);
+            if (child == null) {
+                continue;
+            }
+            String type = child.getType();
+            if (SPAN.equals(type) || BLOCK.equals(type) || INDENTED_BLOCK.equals(type)) {
+                collectTopLevelSpanElements(child, out);
+                continue;
+            }
+            out.add(child);
+        }
+    }
+
+    private static boolean isLikelyLogOnlyBody(List<TSNode> handlerNodes, SourceContent sourceContent) {
+        TSNode call = null;
+        for (TSNode node : handlerNodes) {
+            if (node == null) {
+                continue;
+            }
+            if (CALL_EXPRESSION.equals(node.getType())) {
+                call = node;
+                break;
+            }
+            call = findFirstNamedDescendant(node, CALL_EXPRESSION);
+            if (call != null) {
+                break;
+            }
+        }
+        if (call == null) {
+            return false;
+        }
+        return isLikelyLoggerCall(call, sourceContent);
+    }
+
+    private static boolean isLikelyLoggerCall(TSNode callExpression, SourceContent sourceContent) {
+        TSNode functionNode = callExpression.getChildByFieldName("function");
+        if (functionNode == null) {
+            return false;
+        }
+        if (!FIELD_EXPRESSION.equals(functionNode.getType())) {
+            return false;
+        }
+        TSNode receiverNode = functionNode.getChildByFieldName("value");
+        TSNode fieldNode = functionNode.getChildByFieldName("field");
+        if (receiverNode == null || fieldNode == null) {
+            return false;
+        }
+        String receiverText = sourceContent.substringFrom(receiverNode).strip().toLowerCase(Locale.ROOT);
+        String methodText = sourceContent.substringFrom(fieldNode).strip().toLowerCase(Locale.ROOT);
+
+        String receiverBase = receiverText;
+        int lastDot = receiverText.lastIndexOf('.');
+        if (lastDot >= 0 && lastDot + 1 < receiverText.length()) {
+            receiverBase = receiverText.substring(lastDot + 1);
+        }
+        return LOG_RECEIVER_BASE_NAMES.contains(receiverBase) && LOG_METHOD_NAMES.contains(methodText);
+    }
+
+    private static String compactExcerpt(String text) {
+        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        if (compact.length() <= 180) {
+            return compact;
+        }
+        return compact.substring(0, 180) + "...";
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/scala/ScalaTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/scala/ScalaTreeSitterNodeTypes.java
@@ -40,5 +40,23 @@ public class ScalaTreeSitterNodeTypes {
     public static final String IMPORT_DECLARATION_NODE = "import_declaration";
     public static final String SCALATEST_IMPORT_SNIPPET = "org.scalatest";
 
+    // Exception handling (Scala)
+    public static final String TRY_EXPRESSION = "try_expression";
+    public static final String CATCH_CLAUSE = "catch_clause";
+    public static final String CASE_CLAUSE = "case_clause";
+    public static final String CASE_BLOCK = "case_block";
+    public static final String INDENTED_CASES = "indented_cases";
+    public static final String BLOCK = "block";
+    public static final String INDENTED_BLOCK = "indented_block";
+    public static final String TYPED_PATTERN = "typed_pattern";
+    public static final String GUARD = "guard";
+    public static final String THROW_EXPRESSION = "throw_expression";
+    public static final String UNIT = "unit";
+    public static final String COMMENT = "comment";
+    public static final String BLOCK_COMMENT = "block_comment";
+    public static final String LINE_COMMENT = "line_comment";
+    public static final String SPAN = "span";
+    public static final String FIELD_EXPRESSION = "field_expression";
+
     private ScalaTreeSitterNodeTypes() {}
 }


### PR DESCRIPTION
### Description
Add Scala support for `reportExceptionHandlingSmells` so the tool produces findings for Scala exception handlers and keeps the output format aligned with the existing analyzers.

**Key Changes**:
- Implement Scala exception-handling smell detection in `ScalaAnalyzer` using Tree-sitter CST traversal.
- Add Scala-specific node type constants to support catch/case traversal and logger-call detection.
- Extend code-quality coverage with `ScalaExceptionHandlingSmellTest` for non-empty findings and no-findings behavior.
- Update the tool description to apply to exception handlers generally, not just Java catch blocks.

**Touch Points**:
- `app/src/main/java/ai/brokk/tools/CodeQualityTools.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/ScalaAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/scala/ScalaTreeSitterNodeTypes.java`
- `app/src/test/java/ai/brokk/analyzer/code_quality/ScalaExceptionHandlingSmellTest.java`

### Testing
- `./gradlew :app:test --tests "ai.brokk.analyzer.code_quality.ScalaExceptionHandlingSmellTest"`
- `./gradlew fix tidy`
- `./gradlew analyze`