### PR TITLE
Add code quality analysis tools to brokk-core MCP server

### DIFF
--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -151,12 +151,14 @@ public class CodeQualityTools {
             ProjectFile file = contextManager.toFile(path);
             if (!file.exists()) {
                 lines.add("- Missing file (skipped): `" + path + "`");
+                filesShown++;
                 continue;
             }
             if (!"java".equals(file.extension())) {
                 lines.add("### `" + path + "`");
                 lines.add("(not a Java file; skipped)");
                 lines.add("");
+                filesShown++;
                 continue;
             }
             List<CommentDensityStats> stats = analyzer.commentDensityByTopLevel(file);
@@ -327,7 +329,8 @@ public class CodeQualityTools {
             String left = finding.file() + "#" + finding.enclosingFqName();
             String right = finding.peerFile() + "#" + finding.peerEnclosingFqName();
             String key = left.compareTo(right) <= 0 ? left + "||" + right : right + "||" + left;
-            deduped.putIfAbsent(key, finding);
+            deduped.merge(
+                    key, finding, (existing, incoming) -> incoming.score() > existing.score() ? incoming : existing);
         }
         var filtered = deduped.values().stream()
                 .filter(f -> f.score() >= threshold)

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -7,6 +7,7 @@ import ai.brokk.analyzer.DisabledAnalyzer;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.Languages;
 import ai.brokk.project.CoreProject;
+import ai.brokk.tools.CodeQualityToolsMcp;
 import ai.brokk.tools.SearchTools;
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
@@ -22,6 +23,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import static java.util.Map.entry;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,12 +46,14 @@ public class BrokkCoreMcpServer {
     private CoreProject project;
     private ICodeIntelligence intelligence;
     private SearchTools searchTools;
+    private CodeQualityToolsMcp codeQualityTools;
     private Path activeWorkspaceRoot;
 
     public BrokkCoreMcpServer(CoreProject project, ICodeIntelligence intelligence, SearchTools searchTools) {
         this.project = project;
         this.intelligence = intelligence;
         this.searchTools = searchTools;
+        this.codeQualityTools = new CodeQualityToolsMcp(intelligence);
         this.activeWorkspaceRoot = project.getRoot();
     }
 
@@ -207,6 +212,7 @@ public class BrokkCoreMcpServer {
             this.project = newProject;
             this.intelligence = new StandaloneCodeIntelligence(newProject, newAnalyzer);
             this.searchTools = new SearchTools(this.intelligence);
+            this.codeQualityTools = new CodeQualityToolsMcp(this.intelligence);
             this.activeWorkspaceRoot = newRoot;
             logger.info("Workspace switched to {}", newRoot);
         } finally {
@@ -491,6 +497,125 @@ public class BrokkCoreMcpServer {
                     return textResult(
                             searchTools.xmlSelect(filepath, xpath, output, attrName, maxFiles, matchesPerFile));
                 })));
+
+        // -- Code quality analysis tools --
+
+        specs.add(tool(
+                "computeCyclomaticComplexity",
+                "Computes heuristic cyclomatic complexity for methods in the given files. "
+                        + "Flags methods above the threshold (typical default 10) for review or refactor. "
+                        + "Returns a markdown-friendly report of flagged methods.",
+                schema(
+                        Map.of(
+                                "filePaths", arrayProp("File paths relative to the project root."),
+                                "threshold", intProp("Complexity threshold; methods above this are flagged. Use 0 or negative for default (10).")),
+                        List.of("filePaths")),
+                (exchange, request) -> withReadLock(() -> {
+                    var filePaths = stringListArg(request, "filePaths");
+                    var threshold = intArg(request, "threshold", 0);
+                    return textResult(codeQualityTools.computeCyclomaticComplexity(filePaths, threshold));
+                })));
+
+        specs.add(tool(
+                "reportCommentDensityForCodeUnit",
+                "Java comment density for one symbol identified by fully qualified name. "
+                        + "Reports header vs inline comment line counts, declaration span lines, and rolled-up totals for class-like units.",
+                schema(
+                        Map.of(
+                                "fqName", stringProp("Fully qualified name (e.g. com.example.MyClass or com.example.MyClass.method)."),
+                                "maxLines", intProp("Maximum output lines; values <= 0 default to 120.")),
+                        List.of("fqName")),
+                (exchange, request) -> withReadLock(() -> {
+                    var fqName = stringArg(request, "fqName");
+                    var maxLines = intArg(request, "maxLines", 0);
+                    return textResult(codeQualityTools.reportCommentDensityForCodeUnit(fqName, maxLines));
+                })));
+
+        specs.add(tool(
+                "reportCommentDensityForFiles",
+                "Java comment density tables for the given source files: one section per file and one row per top-level declaration. "
+                        + "Includes own and rolled-up header/inline line counts.",
+                schema(
+                        Map.of(
+                                "filePaths", arrayProp("File paths relative to the project root."),
+                                "maxTopLevelRows", intProp("Maximum declaration rows across all files; values <= 0 default to 60."),
+                                "maxFiles", intProp("Maximum files to include; values <= 0 default to 25.")),
+                        List.of("filePaths")),
+                (exchange, request) -> withReadLock(() -> {
+                    var filePaths = stringListArg(request, "filePaths");
+                    var maxTopLevelRows = intArg(request, "maxTopLevelRows", 0);
+                    var maxFiles = intArg(request, "maxFiles", 0);
+                    return textResult(codeQualityTools.reportCommentDensityForFiles(filePaths, maxTopLevelRows, maxFiles));
+                })));
+
+        specs.add(tool(
+                "reportExceptionHandlingSmells",
+                "Detects suspicious exception handlers using weighted heuristics designed for high-recall triage. "
+                        + "Scores generic catches and tiny/empty handlers, then subtracts credit for richer handling bodies. "
+                        + "Use minScore, maxFindings, and weight parameters to tune precision/recall.",
+                schema(
+                        Map.ofEntries(
+                                entry("filePaths", arrayProp("File paths relative to the project root.")),
+                                entry("minScore", intProp("Minimum score to include a finding; values <= 0 default to 4.")),
+                                entry("maxFindings", intProp("Maximum findings to emit; values <= 0 default to 80.")),
+                                entry("genericThrowableWeight", intProp("Weight for catching Throwable; values < 0 use default.")),
+                                entry("genericExceptionWeight", intProp("Weight for catching Exception; values < 0 use default.")),
+                                entry("genericRuntimeExceptionWeight", intProp("Weight for catching RuntimeException; values < 0 use default.")),
+                                entry("emptyBodyWeight", intProp("Weight for empty catch bodies; values < 0 use default.")),
+                                entry("commentOnlyBodyWeight", intProp("Weight for comment-only catch bodies; values < 0 use default.")),
+                                entry("smallBodyWeight", intProp("Weight for small catch bodies; values < 0 use default.")),
+                                entry("logOnlyBodyWeight", intProp("Weight for log-only catch bodies; values < 0 use default.")),
+                                entry("meaningfulBodyCreditPerStatement", intProp("Score credit subtracted per catch statement in the body; values < 0 use default.")),
+                                entry("meaningfulBodyStatementThreshold", intProp("Maximum statements that earn meaningful-body credit; values < 0 use default.")),
+                                entry("smallBodyMaxStatements", intProp("Maximum statement count considered a small body; values < 0 use default."))),
+                        List.of("filePaths")),
+                (exchange, request) -> withReadLock(() -> {
+                    var filePaths = stringListArg(request, "filePaths");
+                    return textResult(codeQualityTools.reportExceptionHandlingSmells(
+                            filePaths,
+                            intArg(request, "minScore", -1),
+                            intArg(request, "maxFindings", -1),
+                            intArg(request, "genericThrowableWeight", -1),
+                            intArg(request, "genericExceptionWeight", -1),
+                            intArg(request, "genericRuntimeExceptionWeight", -1),
+                            intArg(request, "emptyBodyWeight", -1),
+                            intArg(request, "commentOnlyBodyWeight", -1),
+                            intArg(request, "smallBodyWeight", -1),
+                            intArg(request, "logOnlyBodyWeight", -1),
+                            intArg(request, "meaningfulBodyCreditPerStatement", -1),
+                            intArg(request, "meaningfulBodyStatementThreshold", -1),
+                            intArg(request, "smallBodyMaxStatements", -1)));
+                })));
+
+        specs.add(tool(
+                "reportStructuralCloneSmells",
+                "Detects duplicated implementation patterns across functions using normalized token similarity. "
+                        + "Uses analyzer-provided structural clone smells (with AST refinement) for high-recall triage. "
+                        + "Tune similarity and size thresholds to reduce noise.",
+                schema(
+                        Map.of(
+                                "filePaths", arrayProp("File paths relative to the project root."),
+                                "minScore", intProp("Minimum similarity score (0-100) to include; values <= 0 default to 60."),
+                                "minNormalizedTokens", intProp("Minimum normalized token count; values <= 0 default to 12."),
+                                "shingleSize", intProp("Shingle size used for token overlap; values <= 0 default to 2."),
+                                "minSharedShingles", intProp("Minimum shared shingles before scoring; values <= 0 default to 3."),
+                                "astSimilarityPercent", intProp("AST refinement threshold (0-100); values <= 0 default to 70."),
+                                "maxFindings", intProp("Maximum findings to emit; values <= 0 default to 80.")),
+                        List.of("filePaths")),
+                (exchange, request) -> withReadLock(() -> {
+                    var filePaths = stringListArg(request, "filePaths");
+                    return textResult(codeQualityTools.reportStructuralCloneSmells(
+                            filePaths,
+                            intArg(request, "minScore", -1),
+                            intArg(request, "minNormalizedTokens", -1),
+                            intArg(request, "shingleSize", -1),
+                            intArg(request, "minSharedShingles", -1),
+                            intArg(request, "astSimilarityPercent", -1),
+                            intArg(request, "maxFindings", -1)));
+                })));
+
+        // NOTE: analyzeGitHotspots is not exposed here because GitHotspotAnalyzer
+        // lives in the app module with dependencies not available in brokk-core.
 
         return specs;
     }

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -1,5 +1,6 @@
 package ai.brokk.mcpserver;
 
+import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
 
 import ai.brokk.ICodeIntelligence;
@@ -23,8 +24,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import static java.util.Map.entry;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -508,7 +507,9 @@ public class BrokkCoreMcpServer {
                 schema(
                         Map.of(
                                 "filePaths", arrayProp("File paths relative to the project root."),
-                                "threshold", intProp("Complexity threshold; methods above this are flagged. Use 0 or negative for default (10).")),
+                                "threshold",
+                                        intProp(
+                                                "Complexity threshold; methods above this are flagged. Use 0 or negative for default (10).")),
                         List.of("filePaths")),
                 (exchange, request) -> withReadLock(() -> {
                     var filePaths = stringListArg(request, "filePaths");
@@ -522,7 +523,9 @@ public class BrokkCoreMcpServer {
                         + "Reports header vs inline comment line counts, declaration span lines, and rolled-up totals for class-like units.",
                 schema(
                         Map.of(
-                                "fqName", stringProp("Fully qualified name (e.g. com.example.MyClass or com.example.MyClass.method)."),
+                                "fqName",
+                                        stringProp(
+                                                "Fully qualified name (e.g. com.example.MyClass or com.example.MyClass.method)."),
                                 "maxLines", intProp("Maximum output lines; values <= 0 default to 120.")),
                         List.of("fqName")),
                 (exchange, request) -> withReadLock(() -> {
@@ -538,14 +541,17 @@ public class BrokkCoreMcpServer {
                 schema(
                         Map.of(
                                 "filePaths", arrayProp("File paths relative to the project root."),
-                                "maxTopLevelRows", intProp("Maximum declaration rows across all files; values <= 0 default to 60."),
+                                "maxTopLevelRows",
+                                        intProp(
+                                                "Maximum declaration rows across all files; values <= 0 default to 60."),
                                 "maxFiles", intProp("Maximum files to include; values <= 0 default to 25.")),
                         List.of("filePaths")),
                 (exchange, request) -> withReadLock(() -> {
                     var filePaths = stringListArg(request, "filePaths");
                     var maxTopLevelRows = intArg(request, "maxTopLevelRows", 0);
                     var maxFiles = intArg(request, "maxFiles", 0);
-                    return textResult(codeQualityTools.reportCommentDensityForFiles(filePaths, maxTopLevelRows, maxFiles));
+                    return textResult(
+                            codeQualityTools.reportCommentDensityForFiles(filePaths, maxTopLevelRows, maxFiles));
                 })));
 
         specs.add(tool(
@@ -556,18 +562,43 @@ public class BrokkCoreMcpServer {
                 schema(
                         Map.ofEntries(
                                 entry("filePaths", arrayProp("File paths relative to the project root.")),
-                                entry("minScore", intProp("Minimum score to include a finding; values <= 0 default to 4.")),
+                                entry(
+                                        "minScore",
+                                        intProp("Minimum score to include a finding; values <= 0 default to 4.")),
                                 entry("maxFindings", intProp("Maximum findings to emit; values <= 0 default to 80.")),
-                                entry("genericThrowableWeight", intProp("Weight for catching Throwable; values < 0 use default.")),
-                                entry("genericExceptionWeight", intProp("Weight for catching Exception; values < 0 use default.")),
-                                entry("genericRuntimeExceptionWeight", intProp("Weight for catching RuntimeException; values < 0 use default.")),
-                                entry("emptyBodyWeight", intProp("Weight for empty catch bodies; values < 0 use default.")),
-                                entry("commentOnlyBodyWeight", intProp("Weight for comment-only catch bodies; values < 0 use default.")),
-                                entry("smallBodyWeight", intProp("Weight for small catch bodies; values < 0 use default.")),
-                                entry("logOnlyBodyWeight", intProp("Weight for log-only catch bodies; values < 0 use default.")),
-                                entry("meaningfulBodyCreditPerStatement", intProp("Score credit subtracted per catch statement in the body; values < 0 use default.")),
-                                entry("meaningfulBodyStatementThreshold", intProp("Maximum statements that earn meaningful-body credit; values < 0 use default.")),
-                                entry("smallBodyMaxStatements", intProp("Maximum statement count considered a small body; values < 0 use default."))),
+                                entry(
+                                        "genericThrowableWeight",
+                                        intProp("Weight for catching Throwable; values < 0 use default.")),
+                                entry(
+                                        "genericExceptionWeight",
+                                        intProp("Weight for catching Exception; values < 0 use default.")),
+                                entry(
+                                        "genericRuntimeExceptionWeight",
+                                        intProp("Weight for catching RuntimeException; values < 0 use default.")),
+                                entry(
+                                        "emptyBodyWeight",
+                                        intProp("Weight for empty catch bodies; values < 0 use default.")),
+                                entry(
+                                        "commentOnlyBodyWeight",
+                                        intProp("Weight for comment-only catch bodies; values < 0 use default.")),
+                                entry(
+                                        "smallBodyWeight",
+                                        intProp("Weight for small catch bodies; values < 0 use default.")),
+                                entry(
+                                        "logOnlyBodyWeight",
+                                        intProp("Weight for log-only catch bodies; values < 0 use default.")),
+                                entry(
+                                        "meaningfulBodyCreditPerStatement",
+                                        intProp(
+                                                "Score credit subtracted per catch statement in the body; values < 0 use default.")),
+                                entry(
+                                        "meaningfulBodyStatementThreshold",
+                                        intProp(
+                                                "Maximum statements that earn meaningful-body credit; values < 0 use default.")),
+                                entry(
+                                        "smallBodyMaxStatements",
+                                        intProp(
+                                                "Maximum statement count considered a small body; values < 0 use default."))),
                         List.of("filePaths")),
                 (exchange, request) -> withReadLock(() -> {
                     var filePaths = stringListArg(request, "filePaths");
@@ -595,11 +626,17 @@ public class BrokkCoreMcpServer {
                 schema(
                         Map.of(
                                 "filePaths", arrayProp("File paths relative to the project root."),
-                                "minScore", intProp("Minimum similarity score (0-100) to include; values <= 0 default to 60."),
-                                "minNormalizedTokens", intProp("Minimum normalized token count; values <= 0 default to 12."),
-                                "shingleSize", intProp("Shingle size used for token overlap; values <= 0 default to 2."),
-                                "minSharedShingles", intProp("Minimum shared shingles before scoring; values <= 0 default to 3."),
-                                "astSimilarityPercent", intProp("AST refinement threshold (0-100); values <= 0 default to 70."),
+                                "minScore",
+                                        intProp(
+                                                "Minimum similarity score (0-100) to include; values <= 0 default to 60."),
+                                "minNormalizedTokens",
+                                        intProp("Minimum normalized token count; values <= 0 default to 12."),
+                                "shingleSize",
+                                        intProp("Shingle size used for token overlap; values <= 0 default to 2."),
+                                "minSharedShingles",
+                                        intProp("Minimum shared shingles before scoring; values <= 0 default to 3."),
+                                "astSimilarityPercent",
+                                        intProp("AST refinement threshold (0-100); values <= 0 default to 70."),
                                 "maxFindings", intProp("Maximum findings to emit; values <= 0 default to 80.")),
                         List.of("filePaths")),
                 (exchange, request) -> withReadLock(() -> {

--- a/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
@@ -1,0 +1,381 @@
+package ai.brokk.tools;
+
+import ai.brokk.ICodeIntelligence;
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.CommentDensityStats;
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Read-only static analysis helpers for code quality, adapted for the MCP server.
+ * Uses {@link ICodeIntelligence} instead of IContextManager, so no LLM or console dependencies.
+ */
+public class CodeQualityToolsMcp {
+    private static final String COMMENT_DENSITY_JAVA_ONLY =
+            "Comment density is only available for Java symbols in this analyzer snapshot.";
+
+    private final ICodeIntelligence intelligence;
+
+    public CodeQualityToolsMcp(ICodeIntelligence intelligence) {
+        this.intelligence = intelligence;
+    }
+
+    // -- computeCyclomaticComplexity --
+
+    public String computeCyclomaticComplexity(List<String> filePaths, int threshold) {
+        int limit = threshold > 0 ? threshold : 10;
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        var lines = new ArrayList<String>();
+        lines.add("Cyclomatic complexity (threshold: " + limit + "):");
+        boolean foundAny = false;
+
+        for (String path : filePaths) {
+            ProjectFile file = intelligence.toFile(path);
+            if (!file.exists()) continue;
+
+            List<CodeUnit> declarations = analyzer.getTopLevelDeclarations(file);
+            for (CodeUnit cu : declarations) {
+                foundAny |= analyzeUnitComplexity(analyzer, cu, limit, lines);
+            }
+        }
+
+        return foundAny ? String.join("\n", lines) : "No methods exceeded the complexity threshold of " + limit + ".";
+    }
+
+    private boolean analyzeUnitComplexity(IAnalyzer analyzer, CodeUnit cu, int threshold, List<String> lines) {
+        boolean flagged = false;
+        if (cu.isFunction()) {
+            int complexity = analyzer.computeCyclomaticComplexity(cu);
+            if (complexity > threshold) {
+                lines.add("- " + cu.fqName() + ": " + complexity + " (in " + cu.source() + ")");
+                flagged = true;
+            }
+        }
+        for (CodeUnit child : analyzer.getDirectChildren(cu)) {
+            flagged |= analyzeUnitComplexity(analyzer, child, threshold, lines);
+        }
+        return flagged;
+    }
+
+    // -- reportCommentDensityForCodeUnit --
+
+    public String reportCommentDensityForCodeUnit(String fqName, int maxLines) {
+        if (fqName.isBlank()) {
+            return "Missing fqName.";
+        }
+        int cap = maxLines > 0 ? maxLines : 120;
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        String key = fqName.strip();
+        var defs = analyzer.getDefinitions(key);
+        if (defs.isEmpty()) {
+            return "No definition found for: " + key;
+        }
+        CodeUnit cu = defs.stream()
+                .filter(d -> "java".equals(d.source().extension()))
+                .findFirst()
+                .orElse(defs.getFirst());
+        Optional<CommentDensityStats> stats = analyzer.commentDensity(cu);
+        if (stats.isEmpty()) {
+            return COMMENT_DENSITY_JAVA_ONLY;
+        }
+        return truncateToLineCap(formatCommentDensityForUnit(stats.get()), cap);
+    }
+
+    // -- reportCommentDensityForFiles --
+
+    public String reportCommentDensityForFiles(List<String> filePaths, int maxTopLevelRows, int maxFiles) {
+        int rowCap = maxTopLevelRows > 0 ? maxTopLevelRows : 60;
+        int fileCap = maxFiles > 0 ? maxFiles : 25;
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        var lines = new ArrayList<String>();
+        lines.add("## Comment density by file");
+        lines.add("");
+        int filesShown = 0;
+        int rowsEmitted = 0;
+        boolean rowsTruncated = false;
+        boolean filesTruncated = false;
+
+        outer:
+        for (String path : filePaths) {
+            if (filesShown >= fileCap) {
+                filesTruncated = true;
+                break;
+            }
+            ProjectFile file = intelligence.toFile(path);
+            if (!file.exists()) {
+                lines.add("- Missing file (skipped): `" + path + "`");
+                continue;
+            }
+            if (!"java".equals(file.extension())) {
+                lines.add("### `" + path + "`");
+                lines.add("(not a Java file; skipped)");
+                lines.add("");
+                continue;
+            }
+            List<CommentDensityStats> stats = analyzer.commentDensityByTopLevel(file);
+            if (stats.isEmpty()) {
+                lines.add("### `" + path + "`");
+                lines.add(COMMENT_DENSITY_JAVA_ONLY);
+                lines.add("");
+                filesShown++;
+                continue;
+            }
+            filesShown++;
+            lines.add("### `" + path + "`");
+            lines.add("| Declaration | Hdr | Inl | Span | Roll H | Roll I | Roll S |");
+            lines.add("|-------------|-----|-----|------|--------|--------|--------|");
+            for (CommentDensityStats s : stats) {
+                if (rowsEmitted >= rowCap) {
+                    rowsTruncated = true;
+                    break outer;
+                }
+                lines.add("| `%s` | %d | %d | %d | %d | %d | %d |"
+                        .formatted(
+                                sanitizeTableCell(s.fqName()),
+                                s.headerCommentLines(),
+                                s.inlineCommentLines(),
+                                s.spanLines(),
+                                s.rolledUpHeaderCommentLines(),
+                                s.rolledUpInlineCommentLines(),
+                                s.rolledUpSpanLines()));
+                rowsEmitted++;
+            }
+            lines.add("");
+        }
+        var footer = new ArrayList<String>();
+        footer.add("");
+        footer.add("- Files shown: %d (cap %d%s)"
+                .formatted(filesShown, fileCap, filesTruncated ? ", list truncated" : ""));
+        footer.add("- Declaration rows: %d (cap %d%s)"
+                .formatted(rowsEmitted, rowCap, rowsTruncated ? ", table truncated" : ""));
+        if (rowsTruncated || filesTruncated) {
+            footer.add("- Note: narrow the path list or increase caps to see more.");
+        }
+        lines.addAll(footer);
+        return String.join("\n", lines);
+    }
+
+    // -- reportExceptionHandlingSmells --
+
+    public String reportExceptionHandlingSmells(
+            List<String> filePaths,
+            int minScore,
+            int maxFindings,
+            int genericThrowableWeight,
+            int genericExceptionWeight,
+            int genericRuntimeExceptionWeight,
+            int emptyBodyWeight,
+            int commentOnlyBodyWeight,
+            int smallBodyWeight,
+            int logOnlyBodyWeight,
+            int meaningfulBodyCreditPerStatement,
+            int meaningfulBodyStatementThreshold,
+            int smallBodyMaxStatements) {
+
+        int threshold = minScore > 0 ? minScore : 4;
+        int findingsCap = maxFindings > 0 ? maxFindings : 80;
+        var defaults = IAnalyzer.ExceptionSmellWeights.defaults();
+        var weights = new IAnalyzer.ExceptionSmellWeights(
+                pickWeight(genericThrowableWeight, defaults.genericThrowableWeight()),
+                pickWeight(genericExceptionWeight, defaults.genericExceptionWeight()),
+                pickWeight(genericRuntimeExceptionWeight, defaults.genericRuntimeExceptionWeight()),
+                pickWeight(emptyBodyWeight, defaults.emptyBodyWeight()),
+                pickWeight(commentOnlyBodyWeight, defaults.commentOnlyBodyWeight()),
+                pickWeight(smallBodyWeight, defaults.smallBodyWeight()),
+                pickWeight(logOnlyBodyWeight, defaults.logOnlyWeight()),
+                pickWeight(meaningfulBodyCreditPerStatement, defaults.meaningfulBodyCreditPerStatement()),
+                pickWeight(meaningfulBodyStatementThreshold, defaults.meaningfulBodyStatementThreshold()),
+                pickWeight(smallBodyMaxStatements, defaults.smallBodyMaxStatements()));
+
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        var findings = new ArrayList<IAnalyzer.ExceptionHandlingSmell>();
+        for (String path : filePaths) {
+            ProjectFile file = intelligence.toFile(path);
+            if (!file.exists()) {
+                continue;
+            }
+            findings.addAll(analyzer.findExceptionHandlingSmells(file, weights));
+        }
+
+        var filtered = findings.stream()
+                .filter(f -> f.score() >= threshold)
+                .sorted(Comparator.comparingInt(IAnalyzer.ExceptionHandlingSmell::score)
+                        .reversed()
+                        .thenComparing(f -> f.file().toString())
+                        .thenComparing(IAnalyzer.ExceptionHandlingSmell::enclosingFqName))
+                .toList();
+
+        if (filtered.isEmpty()) {
+            return "No exception-handling smells met minScore " + threshold + ".";
+        }
+        int shown = Math.min(findingsCap, filtered.size());
+        var lines = new ArrayList<String>();
+        lines.add("## Exception handling smells");
+        lines.add("");
+        lines.add("- Min score: %d".formatted(threshold));
+        lines.add("- Findings shown: %d of %d".formatted(shown, filtered.size()));
+        lines.add("- Weights: %s".formatted(formatExceptionWeights(weights)));
+        lines.add("");
+        lines.add("| Score | Catch Type | Statements | Symbol | File | Reasons | Excerpt |");
+        lines.add("|------:|------------|-----------:|--------|------|---------|---------|");
+        for (IAnalyzer.ExceptionHandlingSmell finding : filtered.subList(0, shown)) {
+            String reasons = sanitizeTableCell(String.join(", ", finding.reasons()));
+            String catchType = sanitizeTableCell(finding.catchType());
+            String symbol = sanitizeTableCell(finding.enclosingFqName());
+            String file = sanitizeTableCell(finding.file().toString());
+            lines.add("| %d | `%s` | %d | `%s` | `%s` | %s | `%s` |"
+                    .formatted(
+                            finding.score(),
+                            catchType,
+                            finding.bodyStatementCount(),
+                            symbol,
+                            file,
+                            "`" + reasons + "`",
+                            sanitizeTableCell(finding.excerpt())));
+        }
+        if (filtered.size() > shown) {
+            lines.add("");
+            lines.add("- Note: output truncated; increase maxFindings to see more.");
+        }
+        return String.join("\n", lines);
+    }
+
+    // -- reportStructuralCloneSmells --
+
+    public String reportStructuralCloneSmells(
+            List<String> filePaths,
+            int minScore,
+            int minNormalizedTokens,
+            int shingleSize,
+            int minSharedShingles,
+            int astSimilarityPercent,
+            int maxFindings) {
+
+        var defaults = IAnalyzer.CloneSmellWeights.defaults();
+        int threshold = minScore > 0 ? minScore : defaults.minSimilarityPercent();
+        int findingsCap = maxFindings > 0 ? maxFindings : 80;
+        var weights = new IAnalyzer.CloneSmellWeights(
+                minNormalizedTokens > 0 ? minNormalizedTokens : defaults.minNormalizedTokens(),
+                threshold,
+                shingleSize > 0 ? shingleSize : defaults.shingleSize(),
+                minSharedShingles > 0 ? minSharedShingles : defaults.minSharedShingles(),
+                astSimilarityPercent > 0 ? astSimilarityPercent : defaults.astSimilarityPercent());
+
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        List<ProjectFile> files = filePaths.stream()
+                .map(intelligence::toFile)
+                .filter(ProjectFile::exists)
+                .toList();
+        var findings = new ArrayList<>(analyzer.findStructuralCloneSmells(files, weights));
+        var deduped = new LinkedHashMap<String, IAnalyzer.CloneSmell>();
+        for (IAnalyzer.CloneSmell finding : findings) {
+            String left = finding.file() + "#" + finding.enclosingFqName();
+            String right = finding.peerFile() + "#" + finding.peerEnclosingFqName();
+            String key = left.compareTo(right) <= 0 ? left + "||" + right : right + "||" + left;
+            deduped.putIfAbsent(key, finding);
+        }
+        var filtered = deduped.values().stream()
+                .filter(f -> f.score() >= threshold)
+                .sorted(Comparator.comparingInt(IAnalyzer.CloneSmell::score)
+                        .reversed()
+                        .thenComparing(f -> f.file().toString())
+                        .thenComparing(IAnalyzer.CloneSmell::enclosingFqName)
+                        .thenComparing(f -> f.peerFile().toString())
+                        .thenComparing(IAnalyzer.CloneSmell::peerEnclosingFqName))
+                .toList();
+        if (filtered.isEmpty()) {
+            return "No structural clone smells met minScore " + threshold + ".";
+        }
+
+        int shown = Math.min(findingsCap, filtered.size());
+        var lines = new ArrayList<String>();
+        lines.add("## Structural clone smells");
+        lines.add("");
+        lines.add("- Min score: %d".formatted(threshold));
+        lines.add("- Findings shown: %d of %d".formatted(shown, filtered.size()));
+        lines.add("- Weights: minTokens=%d, shingleSize=%d, minShared=%d, astThreshold=%d"
+                .formatted(
+                        weights.minNormalizedTokens(),
+                        weights.shingleSize(),
+                        weights.minSharedShingles(),
+                        weights.astSimilarityPercent()));
+        lines.add("");
+        lines.add("| Score | Tokens | Symbol | Peer Symbol | Reasons | Excerpt |");
+        lines.add("|------:|-------:|--------|-------------|---------|---------|");
+        for (IAnalyzer.CloneSmell finding : filtered.subList(0, shown)) {
+            lines.add("| %d | %d | `%s` (%s) | `%s` (%s) | `%s` | `%s` |"
+                    .formatted(
+                            finding.score(),
+                            finding.normalizedTokenCount(),
+                            sanitizeTableCell(finding.enclosingFqName()),
+                            sanitizeTableCell(finding.file().toString()),
+                            sanitizeTableCell(finding.peerEnclosingFqName()),
+                            sanitizeTableCell(finding.peerFile().toString()),
+                            sanitizeTableCell(String.join(", ", finding.reasons())),
+                            sanitizeTableCell(finding.excerpt())));
+        }
+        if (filtered.size() > shown) {
+            lines.add("");
+            lines.add("- Note: output truncated; increase maxFindings to see more.");
+        }
+        return String.join("\n", lines);
+    }
+
+    // NOTE: analyzeGitHotspots is not available in brokk-core because GitHotspotAnalyzer
+    // lives in the app module with dependencies (ai.brokk.concurrent.*) not available here.
+    // It could be added if GitHotspotAnalyzer is moved to brokk-core or brokk-shared.
+
+    // -- Formatting helpers --
+
+    private static String formatCommentDensityForUnit(CommentDensityStats s) {
+        var lines = new ArrayList<String>();
+        lines.add("## Comment density");
+        lines.add("");
+        lines.add("- Symbol: `%s`".formatted(s.fqName()));
+        lines.add("- File: `%s`".formatted(s.relativePath()));
+        lines.add("- Own: header %d, inline %d, span %d"
+                .formatted(s.headerCommentLines(), s.inlineCommentLines(), s.spanLines()));
+        lines.add("- Rolled-up: header %d, inline %d, span %d"
+                .formatted(s.rolledUpHeaderCommentLines(), s.rolledUpInlineCommentLines(), s.rolledUpSpanLines()));
+        return String.join("\n", lines);
+    }
+
+    private static String truncateToLineCap(String text, int maxLines) {
+        List<String> lines = text.lines().toList();
+        if (lines.size() <= maxLines) {
+            return text;
+        }
+        return String.join("\n", lines.subList(0, maxLines)) + "\n\n... (" + (lines.size() - maxLines)
+                + " more lines omitted)";
+    }
+
+    private static int pickWeight(int candidate, int fallback) {
+        return candidate >= 0 ? candidate : fallback;
+    }
+
+    private static String sanitizeTableCell(String value) {
+        return value.replace("|", "\\|");
+    }
+
+    private static String formatExceptionWeights(IAnalyzer.ExceptionSmellWeights w) {
+        return "Throwable=%d, Exception=%d, RuntimeException=%d, empty=%d, commentOnly=%d, small=%d, logOnly=%d,"
+                        .formatted(
+                                w.genericThrowableWeight(),
+                                w.genericExceptionWeight(),
+                                w.genericRuntimeExceptionWeight(),
+                                w.emptyBodyWeight(),
+                                w.commentOnlyBodyWeight(),
+                                w.smallBodyWeight(),
+                                w.logOnlyWeight())
+                + " creditPerStmt=%d, creditCap=%d, smallBodyMax=%d"
+                        .formatted(
+                                w.meaningfulBodyCreditPerStatement(),
+                                w.meaningfulBodyStatementThreshold(),
+                                w.smallBodyMaxStatements());
+    }
+}

--- a/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
@@ -109,12 +109,14 @@ public class CodeQualityToolsMcp {
             ProjectFile file = intelligence.toFile(path);
             if (!file.exists()) {
                 lines.add("- Missing file (skipped): `" + path + "`");
+                filesShown++;
                 continue;
             }
             if (!"java".equals(file.extension())) {
                 lines.add("### `" + path + "`");
                 lines.add("(not a Java file; skipped)");
                 lines.add("");
+                filesShown++;
                 continue;
             }
             List<CommentDensityStats> stats = analyzer.commentDensityByTopLevel(file);
@@ -277,7 +279,8 @@ public class CodeQualityToolsMcp {
             String left = finding.file() + "#" + finding.enclosingFqName();
             String right = finding.peerFile() + "#" + finding.peerEnclosingFqName();
             String key = left.compareTo(right) <= 0 ? left + "||" + right : right + "||" + left;
-            deduped.putIfAbsent(key, finding);
+            deduped.merge(
+                    key, finding, (existing, incoming) -> incoming.score() > existing.score() ? incoming : existing);
         }
         var filtered = deduped.values().stream()
                 .filter(f -> f.score() >= threshold)

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -8,8 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.brokk.analyzer.DisabledAnalyzer;
 import ai.brokk.project.CoreProject;
 import ai.brokk.tools.SearchTools;
+import io.modelcontextprotocol.spec.McpSchema;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -157,7 +159,7 @@ class BrokkCoreMcpServerTest {
                 .findFirst()
                 .orElseThrow();
 
-        var request = new io.modelcontextprotocol.spec.McpSchema.CallToolRequest("getActiveWorkspace", Map.of());
+        var request = new McpSchema.CallToolRequest("getActiveWorkspace", Map.of());
         var result = activeTool.callHandler().apply(null, request);
 
         assertNotNull(result);
@@ -166,21 +168,20 @@ class BrokkCoreMcpServerTest {
 
     // -- Code quality tool execution tests --
 
-    private io.modelcontextprotocol.spec.McpSchema.CallToolResult callTool(String name, Map<String, Object> args) {
+    private McpSchema.CallToolResult callTool(String name, Map<String, Object> args) {
         var specs = server.toolSpecifications();
         var tool = specs.stream()
                 .filter(s -> name.equals(s.tool().name()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Tool not found: " + name));
-        var request = new io.modelcontextprotocol.spec.McpSchema.CallToolRequest(name, args);
+        var request = new McpSchema.CallToolRequest(name, args);
         return tool.callHandler().apply(null, request);
     }
 
     @Test
     void computeCyclomaticComplexityRunsWithoutError() {
-        var result = callTool("computeCyclomaticComplexity", Map.of(
-                "filePaths", java.util.List.of("README.md"),
-                "threshold", 10));
+        var result =
+                callTool("computeCyclomaticComplexity", Map.of("filePaths", List.of("README.md"), "threshold", 10));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());
@@ -188,9 +189,8 @@ class BrokkCoreMcpServerTest {
 
     @Test
     void reportCommentDensityForCodeUnitRunsWithoutError() {
-        var result = callTool("reportCommentDensityForCodeUnit", Map.of(
-                "fqName", "com.example.NonExistent",
-                "maxLines", 120));
+        var result = callTool(
+                "reportCommentDensityForCodeUnit", Map.of("fqName", "com.example.NonExistent", "maxLines", 120));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());
@@ -198,10 +198,12 @@ class BrokkCoreMcpServerTest {
 
     @Test
     void reportCommentDensityForFilesRunsWithoutError() {
-        var result = callTool("reportCommentDensityForFiles", Map.of(
-                "filePaths", java.util.List.of("README.md"),
-                "maxTopLevelRows", 60,
-                "maxFiles", 25));
+        var result = callTool(
+                "reportCommentDensityForFiles",
+                Map.of(
+                        "filePaths", List.of("README.md"),
+                        "maxTopLevelRows", 60,
+                        "maxFiles", 25));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());
@@ -209,8 +211,7 @@ class BrokkCoreMcpServerTest {
 
     @Test
     void reportExceptionHandlingSmellsRunsWithoutError() {
-        var result = callTool("reportExceptionHandlingSmells", Map.of(
-                "filePaths", java.util.List.of("README.md")));
+        var result = callTool("reportExceptionHandlingSmells", Map.of("filePaths", List.of("README.md")));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());
@@ -218,8 +219,7 @@ class BrokkCoreMcpServerTest {
 
     @Test
     void reportStructuralCloneSmellsRunsWithoutError() {
-        var result = callTool("reportStructuralCloneSmells", Map.of(
-                "filePaths", java.util.List.of("README.md")));
+        var result = callTool("reportStructuralCloneSmells", Map.of("filePaths", List.of("README.md")));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -85,7 +85,12 @@ class BrokkCoreMcpServerTest {
                 "skimFiles",
                 "jq",
                 "xmlSkim",
-                "xmlSelect");
+                "xmlSelect",
+                "computeCyclomaticComplexity",
+                "reportCommentDensityForCodeUnit",
+                "reportCommentDensityForFiles",
+                "reportExceptionHandlingSmells",
+                "reportStructuralCloneSmells");
 
         for (var expected : expectedTools) {
             assertTrue(toolNames.contains(expected), "Missing tool: " + expected);
@@ -156,6 +161,67 @@ class BrokkCoreMcpServerTest {
         var result = activeTool.callHandler().apply(null, request);
 
         assertNotNull(result);
+        assertFalse(result.content().isEmpty());
+    }
+
+    // -- Code quality tool execution tests --
+
+    private io.modelcontextprotocol.spec.McpSchema.CallToolResult callTool(String name, Map<String, Object> args) {
+        var specs = server.toolSpecifications();
+        var tool = specs.stream()
+                .filter(s -> name.equals(s.tool().name()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Tool not found: " + name));
+        var request = new io.modelcontextprotocol.spec.McpSchema.CallToolRequest(name, args);
+        return tool.callHandler().apply(null, request);
+    }
+
+    @Test
+    void computeCyclomaticComplexityRunsWithoutError() {
+        var result = callTool("computeCyclomaticComplexity", Map.of(
+                "filePaths", java.util.List.of("README.md"),
+                "threshold", 10));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportCommentDensityForCodeUnitRunsWithoutError() {
+        var result = callTool("reportCommentDensityForCodeUnit", Map.of(
+                "fqName", "com.example.NonExistent",
+                "maxLines", 120));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportCommentDensityForFilesRunsWithoutError() {
+        var result = callTool("reportCommentDensityForFiles", Map.of(
+                "filePaths", java.util.List.of("README.md"),
+                "maxTopLevelRows", 60,
+                "maxFiles", 25));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportExceptionHandlingSmellsRunsWithoutError() {
+        var result = callTool("reportExceptionHandlingSmells", Map.of(
+                "filePaths", java.util.List.of("README.md")));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportStructuralCloneSmellsRunsWithoutError() {
+        var result = callTool("reportStructuralCloneSmells", Map.of(
+                "filePaths", java.util.List.of("README.md")));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/MultiAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/MultiAnalyzer.java
@@ -236,6 +236,37 @@ public class MultiAnalyzer
     }
 
     @Override
+    public List<ExceptionHandlingSmell> findExceptionHandlingSmells(ProjectFile file, ExceptionSmellWeights weights) {
+        return delegateFor(file)
+                .map(delegate -> delegate.findExceptionHandlingSmells(file, weights))
+                .orElse(List.of());
+    }
+
+    @Override
+    public List<CloneSmell> findStructuralCloneSmells(ProjectFile file, CloneSmellWeights weights) {
+        return delegateFor(file)
+                .map(delegate -> delegate.findStructuralCloneSmells(file, weights))
+                .orElse(List.of());
+    }
+
+    @Override
+    public List<CloneSmell> findStructuralCloneSmells(List<ProjectFile> files, CloneSmellWeights weights) {
+        return files.stream()
+                .collect(Collectors.groupingBy(
+                        file -> Languages.fromExtension(file.extension()), LinkedHashMap::new, Collectors.toList()))
+                .entrySet()
+                .stream()
+                .flatMap(entry -> {
+                    var delegate = delegates.get(entry.getKey());
+                    if (delegate == null) {
+                        return Stream.<CloneSmell>empty();
+                    }
+                    return delegate.findStructuralCloneSmells(entry.getValue(), weights).stream();
+                })
+                .toList();
+    }
+
+    @Override
     public Optional<String> getSource(CodeUnit codeUnit, boolean includeComments) {
         return delegateFor(codeUnit).flatMap(analyzer -> analyzer.getSource(codeUnit, includeComments));
     }

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerCapabilityTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerCapabilityTest.java
@@ -1,13 +1,17 @@
 package ai.brokk.analyzer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.project.ICoreProject;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class MultiAnalyzerCapabilityTest {
 
@@ -52,6 +56,75 @@ public class MultiAnalyzerCapabilityTest {
         assertTrue(
                 provider.isPresent(), "MultiAnalyzer should return a provider for TypeAlias when delegate supports it");
         assertTrue(provider.get() == multi, "MultiAnalyzer should return itself as the provider");
+    }
+
+    @Test
+    void findExceptionHandlingSmells_DelegatesToFileLanguageAnalyzer(@TempDir Path root) {
+        var javaFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/App.java");
+        var pythonFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/app.py");
+        var javaFinding = new IAnalyzer.ExceptionHandlingSmell(
+                javaFile, "App.run", "Exception", 5, 0, List.of("empty catch body"), "catch (Exception e) {}");
+        var pythonFinding = new IAnalyzer.ExceptionHandlingSmell(
+                pythonFile, "app.run", "Exception", 5, 0, List.of("empty except body"), "except Exception:");
+        var javaAnalyzer = new QualitySmellAnalyzer(List.of(javaFinding), List.of());
+        var pythonAnalyzer = new QualitySmellAnalyzer(List.of(pythonFinding), List.of());
+        var multi = new MultiAnalyzer(Map.of(Languages.JAVA, javaAnalyzer, Languages.PYTHON, pythonAnalyzer));
+
+        var findings = multi.findExceptionHandlingSmells(javaFile, IAnalyzer.ExceptionSmellWeights.defaults());
+
+        assertEquals(List.of(javaFinding), findings);
+        assertEquals(List.of(javaFile), javaAnalyzer.exceptionFiles);
+        assertTrue(pythonAnalyzer.exceptionFiles.isEmpty());
+    }
+
+    @Test
+    void findStructuralCloneSmells_DelegatesSingleFileToFileLanguageAnalyzer(@TempDir Path root) {
+        var javaFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/App.java");
+        var peerFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/Peer.java");
+        var pythonFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/app.py");
+        var javaFinding = new IAnalyzer.CloneSmell(
+                javaFile, "App.run", peerFile, "Peer.run", 90, 20, List.of("shared structure"), "run();", "run();");
+        var pythonFinding = new IAnalyzer.CloneSmell(
+                pythonFile, "app.run", pythonFile, "app.other", 90, 20, List.of("shared structure"), "run()", "run()");
+        var javaAnalyzer = new QualitySmellAnalyzer(List.of(), List.of(javaFinding));
+        var pythonAnalyzer = new QualitySmellAnalyzer(List.of(), List.of(pythonFinding));
+        var multi = new MultiAnalyzer(Map.of(Languages.JAVA, javaAnalyzer, Languages.PYTHON, pythonAnalyzer));
+
+        var findings = multi.findStructuralCloneSmells(javaFile, IAnalyzer.CloneSmellWeights.defaults());
+
+        assertEquals(List.of(javaFinding), findings);
+        assertEquals(List.of(List.of(javaFile)), javaAnalyzer.cloneFileGroups);
+        assertTrue(pythonAnalyzer.cloneFileGroups.isEmpty());
+    }
+
+    @Test
+    void findStructuralCloneSmells_DelegatesFileGroupsByLanguage(@TempDir Path root) {
+        var javaFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/App.java");
+        var javaPeerFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/Peer.java");
+        var pythonFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/app.py");
+        var pythonPeerFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/peer.py");
+        var javaFinding = new IAnalyzer.CloneSmell(
+                javaFile, "App.run", javaPeerFile, "Peer.run", 90, 20, List.of("shared structure"), "run();", "run();");
+        var pythonFinding = new IAnalyzer.CloneSmell(
+                pythonFile,
+                "app.run",
+                pythonPeerFile,
+                "peer.run",
+                88,
+                18,
+                List.of("shared structure"),
+                "run()",
+                "run()");
+        var javaAnalyzer = new QualitySmellAnalyzer(List.of(), List.of(javaFinding));
+        var pythonAnalyzer = new QualitySmellAnalyzer(List.of(), List.of(pythonFinding));
+        var multi = new MultiAnalyzer(Map.of(Languages.JAVA, javaAnalyzer, Languages.PYTHON, pythonAnalyzer));
+
+        var findings = multi.findStructuralCloneSmells(
+                List.of(javaFile, pythonFile, javaPeerFile, pythonPeerFile), IAnalyzer.CloneSmellWeights.defaults());
+
+        assertEquals(List.of(javaFinding, pythonFinding), findings);
+        assertEquals(List.of(List.of(javaFile, javaPeerFile)), javaAnalyzer.cloneFileGroups);
+        assertEquals(List.of(List.of(pythonFile, pythonPeerFile)), pythonAnalyzer.cloneFileGroups);
     }
 
     private abstract static class BaseStubAnalyzer implements IAnalyzer {
@@ -174,6 +247,48 @@ public class MultiAnalyzerCapabilityTest {
         @Override
         public boolean isTypeAlias(CodeUnit cu) {
             return false;
+        }
+    }
+
+    private static final class QualitySmellAnalyzer extends BaseStubAnalyzer {
+        final List<ProjectFile> exceptionFiles = new ArrayList<>();
+        final List<List<ProjectFile>> cloneFileGroups = new ArrayList<>();
+
+        private final List<IAnalyzer.ExceptionHandlingSmell> exceptionFindings;
+        private final List<IAnalyzer.CloneSmell> cloneFindings;
+
+        QualitySmellAnalyzer(
+                List<IAnalyzer.ExceptionHandlingSmell> exceptionFindings, List<IAnalyzer.CloneSmell> cloneFindings) {
+            this.exceptionFindings = exceptionFindings;
+            this.cloneFindings = cloneFindings;
+        }
+
+        @Override
+        public List<IAnalyzer.ExceptionHandlingSmell> findExceptionHandlingSmells(
+                ProjectFile file, IAnalyzer.ExceptionSmellWeights weights) {
+            exceptionFiles.add(file);
+            return exceptionFindings.stream()
+                    .filter(finding -> finding.file().equals(file))
+                    .toList();
+        }
+
+        @Override
+        public List<IAnalyzer.CloneSmell> findStructuralCloneSmells(
+                ProjectFile file, IAnalyzer.CloneSmellWeights weights) {
+            cloneFileGroups.add(List.of(file));
+            return cloneFindings.stream()
+                    .filter(finding ->
+                            finding.file().equals(file) || finding.peerFile().equals(file))
+                    .toList();
+        }
+
+        @Override
+        public List<IAnalyzer.CloneSmell> findStructuralCloneSmells(
+                List<ProjectFile> files, IAnalyzer.CloneSmellWeights weights) {
+            cloneFileGroups.add(List.copyOf(files));
+            return cloneFindings.stream()
+                    .filter(finding -> files.contains(finding.file()) && files.contains(finding.peerFile()))
+                    .toList();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Expose 5 CodeQualityTools via the brokk-core MCP server: `computeCyclomaticComplexity`, `reportCommentDensityForCodeUnit`, `reportCommentDensityForFiles`, `reportExceptionHandlingSmells`, `reportStructuralCloneSmells`
- New `CodeQualityToolsMcp` class adapted from app's `CodeQualityTools` to use `ICodeIntelligence` instead of `IContextManager`
- `analyzeGitHotspots` not included — `GitHotspotAnalyzer` depends on `ai.brokk.concurrent.*` which is in the app module

## Motivation
External consumers using brokk-core as an MCP tool provider (e.g. ACP agents, SlopScan) need access to deterministic, tree-sitter-powered analysis tools — not just search/navigation.

## Test plan
- [x] Updated `registersAllExpectedTools` to include 5 new tool names
- [x] Added 5 new execution tests that invoke each tool through the MCP handler
- [x] All 35 brokk-core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)