### PR TITLE
Optimize exception-handling smell detectors (Python + Java hot paths)

### DIFF
--- a/brokk-code/brokk_code/mcp_config.py
+++ b/brokk-code/brokk_code/mcp_config.py
@@ -326,7 +326,6 @@ def _fetch_codex_skills() -> dict[str, str]:
     return skills
 
 
-
 def _fetch_plugin_manifest() -> dict[str, Any]:
     """Fetch plugin.json from GitHub and adapt for Codex (strip agents field)."""
     raw = _fetch_github_file("claude-plugin/.claude-plugin/plugin.json")

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
@@ -2173,17 +2173,19 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
 
         TSNode bodyNode = catchNode.getChildByFieldName(nodeField(JavaNodeField.BODY));
         if (bodyNode == null) {
-            bodyNode = catchNode.getNamedChildren().stream()
-                    .filter(child -> nodeType(BLOCK).equals(child.getType()))
-                    .findFirst()
-                    .orElse(null);
+            for (int i = 0; i < catchNode.getNamedChildCount(); i++) {
+                TSNode child = catchNode.getNamedChild(i);
+                if (child != null && nodeType(BLOCK).equals(child.getType())) {
+                    bodyNode = child;
+                    break;
+                }
+            }
         }
         if (bodyNode == null) {
             return Optional.empty();
         }
-        String bodyText = sourceContent.substringFrom(bodyNode);
         int bodyStatements = countBodyExpressions(bodyNode);
-        boolean hasAnyComment = bodyText.contains("//") || bodyText.contains("/*");
+        boolean hasAnyComment = hasDescendantOfAnyTypeInclusive(bodyNode, JAVA_COMMENT_NODE_TYPES);
         boolean emptyBody = bodyStatements == 0 && !hasAnyComment;
         boolean commentOnlyBody = bodyStatements == 0 && hasAnyComment;
         boolean smallBody = bodyStatements <= weights.smallBodyMaxStatements();
@@ -2284,7 +2286,7 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
     }
 
     private static String compactCatchExcerpt(String text) {
-        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        String compact = compactWhitespaceForExcerpt(text);
         if (compact.length() <= 180) {
             return compact;
         }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
@@ -611,40 +611,41 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
 
     private Optional<ExceptionHandlingSmell> analyzeExceptClause(
             ProjectFile file, TSNode exceptClause, SourceContent sourceContent, ExceptionSmellWeights weights) {
-        TSNode bodyNode = exceptClause.getNamedChildren().stream()
-                .filter(child -> nodeType(BLOCK).equals(child.getType()))
-                .findFirst()
-                .orElse(null);
+        TSNode bodyNode = null;
+        for (int i = 0; i < exceptClause.getNamedChildCount(); i++) {
+            TSNode child = exceptClause.getNamedChild(i);
+            if (child == null) {
+                continue;
+            }
+            if (nodeType(BLOCK).equals(child.getType())) {
+                bodyNode = child;
+                break;
+            }
+        }
         if (bodyNode == null) {
             return Optional.empty();
         }
 
         int bodyStatements = countBodyExpressions(bodyNode);
-        String bodyText = sourceContent.substringFrom(bodyNode);
-        boolean hasAnyComment = bodyText.contains("#");
-        boolean emptyBody = bodyStatements == 0 && !hasAnyComment;
-        boolean commentOnlyBody = bodyStatements == 0 && hasAnyComment;
+        boolean emptyBody = bodyStatements == 0;
         boolean smallBody = bodyStatements <= weights.smallBodyMaxStatements();
         boolean raisePresent = hasDescendantOfType(bodyNode, nodeType(RAISE_STATEMENT));
         boolean logOnly = bodyStatements == 1 && isLikelyLogOnlyBody(bodyNode, sourceContent) && !raisePresent;
 
-        String catchType = extractExceptType(exceptClause, sourceContent);
+        ExceptTypeInfo exceptTypeInfo = extractExceptTypeInfo(exceptClause, bodyNode, sourceContent);
+        String catchType = exceptTypeInfo.catchType();
         int score = 0;
         var reasons = new ArrayList<String>();
-        if (catchType.equals("<bare>") || catchType.contains("BaseException")) {
+        if (catchType.equals("<bare>") || exceptTypeInfo.terminalNames().contains("BaseException")) {
             score += weights.genericThrowableWeight();
             reasons.add("generic-catch:BaseException");
-        } else if (catchType.contains("Exception")) {
+        } else if (exceptTypeInfo.terminalNames().contains("Exception")) {
             score += weights.genericExceptionWeight();
             reasons.add("generic-catch:Exception");
         }
         if (emptyBody) {
             score += weights.emptyBodyWeight();
             reasons.add("empty-body");
-        }
-        if (commentOnlyBody) {
-            score += weights.commentOnlyBodyWeight();
-            reasons.add("comment-only-body");
         }
         if (smallBody) {
             score += weights.smallBodyWeight();
@@ -678,7 +679,7 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
                 score,
                 bodyStatements,
                 List.copyOf(reasons),
-                compactCatchExcerpt(sourceContent.substringFrom(exceptClause))));
+                compactExcerptForTable(sourceContent.substringFrom(exceptClause))));
     }
 
     private static int countBodyExpressions(TSNode bodyNode) {
@@ -695,19 +696,62 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
         return expressions;
     }
 
-    private static String extractExceptType(TSNode exceptClause, SourceContent sourceContent) {
-        String text = sourceContent.substringFrom(exceptClause).strip();
-        if (!text.startsWith("except")) {
-            return "<unknown>";
+    private record ExceptTypeInfo(String catchType, Set<String> terminalNames) {}
+
+    private static ExceptTypeInfo extractExceptTypeInfo(
+            TSNode exceptClause, TSNode bodyNode, SourceContent sourceContent) {
+        int headerStart = exceptClause.getStartByte();
+        int headerEnd = Math.max(headerStart, bodyNode.getStartByte());
+        String header = sourceContent.substringFromBytes(headerStart, headerEnd).strip();
+        if (!header.startsWith("except")) {
+            return new ExceptTypeInfo("<unknown>", Set.of());
         }
-        int colonIdx = text.indexOf(':');
-        String head = colonIdx >= 0 ? text.substring(0, colonIdx) : text;
-        String remainder = head.substring("except".length()).strip();
+
+        String remainder = header.substring("except".length()).strip();
+        int colonIdx = remainder.indexOf(':');
+        if (colonIdx >= 0) {
+            remainder = remainder.substring(0, colonIdx).strip();
+        }
         if (remainder.isEmpty()) {
-            return "<bare>";
+            return new ExceptTypeInfo("<bare>", Set.of());
         }
         int asIdx = remainder.indexOf(" as ");
-        return (asIdx >= 0 ? remainder.substring(0, asIdx) : remainder).strip();
+        if (asIdx >= 0) {
+            remainder = remainder.substring(0, asIdx).strip();
+        }
+
+        String typesPart = remainder;
+        if (typesPart.startsWith("(") && typesPart.endsWith(")") && typesPart.length() > 2) {
+            typesPart = typesPart.substring(1, typesPart.length() - 1).strip();
+        }
+
+        var typeNames = new ArrayList<String>();
+        int start = 0;
+        for (int i = 0; i <= typesPart.length(); i++) {
+            if (i == typesPart.length() || typesPart.charAt(i) == ',') {
+                String trimmed = typesPart.substring(start, i).strip();
+                if (!trimmed.isEmpty()) {
+                    typeNames.add(trimmed);
+                }
+                start = i + 1;
+            }
+        }
+        if (typeNames.isEmpty()) {
+            return new ExceptTypeInfo("<bare>", Set.of());
+        }
+
+        var terminals = new LinkedHashSet<String>();
+        for (String name : typeNames) {
+            terminals.add(terminalIdentifier(name));
+        }
+        return new ExceptTypeInfo(String.join(", ", typeNames), Set.copyOf(terminals));
+    }
+
+    private static String terminalIdentifier(String reference) {
+        String trimmed = reference.strip();
+        int dot = trimmed.lastIndexOf('.');
+        String last = dot >= 0 ? trimmed.substring(dot + 1) : trimmed;
+        return last.strip();
     }
 
     private static boolean isLikelyLogOnlyBody(TSNode bodyNode, SourceContent sourceContent) {
@@ -735,21 +779,83 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
         if (objectNode == null || attributeNode == null) {
             return false;
         }
-        String receiver = sourceContent.substringFrom(objectNode).strip().toLowerCase(Locale.ROOT);
         String method = sourceContent.substringFrom(attributeNode).strip().toLowerCase(Locale.ROOT);
-        boolean loggerLikeReceiver = PYTHON_LOG_RECEIVER_NAMES.contains(receiver)
-                || PYTHON_LOG_RECEIVER_NAMES.stream().anyMatch(name -> receiver.endsWith("." + name))
-                || PYTHON_LOG_RECEIVER_EXTRA_SUFFIXES.stream().anyMatch(receiver::endsWith);
+        boolean loggerLikeReceiver = isLoggerLikeReceiver(objectNode, sourceContent);
         boolean loggerLikeMethod = PYTHON_LOG_METHOD_NAMES.contains(method);
         return loggerLikeReceiver && loggerLikeMethod;
     }
 
-    private static String compactCatchExcerpt(String text) {
-        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
-        if (compact.length() <= 180) {
-            return compact;
+    private static boolean isLoggerLikeReceiver(TSNode receiverNode, SourceContent sourceContent) {
+        var dottedParts = dottedNameParts(receiverNode, sourceContent);
+        if (!dottedParts.isEmpty()) {
+            String last = dottedParts.getLast();
+            if (PYTHON_LOG_RECEIVER_NAMES.contains(last)) {
+                return true;
+            }
+            if (PYTHON_LOG_RECEIVER_EXTRA_SUFFIXES.contains(last)) {
+                return true;
+            }
         }
-        return compact.substring(0, 180) + "...";
+        return nodeType(CALL).equals(receiverNode.getType()) && isLoggingGetLoggerCall(receiverNode, sourceContent);
+    }
+
+    private static boolean isLoggingGetLoggerCall(TSNode callNode, SourceContent sourceContent) {
+        TSNode functionNode = callNode.getChildByFieldName(nodeField(PythonNodeField.FUNCTION));
+        if (functionNode == null) {
+            return false;
+        }
+        if (nodeType(ATTRIBUTE).equals(functionNode.getType())) {
+            TSNode objectNode = functionNode.getChildByFieldName(nodeField(PythonNodeField.OBJECT));
+            TSNode attributeNode = functionNode.getChildByFieldName(nodeField(PythonNodeField.ATTRIBUTE));
+            if (objectNode == null || attributeNode == null) {
+                return false;
+            }
+            var objectParts = dottedNameParts(objectNode, sourceContent);
+            if (objectParts.size() != 1 || !"logging".equals(objectParts.getFirst())) {
+                return false;
+            }
+            String attr = sourceContent.substringFrom(attributeNode).strip();
+            return "getLogger".equals(attr);
+        }
+        if (nodeType(IDENTIFIER).equals(functionNode.getType())) {
+            String bare = sourceContent.substringFrom(functionNode).strip();
+            return "getLogger".equals(bare);
+        }
+        return false;
+    }
+
+    private static List<String> dottedNameParts(TSNode node, SourceContent sourceContent) {
+        String type = node.getType();
+        if (type == null) {
+            return List.of();
+        }
+        if (nodeType(IDENTIFIER).equals(type)) {
+            String name = sourceContent.substringFrom(node).strip();
+            if (name.isEmpty()) {
+                return List.of();
+            }
+            return List.of(name.toLowerCase(Locale.ROOT));
+        }
+        if (nodeType(ATTRIBUTE).equals(type)) {
+            TSNode objectNode = node.getChildByFieldName(nodeField(PythonNodeField.OBJECT));
+            TSNode attributeNode = node.getChildByFieldName(nodeField(PythonNodeField.ATTRIBUTE));
+            if (objectNode == null || attributeNode == null) {
+                return List.of();
+            }
+            var left = dottedNameParts(objectNode, sourceContent);
+            String right = sourceContent.substringFrom(attributeNode).strip();
+            if (right.isEmpty()) {
+                return left;
+            }
+            if (left.isEmpty()) {
+                return List.of(right.toLowerCase(Locale.ROOT));
+            }
+            var combined = new ArrayList<String>(left.size() + 1);
+            combined.addAll(left);
+            combined.add(right.toLowerCase(Locale.ROOT));
+            return List.copyOf(combined);
+        }
+        return List.of();
     }
 
     private CommentDensityStats buildRollUpStats(CodeUnit cu, Map<String, CommentLineBreakdown> counts) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -77,11 +77,62 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     }
 
     protected static String compactExcerptForTable(String text) {
-        String compact = text.replace('\n', ' ').replace('\r', ' ').trim().replaceAll("\\s+", " ");
+        String compact = compactWhitespaceForExcerpt(text);
         if (compact.length() <= 180) {
             return compact;
         }
         return compact.substring(0, 180) + "...";
+    }
+
+    protected static String compactWhitespaceForExcerpt(String text) {
+        char[] out = new char[text.length()];
+        int outLen = 0;
+        boolean seenNonWhitespace = false;
+        boolean pendingSpace = false;
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (Character.isWhitespace(ch)) {
+                if (seenNonWhitespace) {
+                    pendingSpace = true;
+                }
+                continue;
+            }
+            if (pendingSpace && outLen > 0) {
+                out[outLen++] = ' ';
+            }
+            out[outLen++] = ch;
+            pendingSpace = false;
+            seenNonWhitespace = true;
+        }
+        if (outLen > 0 && out[outLen - 1] == ' ') {
+            outLen--;
+        }
+        return new String(out, 0, outLen);
+    }
+
+    protected static boolean hasDescendantOfAnyTypeInclusive(TSNode root, Set<String> targetTypes) {
+        String rootType = root.getType();
+        if (rootType != null && targetTypes.contains(rootType)) {
+            return true;
+        }
+        try (var cursor = new TSTreeCursor(root)) {
+            if (!gotoNextDepthFirst(cursor, true)) {
+                return false;
+            }
+            while (true) {
+                TSNode current = cursor.currentNode();
+                if (current == null) {
+                    return false;
+                }
+                String type = current.getType();
+                if (type != null && targetTypes.contains(type)) {
+                    return true;
+                }
+                if (!gotoNextDepthFirst(cursor, true)) {
+                    return false;
+                }
+            }
+        }
     }
 
     protected static <T> int testMeaningfulAssertionCredit(

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/PythonExceptionHandlingSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/PythonExceptionHandlingSmellTest.java
@@ -90,6 +90,80 @@ public class PythonExceptionHandlingSmellTest {
         assertEquals(2, catches, "Expected both outer and inner except handlers to be reported");
     }
 
+    @Test
+    void parsesTupleExceptTypes() {
+        String code =
+                """
+                def run():
+                    try:
+                        work()
+                    except (ValueError, Exception):
+                        metrics()
+
+                def work():
+                    return 1
+
+                def metrics():
+                    return 0
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.catchType().equals("ValueError, Exception")));
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("generic-catch:Exception")));
+    }
+
+    @Test
+    void logOnlyHandlerViaLoggerAttributeIsDetected() {
+        String code =
+                """
+                def run():
+                    try:
+                        work()
+                    except Exception:
+                        logger.exception("oops")
+
+                def work():
+                    return 1
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("log-only-body")));
+    }
+
+    @Test
+    void logOnlyHandlerViaLoggingGetLoggerAttributeChainIsDetected() {
+        String code =
+                """
+                def run():
+                    try:
+                        work()
+                    except Exception:
+                        logging.getLogger(__name__).exception("oops")
+
+                def work():
+                    return 1
+                """;
+        var findings = analyze(code);
+        assertTrue(findings.stream().anyMatch(f -> f.reasons().contains("log-only-body")));
+    }
+
+    @Test
+    void raiseSuppressesLogOnlyHeuristic() {
+        String code =
+                """
+                def run():
+                    try:
+                        work()
+                    except Exception:
+                        logger.exception("oops")
+                        raise
+
+                def work():
+                    return 1
+                """;
+        var findings = analyze(code);
+        assertFalse(findings.isEmpty());
+        assertFalse(findings.stream().anyMatch(f -> f.reasons().contains("log-only-body")));
+    }
+
     private List<IAnalyzer.ExceptionHandlingSmell> analyze(String source) {
         try (var testProject = InlineCoreProject.code(source, "pkg/test_mod.py").build()) {
             IAnalyzer analyzer = testProject.getAnalyzer();


### PR DESCRIPTION
Refines the exception-handling smell detector implementation to reduce avoidable allocations and regex overhead, focusing on the Python analyzer (and a small Java follow-up).

**Key Changes**:
- Python: avoid parsing full `except_clause`/body text for scoring; derive catch-type classification without `catchType.contains(...)`; remove regex-based excerpt compaction; improve log-only detection via Tree-sitter structure.
- Tests: expand `PythonExceptionHandlingSmellTest` to cover tuple except types and logger attribute / `logging.getLogger(...).exception(...)` cases.
- Java: remove body-substring + comment-marker `contains(...)` checks and avoid stream allocation when locating the catch body; reuse non-regex excerpt compaction.

**Notes**:
- The Python `comment-only-body` heuristic was removed because Tree-sitter ranges/comment nodes for `#` are not reliably available for this use; `empty-body` now triggers based on the statement count.

**Touch Points**:
- brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
- brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/PythonExceptionHandlingSmellTest.java