### PR TITLE
Update agent tool allowlists for code quality scanners

### DIFF
--- a/app/src/main/java/ai/brokk/executor/agents/AgentDefinition.java
+++ b/app/src/main/java/ai/brokk/executor/agents/AgentDefinition.java
@@ -47,6 +47,8 @@ public record AgentDefinition(
             "reportCommentDensityForFiles",
             "reportExceptionHandlingSmells",
             "reportStructuralCloneSmells",
+            "reportSecretLikeCode",
+            "reportTestAssertionSmells",
             "analyzeGitHotspots");
 
     /**
@@ -74,6 +76,8 @@ public record AgentDefinition(
             "reportCommentDensityForFiles",
             "reportExceptionHandlingSmells",
             "reportStructuralCloneSmells",
+            "reportSecretLikeCode",
+            "reportTestAssertionSmells",
             "analyzeGitHotspots",
             // terminal / built-in
             "answer",
@@ -124,6 +128,8 @@ public record AgentDefinition(
             "reportCommentDensityForFiles",
             "reportExceptionHandlingSmells",
             "reportStructuralCloneSmells",
+            "reportSecretLikeCode",
+            "reportTestAssertionSmells",
             "analyzeGitHotspots",
             // Terminal
             "answer",

--- a/app/src/test/java/ai/brokk/executor/agents/AgentDefinitionTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/AgentDefinitionTest.java
@@ -73,6 +73,22 @@ class AgentDefinitionTest {
     }
 
     @Test
+    void validate_codeQualityTools_secretAndTestSmellTools_areKnown() {
+        var def = new AgentDefinition(
+                "test",
+                "desc",
+                List.of("reportSecretLikeCode", "reportTestAssertionSmells"),
+                null,
+                "prompt",
+                "project");
+        assertTrue(def.validate().isEmpty(), "Expected no errors but got: " + def.validate());
+        assertTrue(AgentDefinition.READ_ONLY_TOOL_NAMES.contains("reportSecretLikeCode"));
+        assertTrue(AgentDefinition.READ_ONLY_TOOL_NAMES.contains("reportTestAssertionSmells"));
+        assertTrue(AgentDefinition.PARALLEL_SAFE_SEARCH_TOOL_NAMES.contains("reportSecretLikeCode"));
+        assertTrue(AgentDefinition.PARALLEL_SAFE_SEARCH_TOOL_NAMES.contains("reportTestAssertionSmells"));
+    }
+
+    @Test
     void validate_negativeMaxTurns_returnsError() {
         var def = new AgentDefinition("test", "desc", null, -1, "prompt", "project");
         var errors = def.validate();


### PR DESCRIPTION
### Summary
- Added the secret scan and test assertion smell tools to the agent allowlists so they are recognized as known, read-only, and parallel-safe where applicable.
- Added a regression test covering the new tool names in `AgentDefinition`.

### Testing
- `./gradlew :app:test`
- `./gradlew fix tidy analyze`