### PR TITLE
Auto-approve Brokk MCP tools in Codex plugin install

### DIFF
--- a/brokk-code/brokk_code/mcp_config.py
+++ b/brokk-code/brokk_code/mcp_config.py
@@ -1002,15 +1002,16 @@ def _merge_codex_tool_approval(settings_path: Path | None = None, uvx_command: s
         mcp_servers = {}
         settings["mcp_servers"] = mcp_servers
 
-    server = mcp_servers.get(_SERVER_NAME)
-    if isinstance(server, dict) and server.get("default_tools_approval_mode") == "approve":
-        return
-
-    mcp_servers[_SERVER_NAME] = {
+    expected = {
         "command": uvx_command,
         "args": ["brokk", "mcp-core"],
         "default_tools_approval_mode": "approve",
     }
+    server = mcp_servers.get(_SERVER_NAME)
+    if isinstance(server, dict) and all(server.get(k) == v for k, v in expected.items()):
+        return
+
+    mcp_servers[_SERVER_NAME] = expected
     path.parent.mkdir(parents=True, exist_ok=True)
     toml_text = _serialize_toml(settings)
     _atomic_write_toml(path, toml_text)

--- a/brokk-code/brokk_code/mcp_config.py
+++ b/brokk-code/brokk_code/mcp_config.py
@@ -977,11 +977,51 @@ def _load_marketplace(path: Path) -> dict[str, Any]:
     return data
 
 
+def _merge_codex_tool_approval(settings_path: Path | None = None, uvx_command: str = "uvx") -> None:
+    """Ensure a full ``[mcp_servers.brokk]`` entry with
+    ``default_tools_approval_mode = "approve"`` exists in Codex's ``config.toml``.
+
+    Codex's approval checker only reads the TOML config layers, not
+    plugin-loaded MCP servers, so a complete server definition (including
+    transport) is required here."""
+    path = settings_path or Path.home() / ".codex" / "config.toml"
+    if path.exists():
+        raw_text = path.read_text(encoding="utf-8")
+        if raw_text.strip():
+            try:
+                settings = tomllib.loads(raw_text)
+            except ValueError as exc:
+                raise ValueError(f"Could not parse {path} as TOML: {exc}") from exc
+        else:
+            settings = {}
+    else:
+        settings = {}
+
+    mcp_servers = settings.get("mcp_servers")
+    if mcp_servers is None:
+        mcp_servers = {}
+        settings["mcp_servers"] = mcp_servers
+
+    server = mcp_servers.get(_SERVER_NAME)
+    if isinstance(server, dict) and server.get("default_tools_approval_mode") == "approve":
+        return
+
+    mcp_servers[_SERVER_NAME] = {
+        "command": uvx_command,
+        "args": ["brokk", "mcp-core"],
+        "default_tools_approval_mode": "approve",
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    toml_text = _serialize_toml(settings)
+    _atomic_write_toml(path, toml_text)
+
+
 def install_codex_local_plugin(
     *,
     force: bool = False,
     plugin_path: Path | None = None,
     marketplace_path: Path | None = None,
+    settings_path: Path | None = None,
     uvx_command: str = "uvx",
 ) -> InstalledCodexPlugin:
     plugin_dir = plugin_path or (Path.home() / ".codex" / "plugins" / _BROKK_CODEX_PLUGIN_NAME)
@@ -1042,6 +1082,8 @@ def install_codex_local_plugin(
 
     marketplace.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_settings(marketplace, marketplace_data)
+
+    _merge_codex_tool_approval(settings_path, uvx_command=uvx_command)
 
     return InstalledCodexPlugin(plugin_path=plugin_dir, marketplace_path=marketplace)
 
@@ -1142,6 +1184,7 @@ def configure_codex_mcp_settings(
     server_config = _brokk_mcp_config(uvx_command) | {
         "startup_timeout_sec": 60.0,
         "tool_timeout_sec": 300.0,
+        "default_tools_approval_mode": "approve",
     }
     mcp_servers[_SERVER_NAME] = server_config
 

--- a/brokk-code/tests/test_mcp_config.py
+++ b/brokk-code/tests/test_mcp_config.py
@@ -114,6 +114,8 @@ def test_configure_codex_mcp_settings_appends_to_codex_agents(tmp_path, monkeypa
     agents_md = tmp_path / ".codex" / "AGENTS.md"
 
     assert config_path.exists()
+    config_data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert config_data["mcp_servers"]["brokk"]["default_tools_approval_mode"] == "approve"
     assert agents_md.exists()
     content = agents_md.read_text()
     assert "<!-- BROKK:BEGIN MANAGED SECTION -->" in content
@@ -210,6 +212,7 @@ def test_configure_codex_mcp_settings_uses_uvx_command(tmp_path):
     data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     assert data["mcp_servers"]["brokk"]["command"] == "/home/user/.local/bin/uvx"
     assert data["mcp_servers"]["brokk"]["args"] == ["brokk", "mcp"]
+    assert data["mcp_servers"]["brokk"]["default_tools_approval_mode"] == "approve"
 
 
 def test_configure_claude_code_mcp_settings_defaults_to_uvx(tmp_path):
@@ -334,6 +337,14 @@ def test_install_codex_local_plugin_creates_plugin_and_marketplace(monkeypatch, 
     assert mcp_data["mcpServers"]["brokk"]["type"] == "stdio"
     assert mcp_data["mcpServers"]["brokk"]["command"] == "uvx"
     assert mcp_data["mcpServers"]["brokk"]["args"] == ["brokk", "mcp-core"]
+
+    config_toml_path = tmp_path / ".codex" / "config.toml"
+    assert config_toml_path.exists()
+    config_data = tomllib.loads(config_toml_path.read_text(encoding="utf-8"))
+    brokk_server = config_data["mcp_servers"]["brokk"]
+    assert brokk_server["command"] == "uvx"
+    assert brokk_server["args"] == ["brokk", "mcp-core"]
+    assert brokk_server["default_tools_approval_mode"] == "approve"
 
     marketplace_data = json.loads(marketplace_path.read_text(encoding="utf-8"))
     assert marketplace_data["name"] == "brokk-local"


### PR DESCRIPTION
## Summary
- When `brokk install codex-plugin` runs, write a `[mcp_servers.brokk]` entry with `default_tools_approval_mode = "approve"` to `~/.codex/config.toml` so Brokk's read-only tools are auto-approved
- Also add the same setting to the `brokk install mcp` path
- Codex's approval checker only reads TOML config layers (not plugin `.mcp.json`), so a full server definition in `config.toml` is required

## Test plan
- [x] `uv run pytest tests/test_mcp_config.py` — 22/22 pass
- [x] Manual test: `brokk install codex-plugin`, restart Codex, call `activateWorkspace` — no approval prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)