### PR TITLE
Enhance Rust ACP server: cwd, session persistence, tool calling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,46 @@ jobs:
       - name: Check code formatting
         run: ./gradlew spotlessCheck
 
+  rust-acp:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo registry and build
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          brokk-acp-rust/target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('brokk-acp-rust/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    - name: Build Rust ACP server
+      working-directory: brokk-acp-rust
+      run: cargo build --release
+
+    - name: Run Rust ACP tests
+      working-directory: brokk-acp-rust
+      run: cargo test
+
+    - name: Check Rust formatting
+      working-directory: brokk-acp-rust
+      run: cargo fmt --check
+
+    - name: Run Clippy lints
+      working-directory: brokk-acp-rust
+      run: cargo clippy --all-targets -- -D warnings
+
   dependency-analysis:
     runs-on: ubuntu-latest
 

--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "agent-client-protocol"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brokk-acp-rust"
 version = "0.1.0"
 dependencies = [
@@ -170,6 +205,7 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -178,6 +214,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -187,10 +225,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -199,6 +262,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -220,6 +285,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -269,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +383,55 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -338,6 +468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +481,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -368,6 +515,17 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -429,6 +587,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -581,6 +749,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,13 +771,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -655,6 +847,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -935,6 +1136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1171,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1030,6 +1250,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1290,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1194,6 +1445,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1537,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1307,6 +1574,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1492,6 +1771,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1959,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1993,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2067,6 +2372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2447,22 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2280,6 +2607,15 @@ checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2535,6 +2871,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,6 +2928,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2618,7 +2977,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.14.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -10,10 +10,12 @@ name = "brokk-acp"
 path = "src/main.rs"
 
 [dependencies]
-agent-client-protocol = "0.11"
+agent-client-protocol = { version = "0.11", features = ["unstable_session_resume"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
+zip = "2"
 futures = "0.3"
+regex = "1"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -22,3 +24,4 @@ tokio-util = { version = "0.7", features = ["compat", "rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
+walkdir = "2"

--- a/brokk-acp-rust/PLANS.md
+++ b/brokk-acp-rust/PLANS.md
@@ -1,0 +1,317 @@
+# Plan: Tool Calling pour le serveur ACP Rust
+
+## Etat actuel
+
+Le serveur Rust est un simple proxy chat : il recoit un prompt, l'envoie au LLM, et stream la reponse. Pas de boucle agentique, pas de tool calling, pas d'interaction avec le filesystem.
+
+## Atout majeur : Bifrost (brokk_analyzer)
+
+Le crate `brokk_analyzer` (repo `brokkai/bifrost`) est un analyseur de code Rust natif base sur tree-sitter. Il fournit deja un `SearchToolsService` avec ces tools prets a l'emploi :
+
+| Tool Bifrost | Description |
+|---|---|
+| `search_symbols` | Chercher des symboles indexes dans le workspace |
+| `get_symbol_locations` | Localiser des symboles dans les fichiers |
+| `get_symbol_summaries` | Resumes ranges des symboles |
+| `get_symbol_sources` | Code source des symboles |
+| `get_file_summaries` | Resumes ranges des fichiers |
+| `summarize_symbols` | Resumes recursifs compacts |
+| `skim_files` | Apercu rapide des symboles d'un fichier |
+| `most_relevant_files` | Fichiers lies par historique git et imports |
+| `refresh` | Rafraichir l'index de l'analyseur |
+
+Bifrost supporte : Java, JavaScript, TypeScript, Rust, Go, Python, C++, C#, PHP, Scala.
+
+**L'integration est directe** : ajouter `brokk_analyzer` comme dependance, instancier `SearchToolsService::new(cwd)`, et appeler `service.call_tool_value(name, args)`. Pas de subprocess, pas de MCP, pas de serialisation -- c'est un appel de fonction Rust natif.
+
+## Objectif
+
+Permettre au LLM d'appeler des outils via le protocole OpenAI tool calling, avec une boucle agentique qui itere jusqu'a ce que le LLM donne une reponse finale. Les tools de code intelligence viennent de Bifrost ; les tools filesystem/shell sont implementes dans le serveur ACP.
+
+---
+
+## Phase 1 : Infrastructure du tool calling dans le client LLM
+
+### 1.1 Etendre ChatMessage et ChatCompletionRequest (llm_client.rs)
+
+```rust
+#[derive(Serialize, Deserialize)]
+struct ChatMessage {
+    role: String,                              // "system", "user", "assistant", "tool"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<ToolCall>>,         // reponses assistant avec tool calls
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,              // pour les messages role=tool
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,                      // nom du tool pour role=tool
+}
+
+#[derive(Serialize)]
+struct ChatCompletionRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<ToolDefinition>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<String>,               // "auto" | "none" | "required"
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct ToolDefinition {
+    r#type: String,          // "function"
+    function: FunctionDef,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct FunctionDef {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct ToolCall {
+    id: String,
+    r#type: String,          // "function"
+    function: FunctionCall,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct FunctionCall {
+    name: String,
+    arguments: String,       // JSON serialise en string
+}
+```
+
+### 1.2 Parser les tool calls dans le streaming SSE
+
+Les chunks SSE peuvent contenir des `tool_calls` en fragments :
+
+```json
+{"choices": [{"delta": {"tool_calls": [{"index": 0, "id": "call_abc", "function": {"name": "search_symbols", "arguments": ""}}]}}]}
+{"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": "{\"patterns"}}]}}]}
+{"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": "\": [\"main\"]}"}}]}}]}
+```
+
+Il faut accumuler les fragments par index. Le `stream_chat` doit retourner :
+
+```rust
+enum LlmResponse {
+    Text(String),
+    ToolCalls {
+        text: String,                           // texte emis avant les tool calls
+        calls: Vec<ToolCall>,
+    },
+}
+```
+
+Fichier a modifier : `llm_client.rs`
+
+---
+
+## Phase 2 : ToolRegistry et integration Bifrost
+
+### 2.1 ToolRegistry unifie (tools/mod.rs)
+
+```rust
+struct ToolRegistry {
+    /// Tools Bifrost (code intelligence) -- appels directs au SearchToolsService
+    bifrost: SearchToolsService,
+    /// Repertoire de travail pour les tools filesystem
+    cwd: PathBuf,
+}
+
+impl ToolRegistry {
+    fn new(cwd: PathBuf) -> Result<Self, String>;
+
+    /// Retourner toutes les definitions de tools au format OpenAI
+    fn tool_definitions(&self) -> Vec<ToolDefinition>;
+
+    /// Executer un tool par nom + arguments JSON
+    fn execute(&mut self, name: &str, args: serde_json::Value) -> ToolResult;
+}
+```
+
+### 2.2 Tools Bifrost (integration directe)
+
+Pas besoin de les reimplementer. Le `SearchToolsService` de Bifrost a deja :
+- `call_tool_value(name, arguments) -> Result<Value, Error>`
+
+Le serveur ACP appelle `service.call_tool_value("search_symbols", args)` directement.
+
+Les definitions de tools sont derivees de `list_tools_result()` dans `mcp_server.rs` de Bifrost. On peut les copier ou les generer depuis le service.
+
+### 2.3 Tools supplementaires (filesystem + shell)
+
+En plus des tools Bifrost, le serveur ACP a besoin de :
+
+| Tool | Description | Implementation |
+|---|---|---|
+| `readFile` | Lire un fichier | `std::fs::read_to_string` avec validation de chemin |
+| `writeFile` | Ecrire/creer un fichier | `std::fs::write` avec validation de chemin |
+| `listDirectory` | Lister un repertoire | `std::fs::read_dir` |
+| `runShellCommand` | Executer une commande shell | `tokio::process::Command` |
+| `think` | Espace de reflexion (no-op) | Retourner le texte tel quel |
+
+Ces tools sont simples et s'implementent en quelques dizaines de lignes chacun.
+
+Fichiers a creer :
+- `tools/mod.rs` (ToolRegistry, ToolResult, ToolDefinition)
+- `tools/filesystem.rs` (readFile, writeFile, listDirectory)
+- `tools/shell.rs` (runShellCommand)
+
+---
+
+## Phase 3 : La boucle agentique
+
+### 3.1 Module tool_loop.rs
+
+Reference : `LutzAgent.java` lignes 900-1100.
+
+```
+prompt utilisateur
+    |
+    v
+[system prompt + history + user prompt]
+    |
+    v
+[Envoyer au LLM avec tools=registry.tool_definitions()]
+    |
+    v
+LlmResponse::Text? ----> Reponse finale, sortir
+LlmResponse::ToolCalls?
+    |
+    v
+Pour chaque tool_call:
+  [Notifier le client ACP: "Searching for symbols..."]
+  [registry.execute(name, args)]
+  [Ajouter message role=tool avec le resultat]
+    |
+    v
+[Renvoyer au LLM avec l'historique enrichi] ----> boucler
+```
+
+Protections :
+- **Limite de tours** : max 25 iterations (configurable via `--max-turns`)
+- **Annulation** : verifier `CancellationToken` avant chaque appel LLM et tool
+- **Erreurs fatales** : arreter la boucle sur erreur interne critique
+- **Taille des resultats** : tronquer les resultats de tools trop longs (>50KB)
+
+### 3.2 Integration dans agent.rs
+
+Remplacer `stream_chat` simple par `tool_loop::run(llm, registry, messages, cancel, on_event)`.
+
+Le callback `on_event` envoie les notifications ACP au client :
+- Tokens de texte -> `SessionUpdate::AgentMessageChunk`
+- Debut de tool call -> message italique "_Searching for symbols..._"
+- Resultat de tool -> pas affiche au client (interne au LLM)
+
+---
+
+## Phase 4 : Securite
+
+### 4.1 Validation des chemins
+
+Tous les tools filesystem (`readFile`, `writeFile`, `listDirectory`) doivent :
+- Resoudre le chemin par rapport au cwd de la session
+- Verifier que le chemin canonique reste sous le cwd (pas de `../../etc/passwd`)
+- Refuser les chemins absolus sauf s'ils sont sous le cwd
+
+```rust
+fn safe_resolve(cwd: &Path, requested: &str) -> Result<PathBuf, String> {
+    let resolved = cwd.join(requested).canonicalize()?;
+    if !resolved.starts_with(cwd.canonicalize()?) {
+        return Err("Path escapes the working directory".into());
+    }
+    Ok(resolved)
+}
+```
+
+### 4.2 Sandboxing shell
+
+`runShellCommand` :
+- Timeout : 60 secondes par defaut
+- cwd : toujours le cwd de la session
+- stdin : ferme (pas de commandes interactives)
+- Taille de sortie : tronquer stdout+stderr a 100KB
+- Pas de shell interactif : executer via `sh -c "..."` ou `bash -c "..."`
+
+---
+
+## Phase 5 : Affichage ACP
+
+Pendant la boucle agentique, envoyer des `SessionUpdate::AgentMessageChunk` :
+
+```
+_Searching for symbols..._
+_Getting file summaries..._
+_Running shell command..._
+```
+
+Correspondance des headlines (tiree de `ToolRegistry.java` et adaptee) :
+
+```rust
+fn headline(tool_name: &str) -> &str {
+    match tool_name {
+        "search_symbols" => "Searching for symbols",
+        "get_symbol_locations" => "Finding files for symbols",
+        "get_symbol_sources" => "Fetching symbol source",
+        "get_file_summaries" => "Getting file summaries",
+        "skim_files" => "Skimming files",
+        "most_relevant_files" => "Finding related files",
+        "readFile" => "Reading file",
+        "writeFile" => "Writing file",
+        "listDirectory" => "Listing directory",
+        "runShellCommand" => "Running shell command",
+        "think" => "Thinking",
+        _ => tool_name,
+    }
+}
+```
+
+---
+
+## Ordre d'implementation
+
+| Phase | Travail | Estimation | Dependances |
+|---|---|---|---|
+| 1 | Etendre `llm_client.rs` : tools + tool_calls SSE | ~2 jours | - |
+| 2 | ToolRegistry + integration Bifrost + tools filesystem/shell | ~2-3 jours | Bifrost crate |
+| 3 | Boucle agentique `tool_loop.rs` + integration `agent.rs` | ~2 jours | Phases 1+2 |
+| 4 | Securite (validation chemins, sandboxing shell) | ~1 jour | Phase 2 |
+| 5 | Affichage ACP (headlines, notifications) | ~0.5 jour | Phase 3 |
+
+**Total estime : ~7-8 jours.**
+
+Sans Bifrost ce serait 12-15+ jours (reimplementation de tree-sitter, grammaires, index, etc.).
+
+---
+
+## Dependances a ajouter au Cargo.toml
+
+```toml
+# Bifrost -- analyseur de code Rust natif (code intelligence)
+brokk_analyzer = { git = "https://github.com/brokkai/bifrost.git" }
+
+# Deja present : tokio (avec feature "process" pour le shell)
+# Deja present : serde_json, uuid, etc.
+```
+
+C'est tout. Bifrost apporte tree-sitter + grammaires + git2 + walkdir + glob comme dependances transitives.
+
+---
+
+## Questions ouvertes
+
+1. **Version de Bifrost** : pointer vers `main` ou un tag precis ?
+
+2. **Modeles sans tool calling** : certains modeles locaux (petits Ollama) ne supportent pas le tool calling. Faut-il un fallback text-based ? Ou simplement ne pas envoyer les tools et rester en mode chat simple ?
+
+3. **Refresh automatique** : Bifrost a un `ProjectChangeWatcher` qui rafraichit l'index quand les fichiers changent. Faut-il l'activer ou laisser le LLM appeler `refresh` manuellement ?
+
+4. **MCP tools du client ACP** : le protocole ACP permet au client de fournir des serveurs MCP. Faut-il s'y connecter pour avoir des tools supplementaires ? C'est un scope additionnel significatif.
+
+5. **Persistance des tool calls** : les tool calls intermediaires doivent-ils etre persistes dans le zip de session pour le replay ? Le format actuel du zip supporte les `ChatMessageDto` avec role/contentId, donc c'est faisable.

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 use agent_client_protocol::schema::{
@@ -6,13 +6,13 @@ use agent_client_protocol::schema::{
     InitializeResponse, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
     LoadSessionResponse, NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest,
     PromptResponse, ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionInfo,
-    SessionListCapabilities, SessionMode as AcpSessionMode, SessionModeState,
-    SessionNotification, SessionResumeCapabilities, SessionUpdate, SetSessionModeRequest,
-    SetSessionModeResponse, StopReason, TextContent,
+    SessionListCapabilities, SessionMode as AcpSessionMode, SessionModeState, SessionNotification,
+    SessionResumeCapabilities, SessionUpdate, SetSessionModeRequest, SetSessionModeResponse,
+    StopReason, TextContent,
 };
 use agent_client_protocol::{
-    on_receive_dispatch, on_receive_notification, on_receive_request, Agent, ByteStreams, Client,
-    ConnectionTo, Dispatch, Handled, Responder,
+    Agent, ByteStreams, Client, ConnectionTo, Dispatch, Handled, Responder, on_receive_dispatch,
+    on_receive_notification, on_receive_request,
 };
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -361,7 +361,7 @@ fn send_message(cx: &ConnectionTo<Client>, session_id: &str, text: &str) {
 }
 
 /// Build a system prompt based on the current session mode and working directory.
-fn build_system_prompt(mode: &SessionMode, cwd: &PathBuf) -> String {
+fn build_system_prompt(mode: &SessionMode, cwd: &Path) -> String {
     let cwd_context = format!(
         "The user's working directory is: {}\n\
          All file paths should be interpreted relative to this directory.\n\n",

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -1,10 +1,14 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use agent_client_protocol::schema::{
     AgentCapabilities, CancelNotification, ContentBlock, ContentChunk, InitializeRequest,
-    InitializeResponse, NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest,
-    PromptResponse, SessionMode as AcpSessionMode, SessionModeState, SessionNotification,
-    SessionUpdate, SetSessionModeRequest, SetSessionModeResponse, StopReason, TextContent,
+    InitializeResponse, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
+    LoadSessionResponse, NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest,
+    PromptResponse, ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionInfo,
+    SessionListCapabilities, SessionMode as AcpSessionMode, SessionModeState,
+    SessionNotification, SessionResumeCapabilities, SessionUpdate, SetSessionModeRequest,
+    SetSessionModeResponse, StopReason, TextContent,
 };
 use agent_client_protocol::{
     on_receive_dispatch, on_receive_notification, on_receive_request, Agent, ByteStreams, Client,
@@ -14,6 +18,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::llm_client::{ChatMessage, LlmBackend};
 use crate::session::{ConversationTurn, SessionMode, SessionStore};
+use crate::tools::ToolRegistry;
 
 /// Available session modes exposed to ACP clients.
 fn available_modes() -> Vec<AcpSessionMode> {
@@ -23,6 +28,10 @@ fn available_modes() -> Vec<AcpSessionMode> {
         AcpSessionMode::new("ASK", "ASK").description("Question answering"),
         AcpSessionMode::new("PLAN", "PLAN").description("Planning only"),
     ]
+}
+
+fn mode_state(current: &str) -> SessionModeState {
+    SessionModeState::new(current.to_string(), available_modes())
 }
 
 /// Build and run the ACP agent over stdio.
@@ -35,6 +44,10 @@ pub async fn run_agent(
 
     let llm_new = llm.clone();
     let sessions_new = sessions.clone();
+
+    let sessions_load = sessions.clone();
+    let sessions_resume = sessions.clone();
+    let sessions_list = sessions.clone();
 
     let llm_prompt = llm.clone();
     let sessions_prompt = sessions.clone();
@@ -65,7 +78,13 @@ pub async fn run_agent(
                 }
 
                 let capabilities = AgentCapabilities::new()
-                    .prompt_capabilities(PromptCapabilities::new().embedded_context(true));
+                    .load_session(true)
+                    .prompt_capabilities(PromptCapabilities::new().embedded_context(true))
+                    .session_capabilities(
+                        SessionCapabilities::new()
+                            .list(SessionListCapabilities::new())
+                            .resume(SessionResumeCapabilities::new()),
+                    );
 
                 responder.respond(
                     InitializeResponse::new(req.protocol_version)
@@ -76,11 +95,12 @@ pub async fn run_agent(
         )
         // Handle session/new
         .on_receive_request(
-            async move |_req: NewSessionRequest,
+            async move |req: NewSessionRequest,
                         responder: Responder<NewSessionResponse>,
                         _cx: ConnectionTo<Client>| {
-                tracing::info!("ACP session/new");
-                let session = sessions_new.create_session().await;
+                let cwd = req.cwd.clone();
+                tracing::info!("ACP session/new, cwd={}", cwd.display());
+                let session = sessions_new.create_session(cwd).await;
 
                 // Discover models for the response
                 let models = match llm_new.list_models().await {
@@ -90,9 +110,6 @@ pub async fn run_agent(
                         vec![session.model.clone()]
                     }
                 };
-
-                let mode_state =
-                    SessionModeState::new(session.mode.as_str(), available_modes());
 
                 let meta_value = serde_json::json!({
                     "brokk": {
@@ -106,10 +123,92 @@ pub async fn run_agent(
                 };
 
                 let response = NewSessionResponse::new(session.id.clone())
-                    .modes(mode_state)
+                    .modes(mode_state(session.mode.as_str()))
                     .meta(meta_map);
 
                 responder.respond(response)
+            },
+            on_receive_request!(),
+        )
+        // Handle session/load
+        .on_receive_request(
+            async move |req: LoadSessionRequest,
+                        responder: Responder<LoadSessionResponse>,
+                        cx: ConnectionTo<Client>| {
+                let session_id = req.session_id.to_string();
+                let cwd = req.cwd.clone();
+                tracing::info!("ACP session/load session={session_id}, cwd={}", cwd.display());
+
+                // Look up the session from memory or disk
+                let session = match sessions_load.get_session(&session_id, &cwd).await {
+                    Some(s) => {
+                        sessions_load.update_cwd(&session_id, cwd).await;
+                        s
+                    }
+                    None => {
+                        tracing::warn!("session/load: unknown session {session_id}");
+                        send_message(&cx, &session_id, "Error: unknown session");
+                        return responder.respond(LoadSessionResponse::new());
+                    }
+                };
+
+                // Replay conversation history as session updates
+                for turn in &session.history {
+                    send_message(&cx, &session_id, &turn.agent_response);
+                }
+
+                responder.respond(
+                    LoadSessionResponse::new()
+                        .modes(mode_state(session.mode.as_str())),
+                )
+            },
+            on_receive_request!(),
+        )
+        // Handle session/resume
+        .on_receive_request(
+            async move |req: ResumeSessionRequest,
+                        responder: Responder<ResumeSessionResponse>,
+                        cx: ConnectionTo<Client>| {
+                let session_id = req.session_id.to_string();
+                let cwd = req.cwd.clone();
+                tracing::info!("ACP session/resume session={session_id}, cwd={}", cwd.display());
+
+                match sessions_resume.get_session(&session_id, &cwd).await {
+                    Some(session) => {
+                        sessions_resume.update_cwd(&session_id, cwd).await;
+                        responder.respond(
+                            ResumeSessionResponse::new()
+                                .modes(mode_state(session.mode.as_str())),
+                        )
+                    }
+                    None => {
+                        tracing::warn!("session/resume: unknown session {session_id}");
+                        send_message(&cx, &session_id, "Error: unknown session");
+                        responder.respond(ResumeSessionResponse::new())
+                    }
+                }
+            },
+            on_receive_request!(),
+        )
+        // Handle session/list
+        .on_receive_request(
+            async move |req: ListSessionsRequest,
+                        responder: Responder<ListSessionsResponse>,
+                        _cx: ConnectionTo<Client>| {
+                tracing::info!("ACP session/list, cwd filter={:?}", req.cwd);
+
+                let infos: Vec<SessionInfo> = if let Some(cwd) = &req.cwd {
+                    sessions_list
+                        .list_sessions_from_disk(cwd)
+                        .await
+                        .into_iter()
+                        .map(|m| SessionInfo::new(m.id, cwd.clone()))
+                        .collect()
+                } else {
+                    vec![]
+                };
+
+                responder.respond(ListSessionsResponse::new(infos))
             },
             on_receive_request!(),
         )
@@ -128,8 +227,9 @@ pub async fn run_agent(
                     return responder.respond(PromptResponse::new(StopReason::EndTurn));
                 }
 
-                // Get session state
-                let session = match sessions_prompt.get_session(&session_id).await {
+                // Get session state (prompt doesn't carry cwd, so use current dir as fallback)
+                let fallback_cwd = std::env::current_dir().unwrap_or_default();
+                let session = match sessions_prompt.get_session(&session_id, &fallback_cwd).await {
                     Some(s) => s,
                     None => {
                         send_message(&cx, &session_id, "Error: unknown session");
@@ -144,47 +244,36 @@ pub async fn run_agent(
                 }
 
                 // Build conversation messages from history
-                let mut messages = vec![ChatMessage {
-                    role: "system".to_string(),
-                    content: build_system_prompt(&session.mode),
-                }];
+                let mut messages = vec![
+                    ChatMessage::system(build_system_prompt(&session.mode, &session.cwd)),
+                ];
                 for turn in &session.history {
-                    messages.push(ChatMessage {
-                        role: "user".to_string(),
-                        content: turn.user_prompt.clone(),
-                    });
-                    messages.push(ChatMessage {
-                        role: "assistant".to_string(),
-                        content: turn.agent_response.clone(),
-                    });
+                    messages.push(ChatMessage::user(turn.user_prompt.clone()));
+                    messages.push(ChatMessage::assistant(turn.agent_response.clone()));
                 }
-                messages.push(ChatMessage {
-                    role: "user".to_string(),
-                    content: prompt_text.clone(),
-                });
+                messages.push(ChatMessage::user(prompt_text.clone()));
 
                 // Create a cancellation token for this prompt
                 let cancel = sessions_prompt.start_prompt(&session_id).await;
 
-                // Stream LLM response, sending tokens as session updates
-                let cx_stream = cx.clone();
-                let sid = session_id.clone();
-                let on_token: Box<dyn FnMut(&str) + Send> = Box::new(move |token: &str| {
-                    send_message(&cx_stream, &sid, token);
-                });
+                // Run the agentic tool loop
+                let registry = ToolRegistry::new(session.cwd.clone());
+                let cx_text = cx.clone();
+                let sid_text = session_id.clone();
+                let cx_tool = cx.clone();
+                let sid_tool = session_id.clone();
 
-                let response_text = match llm_prompt
-                    .stream_chat(&session.model, messages, on_token, cancel)
-                    .await
-                {
-                    Ok(text) => text,
-                    Err(e) => {
-                        tracing::error!("LLM request failed for session {session_id}: {e}");
-                        let err_msg = "\n**Error:** LLM request failed. Check server logs for details.\n";
-                        send_message(&cx, &session_id, err_msg);
-                        err_msg.to_string()
-                    }
-                };
+                let response_text = crate::tool_loop::run(
+                    &llm_prompt,
+                    &registry,
+                    &session.model,
+                    messages,
+                    25, // max turns
+                    cancel,
+                    |token| send_message(&cx_text, &sid_text, token),
+                    |headline| send_message(&cx_tool, &sid_tool, headline),
+                )
+                .await;
 
                 // Clean up cancellation token
                 sessions_prompt.finish_prompt(&session_id).await;
@@ -271,29 +360,33 @@ fn send_message(cx: &ConnectionTo<Client>, session_id: &str, text: &str) {
     }
 }
 
-/// Build a system prompt based on the current session mode.
-fn build_system_prompt(mode: &SessionMode) -> String {
-    match mode {
+/// Build a system prompt based on the current session mode and working directory.
+fn build_system_prompt(mode: &SessionMode, cwd: &PathBuf) -> String {
+    let cwd_context = format!(
+        "The user's working directory is: {}\n\
+         All file paths should be interpreted relative to this directory.\n\n",
+        cwd.display()
+    );
+
+    let mode_prompt = match mode {
         SessionMode::Lutz => {
             "You are Brokk, an AI coding assistant. You help users with software engineering tasks \
              using an agentic approach: break complex tasks into steps, execute them, and report \
              results. When appropriate, create a task list to track progress."
-                .to_string()
         }
         SessionMode::Code => {
             "You are Brokk, an AI coding assistant focused on code changes. Generate code \
              modifications, refactors, and implementations. Be concise and focus on the code."
-                .to_string()
         }
         SessionMode::Ask => {
             "You are Brokk, an AI coding assistant. Answer questions about code, architecture, \
              and software engineering concepts. Be thorough but concise."
-                .to_string()
         }
         SessionMode::Plan => {
             "You are Brokk, an AI coding assistant focused on planning. Analyze requirements, \
              design solutions, and create implementation plans. Do not write code directly."
-                .to_string()
         }
-    }
+    };
+
+    format!("{cwd_context}{mode_prompt}")
 }

--- a/brokk-acp-rust/src/llm_client.rs
+++ b/brokk-acp-rust/src/llm_client.rs
@@ -2,11 +2,123 @@ use anyhow::{Context, Result};
 use futures::future::BoxFuture;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-/// Trait abstracting an LLM backend. Allows swapping OpenAiClient for
-/// a Bifrost-backed implementation or a mock for testing.
+// ---------------------------------------------------------------------------
+// Tool calling types (OpenAI-compatible)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    pub r#type: String,
+    pub function: FunctionDef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionDef {
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub r#type: String,
+    pub function: FunctionCall,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionCall {
+    pub name: String,
+    pub arguments: String,
+}
+
+/// What the LLM returned: either final text or tool calls to execute.
+#[derive(Debug)]
+pub enum LlmResponse {
+    Text(String),
+    ToolCalls {
+        text: String,
+        calls: Vec<ToolCall>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Chat message (extended for tool calling)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl ChatMessage {
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: "system".to_string(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".to_string(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    pub fn assistant_tool_calls(calls: Vec<ToolCall>) -> Self {
+        Self {
+            role: "assistant".to_string(),
+            content: None,
+            tool_calls: Some(calls),
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    pub fn tool_result(tool_call_id: impl Into<String>, name: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            role: "tool".to_string(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
+            name: Some(name.into()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LLM backend trait
+// ---------------------------------------------------------------------------
+
 pub trait LlmBackend: Send + Sync {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>>>;
 
@@ -14,19 +126,16 @@ pub trait LlmBackend: Send + Sync {
         &self,
         model: &str,
         messages: Vec<ChatMessage>,
+        tools: Option<Vec<ToolDefinition>>,
         on_token: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
-    ) -> BoxFuture<'_, Result<String>>;
+    ) -> BoxFuture<'_, Result<LlmResponse>>;
 }
 
-/// OpenAI-compatible chat message.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChatMessage {
-    pub role: String,
-    pub content: String,
-}
+// ---------------------------------------------------------------------------
+// Request/response types for the OpenAI-compatible API
+// ---------------------------------------------------------------------------
 
-/// Request body for POST /v1/chat/completions.
 #[derive(Debug, Serialize)]
 struct ChatCompletionRequest {
     model: String,
@@ -36,21 +145,24 @@ struct ChatCompletionRequest {
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<ToolDefinition>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<String>,
 }
 
-/// A single model entry from GET /v1/models.
 #[derive(Debug, Deserialize)]
 struct ModelEntry {
     id: String,
 }
 
-/// Response from GET /v1/models.
 #[derive(Debug, Deserialize)]
 struct ModelsResponse {
     data: Vec<ModelEntry>,
 }
 
-/// A single SSE chunk from streaming chat completions.
+// SSE chunk types for streaming (extended for tool calls)
+
 #[derive(Debug, Deserialize)]
 struct ChatCompletionChunk {
     choices: Vec<ChunkChoice>,
@@ -59,15 +171,81 @@ struct ChatCompletionChunk {
 #[derive(Debug, Deserialize)]
 struct ChunkChoice {
     delta: ChunkDelta,
+    #[serde(default)]
+    finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct ChunkDelta {
     #[serde(default)]
     content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<ChunkToolCall>>,
 }
 
-/// Client for OpenAI-compatible endpoints (Ollama, LM Studio, etc.).
+#[derive(Debug, Deserialize)]
+struct ChunkToolCall {
+    index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<ChunkFunctionCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChunkFunctionCall {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+/// Accumulator for tool calls arriving as SSE fragments.
+#[derive(Default)]
+struct ToolCallAccumulator {
+    calls: HashMap<usize, (String, String, String)>, // index -> (id, name, arguments)
+}
+
+impl ToolCallAccumulator {
+    fn push(&mut self, chunk: &ChunkToolCall) {
+        let entry = self.calls.entry(chunk.index).or_insert_with(|| {
+            (String::new(), String::new(), String::new())
+        });
+        if let Some(id) = &chunk.id {
+            entry.0 = id.clone();
+        }
+        if let Some(func) = &chunk.function {
+            if let Some(name) = &func.name {
+                entry.1 = name.clone();
+            }
+            if let Some(args) = &func.arguments {
+                entry.2.push_str(args);
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.calls.is_empty()
+    }
+
+    fn into_tool_calls(self) -> Vec<ToolCall> {
+        let mut entries: Vec<_> = self.calls.into_iter().collect();
+        entries.sort_by_key(|(idx, _)| *idx);
+        entries
+            .into_iter()
+            .map(|(_, (id, name, arguments))| ToolCall {
+                id,
+                r#type: "function".to_string(),
+                function: FunctionCall { name, arguments },
+            })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible client
+// ---------------------------------------------------------------------------
+
 #[derive(Clone)]
 pub struct OpenAiClient {
     base_url: String,
@@ -75,7 +253,6 @@ pub struct OpenAiClient {
     http: reqwest::Client,
 }
 
-// Manual Debug to avoid leaking the API key in logs.
 impl std::fmt::Debug for OpenAiClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenAiClient")
@@ -92,7 +269,6 @@ impl OpenAiClient {
             .timeout(Duration::from_secs(600))
             .build()
             .expect("failed to build HTTP client");
-        // Normalize: strip trailing slash
         let base_url = base_url.trim_end_matches('/').to_string();
         Self {
             base_url,
@@ -101,7 +277,6 @@ impl OpenAiClient {
         }
     }
 
-    /// Build the full API URL for a given path (handles /v1 normalization).
     fn api_url(&self, path: &str) -> String {
         if self.base_url.ends_with("/v1") {
             format!("{}{}", self.base_url, path)
@@ -120,11 +295,12 @@ impl LlmBackend for OpenAiClient {
         &self,
         model: &str,
         messages: Vec<ChatMessage>,
+        tools: Option<Vec<ToolDefinition>>,
         on_token: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
-    ) -> BoxFuture<'_, Result<String>> {
+    ) -> BoxFuture<'_, Result<LlmResponse>> {
         let model = model.to_string();
-        Box::pin(self.stream_chat_impl(model, messages, on_token, cancel))
+        Box::pin(self.stream_chat_impl(model, messages, tools, on_token, cancel))
     }
 }
 
@@ -154,10 +330,13 @@ impl OpenAiClient {
         &self,
         model: String,
         messages: Vec<ChatMessage>,
+        tools: Option<Vec<ToolDefinition>>,
         mut on_token: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
-    ) -> Result<String> {
+    ) -> Result<LlmResponse> {
         let url = self.api_url("/chat/completions");
+
+        let tool_choice = tools.as_ref().map(|_| "auto".to_string());
 
         let body = ChatCompletionRequest {
             model,
@@ -165,6 +344,8 @@ impl OpenAiClient {
             stream: true,
             temperature: None,
             max_tokens: None,
+            tools,
+            tool_choice,
         };
 
         let mut req = self.http.post(&url).json(&body);
@@ -175,30 +356,26 @@ impl OpenAiClient {
         let resp = req.send().await.context("failed to send chat request")?;
         let status = resp.status();
         if !status.is_success() {
-            anyhow::bail!("chat completion failed (HTTP {})", status);
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("chat completion failed (HTTP {status}): {body_text}");
         }
 
-        let mut full_response = String::new();
+        let mut full_text = String::new();
+        let mut tool_acc = ToolCallAccumulator::default();
         let mut stream = resp.bytes_stream();
-        // Buffer raw bytes to avoid corrupting multi-byte UTF-8 characters
-        // that may be split across TCP chunks.
         let mut raw_buf: Vec<u8> = Vec::new();
 
         loop {
             tokio::select! {
                 _ = cancel.cancelled() => {
                     tracing::info!("streaming cancelled by client");
-                    return Ok(full_response);
+                    break;
                 }
                 chunk = stream.next() => {
-                    let Some(chunk) = chunk else {
-                        break;
-                    };
+                    let Some(chunk) = chunk else { break; };
                     let chunk = chunk.context("stream read error")?;
                     raw_buf.extend_from_slice(&chunk);
 
-                    // Process complete lines (newline-delimited) from the byte buffer.
-                    // Only convert to String once we have a full line.
                     while let Some(pos) = raw_buf.iter().position(|&b| b == b'\n') {
                         let line_bytes = raw_buf.drain(..=pos).collect::<Vec<_>>();
                         let line = String::from_utf8_lossy(&line_bytes).trim().to_string();
@@ -214,15 +391,28 @@ impl OpenAiClient {
                         };
 
                         if data == "[DONE]" {
-                            return Ok(full_response);
+                            if tool_acc.is_empty() {
+                                return Ok(LlmResponse::Text(full_text));
+                            }
+                            return Ok(LlmResponse::ToolCalls {
+                                text: full_text,
+                                calls: tool_acc.into_tool_calls(),
+                            });
                         }
 
                         match serde_json::from_str::<ChatCompletionChunk>(data) {
                             Ok(chunk) => {
                                 for choice in &chunk.choices {
+                                    // Accumulate text content
                                     if let Some(content) = &choice.delta.content {
                                         on_token(content);
-                                        full_response.push_str(content);
+                                        full_text.push_str(content);
+                                    }
+                                    // Accumulate tool call fragments
+                                    if let Some(tc_chunks) = &choice.delta.tool_calls {
+                                        for tc in tc_chunks {
+                                            tool_acc.push(tc);
+                                        }
                                     }
                                 }
                             }
@@ -235,6 +425,13 @@ impl OpenAiClient {
             }
         }
 
-        Ok(full_response)
+        if tool_acc.is_empty() {
+            Ok(LlmResponse::Text(full_text))
+        } else {
+            Ok(LlmResponse::ToolCalls {
+                text: full_text,
+                calls: tool_acc.into_tool_calls(),
+            })
+        }
     }
 }

--- a/brokk-acp-rust/src/llm_client.rs
+++ b/brokk-acp-rust/src/llm_client.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use futures::future::BoxFuture;
 use futures::StreamExt;
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -40,10 +40,7 @@ pub struct FunctionCall {
 #[derive(Debug)]
 pub enum LlmResponse {
     Text(String),
-    ToolCalls {
-        text: String,
-        calls: Vec<ToolCall>,
-    },
+    ToolCalls { text: String, calls: Vec<ToolCall> },
 }
 
 // ---------------------------------------------------------------------------
@@ -104,7 +101,11 @@ impl ChatMessage {
         }
     }
 
-    pub fn tool_result(tool_call_id: impl Into<String>, name: impl Into<String>, content: impl Into<String>) -> Self {
+    pub fn tool_result(
+        tool_call_id: impl Into<String>,
+        name: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
         Self {
             role: "tool".to_string(),
             content: Some(content.into()),
@@ -171,8 +172,6 @@ struct ChatCompletionChunk {
 #[derive(Debug, Deserialize)]
 struct ChunkChoice {
     delta: ChunkDelta,
-    #[serde(default)]
-    finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -208,9 +207,10 @@ struct ToolCallAccumulator {
 
 impl ToolCallAccumulator {
     fn push(&mut self, chunk: &ChunkToolCall) {
-        let entry = self.calls.entry(chunk.index).or_insert_with(|| {
-            (String::new(), String::new(), String::new())
-        });
+        let entry = self
+            .calls
+            .entry(chunk.index)
+            .or_insert_with(|| (String::new(), String::new(), String::new()));
         if let Some(id) = &chunk.id {
             entry.0 = id.clone();
         }
@@ -321,8 +321,10 @@ impl OpenAiClient {
             anyhow::bail!("model discovery failed (HTTP {status})");
         }
 
-        let models: ModelsResponse =
-            resp.json().await.context("failed to parse models response")?;
+        let models: ModelsResponse = resp
+            .json()
+            .await
+            .context("failed to parse models response")?;
         Ok(models.data.into_iter().map(|m| m.id).collect())
     }
 

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -51,10 +51,7 @@ async fn main() -> Result<()> {
         .init();
 
     let args = Args::parse();
-    tracing::info!(
-        "brokk-acp starting, endpoint={}",
-        args.endpoint_url
-    );
+    tracing::info!("brokk-acp starting, endpoint={}", args.endpoint_url);
 
     let llm: Arc<dyn llm_client::LlmBackend> = Arc::new(llm_client::OpenAiClient::new(
         args.endpoint_url,

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -6,6 +6,8 @@ use clap::Parser;
 mod agent;
 mod llm_client;
 mod session;
+mod tool_loop;
+mod tools;
 
 /// Brokk ACP Server -- Rust-based Agent Client Protocol server
 /// with Ollama/OpenAI-compatible LLM backend.

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -1,9 +1,16 @@
 use std::collections::HashMap;
+use std::io::{Read as IoRead, Write as IoWrite};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-/// Session modes matching Brokk's existing mode set.
+// ---------------------------------------------------------------------------
+// Session modes
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SessionMode {
     Lutz,
@@ -33,41 +40,532 @@ impl SessionMode {
     }
 }
 
-/// A single conversation turn in session history.
+// ---------------------------------------------------------------------------
+// Conversation history
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Clone)]
 pub struct ConversationTurn {
     pub user_prompt: String,
     pub agent_response: String,
 }
 
-/// Per-session state.
+// ---------------------------------------------------------------------------
+// Executor-compatible manifest (manifest.json inside the zip)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionManifest {
+    pub id: String,
+    pub name: String,
+    pub created: u64,
+    pub modified: u64,
+    #[serde(default = "default_version")]
+    pub version: String,
+}
+
+fn default_version() -> String {
+    "4.0".to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Per-session state (in-memory)
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Clone)]
 pub struct Session {
     pub id: String,
+    pub cwd: PathBuf,
     pub mode: SessionMode,
     pub model: String,
     pub reasoning_level: String,
     pub history: Vec<ConversationTurn>,
+    pub manifest: SessionManifest,
 }
 
 impl Session {
-    pub fn new(id: String, model: String) -> Self {
+    pub fn new(id: String, cwd: PathBuf, model: String, name: String) -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let manifest = SessionManifest {
+            id: id.clone(),
+            name,
+            created: now,
+            modified: now,
+            version: "4.0".to_string(),
+        };
         Self {
             id,
+            cwd,
             mode: SessionMode::Lutz,
             model,
             reasoning_level: "medium".to_string(),
             history: Vec::new(),
+            manifest,
         }
     }
 }
 
-/// Thread-safe session store.
+// ---------------------------------------------------------------------------
+// Zip I/O: read/write executor-compatible session zips
+// ---------------------------------------------------------------------------
+
+fn sessions_dir(cwd: &Path) -> PathBuf {
+    cwd.join(".brokk").join("sessions")
+}
+
+fn session_zip_path(cwd: &Path, id: &str) -> PathBuf {
+    sessions_dir(cwd).join(format!("{id}.zip"))
+}
+
+/// Read manifest.json from a session zip. Returns None if the zip or manifest is unreadable.
+fn read_manifest_from_zip(zip_path: &Path) -> Option<SessionManifest> {
+    let file = std::fs::File::open(zip_path).ok()?;
+    let mut archive = zip::ZipArchive::new(file).ok()?;
+    let mut manifest_entry = archive.by_name("manifest.json").ok()?;
+    let mut buf = String::new();
+    manifest_entry.read_to_string(&mut buf).ok()?;
+    serde_json::from_str(&buf).ok()
+}
+
+/// Read conversation history from a session zip.
+/// Reads TaskFragmentDto entries from fragments-v4.json and resolves their
+/// markdownContentId / messages[].contentId against content/*.txt files.
+fn read_history_from_zip(zip_path: &Path) -> Vec<ConversationTurn> {
+    let file = match std::fs::File::open(zip_path) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+    let mut archive = match zip::ZipArchive::new(file) {
+        Ok(a) => a,
+        Err(_) => return vec![],
+    };
+
+    // 1. Read all content/*.txt files into a map: content_id -> text
+    let mut content_map: HashMap<String, String> = HashMap::new();
+    for i in 0..archive.len() {
+        let mut entry = match archive.by_index(i) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let name = entry.name().to_string();
+        if let Some(content_id) = name.strip_prefix("content/").and_then(|s| s.strip_suffix(".txt")) {
+            let mut buf = String::new();
+            if entry.read_to_string(&mut buf).is_ok() {
+                content_map.insert(content_id.to_string(), buf);
+            }
+        }
+    }
+
+    // 2. Read fragments-v4.json to find task fragments with conversation content
+    let fragments_json = {
+        let mut entry = match archive.by_name("fragments-v4.json") {
+            Ok(e) => e,
+            Err(_) => return vec![],
+        };
+        let mut buf = String::new();
+        if entry.read_to_string(&mut buf).is_err() {
+            return vec![];
+        }
+        buf
+    };
+
+    let fragments: serde_json::Value = match serde_json::from_str(&fragments_json) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+
+    // 3. Extract conversation from task fragments
+    //    Each task fragment may have:
+    //    - messages: [{role, contentId, reasoningContentId}] (old format)
+    //    - markdownContentId: points to the rendered output (new format)
+    let mut turns = Vec::new();
+    if let Some(tasks) = fragments.get("task").and_then(|t| t.as_object()) {
+        for (_id, task) in tasks {
+            // Try markdownContentId first (newer format: pre-rendered markdown)
+            if let Some(content_id) = task.get("markdownContentId").and_then(|v| v.as_str()) {
+                if let Some(text) = content_map.get(content_id) {
+                    let description = task
+                        .get("taskDescription")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    turns.push(ConversationTurn {
+                        user_prompt: description.to_string(),
+                        agent_response: text.clone(),
+                    });
+                    continue;
+                }
+            }
+
+            // Fall back to messages array (older format)
+            if let Some(messages) = task.get("messages").and_then(|v| v.as_array()) {
+                let mut user_text = String::new();
+                let mut assistant_text = String::new();
+                for msg in messages {
+                    let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
+                    let content_id = msg.get("contentId").and_then(|v| v.as_str()).unwrap_or("");
+                    let text = content_map.get(content_id).cloned().unwrap_or_default();
+                    match role {
+                        "user" => user_text.push_str(&text),
+                        "ai" => assistant_text.push_str(&text),
+                        _ => {}
+                    }
+                }
+                if !assistant_text.is_empty() {
+                    turns.push(ConversationTurn {
+                        user_prompt: user_text,
+                        agent_response: assistant_text,
+                    });
+                }
+            }
+        }
+    }
+
+    turns
+}
+
+/// Write a new empty session zip compatible with the executor.
+fn write_new_session_zip(zip_path: &Path, manifest: &SessionManifest) {
+    let dir = zip_path.parent().unwrap();
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        tracing::warn!("failed to create sessions dir {}: {e}", dir.display());
+        return;
+    }
+
+    let tmp = zip_path.with_extension("tmp");
+    let file = match std::fs::File::create(&tmp) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!("failed to create session zip {}: {e}", tmp.display());
+            return;
+        }
+    };
+
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    // manifest.json
+    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_default();
+    if zip.start_file("manifest.json", options).is_ok() {
+        let _ = zip.write_all(manifest_json.as_bytes());
+    }
+
+    // Empty context (one initial context entry)
+    let ctx_id = uuid::Uuid::new_v4().to_string();
+    let context_line = serde_json::json!({
+        "id": ctx_id,
+        "editable": [],
+        "readonly": [],
+        "virtuals": [],
+        "pinned": [],
+        "tasks": [],
+        "parsedOutputId": null
+    });
+    if zip.start_file("contexts.jsonl", options).is_ok() {
+        let line = serde_json::to_string(&context_line).unwrap_or_default();
+        let _ = zip.write_all(line.as_bytes());
+        let _ = zip.write_all(b"\n");
+    }
+
+    // Empty fragments
+    let fragments = serde_json::json!({
+        "version": 4,
+        "referenced": {},
+        "virtual": {},
+        "task": {}
+    });
+    if zip.start_file("fragments-v4.json", options).is_ok() {
+        let _ = zip.write_all(serde_json::to_string(&fragments).unwrap_or_default().as_bytes());
+    }
+
+    // Empty content metadata
+    if zip.start_file("content_metadata.json", options).is_ok() {
+        let _ = zip.write_all(b"{}");
+    }
+
+    // Empty group info
+    let group_info = serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
+    if zip.start_file("group_info.json", options).is_ok() {
+        let _ = zip.write_all(serde_json::to_string(&group_info).unwrap_or_default().as_bytes());
+    }
+
+    let _ = zip.finish();
+    if let Err(e) = std::fs::rename(&tmp, zip_path) {
+        tracing::warn!("failed to rename session zip: {e}");
+    }
+}
+
+/// Update manifest.json and add a conversation turn to an existing session zip.
+fn append_turn_to_zip(zip_path: &Path, manifest: &SessionManifest, turn: &ConversationTurn) {
+    // Read the existing zip, rebuild with new content
+    let file = match std::fs::File::open(zip_path) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!("failed to open session zip for update: {e}");
+            return;
+        }
+    };
+    let mut archive = match zip::ZipArchive::new(file) {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::warn!("failed to read session zip: {e}");
+            return;
+        }
+    };
+
+    let tmp = zip_path.with_extension("tmp");
+    let out_file = match std::fs::File::create(&tmp) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!("failed to create temp zip: {e}");
+            return;
+        }
+    };
+
+    let mut zip_writer = zip::ZipWriter::new(out_file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    // Generate content IDs for this turn
+    let user_content_id = uuid::Uuid::new_v4().to_string();
+    let response_content_id = uuid::Uuid::new_v4().to_string();
+    let task_fragment_id = uuid::Uuid::new_v4().to_string();
+    let new_context_id = uuid::Uuid::new_v4().to_string();
+
+    // Read existing fragments and contexts
+    let mut existing_fragments: serde_json::Value = serde_json::json!({
+        "version": 4, "referenced": {}, "virtual": {}, "task": {}
+    });
+    let mut existing_contexts = String::new();
+    let mut existing_content_metadata: serde_json::Value = serde_json::json!({});
+    let mut existing_group_info: serde_json::Value =
+        serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
+
+    // Copy existing entries (except ones we'll rewrite), and read their content
+    for i in 0..archive.len() {
+        let mut entry = match archive.by_index(i) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let name = entry.name().to_string();
+
+        match name.as_str() {
+            "manifest.json" => { /* we'll rewrite this */ }
+            "fragments-v4.json" => {
+                let mut buf = String::new();
+                if entry.read_to_string(&mut buf).is_ok() {
+                    if let Ok(v) = serde_json::from_str(&buf) {
+                        existing_fragments = v;
+                    }
+                }
+            }
+            "contexts.jsonl" => {
+                let _ = entry.read_to_string(&mut existing_contexts);
+            }
+            "content_metadata.json" => {
+                let mut buf = String::new();
+                if entry.read_to_string(&mut buf).is_ok() {
+                    if let Ok(v) = serde_json::from_str(&buf) {
+                        existing_content_metadata = v;
+                    }
+                }
+            }
+            "group_info.json" => {
+                let mut buf = String::new();
+                if entry.read_to_string(&mut buf).is_ok() {
+                    if let Ok(v) = serde_json::from_str(&buf) {
+                        existing_group_info = v;
+                    }
+                }
+            }
+            _ => {
+                // Copy other entries as-is (content/*.txt, images, etc.)
+                let mut buf = Vec::new();
+                let _ = entry.read_to_end(&mut buf);
+                if zip_writer.start_file(&name, options).is_ok() {
+                    let _ = zip_writer.write_all(&buf);
+                }
+            }
+        }
+    }
+
+    // Write updated manifest.json
+    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_default();
+    if zip_writer.start_file("manifest.json", options).is_ok() {
+        let _ = zip_writer.write_all(manifest_json.as_bytes());
+    }
+
+    // Add the new task fragment referencing the response content
+    if let Some(tasks) = existing_fragments.get_mut("task").and_then(|t| t.as_object_mut()) {
+        tasks.insert(
+            task_fragment_id.clone(),
+            serde_json::json!({
+                "id": task_fragment_id,
+                "messages": [
+                    {"role": "user", "contentId": user_content_id},
+                    {"role": "ai", "contentId": response_content_id}
+                ],
+                "taskDescription": null,
+                "markdownContentId": response_content_id,
+                "escapeHtml": false
+            }),
+        );
+    }
+
+    // Write updated fragments
+    if zip_writer.start_file("fragments-v4.json", options).is_ok() {
+        let _ = zip_writer.write_all(
+            serde_json::to_string(&existing_fragments)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+    }
+
+    // Add new context entry referencing the task fragment
+    let new_context = serde_json::json!({
+        "id": new_context_id,
+        "editable": [],
+        "readonly": [],
+        "virtuals": [task_fragment_id],
+        "pinned": [],
+        "tasks": [{
+            "sequence": 0,
+            "description": null,
+            "logId": task_fragment_id,
+            "llmLogId": null,
+            "summaryContentId": null,
+            "taskType": null,
+            "primaryModelName": null,
+            "primaryModelReasoning": null
+        }],
+        "parsedOutputId": null
+    });
+
+    let mut contexts = existing_contexts;
+    contexts.push_str(&serde_json::to_string(&new_context).unwrap_or_default());
+    contexts.push('\n');
+    if zip_writer.start_file("contexts.jsonl", options).is_ok() {
+        let _ = zip_writer.write_all(contexts.as_bytes());
+    }
+
+    // Write content metadata
+    if zip_writer
+        .start_file("content_metadata.json", options)
+        .is_ok()
+    {
+        let _ = zip_writer.write_all(
+            serde_json::to_string(&existing_content_metadata)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+    }
+
+    // Write group info
+    if zip_writer.start_file("group_info.json", options).is_ok() {
+        let _ = zip_writer.write_all(
+            serde_json::to_string(&existing_group_info)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+    }
+
+    // Write new content files
+    let user_content_path = format!("content/{user_content_id}.txt");
+    if zip_writer.start_file(&user_content_path, options).is_ok() {
+        let _ = zip_writer.write_all(turn.user_prompt.as_bytes());
+    }
+    let response_content_path = format!("content/{response_content_id}.txt");
+    if zip_writer
+        .start_file(&response_content_path, options)
+        .is_ok()
+    {
+        let _ = zip_writer.write_all(turn.agent_response.as_bytes());
+    }
+
+    let _ = zip_writer.finish();
+    if let Err(e) = std::fs::rename(&tmp, zip_path) {
+        tracing::warn!("failed to rename updated session zip: {e}");
+    }
+}
+
+/// Update only the manifest.json inside an existing zip.
+fn update_manifest_in_zip(zip_path: &Path, manifest: &SessionManifest) {
+    let file = match std::fs::File::open(zip_path) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    let mut archive = match zip::ZipArchive::new(file) {
+        Ok(a) => a,
+        Err(_) => return,
+    };
+
+    let tmp = zip_path.with_extension("tmp");
+    let out_file = match std::fs::File::create(&tmp) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    let mut zip_writer = zip::ZipWriter::new(out_file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    // Copy all entries except manifest.json
+    for i in 0..archive.len() {
+        let mut entry = match archive.by_index(i) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let name = entry.name().to_string();
+        if name == "manifest.json" {
+            continue;
+        }
+        let mut buf = Vec::new();
+        let _ = entry.read_to_end(&mut buf);
+        if zip_writer.start_file(&name, options).is_ok() {
+            let _ = zip_writer.write_all(&buf);
+        }
+    }
+
+    // Write updated manifest
+    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_default();
+    if zip_writer.start_file("manifest.json", options).is_ok() {
+        let _ = zip_writer.write_all(manifest_json.as_bytes());
+    }
+
+    let _ = zip_writer.finish();
+    let _ = std::fs::rename(&tmp, zip_path);
+}
+
+/// List all session manifests from the executor's sessions directory.
+fn list_manifests_from_disk(cwd: &Path) -> Vec<SessionManifest> {
+    let dir = sessions_dir(cwd);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return vec![],
+    };
+    entries
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("zip") {
+                return None;
+            }
+            read_manifest_from_zip(&path)
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Thread-safe session store
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Clone)]
 pub struct SessionStore {
     sessions: Arc<RwLock<HashMap<String, Session>>>,
     default_model: Arc<RwLock<String>>,
-    /// Active cancellation tokens keyed by session ID.
     cancel_tokens: Arc<RwLock<HashMap<String, CancellationToken>>>,
 }
 
@@ -80,16 +578,51 @@ impl SessionStore {
         }
     }
 
-    pub async fn create_session(&self) -> Session {
+    /// Create a new session and write it to disk as a zip.
+    pub async fn create_session(&self, cwd: PathBuf) -> Session {
         let id = uuid::Uuid::new_v4().to_string();
         let model = self.default_model.read().await.clone();
-        let session = Session::new(id.clone(), model);
+        let session = Session::new(id.clone(), cwd.clone(), model, "New Session".to_string());
+
+        // Write to disk in executor-compatible format
+        let zip_path = session_zip_path(&cwd, &id);
+        write_new_session_zip(&zip_path, &session.manifest);
+
         self.sessions.write().await.insert(id, session.clone());
         session
     }
 
-    pub async fn get_session(&self, id: &str) -> Option<Session> {
-        self.sessions.read().await.get(id).cloned()
+    /// Get session from memory, or load from disk if it exists.
+    pub async fn get_session(&self, id: &str, cwd: &Path) -> Option<Session> {
+        // Check memory first
+        if let Some(s) = self.sessions.read().await.get(id).cloned() {
+            return Some(s);
+        }
+        // Try to load from executor's session zip on disk
+        let zip_path = session_zip_path(cwd, id);
+        let manifest = read_manifest_from_zip(&zip_path)?;
+        let history = read_history_from_zip(&zip_path);
+        let model = self.default_model.read().await.clone();
+        let session = Session {
+            id: manifest.id.clone(),
+            cwd: cwd.to_path_buf(),
+            mode: SessionMode::Lutz,
+            model,
+            reasoning_level: "medium".to_string(),
+            history,
+            manifest,
+        };
+        self.sessions
+            .write()
+            .await
+            .insert(id.to_string(), session.clone());
+        Some(session)
+    }
+
+    pub async fn update_cwd(&self, id: &str, cwd: PathBuf) {
+        if let Some(session) = self.sessions.write().await.get_mut(id) {
+            session.cwd = cwd;
+        }
     }
 
     pub async fn set_mode(&self, id: &str, mode: SessionMode) -> bool {
@@ -101,32 +634,31 @@ impl SessionStore {
         }
     }
 
-    pub async fn set_model(&self, id: &str, model: String) {
-        if let Some(session) = self.sessions.write().await.get_mut(id) {
-            session.model = model;
-        }
-    }
-
-    pub async fn add_turn(&self, id: &str, turn: ConversationTurn) {
-        if let Some(session) = self.sessions.write().await.get_mut(id) {
-            session.history.push(turn);
-        }
-    }
-
     pub async fn set_default_model(&self, model: String) {
         *self.default_model.write().await = model;
     }
 
-    pub async fn default_model(&self) -> String {
-        self.default_model.read().await.clone()
+    /// Add a conversation turn and persist it to the session zip.
+    pub async fn add_turn(&self, id: &str, turn: ConversationTurn) {
+        if let Some(session) = self.sessions.write().await.get_mut(id) {
+            session.history.push(turn.clone());
+            // Update modified timestamp
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            session.manifest.modified = now;
+
+            let zip_path = session_zip_path(&session.cwd, &session.id);
+            append_turn_to_zip(&zip_path, &session.manifest, &turn);
+        }
     }
 
-    pub async fn list_sessions(&self) -> Vec<Session> {
-        self.sessions.read().await.values().cloned().collect()
+    /// List sessions from disk, filtered by cwd.
+    pub async fn list_sessions_from_disk(&self, cwd: &Path) -> Vec<SessionManifest> {
+        list_manifests_from_disk(cwd)
     }
 
-    /// Create a new cancellation token for an active prompt on this session.
-    /// Replaces any existing token (cancelling any previous in-flight request).
     pub async fn start_prompt(&self, session_id: &str) -> CancellationToken {
         let token = CancellationToken::new();
         self.cancel_tokens
@@ -136,14 +668,12 @@ impl SessionStore {
         token
     }
 
-    /// Cancel the active prompt for this session (if any).
     pub async fn cancel_prompt(&self, session_id: &str) {
         if let Some(token) = self.cancel_tokens.read().await.get(session_id) {
             token.cancel();
         }
     }
 
-    /// Remove the cancellation token after prompt completes.
     pub async fn finish_prompt(&self, session_id: &str) {
         self.cancel_tokens.write().await.remove(session_id);
     }

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -78,7 +78,6 @@ pub struct Session {
     pub cwd: PathBuf,
     pub mode: SessionMode,
     pub model: String,
-    pub reasoning_level: String,
     pub history: Vec<ConversationTurn>,
     pub manifest: SessionManifest,
 }
@@ -101,7 +100,6 @@ impl Session {
             cwd,
             mode: SessionMode::Lutz,
             model,
-            reasoning_level: "medium".to_string(),
             history: Vec::new(),
             manifest,
         }
@@ -151,7 +149,10 @@ fn read_history_from_zip(zip_path: &Path) -> Vec<ConversationTurn> {
             Err(_) => continue,
         };
         let name = entry.name().to_string();
-        if let Some(content_id) = name.strip_prefix("content/").and_then(|s| s.strip_suffix(".txt")) {
+        if let Some(content_id) = name
+            .strip_prefix("content/")
+            .and_then(|s| s.strip_suffix(".txt"))
+        {
             let mut buf = String::new();
             if entry.read_to_string(&mut buf).is_ok() {
                 content_map.insert(content_id.to_string(), buf);
@@ -185,18 +186,18 @@ fn read_history_from_zip(zip_path: &Path) -> Vec<ConversationTurn> {
     if let Some(tasks) = fragments.get("task").and_then(|t| t.as_object()) {
         for (_id, task) in tasks {
             // Try markdownContentId first (newer format: pre-rendered markdown)
-            if let Some(content_id) = task.get("markdownContentId").and_then(|v| v.as_str()) {
-                if let Some(text) = content_map.get(content_id) {
-                    let description = task
-                        .get("taskDescription")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    turns.push(ConversationTurn {
-                        user_prompt: description.to_string(),
-                        agent_response: text.clone(),
-                    });
-                    continue;
-                }
+            if let Some(content_id) = task.get("markdownContentId").and_then(|v| v.as_str())
+                && let Some(text) = content_map.get(content_id)
+            {
+                let description = task
+                    .get("taskDescription")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                turns.push(ConversationTurn {
+                    user_prompt: description.to_string(),
+                    agent_response: text.clone(),
+                });
+                continue;
             }
 
             // Fall back to messages array (older format)
@@ -278,7 +279,11 @@ fn write_new_session_zip(zip_path: &Path, manifest: &SessionManifest) {
         "task": {}
     });
     if zip.start_file("fragments-v4.json", options).is_ok() {
-        let _ = zip.write_all(serde_json::to_string(&fragments).unwrap_or_default().as_bytes());
+        let _ = zip.write_all(
+            serde_json::to_string(&fragments)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
     }
 
     // Empty content metadata
@@ -289,7 +294,11 @@ fn write_new_session_zip(zip_path: &Path, manifest: &SessionManifest) {
     // Empty group info
     let group_info = serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
     if zip.start_file("group_info.json", options).is_ok() {
-        let _ = zip.write_all(serde_json::to_string(&group_info).unwrap_or_default().as_bytes());
+        let _ = zip.write_all(
+            serde_json::to_string(&group_info)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
     }
 
     let _ = zip.finish();
@@ -356,10 +365,10 @@ fn append_turn_to_zip(zip_path: &Path, manifest: &SessionManifest, turn: &Conver
             "manifest.json" => { /* we'll rewrite this */ }
             "fragments-v4.json" => {
                 let mut buf = String::new();
-                if entry.read_to_string(&mut buf).is_ok() {
-                    if let Ok(v) = serde_json::from_str(&buf) {
-                        existing_fragments = v;
-                    }
+                if entry.read_to_string(&mut buf).is_ok()
+                    && let Ok(v) = serde_json::from_str(&buf)
+                {
+                    existing_fragments = v;
                 }
             }
             "contexts.jsonl" => {
@@ -367,18 +376,18 @@ fn append_turn_to_zip(zip_path: &Path, manifest: &SessionManifest, turn: &Conver
             }
             "content_metadata.json" => {
                 let mut buf = String::new();
-                if entry.read_to_string(&mut buf).is_ok() {
-                    if let Ok(v) = serde_json::from_str(&buf) {
-                        existing_content_metadata = v;
-                    }
+                if entry.read_to_string(&mut buf).is_ok()
+                    && let Ok(v) = serde_json::from_str(&buf)
+                {
+                    existing_content_metadata = v;
                 }
             }
             "group_info.json" => {
                 let mut buf = String::new();
-                if entry.read_to_string(&mut buf).is_ok() {
-                    if let Ok(v) = serde_json::from_str(&buf) {
-                        existing_group_info = v;
-                    }
+                if entry.read_to_string(&mut buf).is_ok()
+                    && let Ok(v) = serde_json::from_str(&buf)
+                {
+                    existing_group_info = v;
                 }
             }
             _ => {
@@ -399,7 +408,10 @@ fn append_turn_to_zip(zip_path: &Path, manifest: &SessionManifest, turn: &Conver
     }
 
     // Add the new task fragment referencing the response content
-    if let Some(tasks) = existing_fragments.get_mut("task").and_then(|t| t.as_object_mut()) {
+    if let Some(tasks) = existing_fragments
+        .get_mut("task")
+        .and_then(|t| t.as_object_mut())
+    {
         tasks.insert(
             task_fragment_id.clone(),
             serde_json::json!({
@@ -491,54 +503,6 @@ fn append_turn_to_zip(zip_path: &Path, manifest: &SessionManifest, turn: &Conver
     }
 }
 
-/// Update only the manifest.json inside an existing zip.
-fn update_manifest_in_zip(zip_path: &Path, manifest: &SessionManifest) {
-    let file = match std::fs::File::open(zip_path) {
-        Ok(f) => f,
-        Err(_) => return,
-    };
-    let mut archive = match zip::ZipArchive::new(file) {
-        Ok(a) => a,
-        Err(_) => return,
-    };
-
-    let tmp = zip_path.with_extension("tmp");
-    let out_file = match std::fs::File::create(&tmp) {
-        Ok(f) => f,
-        Err(_) => return,
-    };
-
-    let mut zip_writer = zip::ZipWriter::new(out_file);
-    let options = zip::write::SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Deflated);
-
-    // Copy all entries except manifest.json
-    for i in 0..archive.len() {
-        let mut entry = match archive.by_index(i) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        let name = entry.name().to_string();
-        if name == "manifest.json" {
-            continue;
-        }
-        let mut buf = Vec::new();
-        let _ = entry.read_to_end(&mut buf);
-        if zip_writer.start_file(&name, options).is_ok() {
-            let _ = zip_writer.write_all(&buf);
-        }
-    }
-
-    // Write updated manifest
-    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_default();
-    if zip_writer.start_file("manifest.json", options).is_ok() {
-        let _ = zip_writer.write_all(manifest_json.as_bytes());
-    }
-
-    let _ = zip_writer.finish();
-    let _ = std::fs::rename(&tmp, zip_path);
-}
-
 /// List all session manifests from the executor's sessions directory.
 fn list_manifests_from_disk(cwd: &Path) -> Vec<SessionManifest> {
     let dir = sessions_dir(cwd);
@@ -608,7 +572,6 @@ impl SessionStore {
             cwd: cwd.to_path_buf(),
             mode: SessionMode::Lutz,
             model,
-            reasoning_level: "medium".to_string(),
             history,
             manifest,
         };

--- a/brokk-acp-rust/src/tool_loop.rs
+++ b/brokk-acp-rust/src/tool_loop.rs
@@ -15,6 +15,7 @@ const MAX_TOOL_RESULT_BYTES: usize = 50_000;
 ///
 /// `on_text` is called for each text token streamed from the LLM.
 /// `on_tool_event` is called with a human-readable headline when a tool starts executing.
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     llm: &Arc<dyn LlmBackend>,
     registry: &ToolRegistry,
@@ -49,7 +50,13 @@ pub async fn run(
         });
 
         let response = llm
-            .stream_chat(model, messages.clone(), turn_tools, on_token, cancel.clone())
+            .stream_chat(
+                model,
+                messages.clone(),
+                turn_tools,
+                on_token,
+                cancel.clone(),
+            )
             .await;
 
         // Flush buffered tokens to the caller
@@ -84,7 +91,11 @@ pub async fn run(
                     let args: serde_json::Value =
                         serde_json::from_str(&call.function.arguments).unwrap_or_default();
 
-                    tracing::info!("executing tool {} with args: {}", tool_name, call.function.arguments);
+                    tracing::info!(
+                        "executing tool {} with args: {}",
+                        tool_name,
+                        call.function.arguments
+                    );
 
                     let result = registry.execute(tool_name, args).await;
 
@@ -100,11 +111,7 @@ pub async fn run(
                         output.push_str("\n... output truncated");
                     }
 
-                    messages.push(ChatMessage::tool_result(
-                        &call.id,
-                        tool_name,
-                        &output,
-                    ));
+                    messages.push(ChatMessage::tool_result(&call.id, tool_name, &output));
                 }
             }
             Err(e) => {

--- a/brokk-acp-rust/src/tool_loop.rs
+++ b/brokk-acp-rust/src/tool_loop.rs
@@ -1,0 +1,120 @@
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::llm_client::{ChatMessage, LlmBackend, LlmResponse, ToolDefinition};
+use crate::tools::{ToolRegistry, ToolStatus};
+
+const MAX_TOOL_RESULT_BYTES: usize = 50_000;
+
+/// Run the agentic tool-calling loop.
+///
+/// Sends messages to the LLM with tool definitions. If the LLM responds with
+/// tool calls, executes them, appends results, and loops. Stops when the LLM
+/// responds with text only or the turn limit is reached.
+///
+/// `on_text` is called for each text token streamed from the LLM.
+/// `on_tool_event` is called with a human-readable headline when a tool starts executing.
+pub async fn run(
+    llm: &Arc<dyn LlmBackend>,
+    registry: &ToolRegistry,
+    model: &str,
+    mut messages: Vec<ChatMessage>,
+    max_turns: usize,
+    cancel: CancellationToken,
+    mut on_text: impl FnMut(&str),
+    mut on_tool_event: impl FnMut(&str),
+) -> String {
+    let tools: Vec<ToolDefinition> = registry.tool_definitions();
+    let mut full_response = String::new();
+
+    for turn in 0..max_turns {
+        if cancel.is_cancelled() {
+            break;
+        }
+
+        // For the last turn, don't offer tools -- force a text response
+        let turn_tools = if turn < max_turns - 1 {
+            Some(tools.clone())
+        } else {
+            None
+        };
+
+        // We need on_text to receive tokens during streaming. Since the LlmBackend
+        // takes a boxed FnMut, let's forward tokens through a shared buffer.
+        let token_buf = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let buf_clone = token_buf.clone();
+        let on_token: Box<dyn FnMut(&str) + Send> = Box::new(move |token: &str| {
+            buf_clone.lock().unwrap().push(token.to_string());
+        });
+
+        let response = llm
+            .stream_chat(model, messages.clone(), turn_tools, on_token, cancel.clone())
+            .await;
+
+        // Flush buffered tokens to the caller
+        {
+            let tokens = token_buf.lock().unwrap();
+            for token in tokens.iter() {
+                on_text(token);
+            }
+        }
+
+        match response {
+            Ok(LlmResponse::Text(text)) => {
+                full_response.push_str(&text);
+                // Final text response -- we're done
+                break;
+            }
+            Ok(LlmResponse::ToolCalls { text, calls }) => {
+                // Any text emitted before tool calls
+                if !text.is_empty() {
+                    full_response.push_str(&text);
+                }
+
+                // Record the assistant message with tool_calls
+                messages.push(ChatMessage::assistant_tool_calls(calls.clone()));
+
+                // Execute each tool call
+                for call in &calls {
+                    let tool_name = &call.function.name;
+                    let headline = ToolRegistry::headline(tool_name);
+                    on_tool_event(&format!("_{headline}..._\n"));
+
+                    let args: serde_json::Value =
+                        serde_json::from_str(&call.function.arguments).unwrap_or_default();
+
+                    tracing::info!("executing tool {} with args: {}", tool_name, call.function.arguments);
+
+                    let result = registry.execute(tool_name, args).await;
+
+                    let status_prefix = match result.status {
+                        ToolStatus::Success => "",
+                        ToolStatus::RequestError => "Error: ",
+                        ToolStatus::InternalError => "Internal error: ",
+                    };
+
+                    let mut output = format!("{}{}", status_prefix, result.output);
+                    if output.len() > MAX_TOOL_RESULT_BYTES {
+                        output.truncate(MAX_TOOL_RESULT_BYTES);
+                        output.push_str("\n... output truncated");
+                    }
+
+                    messages.push(ChatMessage::tool_result(
+                        &call.id,
+                        tool_name,
+                        &output,
+                    ));
+                }
+            }
+            Err(e) => {
+                let err_msg = format!("\n**Error:** LLM request failed: {e}\n");
+                on_text(&err_msg);
+                full_response.push_str(&err_msg);
+                break;
+            }
+        }
+    }
+
+    full_response
+}

--- a/brokk-acp-rust/src/tools/filesystem.rs
+++ b/brokk-acp-rust/src/tools/filesystem.rs
@@ -1,0 +1,173 @@
+use super::{ToolResult, ToolStatus, safe_resolve, safe_resolve_for_write};
+use regex::Regex;
+use std::path::Path;
+use walkdir::WalkDir;
+
+pub fn read_file(cwd: &Path, path: &str) -> ToolResult {
+    let resolved = match safe_resolve(cwd, path) {
+        Ok(p) => p,
+        Err(e) => return ToolResult { status: ToolStatus::RequestError, output: e },
+    };
+    match std::fs::read_to_string(&resolved) {
+        Ok(content) => ToolResult {
+            status: ToolStatus::Success,
+            output: content,
+        },
+        Err(e) => ToolResult {
+            status: ToolStatus::RequestError,
+            output: format!("Failed to read '{}': {}", path, e),
+        },
+    }
+}
+
+pub fn write_file(cwd: &Path, path: &str, content: &str) -> ToolResult {
+    let resolved = match safe_resolve_for_write(cwd, path) {
+        Ok(p) => p,
+        Err(e) => return ToolResult { status: ToolStatus::RequestError, output: e },
+    };
+    // Create parent directories if needed
+    if let Some(parent) = resolved.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return ToolResult {
+                status: ToolStatus::InternalError,
+                output: format!("Failed to create directories for '{}': {}", path, e),
+            };
+        }
+    }
+    match std::fs::write(&resolved, content) {
+        Ok(()) => ToolResult {
+            status: ToolStatus::Success,
+            output: format!("Written {} bytes to '{}'", content.len(), path),
+        },
+        Err(e) => ToolResult {
+            status: ToolStatus::RequestError,
+            output: format!("Failed to write '{}': {}", path, e),
+        },
+    }
+}
+
+pub fn list_directory(cwd: &Path, path: &str) -> ToolResult {
+    let resolved = match safe_resolve(cwd, path) {
+        Ok(p) => p,
+        Err(e) => return ToolResult { status: ToolStatus::RequestError, output: e },
+    };
+    let entries = match std::fs::read_dir(&resolved) {
+        Ok(e) => e,
+        Err(e) => {
+            return ToolResult {
+                status: ToolStatus::RequestError,
+                output: format!("Failed to list '{}': {}", path, e),
+            }
+        }
+    };
+
+    let mut lines: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        if is_dir {
+            lines.push(format!("{}/", name));
+        } else {
+            lines.push(name);
+        }
+    }
+    lines.sort();
+    ToolResult {
+        status: ToolStatus::Success,
+        output: lines.join("\n"),
+    }
+}
+
+pub fn search_file_contents(
+    cwd: &Path,
+    pattern: &str,
+    glob_filter: Option<&str>,
+    max_results: usize,
+) -> ToolResult {
+    let re = match Regex::new(pattern) {
+        Ok(r) => r,
+        Err(e) => {
+            return ToolResult {
+                status: ToolStatus::RequestError,
+                output: format!("Invalid regex '{}': {}", pattern, e),
+            }
+        }
+    };
+
+    let glob_re = glob_filter.and_then(|g| {
+        // Convert simple glob to regex: *.rs -> .*\.rs$, **/*.java -> .*\.java$
+        let re_str = g
+            .replace('.', "\\.")
+            .replace("**", "<<GLOBSTAR>>")
+            .replace('*', "[^/]*")
+            .replace("<<GLOBSTAR>>", ".*");
+        Regex::new(&format!("{}$", re_str)).ok()
+    });
+
+    let cwd_canonical = match cwd.canonicalize() {
+        Ok(c) => c,
+        Err(e) => {
+            return ToolResult {
+                status: ToolStatus::InternalError,
+                output: format!("Cannot resolve cwd: {}", e),
+            }
+        }
+    };
+
+    let mut results = Vec::new();
+    for entry in WalkDir::new(cwd)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            // Skip hidden dirs and common noise
+            !name.starts_with('.') && name != "node_modules" && name != "target" && name != "__pycache__"
+        })
+        .flatten()
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let rel = path
+            .strip_prefix(&cwd_canonical)
+            .or_else(|_| path.strip_prefix(cwd))
+            .unwrap_or(path);
+        let rel_str = rel.to_string_lossy();
+
+        if let Some(glob_re) = &glob_re {
+            if !glob_re.is_match(&rel_str) {
+                continue;
+            }
+        }
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue, // skip binary or unreadable files
+        };
+
+        for (line_num, line) in content.lines().enumerate() {
+            if re.is_match(line) {
+                results.push(format!("{}:{}: {}", rel_str, line_num + 1, line.trim()));
+                if results.len() >= max_results {
+                    results.push(format!("... truncated at {} results", max_results));
+                    return ToolResult {
+                        status: ToolStatus::Success,
+                        output: results.join("\n"),
+                    };
+                }
+            }
+        }
+    }
+
+    if results.is_empty() {
+        ToolResult {
+            status: ToolStatus::Success,
+            output: format!("No matches found for '{}'", pattern),
+        }
+    } else {
+        ToolResult {
+            status: ToolStatus::Success,
+            output: results.join("\n"),
+        }
+    }
+}

--- a/brokk-acp-rust/src/tools/filesystem.rs
+++ b/brokk-acp-rust/src/tools/filesystem.rs
@@ -6,7 +6,12 @@ use walkdir::WalkDir;
 pub fn read_file(cwd: &Path, path: &str) -> ToolResult {
     let resolved = match safe_resolve(cwd, path) {
         Ok(p) => p,
-        Err(e) => return ToolResult { status: ToolStatus::RequestError, output: e },
+        Err(e) => {
+            return ToolResult {
+                status: ToolStatus::RequestError,
+                output: e,
+            };
+        }
     };
     match std::fs::read_to_string(&resolved) {
         Ok(content) => ToolResult {
@@ -23,16 +28,21 @@ pub fn read_file(cwd: &Path, path: &str) -> ToolResult {
 pub fn write_file(cwd: &Path, path: &str, content: &str) -> ToolResult {
     let resolved = match safe_resolve_for_write(cwd, path) {
         Ok(p) => p,
-        Err(e) => return ToolResult { status: ToolStatus::RequestError, output: e },
-    };
-    // Create parent directories if needed
-    if let Some(parent) = resolved.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
+        Err(e) => {
             return ToolResult {
-                status: ToolStatus::InternalError,
-                output: format!("Failed to create directories for '{}': {}", path, e),
+                status: ToolStatus::RequestError,
+                output: e,
             };
         }
+    };
+    // Create parent directories if needed
+    if let Some(parent) = resolved.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        return ToolResult {
+            status: ToolStatus::InternalError,
+            output: format!("Failed to create directories for '{}': {}", path, e),
+        };
     }
     match std::fs::write(&resolved, content) {
         Ok(()) => ToolResult {
@@ -49,7 +59,12 @@ pub fn write_file(cwd: &Path, path: &str, content: &str) -> ToolResult {
 pub fn list_directory(cwd: &Path, path: &str) -> ToolResult {
     let resolved = match safe_resolve(cwd, path) {
         Ok(p) => p,
-        Err(e) => return ToolResult { status: ToolStatus::RequestError, output: e },
+        Err(e) => {
+            return ToolResult {
+                status: ToolStatus::RequestError,
+                output: e,
+            };
+        }
     };
     let entries = match std::fs::read_dir(&resolved) {
         Ok(e) => e,
@@ -57,7 +72,7 @@ pub fn list_directory(cwd: &Path, path: &str) -> ToolResult {
             return ToolResult {
                 status: ToolStatus::RequestError,
                 output: format!("Failed to list '{}': {}", path, e),
-            }
+            };
         }
     };
 
@@ -90,7 +105,7 @@ pub fn search_file_contents(
             return ToolResult {
                 status: ToolStatus::RequestError,
                 output: format!("Invalid regex '{}': {}", pattern, e),
-            }
+            };
         }
     };
 
@@ -110,7 +125,7 @@ pub fn search_file_contents(
             return ToolResult {
                 status: ToolStatus::InternalError,
                 output: format!("Cannot resolve cwd: {}", e),
-            }
+            };
         }
     };
 
@@ -120,7 +135,10 @@ pub fn search_file_contents(
         .filter_entry(|e| {
             let name = e.file_name().to_string_lossy();
             // Skip hidden dirs and common noise
-            !name.starts_with('.') && name != "node_modules" && name != "target" && name != "__pycache__"
+            !name.starts_with('.')
+                && name != "node_modules"
+                && name != "target"
+                && name != "__pycache__"
         })
         .flatten()
     {
@@ -134,10 +152,10 @@ pub fn search_file_contents(
             .unwrap_or(path);
         let rel_str = rel.to_string_lossy();
 
-        if let Some(glob_re) = &glob_re {
-            if !glob_re.is_match(&rel_str) {
-                continue;
-            }
+        if let Some(glob_re) = &glob_re
+            && !glob_re.is_match(&rel_str)
+        {
+            continue;
         }
 
         let content = match std::fs::read_to_string(path) {

--- a/brokk-acp-rust/src/tools/mod.rs
+++ b/brokk-acp-rust/src/tools/mod.rs
@@ -31,84 +31,108 @@ impl ToolRegistry {
     /// All tool definitions for the OpenAI tools parameter.
     pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
         vec![
-            tool_def("think", "Use this tool to think through a problem step by step before acting. The input is not used for anything -- it is just a scratchpad for your thoughts.", json!({
-                "type": "object",
-                "properties": {
-                    "thought": {
-                        "type": "string",
-                        "description": "Your reasoning or thought process."
-                    }
-                },
-                "required": ["thought"]
-            })),
-            tool_def("readFile", "Read the contents of a file. Path is relative to the working directory.", json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Relative path to the file to read."
-                    }
-                },
-                "required": ["path"]
-            })),
-            tool_def("writeFile", "Write content to a file, creating it if it does not exist. Path is relative to the working directory.", json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Relative path to the file to write."
+            tool_def(
+                "think",
+                "Use this tool to think through a problem step by step before acting. The input is not used for anything -- it is just a scratchpad for your thoughts.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "thought": {
+                            "type": "string",
+                            "description": "Your reasoning or thought process."
+                        }
                     },
-                    "content": {
-                        "type": "string",
-                        "description": "Content to write to the file."
-                    }
-                },
-                "required": ["path", "content"]
-            })),
-            tool_def("listDirectory", "List files and directories at the given path. Path is relative to the working directory.", json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Relative path to the directory to list. Use '.' for the working directory root."
-                    }
-                },
-                "required": ["path"]
-            })),
-            tool_def("searchFileContents", "Search for a regex pattern across files in the working directory. Returns matching lines with file paths and line numbers.", json!({
-                "type": "object",
-                "properties": {
-                    "pattern": {
-                        "type": "string",
-                        "description": "Regex pattern to search for."
+                    "required": ["thought"]
+                }),
+            ),
+            tool_def(
+                "readFile",
+                "Read the contents of a file. Path is relative to the working directory.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Relative path to the file to read."
+                        }
                     },
-                    "glob": {
-                        "type": "string",
-                        "description": "Optional glob to filter files (e.g. '*.rs', '**/*.java'). Defaults to all files."
+                    "required": ["path"]
+                }),
+            ),
+            tool_def(
+                "writeFile",
+                "Write content to a file, creating it if it does not exist. Path is relative to the working directory.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Relative path to the file to write."
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Content to write to the file."
+                        }
                     },
-                    "maxResults": {
-                        "type": "integer",
-                        "default": 50,
-                        "description": "Maximum number of matching lines to return."
-                    }
-                },
-                "required": ["pattern"]
-            })),
-            tool_def("runShellCommand", "Execute a shell command in the working directory. Returns stdout and stderr. Use for build, test, git, or other CLI operations.", json!({
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "description": "The shell command to execute (passed to sh -c)."
+                    "required": ["path", "content"]
+                }),
+            ),
+            tool_def(
+                "listDirectory",
+                "List files and directories at the given path. Path is relative to the working directory.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Relative path to the directory to list. Use '.' for the working directory root."
+                        }
                     },
-                    "timeoutSeconds": {
-                        "type": "integer",
-                        "default": 60,
-                        "description": "Maximum execution time in seconds."
-                    }
-                },
-                "required": ["command"]
-            })),
+                    "required": ["path"]
+                }),
+            ),
+            tool_def(
+                "searchFileContents",
+                "Search for a regex pattern across files in the working directory. Returns matching lines with file paths and line numbers.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "pattern": {
+                            "type": "string",
+                            "description": "Regex pattern to search for."
+                        },
+                        "glob": {
+                            "type": "string",
+                            "description": "Optional glob to filter files (e.g. '*.rs', '**/*.java'). Defaults to all files."
+                        },
+                        "maxResults": {
+                            "type": "integer",
+                            "default": 50,
+                            "description": "Maximum number of matching lines to return."
+                        }
+                    },
+                    "required": ["pattern"]
+                }),
+            ),
+            tool_def(
+                "runShellCommand",
+                "Execute a shell command in the working directory. Returns stdout and stderr. Use for build, test, git, or other CLI operations.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The shell command to execute (passed to sh -c)."
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer",
+                            "default": 60,
+                            "description": "Maximum execution time in seconds."
+                        }
+                    },
+                    "required": ["command"]
+                }),
+            ),
         ]
     }
 
@@ -138,12 +162,18 @@ impl ToolRegistry {
             "searchFileContents" => {
                 let pattern = args.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
                 let glob = args.get("glob").and_then(|v| v.as_str());
-                let max_results = args.get("maxResults").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
+                let max_results = args
+                    .get("maxResults")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(50) as usize;
                 filesystem::search_file_contents(&self.cwd, pattern, glob, max_results)
             }
             "runShellCommand" => {
                 let command = args.get("command").and_then(|v| v.as_str()).unwrap_or("");
-                let timeout = args.get("timeoutSeconds").and_then(|v| v.as_u64()).unwrap_or(60);
+                let timeout = args
+                    .get("timeoutSeconds")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(60);
                 shell::run_shell_command(&self.cwd, command, timeout).await
             }
             _ => ToolResult {
@@ -194,7 +224,10 @@ pub fn safe_resolve(cwd: &Path, requested: &str) -> Result<PathBuf, String> {
         .canonicalize()
         .map_err(|e| format!("Cannot resolve cwd: {}", e))?;
     if !resolved.starts_with(&cwd_canonical) {
-        return Err(format!("Path '{}' escapes the working directory", requested));
+        return Err(format!(
+            "Path '{}' escapes the working directory",
+            requested
+        ));
     }
     Ok(resolved)
 }
@@ -212,7 +245,10 @@ pub fn safe_resolve_for_write(cwd: &Path, requested: &str) -> Result<PathBuf, St
             .canonicalize()
             .map_err(|e| format!("Cannot resolve cwd: {}", e))?;
         if !parent_canonical.starts_with(&cwd_canonical) {
-            return Err(format!("Path '{}' escapes the working directory", requested));
+            return Err(format!(
+                "Path '{}' escapes the working directory",
+                requested
+            ));
         }
     }
     Ok(joined)

--- a/brokk-acp-rust/src/tools/mod.rs
+++ b/brokk-acp-rust/src/tools/mod.rs
@@ -1,0 +1,219 @@
+mod filesystem;
+mod shell;
+
+use crate::llm_client::{FunctionDef, ToolDefinition};
+use serde_json::json;
+use std::path::{Path, PathBuf};
+
+/// Result of executing a tool.
+pub struct ToolResult {
+    pub status: ToolStatus,
+    pub output: String,
+}
+
+pub enum ToolStatus {
+    Success,
+    RequestError,
+    InternalError,
+}
+
+/// Unified tool registry: filesystem tools + shell + think.
+/// Bifrost (brokk_analyzer) will be added here when integrated as a dependency.
+pub struct ToolRegistry {
+    cwd: PathBuf,
+}
+
+impl ToolRegistry {
+    pub fn new(cwd: PathBuf) -> Self {
+        Self { cwd }
+    }
+
+    /// All tool definitions for the OpenAI tools parameter.
+    pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        vec![
+            tool_def("think", "Use this tool to think through a problem step by step before acting. The input is not used for anything -- it is just a scratchpad for your thoughts.", json!({
+                "type": "object",
+                "properties": {
+                    "thought": {
+                        "type": "string",
+                        "description": "Your reasoning or thought process."
+                    }
+                },
+                "required": ["thought"]
+            })),
+            tool_def("readFile", "Read the contents of a file. Path is relative to the working directory.", json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative path to the file to read."
+                    }
+                },
+                "required": ["path"]
+            })),
+            tool_def("writeFile", "Write content to a file, creating it if it does not exist. Path is relative to the working directory.", json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative path to the file to write."
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Content to write to the file."
+                    }
+                },
+                "required": ["path", "content"]
+            })),
+            tool_def("listDirectory", "List files and directories at the given path. Path is relative to the working directory.", json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative path to the directory to list. Use '.' for the working directory root."
+                    }
+                },
+                "required": ["path"]
+            })),
+            tool_def("searchFileContents", "Search for a regex pattern across files in the working directory. Returns matching lines with file paths and line numbers.", json!({
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "description": "Regex pattern to search for."
+                    },
+                    "glob": {
+                        "type": "string",
+                        "description": "Optional glob to filter files (e.g. '*.rs', '**/*.java'). Defaults to all files."
+                    },
+                    "maxResults": {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Maximum number of matching lines to return."
+                    }
+                },
+                "required": ["pattern"]
+            })),
+            tool_def("runShellCommand", "Execute a shell command in the working directory. Returns stdout and stderr. Use for build, test, git, or other CLI operations.", json!({
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "The shell command to execute (passed to sh -c)."
+                    },
+                    "timeoutSeconds": {
+                        "type": "integer",
+                        "default": 60,
+                        "description": "Maximum execution time in seconds."
+                    }
+                },
+                "required": ["command"]
+            })),
+        ]
+    }
+
+    /// Execute a tool by name with JSON arguments.
+    pub async fn execute(&self, name: &str, args: serde_json::Value) -> ToolResult {
+        match name {
+            "think" => {
+                let thought = args.get("thought").and_then(|v| v.as_str()).unwrap_or("");
+                ToolResult {
+                    status: ToolStatus::Success,
+                    output: format!("Thought noted: {thought}"),
+                }
+            }
+            "readFile" => {
+                let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+                filesystem::read_file(&self.cwd, path)
+            }
+            "writeFile" => {
+                let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+                let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                filesystem::write_file(&self.cwd, path, content)
+            }
+            "listDirectory" => {
+                let path = args.get("path").and_then(|v| v.as_str()).unwrap_or(".");
+                filesystem::list_directory(&self.cwd, path)
+            }
+            "searchFileContents" => {
+                let pattern = args.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+                let glob = args.get("glob").and_then(|v| v.as_str());
+                let max_results = args.get("maxResults").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
+                filesystem::search_file_contents(&self.cwd, pattern, glob, max_results)
+            }
+            "runShellCommand" => {
+                let command = args.get("command").and_then(|v| v.as_str()).unwrap_or("");
+                let timeout = args.get("timeoutSeconds").and_then(|v| v.as_u64()).unwrap_or(60);
+                shell::run_shell_command(&self.cwd, command, timeout).await
+            }
+            _ => ToolResult {
+                status: ToolStatus::RequestError,
+                output: format!("Unknown tool: {name}"),
+            },
+        }
+    }
+
+    /// Human-readable headline for a tool call (shown to ACP client).
+    pub fn headline(tool_name: &str) -> &'static str {
+        match tool_name {
+            "think" => "Thinking",
+            "readFile" => "Reading file",
+            "writeFile" => "Writing file",
+            "listDirectory" => "Listing directory",
+            "searchFileContents" => "Searching file contents",
+            "runShellCommand" => "Running shell command",
+            "search_symbols" => "Searching for symbols",
+            "get_symbol_locations" => "Finding symbol locations",
+            "get_symbol_sources" => "Fetching symbol source",
+            "get_file_summaries" => "Getting file summaries",
+            "skim_files" => "Skimming files",
+            "most_relevant_files" => "Finding related files",
+            _ => "Executing tool",
+        }
+    }
+}
+
+fn tool_def(name: &str, description: &str, parameters: serde_json::Value) -> ToolDefinition {
+    ToolDefinition {
+        r#type: "function".to_string(),
+        function: FunctionDef {
+            name: name.to_string(),
+            description: description.to_string(),
+            parameters,
+        },
+    }
+}
+
+/// Resolve a relative path against cwd and ensure it stays within cwd.
+pub fn safe_resolve(cwd: &Path, requested: &str) -> Result<PathBuf, String> {
+    let joined = cwd.join(requested);
+    let resolved = joined
+        .canonicalize()
+        .map_err(|e| format!("Cannot resolve path '{}': {}", requested, e))?;
+    let cwd_canonical = cwd
+        .canonicalize()
+        .map_err(|e| format!("Cannot resolve cwd: {}", e))?;
+    if !resolved.starts_with(&cwd_canonical) {
+        return Err(format!("Path '{}' escapes the working directory", requested));
+    }
+    Ok(resolved)
+}
+
+/// Like safe_resolve but allows the path to not exist yet (for writes).
+pub fn safe_resolve_for_write(cwd: &Path, requested: &str) -> Result<PathBuf, String> {
+    let joined = cwd.join(requested);
+    // Canonicalize the parent to check it's under cwd
+    let parent = joined.parent().ok_or("Invalid path")?;
+    if parent.exists() {
+        let parent_canonical = parent
+            .canonicalize()
+            .map_err(|e| format!("Cannot resolve parent of '{}': {}", requested, e))?;
+        let cwd_canonical = cwd
+            .canonicalize()
+            .map_err(|e| format!("Cannot resolve cwd: {}", e))?;
+        if !parent_canonical.starts_with(&cwd_canonical) {
+            return Err(format!("Path '{}' escapes the working directory", requested));
+        }
+    }
+    Ok(joined)
+}

--- a/brokk-acp-rust/src/tools/shell.rs
+++ b/brokk-acp-rust/src/tools/shell.rs
@@ -1,0 +1,79 @@
+use super::{ToolResult, ToolStatus};
+use std::path::Path;
+use std::time::Duration;
+use tokio::process::Command;
+
+const MAX_OUTPUT_BYTES: usize = 100_000; // 100KB
+
+pub async fn run_shell_command(cwd: &Path, command: &str, timeout_seconds: u64) -> ToolResult {
+    if command.trim().is_empty() {
+        return ToolResult {
+            status: ToolStatus::RequestError,
+            output: "Command must not be empty".to_string(),
+        };
+    }
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(timeout_seconds),
+        Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .current_dir(cwd)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(output)) => {
+            let mut combined = String::new();
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if !stdout.is_empty() {
+                combined.push_str(&stdout);
+            }
+
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !stderr.is_empty() {
+                if !combined.is_empty() {
+                    combined.push_str("\n--- stderr ---\n");
+                }
+                combined.push_str(&stderr);
+            }
+
+            // Truncate if too large
+            if combined.len() > MAX_OUTPUT_BYTES {
+                combined.truncate(MAX_OUTPUT_BYTES);
+                combined.push_str("\n... output truncated");
+            }
+
+            let exit_code = output.status.code().unwrap_or(-1);
+            if !output.status.success() {
+                combined.push_str(&format!("\n\nExit code: {exit_code}"));
+            }
+
+            ToolResult {
+                status: if output.status.success() {
+                    ToolStatus::Success
+                } else {
+                    ToolStatus::RequestError
+                },
+                output: if combined.is_empty() {
+                    format!("Command completed with exit code {exit_code}")
+                } else {
+                    combined
+                },
+            }
+        }
+        Ok(Err(e)) => ToolResult {
+            status: ToolStatus::InternalError,
+            output: format!("Failed to execute command: {e}"),
+        },
+        Err(_) => ToolResult {
+            status: ToolStatus::RequestError,
+            output: format!("Command timed out after {timeout_seconds}s"),
+        },
+    }
+}


### PR DESCRIPTION
## Summary

- **cwd handling**: The Rust ACP server now reads and uses the `cwd` parameter from `session/new`, `session/load`, `session/resume`, and `session/list` per the ACP spec
- **Session persistence**: Sessions are stored as executor-compatible zip files in `<cwd>/.brokk/sessions/`, using the same format (manifest.json, contexts.jsonl, fragments-v4.json, content/*.txt) so sessions are interchangeable between the Java executor and the Rust server
- **Tool calling**: Agentic loop with OpenAI-compatible tool calling protocol. 6 built-in tools: `readFile`, `writeFile`, `listDirectory`, `searchFileContents`, `runShellCommand`, `think`. Path traversal protection and shell sandboxing included
- **PLANS.md**: Documents the roadmap for integrating Bifrost (brokk_analyzer) for code intelligence tools

## Test plan

- [ ] Start the Rust ACP server in Zed, create a new session, verify cwd is logged
- [ ] Create sessions with the Java executor, then load them from the Rust server — verify they appear in session/list
- [ ] Ask the LLM to read a file or search for code — verify tool calling works with a model that supports it (e.g. qwen2.5, llama3.1+)
- [ ] Verify session conversation history survives server restarts
- [ ] Verify path traversal protection (try reading `../../etc/passwd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)