### PR TITLE
Refactor cyclomatic complexity analysis to reuse file-level Tree-sitter parses

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
@@ -1556,63 +1556,61 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
     public int computeCyclomaticComplexity(CodeUnit cu) {
         if (!cu.isFunction()) return 0;
 
-        return getSource(cu, false)
-                .map(source -> {
-                    try (TSTree tree = getTSParser().parseStringOrThrow(null, source)) {
-                        TSNode root = tree.getRootNode();
-                        if (root == null) return 1;
-
-                        SourceContent content = SourceContent.of(source);
-                        int complexity = 1; // Base complexity
-
-                        Deque<TSNode> stack = new ArrayDeque<>();
-                        stack.push(root);
-
-                        while (!stack.isEmpty()) {
-                            TSNode node = stack.pop();
-                            String type = node.getType();
-                            if (type == null) {
-                                continue;
+        Integer result = withTreeOf(
+                cu.source(),
+                tree -> withSource(
+                        cu.source(),
+                        content -> {
+                            TSNode cuNode = primaryNodeForCodeUnit(tree, cu);
+                            if (cuNode == null) {
+                                return 1;
                             }
 
-                            switch (JavaNodeType.fromType(type)) {
-                                case IF_STATEMENT,
-                                        FOR_STATEMENT,
-                                        ENHANCED_FOR_STATEMENT,
-                                        WHILE_STATEMENT,
-                                        DO_STATEMENT,
-                                        CATCH_CLAUSE,
-                                        TERNARY_EXPRESSION -> complexity++;
-                                case SWITCH_LABEL -> {
-                                    // Only count if not the 'default' case
-                                    if (!content.substringFrom(node).contains("default")) {
-                                        complexity++;
+                            int complexity = 1;
+                            Deque<TSNode> stack = new ArrayDeque<>();
+                            stack.push(cuNode);
+
+                            while (!stack.isEmpty()) {
+                                TSNode node = stack.pop();
+                                String type = node.getType();
+                                if (type == null) {
+                                    continue;
+                                }
+
+                                switch (JavaNodeType.fromType(type)) {
+                                    case IF_STATEMENT,
+                                            FOR_STATEMENT,
+                                            ENHANCED_FOR_STATEMENT,
+                                            WHILE_STATEMENT,
+                                            DO_STATEMENT,
+                                            CATCH_CLAUSE,
+                                            TERNARY_EXPRESSION -> complexity++;
+                                    case SWITCH_LABEL -> {
+                                        if (!content.substringFrom(node).contains("default")) {
+                                            complexity++;
+                                        }
+                                    }
+                                    case BINARY_EXPRESSION -> {
+                                        String operator = content.substringFrom(node);
+                                        if (operator.contains("&&") || operator.contains("||")) {
+                                            complexity++;
+                                        }
+                                    }
+                                    default -> {}
+                                }
+
+                                for (int i = 0; i < node.getNamedChildCount(); i++) {
+                                    TSNode child = node.getNamedChild(i);
+                                    if (child != null) {
+                                        stack.push(child);
                                     }
                                 }
-                                case BINARY_EXPRESSION -> {
-                                    // Check for && or ||
-                                    String operator = content.substringFrom(node);
-                                    if (operator.contains("&&") || operator.contains("||")) {
-                                        complexity++;
-                                    }
-                                }
-                                default -> {}
                             }
-
-                            for (int i = 0; i < node.getNamedChildCount(); i++) {
-                                TSNode child = node.getNamedChild(i);
-                                if (child != null) {
-                                    stack.push(child);
-                                }
-                            }
-                        }
-                        return complexity;
-                    } catch (Exception e) {
-                        log.warn("Failed to compute complexity for {} using AST; falling back", cu.fqName(), e);
-                        return super.computeCyclomaticComplexity(cu);
-                    }
-                })
-                .orElse(0);
+                            return complexity;
+                        },
+                        1),
+                1);
+        return result != null ? result : 1;
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
@@ -1555,6 +1555,7 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
     @Override
     public int computeCyclomaticComplexity(CodeUnit cu) {
         if (!cu.isFunction()) return 0;
+        int fallbackComplexity = super.computeCyclomaticComplexity(cu);
 
         Integer result = withTreeOf(
                 cu.source(),
@@ -1608,9 +1609,9 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
                             }
                             return complexity;
                         },
-                        1),
-                1);
-        return result != null ? result : 1;
+                        fallbackComplexity),
+                fallbackComplexity);
+        return result != null ? result : fallbackComplexity;
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
@@ -782,6 +782,7 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
     @Override
     public int computeCyclomaticComplexity(CodeUnit cu) {
         if (!cu.isFunction()) return 0;
+        int fallbackComplexity = super.computeCyclomaticComplexity(cu);
 
         Integer result = withTreeOf(
                 cu.source(),
@@ -829,9 +830,9 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
                             }
                             return complexity;
                         },
-                        1),
-                1);
-        return result != null ? result : 1;
+                        fallbackComplexity),
+                fallbackComplexity);
+        return result != null ? result : fallbackComplexity;
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
@@ -783,55 +783,55 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
     public int computeCyclomaticComplexity(CodeUnit cu) {
         if (!cu.isFunction()) return 0;
 
-        return getSource(cu, false)
-                .map(source -> {
-                    try (TSTree tree = getTSParser().parseStringOrThrow(null, source)) {
-                        TSNode root = tree.getRootNode();
-                        if (root == null) return 1;
-
-                        SourceContent content = SourceContent.of(source);
-                        int complexity = 1; // Base complexity
-
-                        Deque<TSNode> stack = new ArrayDeque<>();
-                        stack.push(root);
-
-                        while (!stack.isEmpty()) {
-                            TSNode node = stack.pop();
-                            String type = node.getType();
-                            if (type == null) {
-                                continue;
+        Integer result = withTreeOf(
+                cu.source(),
+                tree -> withSource(
+                        cu.source(),
+                        content -> {
+                            TSNode cuNode = primaryNodeForCodeUnit(tree, cu);
+                            if (cuNode == null) {
+                                return 1;
                             }
 
-                            switch (type) {
-                                case IF_STATEMENT,
-                                        ELIF_CLAUSE,
-                                        FOR_STATEMENT,
-                                        WHILE_STATEMENT,
-                                        EXCEPT_CLAUSE,
-                                        CONDITIONAL_EXPRESSION,
-                                        CASE_CLAUSE -> complexity++;
-                                case BOOLEAN_OPERATOR -> {
-                                    String op = content.substringFrom(node);
-                                    if (op.contains("and") || op.contains("or")) {
-                                        complexity++;
+                            int complexity = 1;
+                            Deque<TSNode> stack = new ArrayDeque<>();
+                            stack.push(cuNode);
+
+                            while (!stack.isEmpty()) {
+                                TSNode node = stack.pop();
+                                String type = node.getType();
+                                if (type == null) {
+                                    continue;
+                                }
+
+                                switch (type) {
+                                    case IF_STATEMENT,
+                                            ELIF_CLAUSE,
+                                            FOR_STATEMENT,
+                                            WHILE_STATEMENT,
+                                            EXCEPT_CLAUSE,
+                                            CONDITIONAL_EXPRESSION,
+                                            CASE_CLAUSE -> complexity++;
+                                    case BOOLEAN_OPERATOR -> {
+                                        String op = content.substringFrom(node);
+                                        if (op.contains("and") || op.contains("or")) {
+                                            complexity++;
+                                        }
+                                    }
+                                }
+
+                                for (int i = 0; i < node.getNamedChildCount(); i++) {
+                                    TSNode child = node.getNamedChild(i);
+                                    if (child != null) {
+                                        stack.push(child);
                                     }
                                 }
                             }
-
-                            for (int i = 0; i < node.getNamedChildCount(); i++) {
-                                TSNode child = node.getNamedChild(i);
-                                if (child != null) {
-                                    stack.push(child);
-                                }
-                            }
-                        }
-                        return complexity;
-                    } catch (Exception e) {
-                        log.warn("Failed to compute complexity for {} using AST; falling back", cu.fqName(), e);
-                        return super.computeCyclomaticComplexity(cu);
-                    }
-                })
-                .orElse(0);
+                            return complexity;
+                        },
+                        1),
+                1);
+        return result != null ? result : 1;
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1550,16 +1550,17 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
         // For classes, expect one primary definition range (already expanded with comments)
         var range = ranges.getFirst();
-
-        var scOpt = SourceContent.read(cu.source());
-        if (scOpt.isEmpty()) {
+        String extractedSource = withSource(
+                cu.source(),
+                sc -> {
+                    // Choose start byte based on includeComments parameter
+                    int extractStartByte = includeComments ? range.commentStartByte() : range.startByte();
+                    return sc.substringFromBytes(extractStartByte, range.endByte());
+                },
+                "");
+        if (extractedSource.isEmpty()) {
             return Optional.empty();
         }
-
-        // Choose start byte based on includeComments parameter
-        int extractStartByte = includeComments ? range.commentStartByte() : range.startByte();
-        var extractedSource = scOpt.get().substringFromBytes(extractStartByte, range.endByte());
-
         return Optional.of(extractedSource);
     }
 
@@ -1574,38 +1575,40 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
             return Collections.emptySet();
         }
 
-        var scOpt = SourceContent.read(cu.source());
-        if (scOpt.isEmpty()) {
-            log.warn("Could not read source for CU {} (fqName {}): {}", cu, cu.fqName(), "unreadable");
-            return Collections.emptySet();
-        }
+        return withSource(
+                cu.source(),
+                sc -> {
+                    // Sort ranges by startByte to ensure they appear in source order (important for function overloads)
+                    // Always sort by the actual code start byte, not the comment start byte, to maintain source order
+                    var sortedRanges = rangesForOverloads.stream()
+                            .sorted(Comparator.comparingInt(Range::startByte))
+                            .toList();
 
-        // Sort ranges by startByte to ensure they appear in source order (important for function overloads)
-        // Always sort by the actual code start byte, not the comment start byte, to maintain source order
-        var sortedRanges = rangesForOverloads.stream()
-                .sorted(Comparator.comparingInt(Range::startByte))
-                .toList();
-
-        var methodSources = new LinkedHashSet<String>();
-        for (Range range : sortedRanges) {
-            // Choose start byte based on includeComments parameter
-            int extractStartByte = includeComments ? range.commentStartByte() : range.startByte();
-            String methodSource = scOpt.get().substringFromBytes(extractStartByte, range.endByte());
-            if (!methodSource.isEmpty()) {
-                methodSources.add(methodSource);
-            } else {
-                log.warn(
-                        "Could not extract valid method source for range [{}, {}] for CU {} (fqName {}). Skipping this range.",
-                        extractStartByte,
-                        range.endByte(),
-                        cu,
-                        cu.fqName());
-            }
-        }
-        if (methodSources.isEmpty()) {
-            log.warn("After processing ranges, no valid method sources found for CU {} (fqName {}).", cu, cu.fqName());
-        }
-        return Collections.unmodifiableSequencedSet(methodSources);
+                    var methodSources = new LinkedHashSet<String>();
+                    for (Range range : sortedRanges) {
+                        // Choose start byte based on includeComments parameter
+                        int extractStartByte = includeComments ? range.commentStartByte() : range.startByte();
+                        String methodSource = sc.substringFromBytes(extractStartByte, range.endByte());
+                        if (!methodSource.isEmpty()) {
+                            methodSources.add(methodSource);
+                        } else {
+                            log.warn(
+                                    "Could not extract valid method source for range [{}, {}] for CU {} (fqName {}). Skipping this range.",
+                                    extractStartByte,
+                                    range.endByte(),
+                                    cu,
+                                    cu.fqName());
+                        }
+                    }
+                    if (methodSources.isEmpty()) {
+                        log.warn(
+                                "After processing ranges, no valid method sources found for CU {} (fqName {}).",
+                                cu,
+                                cu.fqName());
+                    }
+                    return Collections.unmodifiableSequencedSet(methodSources);
+                },
+                Collections.emptySet());
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1127,6 +1127,21 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 defaultValue);
     }
 
+    protected @Nullable TSNode primaryNodeForCodeUnit(TSTree tree, CodeUnit cu) {
+        List<Range> ranges = rangesOf(cu);
+        if (ranges.isEmpty()) {
+            return null;
+        }
+
+        TSNode root = tree.getRootNode();
+        if (root == null) {
+            return null;
+        }
+
+        Range primary = ranges.getFirst();
+        return root.getDescendantForByteRange(primary.startByte(), primary.endByte());
+    }
+
     // ---------- IAnalyzer ----------
     @Override
     public Set<Language> languages() {


### PR DESCRIPTION
### Summary
- Align Java and Python cyclomatic complexity analysis with the existing file-level Tree-sitter approach used by JS/TS.
- Remove the per-function parse path so complexity checks reuse the parsed file tree and resolve the target function/class node by byte range.
- Keep the scoring logic unchanged while reducing redundant parsing and source extraction overhead.

**Key Changes**:
- Updated `JavaAnalyzer` and `PythonAnalyzer` to traverse the code unit subtree from a single file parse instead of reparsing extracted function source.
- Added a shared helper in `TreeSitterAnalyzer` to resolve the primary AST node for a `CodeUnit`.
- Preserved the existing complexity rules and fallback behavior.

**Touch Points**:
- `brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java`

### Testing
- `./gradlew fix tidy`
- `./gradlew :brokk-shared:compileJava`
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.complexity.JavaCyclomaticComplexityTest --tests ai.brokk.analyzer.complexity.PythonCyclomaticComplexityTest`