### PR TITLE
Fix comment density support for JS/TS analyzers

### DIFF
--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -112,10 +112,7 @@ public class CodeQualityTools {
         if (defs.isEmpty()) {
             return "No definition found for: " + key;
         }
-        Optional<CommentDensityStats> stats = defs.stream()
-                .map(analyzer::commentDensity)
-                .flatMap(Optional::stream)
-                .findFirst();
+        Optional<CommentDensityStats> stats = analyzer.commentDensity(key);
         if (stats.isEmpty()) {
             return COMMENT_DENSITY_UNAVAILABLE;
         }

--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -31,8 +31,8 @@ import org.jetbrains.annotations.Blocking;
 public class CodeQualityTools {
     private static final String FINDING_PREFIX = "[CODE_QUALITY]";
 
-    private static final String COMMENT_DENSITY_JAVA_ONLY =
-            "Comment density is only available for Java symbols in this analyzer snapshot.";
+    private static final String COMMENT_DENSITY_UNAVAILABLE =
+            "Comment density is unavailable for this symbol in the current analyzer snapshot.";
 
     private static final int DEFAULT_SECRET_MAX_FINDINGS = 100;
     private static final int DEFAULT_SECRET_MAX_COMMITS = 2000;
@@ -94,7 +94,8 @@ public class CodeQualityTools {
 
     @Tool(
             """
-            Java comment density for one symbol identified by fully qualified name (same resolution as getDefinitions).
+            Comment density for one symbol identified by fully qualified name (same resolution as getDefinitions).
+            Works for analyzers that provide comment-density stats (for example Java, JavaScript, or TypeScript).
             Reports header vs inline comment line counts, declaration span lines, and rolled-up totals for class-like units.
             For semantic review, follow up with getFileContents or getMethodSources. Output is truncated to maxLines.""")
     public String reportCommentDensityForCodeUnit(
@@ -111,15 +112,14 @@ public class CodeQualityTools {
         if (defs.isEmpty()) {
             return "No definition found for: " + key;
         }
-        CodeUnit cu = defs.stream()
-                .filter(d -> "java".equals(d.source().extension()))
-                .findFirst()
-                .orElse(defs.getFirst());
-        Optional<CommentDensityStats> stats = analyzer.commentDensity(cu);
+        Optional<CommentDensityStats> stats = defs.stream()
+                .map(analyzer::commentDensity)
+                .flatMap(Optional::stream)
+                .findFirst();
         if (stats.isEmpty()) {
-            return COMMENT_DENSITY_JAVA_ONLY;
+            return COMMENT_DENSITY_UNAVAILABLE;
         }
-        return truncateToLineCap(formatCommentDensityForUnit(stats.get()), cap);
+        return truncateToLineCap(formatCommentDensityForUnit(stats.orElseThrow()), cap);
     }
 
     @Tool(
@@ -164,7 +164,7 @@ public class CodeQualityTools {
             List<CommentDensityStats> stats = analyzer.commentDensityByTopLevel(file);
             if (stats.isEmpty()) {
                 lines.add("### `" + path + "`");
-                lines.add(COMMENT_DENSITY_JAVA_ONLY);
+                lines.add(COMMENT_DENSITY_UNAVAILABLE);
                 lines.add("");
                 filesShown++;
                 continue;

--- a/app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java
+++ b/app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java
@@ -1,0 +1,105 @@
+package ai.brokk.tools;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.CodeUnitType;
+import ai.brokk.analyzer.CommentDensityStats;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import ai.brokk.testutil.TestAnalyzer;
+import ai.brokk.testutil.TestConsoleIO;
+import ai.brokk.testutil.TestContextManager;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CodeQualityToolsCommentDensityJsTsTest {
+
+    @Test
+    void reportCommentDensityForCodeUnit_supportsJavaScript() throws IOException {
+        try (var project = InlineTestProjectCreator.code(
+                        """
+                // header docs
+                function documented(value) {
+                    return value + 1; // inline docs
+                }
+
+                function bare(value) {
+                    return value * 2;
+                }
+                """,
+                        "src/sample.js")
+                .build()) {
+            var contextManager =
+                    new TestContextManager(project, new TestConsoleIO(), java.util.Set.of(), project.getAnalyzer());
+            var tools = new CodeQualityTools(contextManager);
+
+            String documentedReport = tools.reportCommentDensityForCodeUnit("src.documented", 120);
+            assertTrue(documentedReport.contains("## Comment density"), documentedReport);
+            assertTrue(documentedReport.contains("`src.documented`"), documentedReport);
+            assertTrue(documentedReport.contains("Own: header 1, inline 1"), documentedReport);
+            assertFalse(documentedReport.contains("unavailable"), documentedReport);
+
+            String bareReport = tools.reportCommentDensityForCodeUnit("src.bare", 120);
+            assertTrue(bareReport.contains("Own: header 0, inline 0"), bareReport);
+        }
+    }
+
+    @Test
+    void reportCommentDensityForCodeUnit_supportsTypeScript() throws IOException {
+        try (var project = InlineTestProjectCreator.code(
+                        """
+                // header docs
+                function typed(value: number): number {
+                    return value + 1; // inline docs
+                }
+                """,
+                        "src/sample.ts")
+                .build()) {
+            var contextManager =
+                    new TestContextManager(project, new TestConsoleIO(), java.util.Set.of(), project.getAnalyzer());
+            var tools = new CodeQualityTools(contextManager);
+
+            String report = tools.reportCommentDensityForCodeUnit("src.typed", 120);
+            assertTrue(report.contains("## Comment density"), report);
+            assertTrue(report.contains("`src.typed`"), report);
+            assertTrue(report.contains("Own: header 1, inline 1"), report);
+            assertFalse(report.contains("unavailable"), report);
+        }
+    }
+
+    @Test
+    void reportCommentDensityForCodeUnit_checksAllResolvedDefinitions() throws IOException {
+        try (var project = InlineTestProjectCreator.code(
+                        "export function typed(v: number) { return v; }\n", "src/sample.ts")
+                .build()) {
+            ProjectFile unsupported = new ProjectFile(project.getRoot(), "src/placeholder.txt");
+            ProjectFile supported = new ProjectFile(project.getRoot(), "src/sample.ts");
+            CodeUnit unsupportedCu = new CodeUnit(unsupported, CodeUnitType.FUNCTION, "", "typed");
+            CodeUnit supportedCu = new CodeUnit(supported, CodeUnitType.FUNCTION, "", "typed");
+            var analyzer = new TestAnalyzer() {
+                @Override
+                public java.util.SequencedSet<CodeUnit> getDefinitions(String fqName) {
+                    return new LinkedHashSet<>(java.util.List.of(unsupportedCu, supportedCu));
+                }
+
+                @Override
+                public Optional<CommentDensityStats> commentDensity(CodeUnit cu) {
+                    if (cu.source().equals(supported)) {
+                        return Optional.of(new CommentDensityStats("typed", "src/sample.ts", 1, 1, 3, 1, 1, 3));
+                    }
+                    return Optional.empty();
+                }
+            };
+            var contextManager = new TestContextManager(project, new TestConsoleIO(), java.util.Set.of(), analyzer);
+            var tools = new CodeQualityTools(contextManager);
+
+            String report = tools.reportCommentDensityForCodeUnit("typed", 120);
+            assertTrue(report.contains("`typed`"), report);
+            assertTrue(report.contains("Own: header 1, inline 1"), report);
+        }
+    }
+}

--- a/app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java
+++ b/app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java
@@ -3,17 +3,10 @@ package ai.brokk.tools;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import ai.brokk.analyzer.CodeUnit;
-import ai.brokk.analyzer.CodeUnitType;
-import ai.brokk.analyzer.CommentDensityStats;
-import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.testutil.InlineTestProjectCreator;
-import ai.brokk.testutil.TestAnalyzer;
 import ai.brokk.testutil.TestConsoleIO;
 import ai.brokk.testutil.TestContextManager;
 import java.io.IOException;
-import java.util.LinkedHashSet;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class CodeQualityToolsCommentDensityJsTsTest {
@@ -68,38 +61,6 @@ class CodeQualityToolsCommentDensityJsTsTest {
             assertTrue(report.contains("`src.typed`"), report);
             assertTrue(report.contains("Own: header 1, inline 1"), report);
             assertFalse(report.contains("unavailable"), report);
-        }
-    }
-
-    @Test
-    void reportCommentDensityForCodeUnit_checksAllResolvedDefinitions() throws IOException {
-        try (var project = InlineTestProjectCreator.code(
-                        "export function typed(v: number) { return v; }\n", "src/sample.ts")
-                .build()) {
-            ProjectFile unsupported = new ProjectFile(project.getRoot(), "src/placeholder.txt");
-            ProjectFile supported = new ProjectFile(project.getRoot(), "src/sample.ts");
-            CodeUnit unsupportedCu = new CodeUnit(unsupported, CodeUnitType.FUNCTION, "", "typed");
-            CodeUnit supportedCu = new CodeUnit(supported, CodeUnitType.FUNCTION, "", "typed");
-            var analyzer = new TestAnalyzer() {
-                @Override
-                public java.util.SequencedSet<CodeUnit> getDefinitions(String fqName) {
-                    return new LinkedHashSet<>(java.util.List.of(unsupportedCu, supportedCu));
-                }
-
-                @Override
-                public Optional<CommentDensityStats> commentDensity(CodeUnit cu) {
-                    if (cu.source().equals(supported)) {
-                        return Optional.of(new CommentDensityStats("typed", "src/sample.ts", 1, 1, 3, 1, 1, 3));
-                    }
-                    return Optional.empty();
-                }
-            };
-            var contextManager = new TestContextManager(project, new TestConsoleIO(), java.util.Set.of(), analyzer);
-            var tools = new CodeQualityTools(contextManager);
-
-            String report = tools.reportCommentDensityForCodeUnit("typed", 120);
-            assertTrue(report.contains("`typed`"), report);
-            assertTrue(report.contains("Own: header 1, inline 1"), report);
         }
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
@@ -834,6 +834,16 @@ public interface IAnalyzer {
     }
 
     /**
+     * Comment density for the first resolved declaration that supports it.
+     */
+    default Optional<CommentDensityStats> commentDensity(String fqName) {
+        return getDefinitions(fqName).stream()
+                .map(this::commentDensity)
+                .flatMap(Optional::stream)
+                .findFirst();
+    }
+
+    /**
      * Per-top-level declaration comment density for a file. Default is an empty list.
      */
     default List<CommentDensityStats> commentDensityByTopLevel(ProjectFile file) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
@@ -15,7 +15,9 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -357,7 +359,7 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
         if (!"js".equals(ext) && !"jsx".equals(ext) && !"ts".equals(ext) && !"tsx".equals(ext)) {
             return Optional.empty();
         }
-        Map<String, CommentLineBreakdown> counts = collectCommentLineBreakdown(cu.source(), COMMENT_NODE_TYPES);
+        Map<String, CommentLineBreakdown> counts = collectJsTsCommentLineBreakdown(cu.source());
         return Optional.of(buildRollUpStats(cu, counts));
     }
 
@@ -368,7 +370,7 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
         if (!"js".equals(ext) && !"jsx".equals(ext) && !"ts".equals(ext) && !"tsx".equals(ext)) {
             return List.of();
         }
-        Map<String, CommentLineBreakdown> counts = collectCommentLineBreakdown(file, COMMENT_NODE_TYPES);
+        Map<String, CommentLineBreakdown> counts = collectJsTsCommentLineBreakdown(file);
         List<CommentDensityStats> rows = new ArrayList<>();
         for (CodeUnit top : getTopLevelDeclarations(file)) {
             rows.add(buildRollUpStats(top, counts));
@@ -931,6 +933,55 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
                 || JS_LOG_RECEIVER_NAMES.stream().anyMatch(name -> receiver.endsWith("." + name));
         boolean loggerLikeMethod = JS_LOG_METHOD_NAMES.contains(method);
         return loggerLikeReceiver && loggerLikeMethod;
+    }
+
+    /**
+     * Walks the JavaScript/TypeScript parse tree for comment nodes, associates each comment with the smallest
+     * comment-expanded declaration range that owns it, and classifies leading comments as header lines.
+     */
+    private Map<String, CommentLineBreakdown> collectJsTsCommentLineBreakdown(ProjectFile file) {
+        return withTreeOf(
+                file,
+                tree -> {
+                    TSNode root = tree.getRootNode();
+                    if (root == null) {
+                        return Map.of();
+                    }
+                    List<TSNode> comments = new ArrayList<>();
+                    collectNodesByType(root, COMMENT_NODE_TYPES, comments);
+
+                    Map<String, int[]> counts = new HashMap<>();
+                    for (TSNode comment : comments) {
+                        int startByte = comment.getStartByte();
+                        int endByte = comment.getEndByte();
+                        var cuOpt = enclosingCodeUnitByCommentBytes(file, startByte, endByte);
+                        if (cuOpt.isEmpty()) {
+                            continue;
+                        }
+                        var cu = cuOpt.get();
+                        var rangeOpt = rangesOf(cu).stream()
+                                .filter(r -> startByte >= r.commentStartByte() && endByte <= r.endByte())
+                                .min(Comparator.comparingInt(r -> r.endByte() - r.commentStartByte()));
+                        if (rangeOpt.isEmpty()) {
+                            continue;
+                        }
+                        var range = rangeOpt.get();
+                        int[] entry = counts.computeIfAbsent(cu.fqName(), ignored -> new int[2]);
+                        int lines = comment.getEndPoint().getRow()
+                                - comment.getStartPoint().getRow()
+                                + 1;
+                        if (endByte <= range.startByte()) {
+                            entry[0] += lines;
+                        } else {
+                            entry[1] += lines;
+                        }
+                    }
+                    return counts.entrySet().stream()
+                            .collect(Collectors.toMap(
+                                    Map.Entry::getKey,
+                                    e -> new CommentLineBreakdown(e.getValue()[0], e.getValue()[1])));
+                },
+                Map.of());
     }
 
     private CommentDensityStats buildRollUpStats(CodeUnit cu, Map<String, CommentLineBreakdown> counts) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/MultiAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/MultiAnalyzer.java
@@ -229,6 +229,14 @@ public class MultiAnalyzer
     }
 
     @Override
+    public Optional<CommentDensityStats> commentDensity(String fqName) {
+        return getDefinitions(fqName).stream()
+                .map(cu -> delegateFor(cu).flatMap(delegate -> delegate.commentDensity(cu)))
+                .flatMap(Optional::stream)
+                .findFirst();
+    }
+
+    @Override
     public List<CommentDensityStats> commentDensityByTopLevel(ProjectFile file) {
         return delegateFor(file)
                 .map(delegate -> delegate.commentDensityByTopLevel(file))

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerCapabilityTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerCapabilityTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.brokk.project.ICoreProject;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -125,6 +126,39 @@ public class MultiAnalyzerCapabilityTest {
         assertEquals(List.of(javaFinding, pythonFinding), findings);
         assertEquals(List.of(List.of(javaFile, javaPeerFile)), javaAnalyzer.cloneFileGroups);
         assertEquals(List.of(List.of(pythonFile, pythonPeerFile)), pythonAnalyzer.cloneFileGroups);
+    }
+
+    @Test
+    void commentDensityByFqName_SkipsUnsupportedDefinitions(@TempDir Path root) {
+        var pythonFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/a.py");
+        var jsFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/z.js");
+        var pythonUnit = CodeUnit.fn(pythonFile, "", "shared.symbol");
+        var jsUnit = CodeUnit.fn(jsFile, "", "shared.symbol");
+        var jsStats = new CommentDensityStats("shared.symbol", "src/z.js", 1, 2, 3, 1, 2, 3);
+        var pythonAnalyzer = new CommentDensityAnalyzer(List.of(pythonUnit), Map.of());
+        var jsAnalyzer = new CommentDensityAnalyzer(List.of(jsUnit), Map.of(jsUnit, jsStats));
+        var multi = new MultiAnalyzer(Map.of(Languages.PYTHON, pythonAnalyzer, Languages.JAVASCRIPT, jsAnalyzer));
+
+        Optional<CommentDensityStats> stats = multi.commentDensity("shared.symbol");
+
+        assertEquals(Optional.of(jsStats), stats);
+    }
+
+    @Test
+    void commentDensityByFqName_UsesDefinitionOrderingForDuplicates(@TempDir Path root) {
+        var javaFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/A.java");
+        var jsFile = new ProjectFile(root.toAbsolutePath().normalize(), "src/B.js");
+        var javaUnit = CodeUnit.fn(javaFile, "", "shared.symbol");
+        var jsUnit = CodeUnit.fn(jsFile, "", "shared.symbol");
+        var javaStats = new CommentDensityStats("shared.symbol", "src/A.java", 1, 0, 3, 1, 0, 3);
+        var jsStats = new CommentDensityStats("shared.symbol", "src/B.js", 0, 1, 3, 0, 1, 3);
+        var javaAnalyzer = new CommentDensityAnalyzer(List.of(javaUnit), Map.of(javaUnit, javaStats));
+        var jsAnalyzer = new CommentDensityAnalyzer(List.of(jsUnit), Map.of(jsUnit, jsStats));
+        var multi = new MultiAnalyzer(Map.of(Languages.JAVA, javaAnalyzer, Languages.JAVASCRIPT, jsAnalyzer));
+
+        Optional<CommentDensityStats> stats = multi.commentDensity("shared.symbol");
+
+        assertEquals(Optional.of(javaStats), stats);
     }
 
     private abstract static class BaseStubAnalyzer implements IAnalyzer {
@@ -289,6 +323,28 @@ public class MultiAnalyzerCapabilityTest {
             return cloneFindings.stream()
                     .filter(finding -> files.contains(finding.file()) && files.contains(finding.peerFile()))
                     .toList();
+        }
+    }
+
+    private static final class CommentDensityAnalyzer extends BaseStubAnalyzer {
+        private final List<CodeUnit> definitions;
+        private final Map<CodeUnit, CommentDensityStats> statsByUnit;
+
+        CommentDensityAnalyzer(List<CodeUnit> definitions, Map<CodeUnit, CommentDensityStats> statsByUnit) {
+            this.definitions = List.copyOf(definitions);
+            this.statsByUnit = Map.copyOf(statsByUnit);
+        }
+
+        @Override
+        public java.util.SequencedSet<CodeUnit> getDefinitions(String fqName) {
+            return definitions.stream()
+                    .filter(cu -> cu.fqName().equals(fqName))
+                    .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        }
+
+        @Override
+        public Optional<CommentDensityStats> commentDensity(CodeUnit cu) {
+            return Optional.ofNullable(statsByUnit.get(cu));
         }
     }
 }

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -269,11 +269,11 @@ When you specify a `tools` list, you're choosing which capabilities the agent ha
 | `runShellCommand` | Execute a shell command |
 | `importDependency` | Import a project dependency |
 | `computeCyclomaticComplexity` | Compute cyclomatic complexity for Java code when analysis data is available |
-| `reportCommentDensityForCodeUnit` | Report comment density for one Java symbol, with bounded output |
+| `reportCommentDensityForCodeUnit` | Report comment density for one symbol (Java, JavaScript, TypeScript when analyzer data is available), with bounded output |
 | `reportCommentDensityForFiles` | Report comment density tables for Java files, with bounded output |
 | `analyzeGitHotspots` | Analyze churn hotspots using bounded commit and file limits |
 
-Java comment-density tools return a short message when the analyzer has no Java snapshot. `analyzeGitHotspots` supports `sinceDays` and optional ISO `sinceIso` and `untilIso`, plus bounded `maxCommits` and `maxFiles`.
+Comment-density tools return a short message when the analyzer snapshot cannot provide those stats for a symbol or file. `analyzeGitHotspots` supports `sinceDays` and optional ISO `sinceIso` and `untilIso`, plus bounded `maxCommits` and `maxFiles`.
 
 ### Always available
 


### PR DESCRIPTION
### Summary
- Broaden `reportCommentDensityForCodeUnit` to use any analyzer-provided comment density data instead of hard-wiring Java-only selection.
- Add Tree-sitter-based comment detection in `JsTsAnalyzer` so JavaScript and TypeScript symbols now produce comment-density stats.
- Update the custom agent docs and add regression coverage for JS, TS, and mixed-resolution symbol lookup.

**Key Changes**
- `CodeQualityTools` now picks the first resolved definition that returns comment-density stats and shows a generic unavailable message when none do.
- `JsTsAnalyzer` now explicitly collects JS/TS comment nodes with Tree-sitter and classifies header vs inline lines using the same ownership rules as the other analyzers.
- Added tests covering JS and TS comment density plus a regression where the first resolved definition is unsupported and a later one is supported.

**Touch Points**
- [app/src/main/java/ai/brokk/tools/CodeQualityTools.java](/Users/dave/Workspace/BrokkAi/brokk1/app/src/main/java/ai/brokk/tools/CodeQualityTools.java)
- [app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java](/Users/dave/Workspace/BrokkAi/brokk1/app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java)
- [brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java](/Users/dave/Workspace/BrokkAi/brokk1/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java)
- [docs/custom-agents.md](/Users/dave/Workspace/BrokkAi/brokk1/docs/custom-agents.md)

### Testing
- `./gradlew :app:test --tests ai.brokk.tools.CodeQualityToolsCommentDensityJsTsTest`
- `./gradlew fix tidy`
- `./gradlew analyze`

Resolves #3301
Resolves #3302
