### PR TITLE
Fixes #3343: parseJsonRequest swallows exceptions, causing silent connection hangs

### DIFF
--- a/app/src/main/java/ai/brokk/executor/http/SimpleHttpServer.java
+++ b/app/src/main/java/ai/brokk/executor/http/SimpleHttpServer.java
@@ -12,7 +12,6 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Lightweight wrapper around JDK HttpServer with Bearer token authentication middleware
@@ -95,14 +94,12 @@ public final class SimpleHttpServer {
      * @param exchange The HTTP exchange
      * @param valueType The class to deserialize into
      * @param <T> The type parameter
-     * @return The deserialized object, or null if parsing fails
+     * @return The deserialized object
+     * @throws IOException If reading or parsing the request body fails
      */
-    public static <T> @Nullable T parseJsonRequest(HttpExchange exchange, Class<T> valueType) {
+    public static <T> T parseJsonRequest(HttpExchange exchange, Class<T> valueType) throws IOException {
         try (InputStream is = exchange.getRequestBody()) {
             return objectMapper.readValue(is, valueType);
-        } catch (Exception e) {
-            logger.warn("Failed to parse JSON request body", e);
-            return null;
         }
     }
 

--- a/app/src/main/java/ai/brokk/tools/SftServer.java
+++ b/app/src/main/java/ai/brokk/tools/SftServer.java
@@ -249,11 +249,8 @@ public final class SftServer implements AutoCloseable {
             return;
         }
 
-        var request = SimpleHttpServer.parseJsonRequest(exchange, FormatWorkspaceRequest.class);
-        if (request == null) {
-            RouterUtil.sendValidationError(exchange, "Invalid JSON request body");
-            return;
-        }
+        var request = RouterUtil.parseJsonOr400(exchange, FormatWorkspaceRequest.class, "/v1/sft/format-workspace");
+        if (request == null) return;
 
         try {
             var result = format_workspace(
@@ -279,11 +276,8 @@ public final class SftServer implements AutoCloseable {
             return;
         }
 
-        var request = SimpleHttpServer.parseJsonRequest(exchange, FormatPatchRequest.class);
-        if (request == null) {
-            RouterUtil.sendValidationError(exchange, "Invalid JSON request body");
-            return;
-        }
+        var request = RouterUtil.parseJsonOr400(exchange, FormatPatchRequest.class, "/v1/sft/format-patch");
+        if (request == null) return;
 
         try {
             var result = format_patch(

--- a/app/src/test/java/ai/brokk/executor/http/SimpleHttpServerTest.java
+++ b/app/src/test/java/ai/brokk/executor/http/SimpleHttpServerTest.java
@@ -143,10 +143,10 @@ class SimpleHttpServerTest {
     void testParseJsonRequest() throws Exception {
         server.registerAuthenticatedContext("/test/json", exchange -> {
             var parsed = SimpleHttpServer.parseJsonRequest(exchange, Map.class);
-            if (parsed != null && parsed.containsKey("key")) {
+            if (parsed.containsKey("key")) {
                 SimpleHttpServer.sendJsonResponse(exchange, Map.of("received", "ok"));
             } else {
-                SimpleHttpServer.sendJsonResponse(exchange, 400, ErrorPayload.validationError("Invalid JSON"));
+                SimpleHttpServer.sendJsonResponse(exchange, 400, ErrorPayload.validationError("Missing key"));
             }
         });
 
@@ -163,6 +163,40 @@ class SimpleHttpServerTest {
         }
 
         assertEquals(200, conn.getResponseCode());
+        conn.disconnect();
+    }
+
+    @Test
+    void testParseJsonRequest_MalformedJson_Returns400() throws Exception {
+        server.registerAuthenticatedContext("/test/json-bad", exchange -> {
+            try {
+                var parsed = SimpleHttpServer.parseJsonRequest(exchange, Map.class);
+                SimpleHttpServer.sendJsonResponse(exchange, Map.of("received", "ok"));
+            } catch (Exception e) {
+                SimpleHttpServer.sendJsonResponse(
+                        exchange, 400, ErrorPayload.validationError("Invalid JSON request body"));
+            }
+        });
+
+        var url = new URI("http://127.0.0.1:" + port + "/test/json-bad").toURL();
+        var conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Authorization", "Bearer " + authToken);
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setDoOutput(true);
+
+        var malformedJson = "this is not json";
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(malformedJson.getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertEquals(400, conn.getResponseCode());
+        try (InputStream is = conn.getErrorStream()) {
+            var response = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            var errorPayload = objectMapper.readValue(response, ErrorPayload.class);
+            assertNotNull(errorPayload);
+            assertEquals(ErrorPayload.Code.VALIDATION_ERROR, errorPayload.code());
+        }
         conn.disconnect();
     }
 


### PR DESCRIPTION
Fixes #3343

## Summary

- **`SimpleHttpServer.parseJsonRequest()`** no longer catches and swallows exceptions. It now throws `IOException`, letting callers decide how to handle parse failures.
- **`RouterUtil.parseJsonOr400()`** already had the right catch block to send a 400 response -- it just never received the exception before. Now it works as designed.
- **`SftServer`** callers migrated from direct `parseJsonRequest()` calls to the standard `parseJsonOr400()` pattern used by all other routers.
- Added a test verifying that malformed JSON produces a 400 response instead of a silent hang.

## Root cause

`parseJsonRequest()` caught all exceptions and returned `null`. Its wrapper `parseJsonOr400()` tried to catch exceptions to send a 400, but that catch block was dead code. Callers did `if (request == null) return;` -- returning without ever writing an HTTP response, causing clients to hang indefinitely.

## Test plan

- [x] `./gradlew build` passes (all tests green)
- [x] New test `testParseJsonRequest_MalformedJson_Returns400` confirms malformed JSON returns HTTP 400
- [x] Existing `testParseJsonRequest` updated for non-nullable return type