### PR TITLE
Fix C/C++ test marker detection without path fallback

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
@@ -1938,7 +1938,12 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
                                     continue;
                                 }
                                 TSNode markerNode = capture.getNode();
-                                if (markerNode != null && isStructuredTestMarker(markerNode)) {
+                                if (markerNode == null) {
+                                    continue;
+                                }
+                                String markerName =
+                                        sourceContent.substringFrom(markerNode).strip();
+                                if (isStructuredTestMarker(markerNode, markerName, sourceContent)) {
                                     return true;
                                 }
                             }
@@ -2022,7 +2027,9 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
                                 if (markerNode == null) {
                                     continue;
                                 }
-                                if (!isStructuredTestMarker(markerNode)) {
+                                String markerName =
+                                        sourceContent.substringFrom(markerNode).strip();
+                                if (!isStructuredTestMarker(markerNode, markerName, sourceContent)) {
                                     continue;
                                 }
                                 TSNode bodyNode = testBodyForMarker(markerNode);
@@ -2050,7 +2057,7 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
             if (!TEST_MARKER_NAMES.contains(markerName)) {
                 continue;
             }
-            if (isStructuredTestMarker(identifierNode)) {
+            if (isStructuredTestMarker(identifierNode, markerName, sourceContent)) {
                 return true;
             }
         }
@@ -2066,7 +2073,7 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
             if (!TEST_MARKER_NAMES.contains(markerName)) {
                 continue;
             }
-            if (!isStructuredTestMarker(identifierNode)) {
+            if (!isStructuredTestMarker(identifierNode, markerName, sourceContent)) {
                 continue;
             }
             TSNode bodyNode = testBodyForMarker(identifierNode);
@@ -2080,54 +2087,30 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
         }
     }
 
-    private static boolean isStructuredTestMarker(TSNode markerNode) {
+    private static boolean isStructuredTestMarker(TSNode markerNode, String markerName, SourceContent sourceContent) {
         if (hasAncestorOfType(markerNode, COMPOUND_STATEMENT)) {
             return false;
         }
         TSNode bodyNode = testBodyForMarker(markerNode);
-        if (bodyNode == null || !hasInvocationArguments(markerNode)) {
+        if (bodyNode == null || !hasImmediateInvocationParen(markerNode, sourceContent)) {
+            return false;
+        }
+        if ("TEST_METHOD".equals(markerName) && !hasAncestorOfType(markerNode, FIELD_DECLARATION_LIST)) {
             return false;
         }
         return hasTopLevelLikeOwner(markerNode, bodyNode);
     }
 
-    private static boolean hasInvocationArguments(TSNode markerNode) {
-        TSNode parent = markerNode.getParent();
-        if (parent != null
-                && CALL_EXPRESSION.equals(parent.getType())
-                && parent.getChildByFieldName(FIELD_ARGUMENTS) != null) {
-            return true;
-        }
-
-        int markerStartByte = markerNode.getStartByte();
-        TSNode scope = markerNode;
-        while (scope != null && !TRANSLATION_UNIT.equals(scope.getType())) {
-            if (hasNearbyArgumentList(scope, markerStartByte)) {
-                return true;
+    private static boolean hasImmediateInvocationParen(TSNode markerNode, SourceContent sourceContent) {
+        byte[] bytes = sourceContent.utf8Bytes();
+        int i = markerNode.getEndByte();
+        while (i >= 0 && i < bytes.length) {
+            byte b = bytes[i];
+            if (b == ' ' || b == '\t' || b == '\n' || b == '\r') {
+                i++;
+                continue;
             }
-            scope = scope.getParent();
-        }
-        return false;
-    }
-
-    private static boolean hasNearbyArgumentList(TSNode node, int markerStartByte) {
-        var stack = new ArrayDeque<TSNode>();
-        stack.push(node);
-        while (!stack.isEmpty()) {
-            TSNode current = stack.pop();
-            if (!current.equals(node)
-                    && (ARGUMENT_LIST.equals(current.getType()) || PARAMETER_LIST.equals(current.getType()))) {
-                int delta = current.getStartByte() - markerStartByte;
-                if (delta > 0 && delta <= 64) {
-                    return true;
-                }
-            }
-            for (int i = 0; i < current.getNamedChildCount(); i++) {
-                TSNode child = current.getNamedChild(i);
-                if (child != null) {
-                    stack.push(child);
-                }
-            }
+            return b == '(';
         }
         return false;
     }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
@@ -1980,14 +1980,6 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
         return withSource(file, source -> detectCppTestAssertionSmells(file, source, resolvedWeights), List.of());
     }
 
-    @Override
-    public boolean containsTests(ProjectFile file) {
-        if (super.containsTests(file)) {
-            return true;
-        }
-        return isCppTestLikePath(file);
-    }
-
     private List<TestAssertionSmell> detectCppTestAssertionSmells(
             ProjectFile file, SourceContent sourceContent, TestAssertionWeights weights) {
         var candidates = new ArrayList<TestSmellCandidate>();
@@ -2001,18 +1993,6 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
                 return List.of();
             }
             List<CppTestBlock> testBlocks = collectTestBlocks(rootNode, sourceContent);
-            if (testBlocks.isEmpty() && isCppTestLikePath(file)) {
-                addTestSmellCandidate(
-                        file,
-                        file.toString(),
-                        TEST_ASSERTION_KIND_NO_ASSERTIONS,
-                        weights.noAssertionWeight(),
-                        0,
-                        List.of(TEST_ASSERTION_KIND_NO_ASSERTIONS),
-                        sourceContent.text(),
-                        0,
-                        candidates);
-            }
             for (CppTestBlock testBlock : testBlocks) {
                 String enclosing = file.toString();
                 analyzeCppTestBlock(file, enclosing, testBlock, sourceContent, weights, candidates);
@@ -2022,11 +2002,6 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
                 .sorted(TEST_SMELL_CANDIDATE_COMPARATOR)
                 .map(TestSmellCandidate::smell)
                 .toList();
-    }
-
-    private static boolean isCppTestLikePath(ProjectFile file) {
-        String relPath = file.getRelPath().toString().toLowerCase(Locale.ROOT).replace('\\', '/');
-        return relPath.endsWith("_test.cpp") || relPath.endsWith("_test.cc") || relPath.endsWith("_test.cxx");
     }
 
     private List<CppTestBlock> collectTestBlocks(TSNode rootNode, SourceContent sourceContent) {
@@ -2124,59 +2099,28 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
             return true;
         }
 
-        TSNode current = markerNode;
-        while (current != null) {
-            TSNode currentParent = current.getParent();
-            if (currentParent == null) {
-                return false;
-            }
-            if (hasArgumentListAfter(currentParent, current)) {
+        int markerStartByte = markerNode.getStartByte();
+        TSNode scope = markerNode;
+        while (scope != null && !TRANSLATION_UNIT.equals(scope.getType())) {
+            if (hasNearbyArgumentList(scope, markerStartByte)) {
                 return true;
             }
-            current = currentParent;
+            scope = scope.getParent();
         }
         return false;
     }
 
-    private static boolean hasArgumentListAfter(TSNode parent, TSNode nodeOrDescendant) {
-        boolean pastNode = false;
-        for (int i = 0; i < parent.getNamedChildCount(); i++) {
-            TSNode child = parent.getNamedChild(i);
-            if (child == null) {
-                continue;
-            }
-            if (!pastNode) {
-                if (child.equals(nodeOrDescendant)) {
-                    pastNode = true;
-                    continue;
-                }
-                if (containsNode(child, nodeOrDescendant)) {
-                    if (hasArgumentListDescendantAfter(child, nodeOrDescendant.getStartByte())) {
-                        return true;
-                    }
-                    pastNode = true;
-                }
-                continue;
-            }
-            if (ARGUMENT_LIST.equals(child.getType())) {
-                return true;
-            }
-            if (hasArgumentListDescendantAfter(child, nodeOrDescendant.getStartByte())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean hasArgumentListDescendantAfter(TSNode node, int startByte) {
+    private static boolean hasNearbyArgumentList(TSNode node, int markerStartByte) {
         var stack = new ArrayDeque<TSNode>();
         stack.push(node);
         while (!stack.isEmpty()) {
             TSNode current = stack.pop();
             if (!current.equals(node)
-                    && ARGUMENT_LIST.equals(current.getType())
-                    && current.getStartByte() > startByte) {
-                return true;
+                    && (ARGUMENT_LIST.equals(current.getType()) || PARAMETER_LIST.equals(current.getType()))) {
+                int delta = current.getStartByte() - markerStartByte;
+                if (delta > 0 && delta <= 64) {
+                    return true;
+                }
             }
             for (int i = 0; i < current.getNamedChildCount(); i++) {
                 TSNode child = current.getNamedChild(i);
@@ -2205,12 +2149,16 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
             if (containsNode(current, bodyNode)) {
                 TSNode parent = current.getParent();
                 if (parent == null) {
-                    return false;
+                    return TRANSLATION_UNIT.equals(current.getType());
                 }
                 String parentType = parent.getType();
                 return TRANSLATION_UNIT.equals(parentType)
                         || DECLARATION_LIST.equals(parentType)
-                        || NAMESPACE_DEFINITION.equals(parentType);
+                        || NAMESPACE_DEFINITION.equals(parentType)
+                        || FIELD_DECLARATION_LIST.equals(parentType)
+                        || CLASS_SPECIFIER.equals(parentType)
+                        || STRUCT_SPECIFIER.equals(parentType)
+                        || UNION_SPECIFIER.equals(parentType);
             }
             current = current.getParent();
         }
@@ -2222,7 +2170,8 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
         while (current != null) {
             TSNode bodyNode = current.getChildByFieldName(FIELD_BODY);
             if (bodyNode != null
-                    && COMPOUND_STATEMENT.equals(bodyNode.getType())
+                    && (COMPOUND_STATEMENT.equals(bodyNode.getType())
+                            || FIELD_DECLARATION_LIST.equals(bodyNode.getType()))
                     && bodyNode.getStartByte() >= markerNode.getStartByte()) {
                 return bodyNode;
             }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
@@ -2092,13 +2092,77 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
             return false;
         }
         TSNode bodyNode = testBodyForMarker(markerNode);
-        if (bodyNode == null || !hasImmediateInvocationParen(markerNode, sourceContent)) {
+        if (bodyNode == null) {
             return false;
         }
-        if ("TEST_METHOD".equals(markerName) && !hasAncestorOfType(markerNode, FIELD_DECLARATION_LIST)) {
+        if ("TEST_METHOD".equals(markerName)) {
+            // MS CppUnitTestFramework is macro-driven and Tree-sitter cannot see macro expansion.
+            // In practice the unexpanded token stream can parse with ERROR nodes and without a reliable
+            // argument-list structure we can traverse. We therefore accept TEST_METHOD only when it appears
+            // in a class-like context (field_declaration_list) and when the next non-trivia token is '('.
+            if (!hasAncestorOfType(markerNode, FIELD_DECLARATION_LIST)) {
+                return false;
+            }
+            if (!hasImmediateInvocationParen(markerNode, sourceContent)) {
+                return false;
+            }
+        } else if (!hasInvocationArgumentsByTree(markerNode, bodyNode)) {
             return false;
         }
         return hasTopLevelLikeOwner(markerNode, bodyNode);
+    }
+
+    private static boolean hasInvocationArgumentsByTree(TSNode markerNode, TSNode bodyNode) {
+        TSNode current = markerNode;
+        while (current != null) {
+            TSNode parent = current.getParent();
+            if (parent == null) {
+                break;
+            }
+            if (CALL_EXPRESSION.equals(parent.getType()) && parent.getChildByFieldName(FIELD_ARGUMENTS) != null) {
+                return true;
+            }
+            current = parent;
+        }
+
+        TSNode functionDef = markerNode;
+        while (functionDef != null) {
+            if (FUNCTION_DEFINITION.equals(functionDef.getType()) && containsNode(functionDef, bodyNode)) {
+                break;
+            }
+            functionDef = functionDef.getParent();
+        }
+        if (functionDef == null) {
+            return false;
+        }
+
+        if (functionDef.getChildByFieldName(FIELD_TYPE) != null) {
+            return false;
+        }
+
+        int markerEnd = markerNode.getEndByte();
+        int bodyStart = bodyNode.getStartByte();
+        var stack = new ArrayDeque<TSNode>();
+        stack.push(functionDef);
+        while (!stack.isEmpty()) {
+            TSNode node = stack.pop();
+            if (!node.equals(bodyNode) && containsNode(bodyNode, node)) {
+                continue;
+            }
+            if (PARAMETER_LIST.equals(node.getType())) {
+                int start = node.getStartByte();
+                if (start >= markerEnd && start < bodyStart) {
+                    return true;
+                }
+            }
+            for (int i = 0; i < node.getNamedChildCount(); i++) {
+                TSNode child = node.getNamedChild(i);
+                if (child != null) {
+                    stack.push(child);
+                }
+            }
+        }
+        return false;
     }
 
     private static boolean hasImmediateInvocationParen(TSNode markerNode, SourceContent sourceContent) {
@@ -2109,6 +2173,34 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
             if (b == ' ' || b == '\t' || b == '\n' || b == '\r') {
                 i++;
                 continue;
+            }
+            if (b == '/') {
+                if (i + 1 >= bytes.length) {
+                    return false;
+                }
+                byte next = bytes[i + 1];
+                if (next == '/') {
+                    i += 2;
+                    while (i < bytes.length) {
+                        byte c = bytes[i];
+                        if (c == '\n' || c == '\r') {
+                            break;
+                        }
+                        i++;
+                    }
+                    continue;
+                }
+                if (next == '*') {
+                    i += 2;
+                    while (i + 1 < bytes.length) {
+                        if (bytes[i] == '*' && bytes[i + 1] == '/') {
+                            i += 2;
+                            break;
+                        }
+                        i++;
+                    }
+                    continue;
+                }
             }
             return b == '(';
         }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/cpp/Constants.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/cpp/Constants.java
@@ -19,8 +19,19 @@ public final class Constants {
     }
 
     public static final String TEST_MARKER_CAPTURE = "test.marker";
-    public static final Set<String> TEST_MARKER_NAMES =
-            Set.of("TEST", "TEST_F", "TEST_P", "TYPED_TEST", "TYPED_TEST_P", "TEST_CASE");
+    public static final Set<String> TEST_MARKER_NAMES = Set.of(
+            "TEST",
+            "TEST_F",
+            "TEST_P",
+            "TYPED_TEST",
+            "TYPED_TEST_P",
+            "TEST_CASE",
+            "SCENARIO",
+            "BOOST_AUTO_TEST_CASE",
+            "BOOST_FIXTURE_TEST_CASE",
+            "BOOST_DATA_TEST_CASE",
+            "TEST_CLASS",
+            "TEST_METHOD");
     public static final String ARGUMENT_LIST = nodeType(CppNodeType.ARGUMENT_LIST);
     public static final String CALL_EXPRESSION = nodeType(CppNodeType.CALL_EXPRESSION);
     public static final String DECLARATION_LIST = nodeType(CppNodeType.DECLARATION_LIST);

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/cpp/CppTreeSitterNodeTypes.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/cpp/CppTreeSitterNodeTypes.java
@@ -33,6 +33,7 @@ public final class CppTreeSitterNodeTypes {
     public static final String DESTRUCTOR_DECLARATION = "destructor_declaration";
     public static final String PARAMETER_DECLARATION = "parameter_declaration";
     public static final String FUNCTION_DECLARATOR = "function_declarator";
+    public static final String PARAMETER_LIST = "parameter_list";
     public static final String TYPE_DEFINITION = "type_definition";
     public static final String ALIAS_DECLARATION = "alias_declaration";
     public static final String USING_DECLARATION = "using_declaration";

--- a/brokk-shared/src/main/resources/treesitter/cpp/definitions.scm
+++ b/brokk-shared/src/main/resources/treesitter/cpp/definitions.scm
@@ -91,14 +91,6 @@
 (access_specifier) @access.specifier
 
 ; Test markers (GoogleTest/Catch2 style test macro invocations)
-(function_definition
-  declarator: (function_declarator
-    declarator: [
-                  (identifier) @test.marker
-                  (field_identifier) @test.marker
-                  ])
-  (#match? @test.marker "^(TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P|TEST_CASE|SCENARIO|BOOST_AUTO_TEST_CASE|BOOST_FIXTURE_TEST_CASE|BOOST_DATA_TEST_CASE|TEST_CLASS|TEST_METHOD)$"))
-
 (call_expression
   function: (identifier) @test.marker
   (#match? @test.marker "^(TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P|TEST_CASE|SCENARIO|BOOST_AUTO_TEST_CASE|BOOST_FIXTURE_TEST_CASE|BOOST_DATA_TEST_CASE|TEST_CLASS|TEST_METHOD)$"))

--- a/brokk-shared/src/main/resources/treesitter/cpp/definitions.scm
+++ b/brokk-shared/src/main/resources/treesitter/cpp/definitions.scm
@@ -91,12 +91,20 @@
 (access_specifier) @access.specifier
 
 ; Test markers (GoogleTest/Catch2 style test macro invocations)
+(function_definition
+  declarator: (function_declarator
+    declarator: [
+                  (identifier) @test.marker
+                  (field_identifier) @test.marker
+                  ])
+  (#match? @test.marker "^(TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P|TEST_CASE|SCENARIO|BOOST_AUTO_TEST_CASE|BOOST_FIXTURE_TEST_CASE|BOOST_DATA_TEST_CASE|TEST_CLASS|TEST_METHOD)$"))
+
 (call_expression
   function: (identifier) @test.marker
-  (#match? @test.marker "^(TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P|TEST_CASE)$"))
+  (#match? @test.marker "^(TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P|TEST_CASE|SCENARIO|BOOST_AUTO_TEST_CASE|BOOST_FIXTURE_TEST_CASE|BOOST_DATA_TEST_CASE|TEST_CLASS|TEST_METHOD)$"))
 
 ; Fallback capture: require invocation structure, not a bare identifier.
 ; Some parser shapes expose macro names as bare identifiers. Structure is validated
 ; in CppAnalyzer before accepting a marker (must map to invocation/body context).
 ((identifier) @test.marker
-  (#match? @test.marker "^(TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P|TEST_CASE)$"))
+  (#match? @test.marker "^(TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P|TEST_CASE|SCENARIO|BOOST_AUTO_TEST_CASE|BOOST_FIXTURE_TEST_CASE|BOOST_DATA_TEST_CASE|TEST_CLASS|TEST_METHOD)$"))

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/CppTreeSitterCaptureTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/CppTreeSitterCaptureTest.java
@@ -1,0 +1,144 @@
+package ai.brokk.analyzer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.cpp.Constants;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.treesitter.TSNode;
+import org.treesitter.TSParser;
+import org.treesitter.TSQuery;
+import org.treesitter.TSQueryCapture;
+import org.treesitter.TSQueryCursor;
+import org.treesitter.TSQueryMatch;
+import org.treesitter.TSTree;
+import org.treesitter.TreeSitterCpp;
+
+public class CppTreeSitterCaptureTest {
+    @Test
+    void capturesTestMarkerForCommonMacroShapes() throws IOException {
+        List<String> sources = List.of(
+                """
+                #include <gtest/gtest.h>
+
+                TEST(SampleTest, NoAssertions) {
+                    int value = 42;
+                    value++;
+                }
+                """,
+                """
+                #include <gtest/gtest.h>
+
+                TEST /* comment */ (SampleTest, NoAssertions) {
+                    int value = 42;
+                    value++;
+                }
+                """,
+                """
+                BOOST_AUTO_TEST_CASE(NoAssertions) {
+                    int value = 42;
+                    value++;
+                }
+                """,
+                """
+                TEST_CASE("NoAssertions") {
+                    int value = 42;
+                    value++;
+                }
+                """,
+                """
+                SCENARIO("NoAssertions") {
+                    int value = 42;
+                    value++;
+                }
+                """,
+                """
+                TEST_CLASS(SampleTests) {
+                public:
+                    TEST_METHOD(NoAssertions) {
+                        int value = 42;
+                        value++;
+                    }
+                };
+                """);
+
+        TSQuery query = loadDefinitionsQuery();
+        for (int i = 0; i < sources.size(); i++) {
+            String source = sources.get(i);
+            SourceContent content = SourceContent.of(source);
+            try (TSTree tree = parse(source)) {
+                TSNode root = tree.getRootNode();
+                assertNotNull(root, "rootNode");
+                List<Capture> captures = capturesFor(query, root, content);
+                boolean hasTestMarker = captures.stream().anyMatch(c -> Constants.TEST_MARKER_CAPTURE.equals(c.name()));
+
+                Path dumpDir = Path.of("build", "treesitter-dumps");
+                Files.createDirectories(dumpDir);
+                Path dumpPath = dumpDir.resolve("cpp-case-" + i + ".txt");
+                Files.writeString(
+                        dumpPath,
+                        ("=== case " + i + " ===\n"
+                                + source
+                                + "\n--- root ---\n"
+                                + root
+                                + "\n--- captures ---\n"
+                                + captures.stream().map(Object::toString).reduce("", (a, b) -> a + b + "\n")),
+                        StandardCharsets.UTF_8);
+
+                assertTrue(hasTestMarker, "expected @" + Constants.TEST_MARKER_CAPTURE + " capture for case " + i);
+            }
+        }
+    }
+
+    private static TSTree parse(String source) {
+        var parser = new TSParser();
+        parser.setLanguage(new TreeSitterCpp());
+        TSTree tree = parser.parseString(null, source);
+        assertNotNull(tree, "tree");
+        return tree;
+    }
+
+    private static TSQuery loadDefinitionsQuery() throws IOException {
+        try (InputStream in =
+                CppTreeSitterCaptureTest.class.getClassLoader().getResourceAsStream("treesitter/cpp/definitions.scm")) {
+            assertNotNull(in, "treesitter/cpp/definitions.scm");
+            String scm = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            assertFalse(scm.isBlank(), "definitions.scm");
+            return new TSQuery(new TreeSitterCpp(), scm);
+        }
+    }
+
+    private static List<Capture> capturesFor(TSQuery query, TSNode root, SourceContent content) {
+        var out = new ArrayList<Capture>();
+        try (TSQueryCursor cursor = new TSQueryCursor()) {
+            cursor.exec(query, root, content.text());
+            TSQueryMatch match = new TSQueryMatch();
+            while (cursor.nextMatch(match)) {
+                for (TSQueryCapture capture : match.getCaptures()) {
+                    TSNode node = capture.getNode();
+                    if (node == null) {
+                        continue;
+                    }
+                    String captureName = query.getCaptureNameForId(capture.getIndex());
+                    out.add(new Capture(
+                            captureName,
+                            node.getType(),
+                            node.getStartByte(),
+                            node.getEndByte(),
+                            content.substringFrom(node).strip()));
+                }
+            }
+        }
+        return out;
+    }
+
+    private record Capture(String name, String nodeType, int startByte, int endByte, String text) {}
+}

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CppTestAssertionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CppTestAssertionSmellTest.java
@@ -44,6 +44,21 @@ public class CppTestAssertionSmellTest extends AbstractBrittleTestSuite {
     }
 
     @Test
+    void acceptsMarkerWhenCommentSeparatesNameAndParen() {
+        String code =
+                """
+                #include <gtest/gtest.h>
+
+                TEST /* comment */ (SampleTest, NoAssertions) {
+                    int value = 42;
+                    value++;
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "no-assertions"), findings.toString());
+    }
+
+    @Test
     void flagsNoAssertionsForCatch2StyleTestCase() {
         String code =
                 """

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CppTestAssertionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CppTestAssertionSmellTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class CppTestAssertionSmellTest extends AbstractBrittleTestSuite {
-    private static final String TEST_PATH = "test/sample_test.cpp";
+    private static final String TEST_PATH = "src/sample.cpp";
 
     @Test
     void flagsConstantTruthAndConstantEqualityInGTest() {
@@ -41,6 +41,67 @@ public class CppTestAssertionSmellTest extends AbstractBrittleTestSuite {
                 """;
         var findings = analyze(code);
         assertTrue(hasReason(findings, "no-assertions"), findings.toString());
+    }
+
+    @Test
+    void flagsNoAssertionsForCatch2StyleTestCase() {
+        String code =
+                """
+                TEST_CASE("NoAssertions") {
+                    int value = 42;
+                    value++;
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "no-assertions"), findings.toString());
+    }
+
+    @Test
+    void flagsNoAssertionsForCatch2Scenario() {
+        String code =
+                """
+                SCENARIO("NoAssertions") {
+                    int value = 42;
+                    value++;
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "no-assertions"), findings.toString());
+    }
+
+    @Test
+    void flagsNoAssertionsForBoostTestCase() {
+        String code =
+                """
+                BOOST_AUTO_TEST_CASE(NoAssertions) {
+                    int value = 42;
+                    value++;
+                }
+                """;
+        var findings = analyze(code);
+        assertTrue(hasReason(findings, "no-assertions"), findings.toString());
+    }
+
+    @Test
+    void flagsNoAssertionsForMsTestMethodInsideTestClass() {
+        String code =
+                """
+                TEST_CLASS(SampleTests) {
+                public:
+                    TEST_METHOD(NoAssertions) {
+                        int value = 42;
+                        value++;
+                    }
+                };
+                """;
+        try (var testProject = InlineCoreProject.code(code, TEST_PATH).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), TEST_PATH);
+            boolean containsTests = analyzer.containsTests(file);
+            var findings = analyzer.findTestAssertionSmells(file, null);
+            assertTrue(containsTests, "containsTests=false findings=" + findings);
+            assertTrue(hasReason(findings, "no-assertions"), findings.toString());
+        }
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Remove the filename-based C/C++ test fallback and rely on structured Tree-sitter marker detection.
- Expand marker support for common macro-based frameworks and harden AST-local body association.
- Add regression coverage for non-test-like paths so `no-assertions` is driven by syntax, not filenames.

**Key Changes**:
- Broadened the recognized C/C++ test marker set and updated the C++ Tree-sitter query to capture additional frameworks.
- Tightened C++ marker validation to recognize structured test bodies, including class-scoped test methods, without reintroducing path heuristics.
- Added regression tests covering GTest, Catch2/Doctest, Boost.Test, and MS CppUnitTestFramework patterns.

**Touch Points**:
- `brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/cpp/Constants.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/cpp/CppTreeSitterNodeTypes.java`
- `brokk-shared/src/main/resources/treesitter/cpp/definitions.scm`
- `brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CppTestAssertionSmellTest.java`

### Testing
- `./gradlew fix tidy`
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.code_quality.CppTestAssertionSmellTest`
- `./gradlew analyze`

Resolves #3321
