### PR TITLE
Fix plugin manifest: agents field requires explicit file paths

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -3,7 +3,15 @@
   "description": "Semantic code intelligence -- symbol navigation, cross-reference analysis, and structural code understanding powered by tree-sitter",
   "version": "0.2.0",
   "skills": "./skills/",
-  "agents": "./agents/",
+  "agents": [
+    "./agents/architect-reviewer.md",
+    "./agents/devops-reviewer.md",
+    "./agents/dry-reviewer.md",
+    "./agents/issue-diagnostician.md",
+    "./agents/issue-planner.md",
+    "./agents/security-reviewer.md",
+    "./agents/senior-dev-reviewer.md"
+  ],
   "mcpServers": "./.mcp.json",
   "author": {
     "name": "Brokk AI"


### PR DESCRIPTION
## Summary
- The `agents` field in `plugin.json` doesn't accept directory paths (unlike `skills`) -- it requires individual file paths or an array of them
- Changed `"agents": "./agents/"` to an explicit array listing each agent `.md` file
- Fixes `Validation errors: agents: Invalid input` on plugin install

## Test plan
- [x] `claude plugin validate` passes
- [ ] Plugin installs successfully via `claude plugin install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)