### PR TITLE
Fix misleading skill usage examples in claude-plugin README

### DIFF
--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -74,7 +74,7 @@ Then ask: `What commits touched BrokkCoreMcpServer.java in the last month?`
 ```
 /brokk:structured-data
 ```
-Then ask: `What dependencies are declared in build.gradle.kts? Use jq on the JSON config files.`
+Then ask: `What dependencies are declared in package.json?`
 
 **Workspace** -- Set which project the server analyzes:
 ```

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -39,29 +39,52 @@ The plugin adds the following skills to Claude Code:
 
 ## Skill usage examples
 
+### Tool-guidance skills
+
+These skills load tool-selection tips and usage guidance into the conversation.
+Claude also invokes them automatically when your request matches -- for example,
+asking "show me the SearchTools class" triggers `code-reading` behind the scenes.
+You can invoke them explicitly to prime the context before asking your question.
+
 **Code Navigation** -- Find where symbols are defined and who calls them:
 ```
 /brokk:code-navigation
-Find all implementations of the IAnalyzer interface
 ```
+Then ask: `Find all implementations of the IAnalyzer interface`
 
 **Code Reading** -- Read source code at the right level of detail:
 ```
 /brokk:code-reading
-Show me the full source of the SearchTools class
 ```
+Then ask: `Show me the full source of the SearchTools class`
 
 **Codebase Search** -- Text search and file discovery:
 ```
 /brokk:codebase-search
-Find all files containing "TODO" in the brokk-core module
 ```
+Then ask: `Find all files containing "TODO" in the brokk-core module`
 
 **Git Exploration** -- Understand change history:
 ```
 /brokk:git-exploration
-What commits touched BrokkCoreMcpServer.java in the last month?
 ```
+Then ask: `What commits touched BrokkCoreMcpServer.java in the last month?`
+
+**Structured Data** -- Query JSON and XML/HTML files:
+```
+/brokk:structured-data
+```
+Then ask: `What dependencies are declared in build.gradle.kts? Use jq on the JSON config files.`
+
+**Workspace** -- Set which project the server analyzes:
+```
+/brokk:workspace
+```
+Then ask: `Activate the workspace at /home/user/projects/my-app`
+
+### Workflow skills
+
+These skills drive multi-step processes and accept arguments directly.
 
 **Guided Issue** -- End-to-end issue resolution workflow:
 ```
@@ -78,27 +101,14 @@ What commits touched BrokkCoreMcpServer.java in the last month?
 /brokk:review-pr 42
 ```
 
-**Structured Data** -- Query JSON and XML/HTML files:
-```
-/brokk:structured-data
-What dependencies are declared in build.gradle.kts? Use jq on the JSON config files.
-```
-
 **Today** -- Daily planning with GitHub issues:
 ```
 /brokk:today
 ```
 
-**Workspace** -- Set which project the server analyzes:
-```
-/brokk:workspace
-Activate the workspace at /home/user/projects/my-app
-```
-
 **Write Issue** -- Draft a GitHub issue with code references:
 ```
-/brokk:write-issue
-Draft an issue about the missing error handling in parseJsonRequest
+/brokk:write-issue Draft an issue about the missing error handling in parseJsonRequest
 ```
 
 ## Agents


### PR DESCRIPTION
## Summary
- Split skill examples into **Tool-guidance skills** (reference cards that load context) and **Workflow skills** (multi-step processes that accept arguments)
- Fixed reference-card skill examples that showed two-line code blocks implying the skill processes inline arguments -- it doesn't
- Added explanation that tool-guidance skills are also invoked automatically by Claude when requests match

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm tool-guidance skill examples match actual behavior (invoke skill, then ask separately)
- [ ] Confirm workflow skill examples still match actual behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)