### PR TITLE
Fix C++ test-marker detection to avoid per-file fallback scans

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
@@ -1949,7 +1949,7 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
                             }
                         }
                     }
-                    return hasStructuredMarkerByName(rootNode, sourceContent);
+                    return false;
                 },
                 false);
     }
@@ -2047,21 +2047,6 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
                     return blocks;
                 },
                 List.of());
-    }
-
-    private static boolean hasStructuredMarkerByName(TSNode rootNode, SourceContent sourceContent) {
-        var identifiers = new ArrayList<TSNode>();
-        collectNodesByType(rootNode, Set.of(IDENTIFIER), identifiers);
-        for (TSNode identifierNode : identifiers) {
-            String markerName = sourceContent.substringFrom(identifierNode).strip();
-            if (!TEST_MARKER_NAMES.contains(markerName)) {
-                continue;
-            }
-            if (isStructuredTestMarker(identifierNode, markerName, sourceContent)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static void collectStructuredMarkerBlocks(

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CppTestAssertionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CppTestAssertionSmellTest.java
@@ -13,6 +13,43 @@ public class CppTestAssertionSmellTest extends AbstractBrittleTestSuite {
     private static final String TEST_PATH = "src/sample.cpp";
 
     @Test
+    void containsTestsIsTrueForGTestMacroInNonTestPath() {
+        String code =
+                """
+                #include <gtest/gtest.h>
+
+                TEST(SampleTest, HasTestMarker) {
+                    EXPECT_TRUE(true);
+                }
+                """;
+        try (var testProject = InlineCoreProject.code(code, TEST_PATH).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), TEST_PATH);
+            assertTrue(analyzer.containsTests(file));
+        }
+    }
+
+    @Test
+    void containsTestsIsFalseWhenNoTestMarkersPresent() {
+        String code =
+                """
+                int add(int a, int b) {
+                    return a + b;
+                }
+
+                void usesIdentifierNamedTEST() {
+                    int TEST = 1;
+                    (void) TEST;
+                }
+                """;
+        try (var testProject = InlineCoreProject.code(code, TEST_PATH).build()) {
+            IAnalyzer analyzer = testProject.getAnalyzer();
+            ProjectFile file = new ProjectFile(testProject.getRoot(), TEST_PATH);
+            assertFalse(analyzer.containsTests(file));
+        }
+    }
+
+    @Test
     void flagsConstantTruthAndConstantEqualityInGTest() {
         String code =
                 """


### PR DESCRIPTION
### Description
This change removes the expensive identifier-walk fallback from C++ test-marker detection so `containsTests(...)` stays query-driven and cheap during full-tree analysis. The regression came from running that fallback on every parsed C/C++ file, which was especially costly on large Chromium sources.

**Key Changes**:
- `CppAnalyzer.containsTestMarkers(...)` now returns `false` if the query does not produce a valid `@test.marker` capture, instead of scanning all identifiers as a fallback.
- Added regression coverage for `containsTests(...)` to verify positive detection on a representative gtest case and negative detection when no test marker is present.
- Removed the now-unused fallback helper that performed the full identifier traversal.

**Touch Points**:
- `brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java`
- `brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/CppTestAssertionSmellTest.java`

### Testing
- Added targeted unit tests for `containsTests(...)` positive and negative cases.
- Ran `./gradlew fix tidy` and `./gradlew analyze` successfully.
- Ran the perf benchmark against the offending commit and confirmed the fix brings Chromium C/C++ back to roughly the last-good timing.