### PR TITLE
Use BrokkFile syntax style for ContextFragments (replace guessContentType)

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/context/ContextFragments.java
+++ b/brokk-shared/src/main/java/ai/brokk/context/ContextFragments.java
@@ -31,7 +31,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -225,23 +224,6 @@ public class ContextFragments {
 
     private static LoggingExecutorService createFragmentExecutor() {
         return ExecutorsUtil.newVirtualThreadExecutor("brokk-cf-", 1_000);
-    }
-
-    private static String guessContentType(BrokkFile file) {
-        // Prefer OS-level sniffing, then filename-based guessing, and finally fall back to a safe default.
-        try {
-            if (file instanceof ProjectFile pf) {
-                var detected = Files.probeContentType(pf.absPath());
-                if (detected != null) {
-                    return detected;
-                }
-            }
-        } catch (IOException e) {
-            logger.debug("Failed probing content type for {}", file, e);
-        }
-
-        var guessed = URLConnection.guessContentTypeFromName(file.toString());
-        return guessed != null ? guessed : "application/octet-stream";
     }
 
     public sealed interface PathFragment extends ContextFragment
@@ -552,7 +534,7 @@ public class ContextFragments {
                     contextManager,
                     computeDescription(file),
                     file.getFileName(),
-                    guessContentType(file),
+                    file.getSyntaxStyle(),
                     snapshotText == null
                             ? null
                             : decodeFrozen(file, contextManager, snapshotText.getBytes(StandardCharsets.UTF_8)),
@@ -621,7 +603,7 @@ public class ContextFragments {
                             FragmentType.GIT_FILE,
                             String.format("%s @%s", file.getFileName(), revision),
                             content,
-                            guessContentType(file),
+                            file.getSyntaxStyle(),
                             GitFileFragment.class.getName()));
         }
 
@@ -634,7 +616,7 @@ public class ContextFragments {
                     id,
                     computeDescription(file, revision),
                     "%s @%s".formatted(file.getFileName(), revision),
-                    guessContentType(file),
+                    file.getSyntaxStyle(),
                     ContentSnapshot.textSnapshot(content, Set.of(), Set.of(file)));
             if (file.getRelPath().normalize().getFileName() == null) {
                 throw new IllegalArgumentException("ProjectPathFragment relPath must not be empty");
@@ -723,7 +705,7 @@ public class ContextFragments {
                     contextManager,
                     file.toString(),
                     file.toString(),
-                    guessContentType(file),
+                    file.getSyntaxStyle(),
                     snapshotText == null ? null : decodeFrozen(snapshotText.getBytes(StandardCharsets.UTF_8)),
                     snapshotText == null ? () -> computeSnapshotFor(file) : null);
             assert !file.isDirectory() : file; // assert so we don't do i/o here in prod
@@ -1781,7 +1763,7 @@ public class ContextFragments {
                     contextManager,
                     computeDescription(file, startLine, endLine),
                     computeShortDescription(file, startLine, endLine),
-                    guessContentType(file),
+                    file.getSyntaxStyle(),
                     snapshotText == null ? null : ContentSnapshot.textSnapshot(snapshotText, Set.of(), Set.of(file)),
                     snapshotText == null ? () -> computeSnapshotFor(file, startLine, endLine) : null);
             if (startLine < 1) {


### PR DESCRIPTION
### Motivation
- Context fragments currently used a MIME-style guesser for `syntaxStyle`, which conflates editor highlighting style with content MIME type.
- Align `syntaxStyle` with the editor highlighting semantics provided by `BrokkFile.getSyntaxStyle()` to avoid future confusion and incorrect highlighting.

### Description
- Replaced `guessContentType(file)` with `file.getSyntaxStyle()` at the `ProjectPathFragment` super constructor call.
- Replaced `guessContentType(file)` with `file.getSyntaxStyle()` in the `GitFileFragment` content-hash input and its super constructor call.
- Replaced `guessContentType(file)` with `file.getSyntaxStyle()` at the `ExternalPathFragment` super constructor call and the `LineRangeFragment` super constructor call.
- Removed the now-unused `guessContentType(BrokkFile)` helper and its `URLConnection` import to prevent MIME-vs-syntax-style confusion.

### Testing
- Ran `./gradlew :brokk-shared:compileJava`; the build failed in this environment due to toolchain auto-provisioning being blocked (missing Java 21 JetBrains toolchain download; proxy returned `403 Forbidden`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e1777314832dbf66a0461b0eb5b2)