### PR TITLE
Fix streaming, persistence, and path-traversal in Rust ACP server

### DIFF
--- a/brokk-acp-rust/PLANS.md
+++ b/brokk-acp-rust/PLANS.md
@@ -315,3 +315,79 @@ C'est tout. Bifrost apporte tree-sitter + grammaires + git2 + walkdir + glob com
 4. **MCP tools du client ACP** : le protocole ACP permet au client de fournir des serveurs MCP. Faut-il s'y connecter pour avoir des tools supplementaires ? C'est un scope additionnel significatif.
 
 5. **Persistance des tool calls** : les tool calls intermediaires doivent-ils etre persistes dans le zip de session pour le replay ? Le format actuel du zip supporte les `ChatMessageDto` avec role/contentId, donc c'est faisable.
+
+---
+
+## Audit -- problemes identifies (2026-04-24)
+
+Relecture complete du serveur ACP Rust. Problemes classes par severite.
+
+### Bugs critiques
+
+1. **Streaming casse** (`tool_loop.rs:46-68`). Le callback `on_token` bufferise les tokens dans un `Vec<String>` et ne les flush qu'apres que `stream_chat` ait termine. Le client ACP ne voit donc rien jusqu'a la fin de la reponse LLM. Correction : passer `on_text` directement via un `Arc<Mutex<dyn FnMut>>` partage entre les tours.
+
+2. **Mode et modele de session non persistes** (`session.rs`). `get_session` recharge toujours avec `mode: SessionMode::Lutz` et `model: default_model`, les changements via `set_mode` ne sont jamais ecrits dans le zip. Correction : ajouter `mode` et `model` au `SessionManifest`.
+
+3. **Replay d'historique incomplet** (`agent.rs:156-158`). Seul `turn.agent_response` est renvoye au client, les prompts utilisateur sont omis. Correction : envoyer aussi `turn.user_prompt` (role user).
+
+4. **Tool calls non persistes dans l'historique**. `ConversationTurn` ne stocke que `user_prompt` + `agent_response`. Au rechargement, le LLM ne voit plus ses tool calls/results intermediaires. Scope plus large -- voir "ameliorations differees".
+
+5. **Arguments de tool malformes silencieusement avales** (`tool_loop.rs:92`). `serde_json::from_str(...).unwrap_or_default()` appelle le tool avec `{}` sans signaler l'erreur au LLM. Correction : renvoyer un `tool_result` d'erreur de parsing.
+
+### Securite
+
+6. **Trou dans `safe_resolve_for_write`** (`tools/mod.rs:236-255`). Si le parent du chemin demande n'existe pas, le check `starts_with(cwd)` est totalement saute et le `joined` non canonicalise est retourne. Path traversal possible via `../nouveau_dossier/../../tmp/evil`. Correction : remonter vers le premier ancetre existant, canonicaliser celui-ci, et valider la prefixe.
+
+7. **`runShellCommand` sans sandbox**. `sh -c` execute n'importe quoi (cat /etc/passwd, curl | sh, etc.). Aucun seccomp, namespace ou allow-list. Pour un outil pilote par LLM c'est un risque majeur. Correction : hors scope immediat, mais documenter et envisager une confirmation client ACP.
+
+8. **Symlinks suivis aveuglement**. Un symlink sous cwd pointant dehors laisse passer les ecritures. Mitige par canonicalize dans `safe_resolve` pour la lecture ; le write reste expose.
+
+### Concurrence / performance
+
+9. **I/O bloquantes sous le runtime tokio** (`session.rs`, `tools/filesystem.rs`). Tous les appels `std::fs` et zip se font en `sync` depuis des methodes `async`. Correction : envelopper dans `tokio::task::spawn_blocking`.
+
+10. **`add_turn` bloque tout le `SessionStore`** (`session.rs:605-618`). Le `RwLock::write()` sur `sessions` est tenu pendant toute la compression zip. Correction : cloner les donnees necessaires hors du lock avant `spawn_blocking`.
+
+11. **`list_models()` refait a chaque `session/new`** (`agent.rs:106`). Un appel HTTP par creation de session pour une liste deja recuperee a l'init. Correction : cacher la liste dans `SessionStore`.
+
+12. **`search_file_contents` sans filtre de taille ni detection de binaires** (`filesystem.rs:161`). Tente de lire tout fichier non-filtre par le glob. Correction : skip si > 1 MiB ou si les premiers octets contiennent un NUL.
+
+13. **Pas d'eviction des sessions en memoire**. `SessionStore::sessions` grandit indefiniment. Hors scope immediat (YAGNI).
+
+### Fonctionnalites manquantes
+
+14. **Bifrost/brokk_analyzer jamais integre** (`tools/mod.rs:21`). Le `headline()` reference `search_symbols`, `get_symbol_locations` etc. mais aucun n'est enregistre. Phase 2 du plan non realisee -- scope separe.
+
+15. **`max_turns` hardcode a 25** (`agent.rs:271`). Correction : exposer `--max-turns`.
+
+16. **Pas de fallback pour modeles sans tool calling**. Beaucoup de petits Ollama cassent. Hors scope immediat.
+
+17. **Mode invalide accepte silencieusement** (`agent.rs:315-317`). `SessionMode::parse` None ignore et `SetSessionModeResponse::new()` repond succes. Correction : retourner une erreur JSON-RPC ou un `meta` d'erreur.
+
+18. **`SetSessionModeResponse` succes meme si la session n'existe pas**. Correction : valider l'existence avant de repondre.
+
+### Qualite de code
+
+19. **Tool calls tronques renvoyes sur cancel** (`llm_client.rs:430-437`). Si le stream est coupe au milieu des arguments, `tool_acc.is_empty()` est faux et les calls partiels remontent. Correction : si cancel.is_cancelled(), renvoyer seulement le texte.
+
+20. **Logs qui avalent les erreurs d'ecriture zip** (`session.rs`). `append_turn_to_zip` log `warn` et continue, la memoire croit avoir persiste alors que le disque est desynchronise. Correction (partielle) : propager l'erreur via `Result`.
+
+21. **Pas de tests**. Aucun `#[test]` ni `tests/`. Ecart vs cote Java. Hors scope immediat.
+
+22. **`ChatMessage.role` non type**. `String` partout. Hors scope immediat (YAGNI).
+
+---
+
+## Plan de remediation (ordre d'attaque)
+
+1. Streaming (bug critique)
+2. Path-traversal `safe_resolve_for_write`
+3. Persistance mode/modele
+4. Replay utilisateur
+5. Arguments malformes -> erreur
+6. I/O bloquantes -> spawn_blocking
+7. `max_turns` configurable
+8. Filtre binaires/taille dans `search_file_contents`
+9. Cache des modeles
+10. Validation set_mode
+11. Tool calls tronques sur cancel

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -38,11 +38,11 @@ fn mode_state(current: &str) -> SessionModeState {
 pub async fn run_agent(
     llm: Arc<dyn LlmBackend>,
     sessions: SessionStore,
+    max_turns: usize,
 ) -> agent_client_protocol::Result<()> {
     let llm_init = llm.clone();
     let sessions_init = sessions.clone();
 
-    let llm_new = llm.clone();
     let sessions_new = sessions.clone();
 
     let sessions_load = sessions.clone();
@@ -65,7 +65,7 @@ pub async fn run_agent(
                         _cx: ConnectionTo<Client>| {
                 tracing::info!("ACP initialize");
 
-                // Try to discover models at startup
+                // Try to discover models at startup and cache them for session/new.
                 let models = match llm_init.list_models().await {
                     Ok(m) => m,
                     Err(e) => {
@@ -76,6 +76,7 @@ pub async fn run_agent(
                 if let Some(first) = models.first() {
                     sessions_init.set_default_model(first.clone()).await;
                 }
+                sessions_init.set_available_models(models).await;
 
                 let capabilities = AgentCapabilities::new()
                     .load_session(true)
@@ -102,14 +103,11 @@ pub async fn run_agent(
                 tracing::info!("ACP session/new, cwd={}", cwd.display());
                 let session = sessions_new.create_session(cwd).await;
 
-                // Discover models for the response
-                let models = match llm_new.list_models().await {
-                    Ok(m) => m,
-                    Err(e) => {
-                        tracing::warn!("model discovery failed: {e}");
-                        vec![session.model.clone()]
-                    }
-                };
+                // Reuse the cached list populated at init; fall back to the session's own model.
+                let mut models = sessions_new.available_models().await;
+                if models.is_empty() && !session.model.is_empty() {
+                    models = vec![session.model.clone()];
+                }
 
                 let meta_value = serde_json::json!({
                     "brokk": {
@@ -152,9 +150,14 @@ pub async fn run_agent(
                     }
                 };
 
-                // Replay conversation history as session updates
+                // Replay conversation history as session updates (both sides).
                 for turn in &session.history {
-                    send_message(&cx, &session_id, &turn.agent_response);
+                    if !turn.user_prompt.is_empty() {
+                        send_user_message(&cx, &session_id, &turn.user_prompt);
+                    }
+                    if !turn.agent_response.is_empty() {
+                        send_message(&cx, &session_id, &turn.agent_response);
+                    }
                 }
 
                 responder.respond(
@@ -263,14 +266,21 @@ pub async fn run_agent(
                 let cx_tool = cx.clone();
                 let sid_tool = session_id.clone();
 
+                // Text tokens stream to the client in real time via this shared sink.
+                let text_sink: crate::tool_loop::TextSink = std::sync::Arc::new(
+                    std::sync::Mutex::new(move |token: &str| {
+                        send_message(&cx_text, &sid_text, token);
+                    }),
+                );
+
                 let response_text = crate::tool_loop::run(
                     &llm_prompt,
                     &registry,
                     &session.model,
                     messages,
-                    25, // max turns
+                    max_turns,
                     cancel,
-                    |token| send_message(&cx_text, &sid_text, token),
+                    text_sink,
                     |headline| send_message(&cx_tool, &sid_tool, headline),
                 )
                 .await;
@@ -312,8 +322,26 @@ pub async fn run_agent(
                 let mode_id = req.mode_id.to_string();
                 tracing::info!("ACP set_mode session={session_id} mode={mode_id}");
 
-                if let Some(mode) = SessionMode::parse(&mode_id) {
-                    sessions_mode.set_mode(&session_id, mode).await;
+                let Some(mode) = SessionMode::parse(&mode_id) else {
+                    return responder.respond_with_error(
+                        agent_client_protocol::Error::invalid_params()
+                            .data(serde_json::json!({
+                                "reason": format!("unknown mode '{mode_id}'"),
+                                "supported": available_modes()
+                                    .iter()
+                                    .map(|m| m.id.to_string())
+                                    .collect::<Vec<_>>(),
+                            })),
+                    );
+                };
+
+                if !sessions_mode.set_mode(&session_id, mode).await {
+                    return responder.respond_with_error(
+                        agent_client_protocol::Error::invalid_params()
+                            .data(serde_json::json!({
+                                "reason": format!("unknown session '{session_id}'"),
+                            })),
+                    );
                 }
 
                 responder.respond(SetSessionModeResponse::new())
@@ -357,6 +385,16 @@ fn send_message(cx: &ConnectionTo<Client>, session_id: &str, text: &str) {
     let notification = SessionNotification::new(session_id.to_string(), update);
     if let Err(e) = cx.send_notification(notification) {
         tracing::warn!("failed to send session update: {e}");
+    }
+}
+
+/// Send a user_message_chunk session update to the client (used when replaying history).
+fn send_user_message(cx: &ConnectionTo<Client>, session_id: &str, text: &str) {
+    let chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(text)));
+    let update = SessionUpdate::UserMessageChunk(chunk);
+    let notification = SessionNotification::new(session_id.to_string(), update);
+    if let Err(e) = cx.send_notification(notification) {
+        tracing::warn!("failed to send user session update: {e}");
     }
 }
 

--- a/brokk-acp-rust/src/llm_client.rs
+++ b/brokk-acp-rust/src/llm_client.rs
@@ -427,6 +427,13 @@ impl OpenAiClient {
             }
         }
 
+        // If we exited the loop via cancellation, tool call fragments may be incomplete
+        // (arguments JSON truncated mid-stream). Return only the text we've already
+        // streamed to the caller to avoid dispatching malformed tool calls.
+        if cancel.is_cancelled() {
+            return Ok(LlmResponse::Text(full_text));
+        }
+
         if tool_acc.is_empty() {
             Ok(LlmResponse::Text(full_text))
         } else {

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -26,6 +26,10 @@ struct Args {
     /// Default model to use if not specified by the client
     #[arg(long, default_value = "")]
     default_model: String,
+
+    /// Maximum number of tool-calling turns per prompt before the server forces a final text response.
+    #[arg(long, default_value_t = 25)]
+    max_turns: usize,
 }
 
 // Manual Debug to avoid leaking api_key in logs or process listings.
@@ -35,6 +39,7 @@ impl std::fmt::Debug for Args {
             .field("endpoint_url", &self.endpoint_url)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("default_model", &self.default_model)
+            .field("max_turns", &self.max_turns)
             .finish()
     }
 }
@@ -60,8 +65,11 @@ async fn main() -> Result<()> {
     // SessionStore uses internal Arc -- no outer Arc needed
     let sessions = session::SessionStore::new(args.default_model);
 
-    agent::run_agent(llm, sessions).await.map_err(|e| {
-        tracing::error!("agent error: {e}");
-        anyhow::anyhow!("agent error: {e}")
-    })
+    let max_turns = args.max_turns.max(1);
+    agent::run_agent(llm, sessions, max_turns)
+        .await
+        .map_err(|e| {
+            tracing::error!("agent error: {e}");
+            anyhow::anyhow!("agent error: {e}")
+        })
 }

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -62,6 +62,17 @@ pub struct SessionManifest {
     pub modified: u64,
     #[serde(default = "default_version")]
     pub version: String,
+    /// Brokk ACP-specific: session mode, persisted so it survives reload.
+    /// Absent in manifests produced by the Java executor.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "brokkMode")]
+    pub mode: Option<String>,
+    /// Brokk ACP-specific: last selected model for this session.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "brokkModel"
+    )]
+    pub model: Option<String>,
 }
 
 fn default_version() -> String {
@@ -88,17 +99,24 @@ impl Session {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64;
+        let mode = SessionMode::Lutz;
         let manifest = SessionManifest {
             id: id.clone(),
             name,
             created: now,
             modified: now,
             version: "4.0".to_string(),
+            mode: Some(mode.as_str().to_string()),
+            model: if model.is_empty() {
+                None
+            } else {
+                Some(model.clone())
+            },
         };
         Self {
             id,
             cwd,
-            mode: SessionMode::Lutz,
+            mode,
             model,
             history: Vec::new(),
             manifest,
@@ -503,6 +521,72 @@ fn append_turn_to_zip(zip_path: &Path, manifest: &SessionManifest, turn: &Conver
     }
 }
 
+/// Replace manifest.json in an existing session zip, copying all other entries as-is.
+/// Returns true on success.
+fn rewrite_manifest_in_zip(zip_path: &Path, manifest: &SessionManifest) -> bool {
+    let file = match std::fs::File::open(zip_path) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!("failed to open session zip for manifest rewrite: {e}");
+            return false;
+        }
+    };
+    let mut archive = match zip::ZipArchive::new(file) {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::warn!("failed to read session zip for manifest rewrite: {e}");
+            return false;
+        }
+    };
+
+    let tmp = zip_path.with_extension("tmp");
+    let out_file = match std::fs::File::create(&tmp) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!("failed to create temp zip for manifest rewrite: {e}");
+            return false;
+        }
+    };
+
+    let mut zip_writer = zip::ZipWriter::new(out_file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    for i in 0..archive.len() {
+        let mut entry = match archive.by_index(i) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let name = entry.name().to_string();
+        if name == "manifest.json" {
+            continue;
+        }
+        let mut buf = Vec::new();
+        if entry.read_to_end(&mut buf).is_err() {
+            continue;
+        }
+        if zip_writer.start_file(&name, options).is_ok() {
+            let _ = zip_writer.write_all(&buf);
+        }
+    }
+
+    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_default();
+    if zip_writer.start_file("manifest.json", options).is_ok() {
+        let _ = zip_writer.write_all(manifest_json.as_bytes());
+    }
+
+    if zip_writer.finish().is_err() {
+        return false;
+    }
+    match std::fs::rename(&tmp, zip_path) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!("failed to rename rewritten session zip: {e}");
+            false
+        }
+    }
+}
+
 /// List all session manifests from the executor's sessions directory.
 fn list_manifests_from_disk(cwd: &Path) -> Vec<SessionManifest> {
     let dir = sessions_dir(cwd);
@@ -530,6 +614,9 @@ fn list_manifests_from_disk(cwd: &Path) -> Vec<SessionManifest> {
 pub struct SessionStore {
     sessions: Arc<RwLock<HashMap<String, Session>>>,
     default_model: Arc<RwLock<String>>,
+    /// Last-known list of models, populated by `set_available_models` from the LLM endpoint.
+    /// Used to fulfil `session/new` without re-fetching on every call.
+    available_models: Arc<RwLock<Vec<String>>>,
     cancel_tokens: Arc<RwLock<HashMap<String, CancellationToken>>>,
 }
 
@@ -538,8 +625,17 @@ impl SessionStore {
         Self {
             sessions: Arc::new(RwLock::new(HashMap::new())),
             default_model: Arc::new(RwLock::new(default_model)),
+            available_models: Arc::new(RwLock::new(Vec::new())),
             cancel_tokens: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    pub async fn set_available_models(&self, models: Vec<String>) {
+        *self.available_models.write().await = models;
+    }
+
+    pub async fn available_models(&self) -> Vec<String> {
+        self.available_models.read().await.clone()
     }
 
     /// Create a new session and write it to disk as a zip.
@@ -548,9 +644,11 @@ impl SessionStore {
         let model = self.default_model.read().await.clone();
         let session = Session::new(id.clone(), cwd.clone(), model, "New Session".to_string());
 
-        // Write to disk in executor-compatible format
+        // Write to disk on a blocking worker so we don't stall the tokio runtime.
         let zip_path = session_zip_path(&cwd, &id);
-        write_new_session_zip(&zip_path, &session.manifest);
+        let manifest = session.manifest.clone();
+        let _ =
+            tokio::task::spawn_blocking(move || write_new_session_zip(&zip_path, &manifest)).await;
 
         self.sessions.write().await.insert(id, session.clone());
         session
@@ -562,15 +660,32 @@ impl SessionStore {
         if let Some(s) = self.sessions.read().await.get(id).cloned() {
             return Some(s);
         }
-        // Try to load from executor's session zip on disk
+        // Try to load from executor's session zip on disk (on a blocking worker).
         let zip_path = session_zip_path(cwd, id);
-        let manifest = read_manifest_from_zip(&zip_path)?;
-        let history = read_history_from_zip(&zip_path);
-        let model = self.default_model.read().await.clone();
+        let (manifest, history) = tokio::task::spawn_blocking(move || {
+            let manifest = read_manifest_from_zip(&zip_path)?;
+            let history = read_history_from_zip(&zip_path);
+            Some((manifest, history))
+        })
+        .await
+        .ok()
+        .flatten()?;
+
+        // Prefer persisted mode/model; fall back to server defaults.
+        let mode = manifest
+            .mode
+            .as_deref()
+            .and_then(SessionMode::parse)
+            .unwrap_or(SessionMode::Lutz);
+        let model = match manifest.model.clone() {
+            Some(m) if !m.is_empty() => m,
+            _ => self.default_model.read().await.clone(),
+        };
+
         let session = Session {
             id: manifest.id.clone(),
             cwd: cwd.to_path_buf(),
-            mode: SessionMode::Lutz,
+            mode,
             model,
             history,
             manifest,
@@ -589,11 +704,28 @@ impl SessionStore {
     }
 
     pub async fn set_mode(&self, id: &str, mode: SessionMode) -> bool {
-        if let Some(session) = self.sessions.write().await.get_mut(id) {
-            session.mode = mode;
-            true
-        } else {
-            false
+        // Update in-memory state and snapshot what we need for persistence.
+        let snapshot = {
+            let mut sessions = self.sessions.write().await;
+            match sessions.get_mut(id) {
+                Some(session) => {
+                    session.mode = mode;
+                    session.manifest.mode = Some(mode.as_str().to_string());
+                    Some((session.cwd.clone(), session.manifest.clone()))
+                }
+                None => None,
+            }
+        };
+        match snapshot {
+            Some((cwd, manifest)) => {
+                let zip_path = session_zip_path(&cwd, id);
+                let _ = tokio::task::spawn_blocking(move || {
+                    rewrite_manifest_in_zip(&zip_path, &manifest)
+                })
+                .await;
+                true
+            }
+            None => false,
         }
     }
 
@@ -603,23 +735,39 @@ impl SessionStore {
 
     /// Add a conversation turn and persist it to the session zip.
     pub async fn add_turn(&self, id: &str, turn: ConversationTurn) {
-        if let Some(session) = self.sessions.write().await.get_mut(id) {
-            session.history.push(turn.clone());
-            // Update modified timestamp
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
-            session.manifest.modified = now;
-
-            let zip_path = session_zip_path(&session.cwd, &session.id);
-            append_turn_to_zip(&zip_path, &session.manifest, &turn);
+        // Mutate in-memory state first, then release the lock BEFORE blocking I/O.
+        let snapshot = {
+            let mut sessions = self.sessions.write().await;
+            match sessions.get_mut(id) {
+                Some(session) => {
+                    session.history.push(turn.clone());
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as u64;
+                    session.manifest.modified = now;
+                    Some((
+                        session_zip_path(&session.cwd, &session.id),
+                        session.manifest.clone(),
+                    ))
+                }
+                None => None,
+            }
+        };
+        if let Some((zip_path, manifest)) = snapshot {
+            let _ = tokio::task::spawn_blocking(move || {
+                append_turn_to_zip(&zip_path, &manifest, &turn)
+            })
+            .await;
         }
     }
 
     /// List sessions from disk, filtered by cwd.
     pub async fn list_sessions_from_disk(&self, cwd: &Path) -> Vec<SessionManifest> {
-        list_manifests_from_disk(cwd)
+        let cwd = cwd.to_path_buf();
+        tokio::task::spawn_blocking(move || list_manifests_from_disk(&cwd))
+            .await
+            .unwrap_or_default()
     }
 
     pub async fn start_prompt(&self, session_id: &str) -> CancellationToken {

--- a/brokk-acp-rust/src/tool_loop.rs
+++ b/brokk-acp-rust/src/tool_loop.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio_util::sync::CancellationToken;
 
@@ -7,13 +7,17 @@ use crate::tools::{ToolRegistry, ToolStatus};
 
 const MAX_TOOL_RESULT_BYTES: usize = 50_000;
 
+/// Shared text-emit callback. Held behind `Arc<Mutex<>>` so it can be cloned
+/// into each streaming turn's `Box<dyn FnMut>` without being consumed.
+pub type TextSink = Arc<Mutex<dyn FnMut(&str) + Send>>;
+
 /// Run the agentic tool-calling loop.
 ///
 /// Sends messages to the LLM with tool definitions. If the LLM responds with
 /// tool calls, executes them, appends results, and loops. Stops when the LLM
 /// responds with text only or the turn limit is reached.
 ///
-/// `on_text` is called for each text token streamed from the LLM.
+/// `on_text` is invoked for each text token streamed from the LLM, in real time.
 /// `on_tool_event` is called with a human-readable headline when a tool starts executing.
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
@@ -23,7 +27,7 @@ pub async fn run(
     mut messages: Vec<ChatMessage>,
     max_turns: usize,
     cancel: CancellationToken,
-    mut on_text: impl FnMut(&str),
+    on_text: TextSink,
     mut on_tool_event: impl FnMut(&str),
 ) -> String {
     let tools: Vec<ToolDefinition> = registry.tool_definitions();
@@ -41,12 +45,12 @@ pub async fn run(
             None
         };
 
-        // We need on_text to receive tokens during streaming. Since the LlmBackend
-        // takes a boxed FnMut, let's forward tokens through a shared buffer.
-        let token_buf = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
-        let buf_clone = token_buf.clone();
+        // Forward tokens straight through to the caller; no buffering.
+        let sink = on_text.clone();
         let on_token: Box<dyn FnMut(&str) + Send> = Box::new(move |token: &str| {
-            buf_clone.lock().unwrap().push(token.to_string());
+            if let Ok(mut cb) = sink.lock() {
+                cb(token);
+            }
         });
 
         let response = llm
@@ -58,14 +62,6 @@ pub async fn run(
                 cancel.clone(),
             )
             .await;
-
-        // Flush buffered tokens to the caller
-        {
-            let tokens = token_buf.lock().unwrap();
-            for token in tokens.iter() {
-                on_text(token);
-            }
-        }
 
         match response {
             Ok(LlmResponse::Text(text)) => {
@@ -88,35 +84,50 @@ pub async fn run(
                     let headline = ToolRegistry::headline(tool_name);
                     on_tool_event(&format!("_{headline}..._\n"));
 
-                    let args: serde_json::Value =
-                        serde_json::from_str(&call.function.arguments).unwrap_or_default();
-
                     tracing::info!(
                         "executing tool {} with args: {}",
                         tool_name,
                         call.function.arguments
                     );
 
-                    let result = registry.execute(tool_name, args).await;
-
-                    let status_prefix = match result.status {
-                        ToolStatus::Success => "",
-                        ToolStatus::RequestError => "Error: ",
-                        ToolStatus::InternalError => "Internal error: ",
-                    };
-
-                    let mut output = format!("{}{}", status_prefix, result.output);
-                    if output.len() > MAX_TOOL_RESULT_BYTES {
-                        output.truncate(MAX_TOOL_RESULT_BYTES);
-                        output.push_str("\n... output truncated");
-                    }
+                    let output =
+                        match serde_json::from_str::<serde_json::Value>(&call.function.arguments) {
+                            Ok(args) => {
+                                let result = registry.execute(tool_name, args).await;
+                                let status_prefix = match result.status {
+                                    ToolStatus::Success => "",
+                                    ToolStatus::RequestError => "Error: ",
+                                    ToolStatus::InternalError => "Internal error: ",
+                                };
+                                let mut output = format!("{}{}", status_prefix, result.output);
+                                if output.len() > MAX_TOOL_RESULT_BYTES {
+                                    output.truncate(MAX_TOOL_RESULT_BYTES);
+                                    output.push_str("\n... output truncated");
+                                }
+                                output
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "tool {} called with invalid JSON arguments ({}): {}",
+                                    tool_name,
+                                    e,
+                                    call.function.arguments
+                                );
+                                format!(
+                                    "Error: tool arguments are not valid JSON ({e}). \
+                                 Please retry with a valid JSON object matching the tool schema."
+                                )
+                            }
+                        };
 
                     messages.push(ChatMessage::tool_result(&call.id, tool_name, &output));
                 }
             }
             Err(e) => {
                 let err_msg = format!("\n**Error:** LLM request failed: {e}\n");
-                on_text(&err_msg);
+                if let Ok(mut cb) = on_text.lock() {
+                    cb(&err_msg);
+                }
                 full_response.push_str(&err_msg);
                 break;
             }

--- a/brokk-acp-rust/src/tools/filesystem.rs
+++ b/brokk-acp-rust/src/tools/filesystem.rs
@@ -1,7 +1,15 @@
 use super::{ToolResult, ToolStatus, safe_resolve, safe_resolve_for_write};
 use regex::Regex;
+use std::io::Read;
 use std::path::Path;
 use walkdir::WalkDir;
+
+/// Hard cap on individual file size scanned by `search_file_contents`.
+/// Files larger than this are skipped to keep memory bounded on big repos.
+const SEARCH_MAX_FILE_BYTES: u64 = 1_048_576; // 1 MiB
+
+/// Number of leading bytes inspected for NUL bytes to classify a file as binary.
+const BINARY_SNIFF_BYTES: usize = 8192;
 
 pub fn read_file(cwd: &Path, path: &str) -> ToolResult {
     let resolved = match safe_resolve(cwd, path) {
@@ -158,9 +166,21 @@ pub fn search_file_contents(
             continue;
         }
 
+        // Size cap: skip files above SEARCH_MAX_FILE_BYTES.
+        match entry.metadata() {
+            Ok(md) if md.len() > SEARCH_MAX_FILE_BYTES => continue,
+            Err(_) => continue,
+            _ => {}
+        }
+
+        // Sniff the first BINARY_SNIFF_BYTES bytes for a NUL. If present, treat as binary and skip.
+        if is_binary_file(path) {
+            continue;
+        }
+
         let content = match std::fs::read_to_string(path) {
             Ok(c) => c,
-            Err(_) => continue, // skip binary or unreadable files
+            Err(_) => continue, // skip non-UTF8 or unreadable files
         };
 
         for (line_num, line) in content.lines().enumerate() {
@@ -188,4 +208,19 @@ pub fn search_file_contents(
             output: results.join("\n"),
         }
     }
+}
+
+/// Classify a file as binary if any of the first BINARY_SNIFF_BYTES bytes is NUL.
+/// Files we cannot open are classified as binary so we skip them.
+fn is_binary_file(path: &Path) -> bool {
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return true,
+    };
+    let mut buf = [0u8; BINARY_SNIFF_BYTES];
+    let n = match file.read(&mut buf) {
+        Ok(n) => n,
+        Err(_) => return true,
+    };
+    buf[..n].contains(&0)
 }

--- a/brokk-acp-rust/src/tools/mod.rs
+++ b/brokk-acp-rust/src/tools/mod.rs
@@ -232,24 +232,61 @@ pub fn safe_resolve(cwd: &Path, requested: &str) -> Result<PathBuf, String> {
     Ok(resolved)
 }
 
-/// Like safe_resolve but allows the path to not exist yet (for writes).
+/// Like safe_resolve but allows the target (and intermediate ancestors) not to exist yet.
+/// We walk up until we find an existing ancestor, canonicalize it, and verify it lies
+/// under the canonical cwd. Returns the canonical cwd joined with the remaining tail,
+/// which guarantees the final path resolves under cwd without relying on canonicalize
+/// of the still-missing target.
 pub fn safe_resolve_for_write(cwd: &Path, requested: &str) -> Result<PathBuf, String> {
+    let cwd_canonical = cwd
+        .canonicalize()
+        .map_err(|e| format!("Cannot resolve cwd: {}", e))?;
+
     let joined = cwd.join(requested);
-    // Canonicalize the parent to check it's under cwd
-    let parent = joined.parent().ok_or("Invalid path")?;
-    if parent.exists() {
-        let parent_canonical = parent
-            .canonicalize()
-            .map_err(|e| format!("Cannot resolve parent of '{}': {}", requested, e))?;
-        let cwd_canonical = cwd
-            .canonicalize()
-            .map_err(|e| format!("Cannot resolve cwd: {}", e))?;
-        if !parent_canonical.starts_with(&cwd_canonical) {
+
+    // Walk up to the first existing ancestor (including the target itself if it exists).
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut cursor: &Path = &joined;
+    let existing = loop {
+        if cursor.exists() {
+            break cursor.to_path_buf();
+        }
+        match (cursor.file_name(), cursor.parent()) {
+            (Some(name), Some(parent)) => {
+                tail.push(name.to_os_string());
+                cursor = parent;
+            }
+            _ => {
+                return Err(format!(
+                    "Cannot resolve path '{}': no existing ancestor",
+                    requested
+                ));
+            }
+        }
+    };
+
+    let existing_canonical = existing
+        .canonicalize()
+        .map_err(|e| format!("Cannot resolve ancestor of '{}': {}", requested, e))?;
+    if !existing_canonical.starts_with(&cwd_canonical) {
+        return Err(format!(
+            "Path '{}' escapes the working directory",
+            requested
+        ));
+    }
+
+    // Reject any `..` components in the still-missing tail so an attacker
+    // can't re-escape via unwritten path components.
+    let mut resolved = existing_canonical;
+    for component in tail.into_iter().rev() {
+        if component == std::ffi::OsStr::new("..") || component == std::ffi::OsStr::new(".") {
             return Err(format!(
-                "Path '{}' escapes the working directory",
+                "Path '{}' contains unsupported '..' or '.' components",
                 requested
             ));
         }
+        resolved.push(component);
     }
-    Ok(joined)
+
+    Ok(resolved)
 }


### PR DESCRIPTION
## Summary

Addresses 11 issues found during an audit of the Rust ACP server (see updated `brokk-acp-rust/PLANS.md` for the full list). Highlights:

- **Streaming is live again.** `tool_loop` no longer buffers tokens until the stream ends — `on_text` is a shared `Arc<Mutex<dyn FnMut>>` forwarded into each turn's `stream_chat`, so the client sees tokens in real time.
- **Path traversal closed.** `safe_resolve_for_write` now walks up to the first existing ancestor, canonicalises it, and rejects `..`/`.` components in the unresolved tail. Previously, a nonexistent parent skipped the `starts_with(cwd)` check entirely.
- **Session mode and model persist.** `SessionManifest` carries `brokkMode`/`brokkModel` (ignored by the Java executor via `@JsonIgnoreProperties`), `get_session` rehydrates them, and `set_mode` now rewrites the manifest in the zip. Replay emits both `UserMessageChunk` and `AgentMessageChunk`.
- **Blocking I/O off the tokio runtime.** All zip read/write/append/list calls run under `tokio::task::spawn_blocking`, and the `SessionStore` write-lock is released before disk I/O so turns don't serialise the whole store.
- **Cleaner error handling.** Malformed tool-argument JSON is surfaced back to the LLM. Unknown modes/sessions return `invalid_params` with the supported list. Cancelled streams no longer emit truncated tool calls.
- **Operational improvements.** `--max-turns` is now configurable (default 25). `search_file_contents` skips files > 1 MiB and NUL-byte-containing files. The model list is cached at init so `session/new` no longer hits the LLM endpoint on every call.

Out of scope (documented in `PLANS.md`): Bifrost integration, `runShellCommand` sandboxing, tool-call persistence, small-model fallback, session eviction, tests.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -D warnings`
- [x] `cargo build --release`
- [ ] Manual smoke test with a real ACP client connected to a local Ollama endpoint to verify streaming, session reload preserves mode/model, and `set_mode` rejects unknown modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)