### PR TITLE
Add PHP support for test assertion smell reporting

### DIFF
--- a/app/src/test/java/ai/brokk/analyzer/code_quality/PhpTestAssertionSmellTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/code_quality/PhpTestAssertionSmellTest.java
@@ -1,0 +1,157 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import ai.brokk.testutil.TestConsoleIO;
+import ai.brokk.testutil.TestContextManager;
+import ai.brokk.tools.CodeQualityTools;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PhpTestAssertionSmellTest extends AbstractBrittleTestSuite {
+
+    @Test
+    void emitsNoAssertionsForTestMethodWithNoAssertions() {
+        String code =
+                """
+                <?php
+                class SampleTest {
+                    public function testNoAssertions(): void {
+                        $value = 42;
+                        $value++;
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "no-assertions"), findings.toString());
+    }
+
+    @Test
+    void flagsConstantTruthAndConstantEquality() {
+        String code =
+                """
+                <?php
+                class SampleTest {
+                    public function testConstants(): void {
+                        $this->assertTrue(true);
+                        $this->assertEquals(1, 1);
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "constant-truth"), findings.toString());
+        assertTrue(hasReason(findings, "constant-equality"), findings.toString());
+    }
+
+    @Test
+    void flagsSelfComparisonAssertion() {
+        String code =
+                """
+                <?php
+                class SampleTest {
+                    public function testSelfComparison(): void {
+                        $value = "x";
+                        $this->assertSame($value, $value);
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "self-comparison"), findings.toString());
+    }
+
+    @Test
+    void flagsNullnessOnlyAndShallowOnly() {
+        String code =
+                """
+                <?php
+                class SampleTest {
+                    public function testNullnessOnly(): void {
+                        $value = new \\stdClass();
+                        $this->assertNotNull($value);
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "nullness-only"), findings.toString());
+        assertTrue(hasReason(findings, "shallow-assertions-only"), findings.toString());
+    }
+
+    @Test
+    void expectExceptionCountsAsAssertionEquivalentSoNoAssertionsIsNotEmitted() {
+        String code =
+                """
+                <?php
+                class SampleTest {
+                    public function testExpectException(): void {
+                        $this->expectException(\\RuntimeException::class);
+                        throw new \\RuntimeException("boom");
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertFalse(hasReason(findings, "no-assertions"), findings.toString());
+    }
+
+    @Test
+    void toolReturnsNoFindingsMessageForCleanTest() {
+        String code =
+                """
+                <?php
+                class SampleTest {
+                    public function testMeaningful(): void {
+                        $value = "expected";
+                        $this->assertEquals("expected", $value);
+                    }
+                }
+                """;
+        String report = toolReport(code, 4);
+        assertTrue(report.startsWith("No test assertion smells met minScore"), report);
+    }
+
+    @Test
+    void toolProducesMarkdownTableForSmellyTest() {
+        String code =
+                """
+                <?php
+                class SampleTest {
+                    public function testSmelly(): void {
+                        $this->assertTrue(true);
+                    }
+                }
+                """;
+        String report = toolReport(code, 1);
+        assertTrue(report.contains("## Test assertion smells"), report);
+        assertTrue(report.contains("| Score | Kind | Assertions | Symbol | File | Reasons | Excerpt |"), report);
+        assertTrue(report.contains("constant-truth"), report);
+    }
+
+    private String toolReport(String source, int minScore) {
+        String path = defaultTestPath();
+        try (var testProject = InlineTestProjectCreator.code(source, path).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            var cm = new TestContextManager(testProject, new TestConsoleIO(), java.util.Set.of(), analyzer);
+            var tools = new CodeQualityTools(cm);
+            return tools.reportTestAssertionSmells(
+                    List.of(path), minScore, 80, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+        }
+    }
+
+    @Override
+    protected String defaultTestPath() {
+        return "tests/SampleTest.php";
+    }
+
+    @Override
+    protected List<IAnalyzer.TestAssertionSmell> analyze(
+            String source, String path, IAnalyzer.TestAssertionWeights weights) {
+        try (var testProject = InlineTestProjectCreator.code(source, path).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), path);
+            return analyzer.findTestAssertionSmells(file, weights);
+        }
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
@@ -266,7 +266,7 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
                 .orElse(file.toString());
         int assertionCount = assertions.size();
         if (assertionCount == 0) {
-            addTestSmell(
+            addTestSmellCandidate(
                     file,
                     enclosing,
                     TEST_ASSERTION_KIND_NO_ASSERTIONS,
@@ -280,7 +280,7 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
         }
         assertions.stream()
                 .filter(signal -> signal.baseScore() > 0)
-                .forEach(signal -> addTestSmell(
+                .forEach(signal -> addTestSmellCandidate(
                         file,
                         enclosing,
                         signal.kind(),
@@ -293,9 +293,9 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
         boolean allShallow = assertions.stream().allMatch(AssertionSignal::shallow);
         if (allShallow) {
             int score = weights.shallowAssertionOnlyWeight()
-                    - meaningfulAssertionCredit(assertions, weights, AssertionSignal::meaningful);
+                    - testMeaningfulAssertionCredit(assertions, weights, AssertionSignal::meaningful);
             if (score > 0) {
-                addTestSmell(
+                addTestSmellCandidate(
                         file,
                         enclosing,
                         TEST_ASSERTION_KIND_SHALLOW_ONLY,
@@ -499,15 +499,6 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
                         && sourceContent.substringFrom(arg).length() >= weights.largeLiteralLengthThreshold());
     }
 
-    private static int meaningfulAssertionCredit(
-            List<AssertionSignal> assertions,
-            TestAssertionWeights weights,
-            java.util.function.Predicate<AssertionSignal> predicate) {
-        long count = assertions.stream().filter(predicate).count();
-        int creditable = Math.min((int) count, Math.max(0, weights.meaningfulAssertionCreditCap()));
-        return Math.max(0, weights.meaningfulAssertionCredit()) * creditable;
-    }
-
     private static @Nullable TSNode firstNamedChildOfType(TSNode node, String type) {
         for (int i = 0; i < node.getNamedChildCount(); i++) {
             TSNode child = node.getNamedChild(i);
@@ -516,30 +507,6 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
             }
         }
         return null;
-    }
-
-    private static void addTestSmell(
-            ProjectFile file,
-            String enclosing,
-            String assertionKind,
-            int score,
-            int assertionCount,
-            List<String> reasons,
-            String excerptSource,
-            int startByte,
-            List<TestSmellCandidate> out) {
-        if (score <= 0 || reasons.isEmpty()) {
-            return;
-        }
-        var smell = new TestAssertionSmell(
-                file,
-                enclosing,
-                assertionKind,
-                score,
-                assertionCount,
-                List.copyOf(reasons),
-                compactCatchExcerpt(excerptSource));
-        out.add(new TestSmellCandidate(smell, startByte));
     }
 
     private record AssertionSignal(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
@@ -934,7 +934,7 @@ public final class PhpAnalyzer extends TreeSitterAnalyzer {
         List<TSNode> args = callArgumentNodes(call);
 
         if (PHPUNIT_ASSERT_TRUE_FALSE.contains(terminalLower) && !args.isEmpty()) {
-            TSNode arg = args.getLast();
+            TSNode arg = args.getFirst();
             String argText = sourceContent.substringFrom(arg).strip().toLowerCase(Locale.ROOT);
             boolean constantTruth = terminalLower.equals("asserttrue") && "true".equals(argText);
             boolean constantFalse = terminalLower.equals("assertfalse") && "false".equals(argText);

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java
@@ -760,6 +760,352 @@ public final class PhpAnalyzer extends TreeSitterAnalyzer {
                 false);
     }
 
+    private static final String TEST_ASSERTION_KIND_NO_ASSERTIONS = "no-assertions";
+    private static final String TEST_ASSERTION_KIND_CONSTANT_TRUTH = "constant-truth";
+    private static final String TEST_ASSERTION_KIND_CONSTANT_EQUALITY = "constant-equality";
+    private static final String TEST_ASSERTION_KIND_SELF_COMPARISON = "self-comparison";
+    private static final String TEST_ASSERTION_KIND_NULLNESS_ONLY = "nullness-only";
+    private static final String TEST_ASSERTION_KIND_SHALLOW_ONLY = "shallow-assertions-only";
+    private static final String TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL = "overspecified-literal";
+
+    private static final Set<String> PHPUNIT_ASSERT_TRUE_FALSE = Set.of("asserttrue", "assertfalse");
+    private static final Set<String> PHPUNIT_ASSERT_COMPARISONS =
+            Set.of("assertequals", "assertsame", "assertnotequals", "assertnotsame");
+    private static final Set<String> PHPUNIT_NULLNESS_ASSERTIONS = Set.of("assertnull", "assertnotnull");
+    private static final Set<String> PHPUNIT_ASSERTION_EQUIVALENT_TERMINALS = Set.of("fail");
+
+    @Override
+    public List<TestAssertionSmell> findTestAssertionSmells(ProjectFile file, TestAssertionWeights weights) {
+        checkStale("findTestAssertionSmells");
+        if (!containsTests(file)) {
+            return List.of();
+        }
+        TestAssertionWeights resolvedWeights = weights != null ? weights : TestAssertionWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file, source -> detectTestAssertionSmells(file, root, source, resolvedWeights), List.of());
+                },
+                List.of());
+    }
+
+    private List<TestAssertionSmell> detectTestAssertionSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, TestAssertionWeights weights) {
+        var candidates = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(FUNCTION_DEFINITION, METHOD_DECLARATION), candidates);
+        var findings = new ArrayList<TestSmellCandidate>();
+        for (TSNode fn : candidates) {
+            if (!isTestFunction(fn, sourceContent)) {
+                continue;
+            }
+            analyzeTestFunction(file, fn, sourceContent, weights, findings);
+        }
+        return findings.stream()
+                .sorted(TEST_SMELL_CANDIDATE_COMPARATOR)
+                .map(TestSmellCandidate::smell)
+                .toList();
+    }
+
+    private boolean isTestFunction(TSNode functionNode, SourceContent sourceContent) {
+        TSNode nameNode = functionNode.getChildByFieldName(NAME);
+        if (nameNode != null) {
+            String nameText = sourceContent.substringFrom(nameNode).strip();
+            if (nameText.toLowerCase(Locale.ROOT).startsWith("test")) {
+                return true;
+            }
+        }
+        return findPrecedingComments(functionNode).stream()
+                .anyMatch(comment -> sourceContent.substringFrom(comment).contains(TEST_TAG_AT_TEST));
+    }
+
+    private void analyzeTestFunction(
+            ProjectFile file,
+            TSNode functionNode,
+            SourceContent sourceContent,
+            TestAssertionWeights weights,
+            List<TestSmellCandidate> out) {
+        TSNode body = functionNode.getChildByFieldName(PHP_SYNTAX_PROFILE.bodyFieldName());
+        if (body == null) {
+            return;
+        }
+
+        List<TSNode> calls = collectCallLikeNodes(body);
+        List<AssertionSignal> assertions = calls.stream()
+                .map(call -> assertionSignal(call, sourceContent, weights))
+                .flatMap(Optional::stream)
+                .toList();
+
+        String enclosing = enclosingCodeUnit(
+                        file,
+                        functionNode.getStartPoint().getRow(),
+                        functionNode.getEndPoint().getRow())
+                .map(CodeUnit::fqName)
+                .orElse(file.toString());
+
+        int assertionCount = assertions.size();
+        if (assertionCount == 0) {
+            addTestSmellCandidate(
+                    file,
+                    enclosing,
+                    TEST_ASSERTION_KIND_NO_ASSERTIONS,
+                    weights.noAssertionWeight(),
+                    0,
+                    List.of(TEST_ASSERTION_KIND_NO_ASSERTIONS),
+                    sourceContent.substringFrom(functionNode),
+                    functionNode.getStartByte(),
+                    out);
+            return;
+        }
+
+        assertions.stream()
+                .filter(signal -> signal.baseScore() > 0)
+                .forEach(signal -> addTestSmellCandidate(
+                        file,
+                        enclosing,
+                        signal.kind(),
+                        signal.baseScore(),
+                        assertionCount,
+                        signal.reasons(),
+                        signal.excerpt(),
+                        signal.startByte(),
+                        out));
+
+        boolean allShallow = assertions.stream().allMatch(AssertionSignal::shallow);
+        if (allShallow) {
+            int score = weights.shallowAssertionOnlyWeight()
+                    - testMeaningfulAssertionCredit(assertions, weights, AssertionSignal::meaningful);
+            if (score > 0) {
+                addTestSmellCandidate(
+                        file,
+                        enclosing,
+                        TEST_ASSERTION_KIND_SHALLOW_ONLY,
+                        score,
+                        assertionCount,
+                        List.of(TEST_ASSERTION_KIND_SHALLOW_ONLY),
+                        sourceContent.substringFrom(functionNode),
+                        functionNode.getStartByte(),
+                        out);
+            }
+        }
+    }
+
+    private record AssertionSignal(
+            String kind,
+            int baseScore,
+            boolean shallow,
+            boolean meaningful,
+            int startByte,
+            List<String> reasons,
+            String excerpt) {}
+
+    private Optional<AssertionSignal> assertionSignal(
+            TSNode call, SourceContent sourceContent, TestAssertionWeights weights) {
+        TSNode functionNode = call.getChildByFieldName("function");
+        if (functionNode == null) {
+            functionNode = call.getChildByFieldName("name");
+        }
+        if (functionNode == null && call.getNamedChildCount() > 0) {
+            functionNode = call.getNamedChild(0);
+        }
+        String terminalLower = terminalCallName(functionNode, sourceContent).toLowerCase(Locale.ROOT);
+        if (terminalLower.isBlank()) {
+            return Optional.empty();
+        }
+
+        boolean assertionEquivalent = terminalLower.startsWith("assert")
+                || terminalLower.startsWith("expectexception")
+                || PHPUNIT_ASSERTION_EQUIVALENT_TERMINALS.contains(terminalLower);
+        if (!assertionEquivalent) {
+            return Optional.empty();
+        }
+
+        String excerpt = sourceContent.substringFrom(call);
+        int score = 0;
+        var reasons = new ArrayList<String>();
+        boolean shallow = false;
+        boolean meaningful = true;
+        String kind = "phpunit-assertion";
+
+        List<TSNode> args = callArgumentNodes(call);
+
+        if (PHPUNIT_ASSERT_TRUE_FALSE.contains(terminalLower) && !args.isEmpty()) {
+            TSNode arg = args.getLast();
+            String argText = sourceContent.substringFrom(arg).strip().toLowerCase(Locale.ROOT);
+            boolean constantTruth = terminalLower.equals("asserttrue") && "true".equals(argText);
+            boolean constantFalse = terminalLower.equals("assertfalse") && "false".equals(argText);
+            if (constantTruth || constantFalse) {
+                score += weights.constantTruthWeight();
+                reasons.add(TEST_ASSERTION_KIND_CONSTANT_TRUTH);
+                kind = TEST_ASSERTION_KIND_CONSTANT_TRUTH;
+                meaningful = false;
+            }
+            if (isSelfComparison(arg, sourceContent)) {
+                score += weights.tautologicalAssertionWeight();
+                reasons.add(TEST_ASSERTION_KIND_SELF_COMPARISON);
+                kind = TEST_ASSERTION_KIND_SELF_COMPARISON;
+                meaningful = false;
+            }
+        }
+
+        if (PHPUNIT_ASSERT_COMPARISONS.contains(terminalLower) && args.size() >= 2) {
+            TSNode left = args.get(0);
+            TSNode right = args.get(1);
+            if (isConstantExpression(left, sourceContent) && isConstantExpression(right, sourceContent)) {
+                score += weights.constantEqualityWeight();
+                reasons.add(TEST_ASSERTION_KIND_CONSTANT_EQUALITY);
+                kind = TEST_ASSERTION_KIND_CONSTANT_EQUALITY;
+                meaningful = false;
+            } else if (sameExpression(left, right, sourceContent)) {
+                score += weights.tautologicalAssertionWeight();
+                reasons.add(TEST_ASSERTION_KIND_SELF_COMPARISON);
+                kind = TEST_ASSERTION_KIND_SELF_COMPARISON;
+                meaningful = false;
+            }
+        }
+
+        if (PHPUNIT_NULLNESS_ASSERTIONS.contains(terminalLower) && args.size() <= 2) {
+            score += weights.nullnessOnlyWeight();
+            reasons.add(TEST_ASSERTION_KIND_NULLNESS_ONLY);
+            kind = TEST_ASSERTION_KIND_NULLNESS_ONLY;
+            shallow = true;
+            meaningful = false;
+        }
+
+        if (containsOverspecifiedLiteral(args, sourceContent, weights)) {
+            score += weights.overspecifiedLiteralWeight();
+            reasons.add(TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL);
+            kind = TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL;
+        }
+
+        return Optional.of(new AssertionSignal(
+                kind, score, shallow, meaningful, call.getStartByte(), List.copyOf(reasons), excerpt));
+    }
+
+    private static List<TSNode> collectCallLikeNodes(TSNode root) {
+        var out = new ArrayList<TSNode>();
+        try (var cursor = new TSTreeCursor(root)) {
+            while (true) {
+                TSNode current = cursor.currentNode();
+                if (current == null) {
+                    return out;
+                }
+                String type = Objects.toString(current.getType(), "");
+                if (type.endsWith(CALL_EXPRESSION) || CALL_EXPRESSION.equals(type)) {
+                    out.add(current);
+                }
+                if (!gotoNextDepthFirst(cursor, true)) {
+                    return out;
+                }
+            }
+        }
+    }
+
+    private static String terminalCallName(@Nullable TSNode functionNode, SourceContent sourceContent) {
+        if (functionNode == null) {
+            return "";
+        }
+
+        if (NAME.equals(functionNode.getType())) {
+            return sourceContent.substringFrom(functionNode).strip();
+        }
+
+        TSNode nameNode = functionNode.getChildByFieldName(NAME);
+        if (nameNode != null) {
+            return sourceContent.substringFrom(nameNode).strip();
+        }
+
+        TSNode memberNode = functionNode.getChildByFieldName("member");
+        if (memberNode != null) {
+            return sourceContent.substringFrom(memberNode).strip();
+        }
+
+        TSNode propertyNode = functionNode.getChildByFieldName("property");
+        if (propertyNode != null) {
+            return sourceContent.substringFrom(propertyNode).strip();
+        }
+
+        return "";
+    }
+
+    private static List<TSNode> callArgumentNodes(TSNode call) {
+        TSNode args = call.getChildByFieldName("arguments");
+        if (args == null) {
+            for (int i = 0; i < call.getNamedChildCount(); i++) {
+                TSNode child = call.getNamedChild(i);
+                if (child != null && ARGUMENTS.equals(child.getType())) {
+                    args = child;
+                    break;
+                }
+            }
+        }
+        if (args == null) {
+            return List.of();
+        }
+        var out = new ArrayList<TSNode>();
+        for (int i = 0; i < args.getNamedChildCount(); i++) {
+            TSNode child = args.getNamedChild(i);
+            if (child != null) {
+                if (ARGUMENT.equals(child.getType()) && child.getNamedChildCount() == 1) {
+                    TSNode inner = child.getNamedChild(0);
+                    if (inner != null) {
+                        out.add(inner);
+                        continue;
+                    }
+                }
+                out.add(child);
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    private static boolean isSelfComparison(TSNode node, SourceContent sourceContent) {
+        String type = Objects.toString(node.getType(), "");
+        if (!type.endsWith(BINARY_EXPRESSION)) {
+            return false;
+        }
+        TSNode left = node.getChildByFieldName("left");
+        TSNode right = node.getChildByFieldName("right");
+        if ((left == null || right == null) && node.getNamedChildCount() >= 2) {
+            left = node.getNamedChild(0);
+            right = node.getNamedChild(1);
+        }
+        return left != null && right != null && sameExpression(left, right, sourceContent);
+    }
+
+    private static boolean sameExpression(TSNode left, TSNode right, SourceContent sourceContent) {
+        return sourceContent
+                .substringFrom(left)
+                .strip()
+                .equals(sourceContent.substringFrom(right).strip());
+    }
+
+    private static final Set<String> CONSTANT_LITERAL_TYPES =
+            Set.of(INTEGER, FLOAT, STRING, ENCAPSED_STRING, BOOLEAN, BOOLEAN_LITERAL, NULL, NULL_LITERAL);
+
+    private static boolean isConstantExpression(TSNode node, SourceContent sourceContent) {
+        if (CONSTANT_LITERAL_TYPES.contains(node.getType())) {
+            return true;
+        }
+        String text = sourceContent.substringFrom(node).strip().toLowerCase(Locale.ROOT);
+        return "true".equals(text) || "false".equals(text) || "null".equals(text);
+    }
+
+    private static boolean containsOverspecifiedLiteral(
+            List<TSNode> args, SourceContent sourceContent, TestAssertionWeights weights) {
+        return args.stream().anyMatch(arg -> {
+            String type = Objects.toString(arg.getType(), "");
+            if (!STRING.equals(type) && !ENCAPSED_STRING.equals(type)) {
+                return false;
+            }
+            return sourceContent.substringFrom(arg).length() >= weights.largeLiteralLengthThreshold();
+        });
+    }
+
     @Override
     public Optional<String> extractCallReceiver(String reference) {
         return ClassNameExtractor.extractForPhp(reference);

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
@@ -247,7 +247,7 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
                 .orElse(file.toString());
         int assertionCount = signals.size();
         if (assertionCount == 0) {
-            addTestSmell(
+            addTestSmellCandidate(
                     file,
                     enclosing,
                     TEST_ASSERTION_KIND_NO_ASSERTIONS,
@@ -262,7 +262,7 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
 
         signals.stream()
                 .filter(signal -> signal.baseScore() > 0)
-                .forEach(signal -> addTestSmell(
+                .forEach(signal -> addTestSmellCandidate(
                         file,
                         enclosing,
                         signal.kind(),
@@ -276,9 +276,9 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
         boolean allShallow = signals.stream().allMatch(AssertionSignal::shallow);
         if (allShallow) {
             int score = weights.shallowAssertionOnlyWeight()
-                    - meaningfulAssertionCredit(signals, weights, AssertionSignal::meaningful);
+                    - testMeaningfulAssertionCredit(signals, weights, AssertionSignal::meaningful);
             if (score > 0) {
-                addTestSmell(
+                addTestSmellCandidate(
                         file,
                         enclosing,
                         TEST_ASSERTION_KIND_SHALLOW_ONLY,
@@ -564,15 +564,6 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
                         && sourceContent.substringFrom(arg).length() >= weights.largeLiteralLengthThreshold());
     }
 
-    private static int meaningfulAssertionCredit(
-            List<AssertionSignal> assertions,
-            TestAssertionWeights weights,
-            java.util.function.Predicate<AssertionSignal> predicate) {
-        long count = assertions.stream().filter(predicate).count();
-        int creditable = Math.min((int) count, Math.max(0, weights.meaningfulAssertionCreditCap()));
-        return Math.max(0, weights.meaningfulAssertionCredit()) * creditable;
-    }
-
     private static @Nullable TSNode firstNamedChild(TSNode node) {
         for (int i = 0; i < node.getNamedChildCount(); i++) {
             TSNode child = node.getNamedChild(i);
@@ -591,30 +582,6 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
             }
         }
         return null;
-    }
-
-    private static void addTestSmell(
-            ProjectFile file,
-            String enclosing,
-            String assertionKind,
-            int score,
-            int assertionCount,
-            List<String> reasons,
-            String excerptSource,
-            int startByte,
-            List<TestSmellCandidate> out) {
-        if (score <= 0 || reasons.isEmpty()) {
-            return;
-        }
-        var smell = new TestAssertionSmell(
-                file,
-                enclosing,
-                assertionKind,
-                score,
-                assertionCount,
-                List.copyOf(reasons),
-                compactCatchExcerpt(excerptSource));
-        out.add(new TestSmellCandidate(smell, startByte));
     }
 
     private record AssertionSignal(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -73,6 +74,45 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         int score() {
             return smell.score();
         }
+    }
+
+    protected static String compactExcerptForTable(String text) {
+        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        if (compact.length() <= 180) {
+            return compact;
+        }
+        return compact.substring(0, 180) + "...";
+    }
+
+    protected static <T> int testMeaningfulAssertionCredit(
+            List<T> assertions, TestAssertionWeights weights, Predicate<T> predicate) {
+        long count = assertions.stream().filter(predicate).count();
+        int creditable = Math.min((int) count, Math.max(0, weights.meaningfulAssertionCreditCap()));
+        return Math.max(0, weights.meaningfulAssertionCredit()) * creditable;
+    }
+
+    protected static void addTestSmellCandidate(
+            ProjectFile file,
+            String enclosing,
+            String assertionKind,
+            int score,
+            int assertionCount,
+            List<String> reasons,
+            String excerptSource,
+            int startByte,
+            List<TestSmellCandidate> out) {
+        if (score <= 0 || reasons.isEmpty()) {
+            return;
+        }
+        var smell = new TestAssertionSmell(
+                file,
+                enclosing,
+                assertionKind,
+                score,
+                assertionCount,
+                List.copyOf(reasons),
+                compactExcerptForTable(excerptSource));
+        out.add(new TestSmellCandidate(smell, startByte));
     }
 
     protected record SmellCandidate(ExceptionHandlingSmell smell, int startByte) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/php/PhpTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/php/PhpTreeSitterNodeTypes.java
@@ -70,6 +70,12 @@ public final class PhpTreeSitterNodeTypes {
     public static final String NAME = "name";
     public static final String COMMENT = "comment";
 
+    // Expressions
+    public static final String CALL_EXPRESSION = "call_expression";
+    public static final String ARGUMENTS = "arguments";
+    public static final String ARGUMENT = "argument";
+    public static final String BINARY_EXPRESSION = "binary_expression";
+
     // Test markers
     public static final String TEST_MARKER = "test_marker";
     public static final String TEST_TAG_AT_TEST = "@test";


### PR DESCRIPTION
### Summary
- Adds `reportTestAssertionSmells` support for PHP by implementing PHP test assertion smell detection in `PhpAnalyzer`.
- Centralizes shared test-smell helpers in `TreeSitterAnalyzer` and reuses them from existing analyzers.
- Adds PHP-focused coverage for analyzer behavior and the `CodeQualityTools` markdown output.

**Key Changes**:
- PHP analyzer now detects PHPUnit-style assertion smells, including no assertions, constant truth/equality, self-comparison, nullness-only, and shallow-only cases.
- Shared helper logic for scoring and emitting test smells is moved into `TreeSitterAnalyzer` and adopted by `JsTsAnalyzer` and `PythonAnalyzer`.
- New PHP test suite verifies direct analyzer findings and the code-quality tool report formatting.

**Touch Points**:
- `app/src/test/java/ai/brokk/analyzer/code_quality/PhpTestAssertionSmellTest.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/PhpAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/php/PhpTreeSitterNodeTypes.java`

### Testing
- `./gradlew fix tidy`
- `./gradlew :app:test --tests '*PhpTestAssertionSmellTest'`
- `./gradlew analyze`