### PR TITLE
Add C# support for test assertion smell reporting

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
@@ -458,7 +458,7 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
                 && args.size() >= 2) {
             TSNode expected = args.get(0);
             TSNode actual = args.get(1);
-            if (isConstantExpression(expected, sourceContent) && isConstantExpression(actual, sourceContent)) {
+            if (isConstantExpression(expected) && isConstantExpression(actual)) {
                 score += weights.constantEqualityWeight();
                 reasons.add(TEST_ASSERTION_KIND_CONSTANT_EQUALITY);
                 kind = TEST_ASSERTION_KIND_CONSTANT_EQUALITY;
@@ -790,7 +790,7 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
                 .equals(sourceContent.substringFrom(right).strip());
     }
 
-    private static boolean isConstantExpression(TSNode node, SourceContent sourceContent) {
+    private static boolean isConstantExpression(TSNode node) {
         String type = node.getType();
         if (nodeType(CSharpNodeType.STRING_LITERAL).equals(type)
                 || nodeType(CSharpNodeType.CHARACTER_LITERAL).equals(type)
@@ -800,13 +800,12 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
                 || nodeType(CSharpNodeType.BOOLEAN_LITERAL).equals(type)) {
             return true;
         }
-        String text = sourceContent.substringFrom(node).strip();
-        return text.matches("-?\\d+(\\.\\d+)?")
-                || text.equals("true")
-                || text.equals("false")
-                || text.equals("null")
-                || (text.length() >= 2 && text.startsWith("\"") && text.endsWith("\""))
-                || (text.length() >= 3 && text.startsWith("'") && text.endsWith("'"));
+        // Some C# literals are wrapped by expression nodes (for example, literal_expression).
+        if (node.getNamedChildCount() == 1) {
+            TSNode onlyNamedChild = node.getNamedChild(0);
+            return onlyNamedChild != null && isConstantExpression(onlyNamedChild);
+        }
+        return false;
     }
 
     private static boolean isBooleanTrueLiteral(TSNode node, SourceContent sourceContent) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
@@ -1,6 +1,7 @@
 package ai.brokk.analyzer;
 
 import static ai.brokk.analyzer.csharp.CSharpTreeSitterNodeTypes.*;
+import static ai.brokk.analyzer.csharp.Constants.*;
 
 import ai.brokk.AnalyzerUtil;
 import ai.brokk.analyzer.cache.AnalyzerCache;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.treesitter.CSharpNodeType;
 import org.treesitter.TSLanguage;
 import org.treesitter.TSNode;
 import org.treesitter.TSQueryCursor;
@@ -45,7 +47,6 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
             "logwarning",
             "logerror",
             "logcritical");
-
     private static final LanguageSyntaxProfile CS_SYNTAX_PROFILE = new LanguageSyntaxProfile(
             Set.of(
                     CLASS_DECLARATION,
@@ -284,6 +285,210 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
                 List.of());
     }
 
+    @Override
+    public List<TestAssertionSmell> findTestAssertionSmells(ProjectFile file, TestAssertionWeights weights) {
+        checkStale("findTestAssertionSmells");
+        if (!containsTests(file)) {
+            return List.of();
+        }
+        TestAssertionWeights resolvedWeights = weights != null ? weights : TestAssertionWeights.defaults();
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return List.of();
+                    }
+                    return withSource(
+                            file, source -> detectTestAssertionSmells(file, root, source, resolvedWeights), List.of());
+                },
+                List.of());
+    }
+
+    private List<TestAssertionSmell> detectTestAssertionSmells(
+            ProjectFile file, TSNode root, SourceContent sourceContent, TestAssertionWeights weights) {
+        var methods = new ArrayList<TSNode>();
+        collectNodesByType(root, Set.of(nodeType(CSharpNodeType.METHOD_DECLARATION)), methods);
+        var findings = new ArrayList<TestSmellCandidate>();
+        for (TSNode method : methods) {
+            if (isTestMethod(method, sourceContent)) {
+                analyzeTestMethod(file, method, sourceContent, weights, findings);
+            }
+        }
+        return findings.stream()
+                .sorted(TEST_SMELL_CANDIDATE_COMPARATOR)
+                .map(TestSmellCandidate::smell)
+                .toList();
+    }
+
+    private void analyzeTestMethod(
+            ProjectFile file,
+            TSNode method,
+            SourceContent sourceContent,
+            TestAssertionWeights weights,
+            List<TestSmellCandidate> out) {
+        TSNode body = method.getChildByFieldName(FIELD_BODY);
+        if (body == null) {
+            body = firstNamedChildOfType(method, nodeType(CSharpNodeType.BLOCK));
+        }
+        if (body == null) {
+            return;
+        }
+
+        var invocations = new ArrayList<TSNode>();
+        collectNodesByType(body, Set.of(nodeType(CSharpNodeType.INVOCATION_EXPRESSION)), invocations);
+        List<AssertionSignal> assertions = invocations.stream()
+                .map(call -> classifyAssertionCall(call, sourceContent, weights))
+                .flatMap(Optional::stream)
+                .toList();
+
+        String enclosing = enclosingCodeUnit(
+                        file,
+                        method.getStartPoint().getRow(),
+                        method.getEndPoint().getRow())
+                .map(CodeUnit::fqName)
+                .orElse(file.toString());
+        int assertionCount = assertions.size();
+        if (assertionCount == 0) {
+            addTestSmellCandidate(
+                    file,
+                    enclosing,
+                    TEST_ASSERTION_KIND_NO_ASSERTIONS,
+                    weights.noAssertionWeight(),
+                    0,
+                    List.of(TEST_ASSERTION_KIND_NO_ASSERTIONS),
+                    sourceContent.substringFrom(method),
+                    method.getStartByte(),
+                    out);
+            return;
+        }
+
+        assertions.stream()
+                .filter(signal -> signal.baseScore() > 0)
+                .forEach(signal -> addTestSmellCandidate(
+                        file,
+                        enclosing,
+                        signal.kind(),
+                        signal.baseScore(),
+                        assertionCount,
+                        signal.reasons(),
+                        signal.excerpt(),
+                        signal.startByte(),
+                        out));
+
+        boolean allShallow = assertions.stream().allMatch(AssertionSignal::shallow);
+        if (allShallow) {
+            int score = weights.shallowAssertionOnlyWeight()
+                    - testMeaningfulAssertionCredit(assertions, weights, AssertionSignal::meaningful);
+            if (score > 0) {
+                addTestSmellCandidate(
+                        file,
+                        enclosing,
+                        TEST_ASSERTION_KIND_SHALLOW_ONLY,
+                        score,
+                        assertionCount,
+                        List.of(TEST_ASSERTION_KIND_SHALLOW_ONLY),
+                        sourceContent.substringFrom(method),
+                        method.getStartByte(),
+                        out);
+            }
+        }
+    }
+
+    private Optional<AssertionSignal> classifyAssertionCall(
+            TSNode call, SourceContent sourceContent, TestAssertionWeights weights) {
+        TSNode function = call.getChildByFieldName(FIELD_FUNCTION);
+        if (function == null) {
+            function = call.getChildByFieldName(FIELD_EXPRESSION);
+        }
+        if (function == null) {
+            function = firstNamedChildOfType(call, nodeType(CSharpNodeType.MEMBER_ACCESS_EXPRESSION));
+        }
+        if (function == null) {
+            function = firstNamedChildOfType(call, nodeType(CSharpNodeType.IDENTIFIER));
+        }
+        if (function == null) {
+            return Optional.empty();
+        }
+        String methodName = invocationMethodName(function, sourceContent);
+        if (methodName.isBlank()) {
+            return Optional.empty();
+        }
+        if (methodName.equals("throws") || methodName.equals("throw")) {
+            return Optional.of(new AssertionSignal(
+                    TEST_ASSERTION_KIND_CSHARP,
+                    0,
+                    false,
+                    true,
+                    call.getStartByte(),
+                    List.of(),
+                    sourceContent.substringFrom(call)));
+        }
+        if (!CSHARP_ASSERTION_METHOD_NAMES.contains(methodName)) {
+            return Optional.empty();
+        }
+
+        List<TSNode> args = argumentNodes(call);
+        int score = 0;
+        var reasons = new ArrayList<String>();
+        boolean shallow = CSHARP_SHALLOW_ASSERTION_METHOD_NAMES.contains(methodName);
+        boolean meaningful = !shallow;
+        String kind = TEST_ASSERTION_KIND_CSHARP;
+        if (("true".equals(methodName) || "false".equals(methodName) || "istrue".equals(methodName)
+                        || "isfalse".equals(methodName))
+                && !args.isEmpty()) {
+            TSNode arg = args.getFirst();
+            boolean constantTruth = (("true".equals(methodName) || "istrue".equals(methodName))
+                            && isBooleanTrueLiteral(arg, sourceContent))
+                    || (("false".equals(methodName) || "isfalse".equals(methodName))
+                            && isBooleanFalseLiteral(arg, sourceContent));
+            if (constantTruth) {
+                score += weights.constantTruthWeight();
+                reasons.add(TEST_ASSERTION_KIND_CONSTANT_TRUTH);
+                kind = TEST_ASSERTION_KIND_CONSTANT_TRUTH;
+                meaningful = false;
+            }
+        }
+        if (("equal".equals(methodName)
+                        || "equals".equals(methodName)
+                        || "same".equals(methodName)
+                        || "areequal".equals(methodName))
+                && args.size() >= 2) {
+            TSNode expected = args.get(0);
+            TSNode actual = args.get(1);
+            if (isConstantExpression(expected, sourceContent) && isConstantExpression(actual, sourceContent)) {
+                score += weights.constantEqualityWeight();
+                reasons.add(TEST_ASSERTION_KIND_CONSTANT_EQUALITY);
+                kind = TEST_ASSERTION_KIND_CONSTANT_EQUALITY;
+                meaningful = false;
+            } else if (sameExpression(expected, actual, sourceContent)) {
+                score += weights.tautologicalAssertionWeight();
+                reasons.add(TEST_ASSERTION_KIND_SELF_COMPARISON);
+                kind = TEST_ASSERTION_KIND_SELF_COMPARISON;
+                meaningful = false;
+            }
+        }
+        if (shallow) {
+            score += weights.nullnessOnlyWeight();
+            reasons.add(TEST_ASSERTION_KIND_NULLNESS_ONLY);
+            kind = TEST_ASSERTION_KIND_NULLNESS_ONLY;
+            meaningful = false;
+        }
+        if (containsOverspecifiedLiteral(args, sourceContent, weights)) {
+            score += weights.overspecifiedLiteralWeight();
+            reasons.add(TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL);
+            kind = TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL;
+        }
+        return Optional.of(new AssertionSignal(
+                kind,
+                score,
+                shallow,
+                meaningful,
+                call.getStartByte(),
+                List.copyOf(reasons),
+                sourceContent.substringFrom(call)));
+    }
+
     private List<ExceptionHandlingSmell> detectExceptionHandlingSmells(
             ProjectFile file, TSNode root, SourceContent sourceContent, ExceptionSmellWeights weights) {
         var catches = new ArrayList<TSNode>();
@@ -504,6 +709,129 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
         }
         return compact.substring(0, 180) + "...";
     }
+
+    private static boolean isTestMethod(TSNode method, SourceContent sourceContent) {
+        for (TSNode child : method.getNamedChildren()) {
+            if (!nodeType(CSharpNodeType.ATTRIBUTE_LIST).equals(child.getType())) {
+                continue;
+            }
+            var attrs = new ArrayList<TSNode>();
+            collectNodesByType(child, Set.of(nodeType(CSharpNodeType.ATTRIBUTE)), attrs);
+            for (TSNode attr : attrs) {
+                TSNode nameNode = attr.getChildByFieldName(FIELD_NAME);
+                if (nameNode == null) {
+                    continue;
+                }
+                String name = sourceContent.substringFrom(nameNode).strip().toLowerCase(Locale.ROOT);
+                if (name.endsWith("attribute")) {
+                    name = name.substring(0, name.length() - "attribute".length());
+                }
+                String simple = lastDotSegment(name);
+                if (TEST_METHOD_ATTRIBUTES.contains(simple)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String invocationMethodName(TSNode functionNode, SourceContent sourceContent) {
+        if (nodeType(CSharpNodeType.MEMBER_ACCESS_EXPRESSION).equals(functionNode.getType())) {
+            TSNode nameNode = functionNode.getChildByFieldName(FIELD_NAME);
+            if (nameNode != null) {
+                return sourceContent.substringFrom(nameNode).strip().toLowerCase(Locale.ROOT);
+            }
+            return lastDotSegment(sourceContent.substringFrom(functionNode).strip().toLowerCase(Locale.ROOT));
+        }
+        if (nodeType(CSharpNodeType.IDENTIFIER).equals(functionNode.getType())
+                || nodeType(CSharpNodeType.GENERIC_NAME).equals(functionNode.getType())) {
+            return sourceContent.substringFrom(functionNode).strip().toLowerCase(Locale.ROOT);
+        }
+        TSNode expression = functionNode.getChildByFieldName(FIELD_EXPRESSION);
+        if (expression != null) {
+            return invocationMethodName(expression, sourceContent);
+        }
+        return "";
+    }
+
+    private static List<TSNode> argumentNodes(TSNode call) {
+        TSNode args = call.getChildByFieldName(FIELD_ARGUMENTS);
+        if (args == null) {
+            args = firstNamedChildOfType(call, nodeType(CSharpNodeType.ARGUMENT_LIST));
+        }
+        if (args == null) {
+            return List.of();
+        }
+        var out = new ArrayList<TSNode>();
+        for (int i = 0; i < args.getNamedChildCount(); i++) {
+            TSNode child = args.getNamedChild(i);
+            if (child != null) {
+                TSNode value = child.getChildByFieldName("expression");
+                out.add(value != null ? value : child);
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    private static boolean containsOverspecifiedLiteral(
+            List<TSNode> args, SourceContent sourceContent, TestAssertionWeights weights) {
+        return args.stream()
+                .anyMatch(arg -> nodeType(CSharpNodeType.STRING_LITERAL).equals(arg.getType())
+                        && sourceContent.substringFrom(arg).length() >= weights.largeLiteralLengthThreshold());
+    }
+
+    private static boolean sameExpression(TSNode left, TSNode right, SourceContent sourceContent) {
+        return sourceContent
+                .substringFrom(left)
+                .strip()
+                .equals(sourceContent.substringFrom(right).strip());
+    }
+
+    private static boolean isConstantExpression(TSNode node, SourceContent sourceContent) {
+        String type = node.getType();
+        if (nodeType(CSharpNodeType.STRING_LITERAL).equals(type)
+                || nodeType(CSharpNodeType.CHARACTER_LITERAL).equals(type)
+                || nodeType(CSharpNodeType.INTEGER_LITERAL).equals(type)
+                || nodeType(CSharpNodeType.REAL_LITERAL).equals(type)
+                || nodeType(CSharpNodeType.NULL_LITERAL).equals(type)
+                || nodeType(CSharpNodeType.BOOLEAN_LITERAL).equals(type)) {
+            return true;
+        }
+        String text = sourceContent.substringFrom(node).strip();
+        return text.matches("-?\\d+(\\.\\d+)?")
+                || text.equals("true")
+                || text.equals("false")
+                || text.equals("null")
+                || (text.length() >= 2 && text.startsWith("\"") && text.endsWith("\""))
+                || (text.length() >= 3 && text.startsWith("'") && text.endsWith("'"));
+    }
+
+    private static boolean isBooleanTrueLiteral(TSNode node, SourceContent sourceContent) {
+        return sourceContent.substringFrom(node).strip().equalsIgnoreCase("true");
+    }
+
+    private static boolean isBooleanFalseLiteral(TSNode node, SourceContent sourceContent) {
+        return sourceContent.substringFrom(node).strip().equalsIgnoreCase("false");
+    }
+
+    private static @Nullable TSNode firstNamedChildOfType(TSNode node, String candidateType) {
+        for (int i = 0; i < node.getNamedChildCount(); i++) {
+            TSNode child = node.getNamedChild(i);
+            if (child != null && candidateType.equals(child.getType())) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private record AssertionSignal(
+            String kind,
+            int baseScore,
+            boolean shallow,
+            boolean meaningful,
+            int startByte,
+            List<String> reasons,
+            String excerpt) {}
 
     @Override
     protected String formatFieldSignature(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
@@ -741,13 +741,22 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
         if (nodeType(CSharpNodeType.MEMBER_ACCESS_EXPRESSION).equals(functionNode.getType())) {
             TSNode nameNode = functionNode.getChildByFieldName(FIELD_NAME);
             if (nameNode != null) {
-                return sourceContent.substringFrom(nameNode).strip().toLowerCase(Locale.ROOT);
+                return invocationMethodName(nameNode, sourceContent);
             }
-            return lastDotSegment(
-                    sourceContent.substringFrom(functionNode).strip().toLowerCase(Locale.ROOT));
+            return "";
         }
-        if (nodeType(CSharpNodeType.IDENTIFIER).equals(functionNode.getType())
-                || nodeType(CSharpNodeType.GENERIC_NAME).equals(functionNode.getType())) {
+        if (nodeType(CSharpNodeType.GENERIC_NAME).equals(functionNode.getType())) {
+            TSNode nameNode = functionNode.getChildByFieldName(FIELD_NAME);
+            if (nameNode != null) {
+                return invocationMethodName(nameNode, sourceContent);
+            }
+            TSNode identifierNode = firstNamedChildOfType(functionNode, nodeType(CSharpNodeType.IDENTIFIER));
+            if (identifierNode != null) {
+                return invocationMethodName(identifierNode, sourceContent);
+            }
+            return "";
+        }
+        if (nodeType(CSharpNodeType.IDENTIFIER).equals(functionNode.getType())) {
             return sourceContent.substringFrom(functionNode).strip().toLowerCase(Locale.ROOT);
         }
         TSNode expression = functionNode.getChildByFieldName(FIELD_EXPRESSION);

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
@@ -434,7 +434,9 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
         boolean shallow = CSHARP_SHALLOW_ASSERTION_METHOD_NAMES.contains(methodName);
         boolean meaningful = !shallow;
         String kind = TEST_ASSERTION_KIND_CSHARP;
-        if (("true".equals(methodName) || "false".equals(methodName) || "istrue".equals(methodName)
+        if (("true".equals(methodName)
+                        || "false".equals(methodName)
+                        || "istrue".equals(methodName)
                         || "isfalse".equals(methodName))
                 && !args.isEmpty()) {
             TSNode arg = args.getFirst();
@@ -741,7 +743,8 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
             if (nameNode != null) {
                 return sourceContent.substringFrom(nameNode).strip().toLowerCase(Locale.ROOT);
             }
-            return lastDotSegment(sourceContent.substringFrom(functionNode).strip().toLowerCase(Locale.ROOT));
+            return lastDotSegment(
+                    sourceContent.substringFrom(functionNode).strip().toLowerCase(Locale.ROOT));
         }
         if (nodeType(CSharpNodeType.IDENTIFIER).equals(functionNode.getType())
                 || nodeType(CSharpNodeType.GENERIC_NAME).equals(functionNode.getType())) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/csharp/Constants.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/csharp/Constants.java
@@ -1,0 +1,49 @@
+package ai.brokk.analyzer.csharp;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+import org.treesitter.CSharpNodeType;
+
+public final class Constants {
+
+    private Constants() {}
+
+    public static String nodeType(CSharpNodeType nodeType) {
+        return requireNonNull(nodeType.getType());
+    }
+
+    public static final Set<String> TEST_METHOD_ATTRIBUTES =
+            Set.of("fact", "theory", "test", "testcase", "testmethod", "datatestmethod");
+
+    public static final Set<String> CSHARP_ASSERTION_METHOD_NAMES = Set.of(
+            "equal",
+            "equals",
+            "same",
+            "notsame",
+            "true",
+            "false",
+            "null",
+            "notnull",
+            "istrue",
+            "isfalse",
+            "areequal",
+            "arenotequal");
+
+    public static final Set<String> CSHARP_SHALLOW_ASSERTION_METHOD_NAMES = Set.of("null", "notnull");
+
+    public static final String TEST_ASSERTION_KIND_CSHARP = "csharp-assertion";
+    public static final String TEST_ASSERTION_KIND_NO_ASSERTIONS = "no-assertions";
+    public static final String TEST_ASSERTION_KIND_CONSTANT_TRUTH = "constant-truth";
+    public static final String TEST_ASSERTION_KIND_CONSTANT_EQUALITY = "constant-equality";
+    public static final String TEST_ASSERTION_KIND_SELF_COMPARISON = "self-comparison";
+    public static final String TEST_ASSERTION_KIND_NULLNESS_ONLY = "nullness-only";
+    public static final String TEST_ASSERTION_KIND_SHALLOW_ONLY = "shallow-assertions-only";
+    public static final String TEST_ASSERTION_KIND_OVERSPECIFIED_LITERAL = "overspecified-literal";
+
+    public static final String FIELD_BODY = "body";
+    public static final String FIELD_ARGUMENTS = "arguments";
+    public static final String FIELD_FUNCTION = "function";
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_EXPRESSION = "expression";
+}

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CSharpTestAssertionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CSharpTestAssertionSmellTest.java
@@ -1,0 +1,170 @@
+package ai.brokk.analyzer.code_quality;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineCoreProject;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CSharpTestAssertionSmellTest extends AbstractBrittleTestSuite {
+
+    @Test
+    void flagsConstantTruthAndConstantEquality() {
+        String code =
+                """
+                using Xunit;
+
+                namespace Example;
+
+                public class SampleTest {
+                    [Fact]
+                    public void Constants() {
+                        Assert.True(true);
+                        Assert.Equal(1, 1);
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertFalse(findings.isEmpty());
+        assertTrue(hasReason(findings, "constant-equality"));
+    }
+
+    @Test
+    void flagsSelfComparisonAssertion() {
+        String code =
+                """
+                using Xunit;
+
+                namespace Example;
+
+                public class SampleTest {
+                    [Fact]
+                    public void SameValue() {
+                        var value = "x";
+                        Assert.Equal(value, value);
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "self-comparison"));
+    }
+
+    @Test
+    void flagsTestMethodWithNoAssertions() {
+        String code =
+                """
+                using Xunit;
+
+                namespace Example;
+
+                public class SampleTest {
+                    [Fact]
+                    public void NoAssertions() {
+                        var value = 42;
+                        _ = value;
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "no-assertions"));
+    }
+
+    @Test
+    void flagsNullnessOnlyAsShallow() {
+        String code =
+                """
+                using Xunit;
+
+                namespace Example;
+
+                public class SampleTest {
+                    [Fact]
+                    public void NullnessOnly() {
+                        object value = new();
+                        Assert.NotNull(value);
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "nullness-only"));
+        assertTrue(hasReason(findings, "shallow-assertions-only"));
+    }
+
+    @Test
+    void meaningfulAssertionIsNotFlaggedWithDefaultWeights() {
+        String code =
+                """
+                using Xunit;
+
+                namespace Example;
+
+                public class SampleTest {
+                    [Fact]
+                    public void Meaningful() {
+                        var result = Name();
+                        Assert.Equal("expected", result);
+                    }
+
+                    private static string Name() => "expected";
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    void nonTestCSharpFileIsSkipped() {
+        String code =
+                """
+                namespace Example;
+
+                public class Sample {
+                    public void LooksLikeAssertion() {
+                        Assert.Equal(1, 1);
+                    }
+                }
+                """;
+        var findings = analyze(code, "src/Sample.cs");
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    void weightTuningCanSuppressFindings() {
+        String code =
+                """
+                using Xunit;
+
+                namespace Example;
+
+                public class SampleTest {
+                    [Fact]
+                    public void Constant() {
+                        Assert.True(true);
+                    }
+                }
+                """;
+        var defaults = analyze(code);
+        var tunedWeights = new IAnalyzer.TestAssertionWeights(0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 4, 120);
+        var tuned = analyze(code, tunedWeights);
+        assertFalse(defaults.isEmpty(), "Default heuristics should flag constant truth");
+        assertTrue(tuned.isEmpty(), "Zeroed smell weights should suppress the same finding");
+    }
+
+    @Override
+    protected String defaultTestPath() {
+        return "com/example/SampleTest.cs";
+    }
+
+    @Override
+    protected List<IAnalyzer.TestAssertionSmell> analyze(
+            String source, String path, IAnalyzer.TestAssertionWeights weights) {
+        try (var testProject = InlineCoreProject.code(source, path).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), path);
+            return analyzer.findTestAssertionSmells(file, weights);
+        }
+    }
+}

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CSharpTestAssertionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CSharpTestAssertionSmellTest.java
@@ -153,6 +153,26 @@ public class CSharpTestAssertionSmellTest extends AbstractBrittleTestSuite {
         assertTrue(tuned.isEmpty(), "Zeroed smell weights should suppress the same finding");
     }
 
+    @Test
+    void genericAssertThrowsCountsAsAssertionEquivalent() {
+        String code =
+                """
+                using System;
+                using Xunit;
+
+                namespace Example;
+
+                public class SampleTest {
+                    [Fact]
+                    public void ThrowsGeneric() {
+                        Assert.Throws<InvalidOperationException>(() => throw new InvalidOperationException());
+                    }
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.isEmpty(), "Assert.Throws<T> should prevent no-assertions findings");
+    }
+
     @Override
     protected String defaultTestPath() {
         return "com/example/SampleTest.cs";


### PR DESCRIPTION
## Summary
- add C# `findTestAssertionSmells` support in `CSharpAnalyzer` so `reportTestAssertionSmells` returns findings for C# tests
- centralize new C# assertion-smell strings and node-type helpers in `ai.brokk.analyzer.csharp.Constants`
- add `CSharpTestAssertionSmellTest` coverage for positive and no-findings/tuned-weight scenarios

## Test plan
- [x] `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.code_quality.CSharpTestAssertionSmellTest`
- [x] `./gradlew :brokk-shared:test --tests "ai.brokk.analyzer.code_quality.CSharp*SmellTest"`

Made with [Cursor](https://cursor.com)