### PR TITLE
Refactor shared smell candidate sorting in TreeSitterAnalyzer

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
@@ -293,11 +293,7 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
             analyzeCatchClause(file, catchNode, sourceContent, weights).ifPresent(findings::add);
         }
         return findings.stream()
-                .sorted(java.util.Comparator.comparingInt(SmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(SmellCandidate::startByte))
+                .sorted(EXCEPTION_SMELL_CANDIDATE_COMPARATOR)
                 .map(SmellCandidate::smell)
                 .toList();
     }
@@ -507,12 +503,6 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
             return compact;
         }
         return compact.substring(0, 180) + "...";
-    }
-
-    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -11,7 +11,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1353,12 +1352,6 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
             List<String> reasons,
             String excerpt) {}
 
-    private record TestSmellCandidate(TestAssertionSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
-    }
-
     private record GoTestFunction(TSNode function, String testParamName) {}
 
     private record GoAssertionAnalysis(
@@ -1455,11 +1448,7 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
         }
 
         return candidates.stream()
-                .sorted(Comparator.comparingInt(TestSmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(TestSmellCandidate::startByte))
+                .sorted(TEST_SMELL_CANDIDATE_COMPARATOR)
                 .map(TestSmellCandidate::smell)
                 .toList();
     }
@@ -2024,11 +2013,7 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
         }
 
         return findings.stream()
-                .sorted(Comparator.comparingInt(SmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(SmellCandidate::startByte))
+                .sorted(EXCEPTION_SMELL_CANDIDATE_COMPARATOR)
                 .map(SmellCandidate::smell)
                 .toList();
     }
@@ -2297,11 +2282,5 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
             return compact;
         }
         return compact.substring(0, 180) + "...";
-    }
-
-    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
@@ -1649,11 +1649,7 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
             }
         }
         return findings.stream()
-                .sorted(Comparator.comparingInt(TestSmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(TestSmellCandidate::startByte))
+                .sorted(TEST_SMELL_CANDIDATE_COMPARATOR)
                 .map(TestSmellCandidate::smell)
                 .toList();
     }
@@ -2097,11 +2093,7 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
         var findings = new ArrayList<SmellCandidate>();
         collectCatchSmells(file, root, sourceContent, weights, findings);
         return findings.stream()
-                .sorted(Comparator.comparingInt(SmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(SmellCandidate::startByte))
+                .sorted(EXCEPTION_SMELL_CANDIDATE_COMPARATOR)
                 .map(SmellCandidate::smell)
                 .toList();
     }
@@ -2277,18 +2269,6 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
             return compact;
         }
         return compact.substring(0, 180) + "...";
-    }
-
-    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
-    }
-
-    private record TestSmellCandidate(TestAssertionSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
     }
 
     private record AssertionSignal(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
@@ -10,7 +10,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
@@ -237,11 +236,7 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
                         .ifPresent(callback ->
                                 analyzeTestCallback(file, call, callback, sourceContent, weights, findings)));
         return findings.stream()
-                .sorted(Comparator.comparingInt(TestSmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(TestSmellCandidate::startByte))
+                .sorted(TEST_SMELL_CANDIDATE_COMPARATOR)
                 .map(TestSmellCandidate::smell)
                 .toList();
     }
@@ -545,12 +540,6 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
                 List.copyOf(reasons),
                 compactCatchExcerpt(excerptSource));
         out.add(new TestSmellCandidate(smell, startByte));
-    }
-
-    private record TestSmellCandidate(TestAssertionSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
     }
 
     private record AssertionSignal(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
@@ -255,11 +255,7 @@ public final class PhpAnalyzer extends TreeSitterAnalyzer {
         var findings = new ArrayList<SmellCandidate>();
         collectCatchSmells(file, root, sourceContent, weights, findings);
         return findings.stream()
-                .sorted(Comparator.comparingInt(SmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(SmellCandidate::startByte))
+                .sorted(EXCEPTION_SMELL_CANDIDATE_COMPARATOR)
                 .map(SmellCandidate::smell)
                 .toList();
     }
@@ -281,12 +277,6 @@ public final class PhpAnalyzer extends TreeSitterAnalyzer {
             if (child != null) {
                 collectCatchSmells(file, child, sourceContent, weights, out);
             }
-        }
-    }
-
-    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
-        int score() {
-            return smell.score();
         }
     }
 

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
@@ -208,11 +208,7 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
             }
         }
         return findings.stream()
-                .sorted(Comparator.comparingInt(TestSmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(TestSmellCandidate::startByte))
+                .sorted(TEST_SMELL_CANDIDATE_COMPARATOR)
                 .map(TestSmellCandidate::smell)
                 .toList();
     }
@@ -619,12 +615,6 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
                 List.copyOf(reasons),
                 compactCatchExcerpt(excerptSource));
         out.add(new TestSmellCandidate(smell, startByte));
-    }
-
-    private record TestSmellCandidate(TestAssertionSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
     }
 
     private record AssertionSignal(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -39,12 +39,6 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
             List<String> reasons,
             String excerpt) {}
 
-    private record TestSmellCandidate(TestAssertionSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
-    }
-
     private record RustAssertionAnalysis(
             int assertionCount,
             int shallowAssertionCount,
@@ -744,11 +738,7 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         }
 
         return findings.stream()
-                .sorted(Comparator.comparingInt(SmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(SmellCandidate::startByte))
+                .sorted(EXCEPTION_SMELL_CANDIDATE_COMPARATOR)
                 .map(SmellCandidate::smell)
                 .toList();
     }
@@ -1016,12 +1006,6 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         return compact.substring(0, 180) + "...";
     }
 
-    private record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
-        int score() {
-            return smell.score();
-        }
-    }
-
     @Override
     public List<TestAssertionSmell> findTestAssertionSmells(ProjectFile file, TestAssertionWeights weights) {
         checkStale("findTestAssertionSmells");
@@ -1112,11 +1096,7 @@ public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnal
         }
 
         return candidates.stream()
-                .sorted(Comparator.comparingInt(TestSmellCandidate::score)
-                        .reversed()
-                        .thenComparing(c -> c.smell().file().toString())
-                        .thenComparing(c -> c.smell().enclosingFqName())
-                        .thenComparingInt(TestSmellCandidate::startByte))
+                .sorted(TEST_SMELL_CANDIDATE_COMPARATOR)
                 .map(TestSmellCandidate::smell)
                 .toList();
     }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -63,6 +63,38 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     protected static final Logger log = LoggerFactory.getLogger(TreeSitterAnalyzer.class);
     // Native library loading is assumed automatic by the io.github.bonede.tree_sitter library.
 
+    /**
+     * Common candidate wrapper used by multiple language analyzers for stable sorting of smells.
+     *
+     * <p>Several analyzers historically carried their own private copy of these small record helpers.
+     * Centralizing them here keeps behavior consistent and avoids drift.
+     */
+    protected record TestSmellCandidate(TestAssertionSmell smell, int startByte) {
+        int score() {
+            return smell.score();
+        }
+    }
+
+    protected record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {
+        int score() {
+            return smell.score();
+        }
+    }
+
+    protected static final Comparator<TestSmellCandidate> TEST_SMELL_CANDIDATE_COMPARATOR = Comparator.comparingInt(
+                    TestSmellCandidate::score)
+            .reversed()
+            .thenComparing(c -> c.smell().file().toString())
+            .thenComparing(c -> c.smell().enclosingFqName())
+            .thenComparingInt(TestSmellCandidate::startByte);
+
+    protected static final Comparator<SmellCandidate> EXCEPTION_SMELL_CANDIDATE_COMPARATOR = Comparator.comparingInt(
+                    SmellCandidate::score)
+            .reversed()
+            .thenComparing(c -> c.smell().file().toString())
+            .thenComparing(c -> c.smell().enclosingFqName())
+            .thenComparingInt(SmellCandidate::startByte);
+
     private volatile boolean isStale = false;
     private final AtomicBoolean staleWarningLogged = new AtomicBoolean(false);
 


### PR DESCRIPTION
## Summary
- Centralize the duplicated `TestSmellCandidate` and `SmellCandidate` helpers in `TreeSitterAnalyzer`.
- Reuse shared comparators across Java, Go, Rust, Python, PHP, C#, and JS/TS analyzers to keep smell ordering consistent.
- Remove the per-analyzer private record copies now that the shared base class provides them.

## Testing
- `./gradlew fix tidy`
- `./gradlew analyze`