### PR TITLE
Refactor structural clone similarity scoring

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -4766,49 +4766,52 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         if (requestedFiles.isEmpty()) {
             return List.of();
         }
-        List<CloneCandidateData> allCandidates = getAllDeclarations().stream()
+        List<CloneCandidateProfile> allCandidates = getAllDeclarations().stream()
                 .filter(CodeUnit::isFunction)
                 .filter(cu -> isRelevantFile(cu.source()))
                 .map(cu -> buildCloneCandidateData(cu, resolved))
                 .flatMap(Optional::stream)
+                .map(candidate -> new CloneCandidateProfile(
+                        candidate, hashedShingles(candidate.normalizedTokens(), resolved.shingleSize())))
                 .toList();
         if (allCandidates.isEmpty()) {
             return List.of();
         }
-        List<CloneCandidateData> requestedCandidates = allCandidates.stream()
-                .filter(c -> requestedFiles.contains(c.unit().source()))
+        List<CloneCandidateProfile> requestedCandidates = allCandidates.stream()
+                .filter(c -> requestedFiles.contains(c.data().unit().source()))
                 .toList();
         if (requestedCandidates.isEmpty()) {
             return List.of();
         }
 
         var findings = new ArrayList<CloneSmell>();
-        for (CloneCandidateData left : requestedCandidates) {
-            for (CloneCandidateData right : allCandidates) {
-                if (left.unit().equals(right.unit())) {
+        for (CloneCandidateProfile left : requestedCandidates) {
+            for (CloneCandidateProfile right : allCandidates) {
+                CloneCandidateData leftData = left.data();
+                CloneCandidateData rightData = right.data();
+                if (leftData.unit().equals(rightData.unit())) {
                     continue;
                 }
-                int tokenSimilarity =
-                        computeCloneTokenSimilarity(left.normalizedTokens(), right.normalizedTokens(), resolved);
+                int tokenSimilarity = computeCloneTokenSimilarity(left.shingles(), right.shingles(), resolved);
                 if (tokenSimilarity < resolved.minSimilarityPercent()) {
                     continue;
                 }
-                int refinedSimilarity = refineCloneSimilarityPercent(left, right, tokenSimilarity, resolved);
+                int refinedSimilarity = refineCloneSimilarityPercent(leftData, rightData, tokenSimilarity, resolved);
                 if (refinedSimilarity < resolved.minSimilarityPercent()) {
                     continue;
                 }
                 findings.add(new CloneSmell(
-                        left.unit().source(),
-                        left.unit().fqName(),
-                        right.unit().source(),
-                        right.unit().fqName(),
+                        leftData.unit().source(),
+                        leftData.unit().fqName(),
+                        rightData.unit().source(),
+                        rightData.unit().fqName(),
                         refinedSimilarity,
                         Math.min(
-                                left.normalizedTokens().size(),
-                                right.normalizedTokens().size()),
+                                leftData.normalizedTokens().size(),
+                                rightData.normalizedTokens().size()),
                         List.of(buildReason(tokenSimilarity, refinedSimilarity)),
-                        left.excerpt(),
-                        right.excerpt()));
+                        leftData.excerpt(),
+                        rightData.excerpt()));
             }
         }
         return findings.stream()
@@ -4858,22 +4861,36 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
     protected int computeCloneTokenSimilarity(
             List<String> leftTokens, List<String> rightTokens, CloneSmellWeights weights) {
-        Set<String> leftShingles = shingles(leftTokens, weights.shingleSize());
-        Set<String> rightShingles = shingles(rightTokens, weights.shingleSize());
+        Set<Long> leftShingles = hashedShingles(leftTokens, weights.shingleSize());
+        Set<Long> rightShingles = hashedShingles(rightTokens, weights.shingleSize());
+        return computeCloneTokenSimilarity(leftShingles, rightShingles, weights);
+    }
+
+    static int computeCloneTokenSimilarity(Set<Long> leftShingles, Set<Long> rightShingles, CloneSmellWeights weights) {
         if (leftShingles.size() < weights.minSharedShingles() || rightShingles.size() < weights.minSharedShingles()) {
             return 0;
         }
-        Set<String> intersection = new HashSet<>(leftShingles);
-        intersection.retainAll(rightShingles);
-        if (intersection.size() < weights.minSharedShingles()) {
+        int intersectionSize = intersectionSize(leftShingles, rightShingles);
+        if (intersectionSize < weights.minSharedShingles()) {
             return 0;
         }
-        Set<String> union = new HashSet<>(leftShingles);
-        union.addAll(rightShingles);
-        if (union.isEmpty()) {
+        int unionSize = leftShingles.size() + rightShingles.size() - intersectionSize;
+        if (unionSize == 0) {
             return 0;
         }
-        return (int) Math.round((intersection.size() * 100.0) / union.size());
+        return (int) Math.round((intersectionSize * 100.0) / unionSize);
+    }
+
+    private static int intersectionSize(Set<Long> left, Set<Long> right) {
+        Set<Long> smaller = left.size() <= right.size() ? left : right;
+        Set<Long> larger = left.size() <= right.size() ? right : left;
+        int count = 0;
+        for (Long shingle : smaller) {
+            if (larger.contains(shingle)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     protected int computeAstLabelMultisetSimilarityPercent(String leftAstSignature, String rightAstSignature) {
@@ -4959,16 +4976,32 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 || label.contains("continue");
     }
 
-    protected static Set<String> shingles(List<String> tokens, int shingleSize) {
+    static Set<Long> hashedShingles(List<String> tokens, int shingleSize) {
         int k = Math.max(1, shingleSize);
         if (tokens.size() < k) {
             return Set.of();
         }
-        var shingles = new LinkedHashSet<String>();
+        var shingles = new LinkedHashSet<Long>();
         for (int i = 0; i <= tokens.size() - k; i++) {
-            shingles.add(String.join("|", tokens.subList(i, i + k)));
+            shingles.add(hashShingle(tokens, i, k));
         }
         return shingles;
+    }
+
+    private static long hashShingle(List<String> tokens, int start, int length) {
+        long hash = 0xcbf29ce484222325L;
+        for (int i = start; i < start + length; i++) {
+            String token = tokens.get(i);
+            hash = fnv1a(hash, token.length());
+            for (int j = 0; j < token.length(); j++) {
+                hash = fnv1a(hash, token.charAt(j));
+            }
+        }
+        return hash;
+    }
+
+    private static long fnv1a(long hash, int value) {
+        return (hash ^ value) * 0x100000001b3L;
     }
 
     protected String normalizeCloneLeafToken(TSNode node, SourceContent sourceContent) {
@@ -5042,6 +5075,8 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
     protected record CloneCandidateData(
             CodeUnit unit, List<String> normalizedTokens, String astSignature, String excerpt) {}
+
+    private record CloneCandidateProfile(CloneCandidateData data, Set<Long> shingles) {}
 
     /**
      * Extracts potential type identifiers from source code.

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java
@@ -1,0 +1,88 @@
+package ai.brokk.analyzer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class TreeSitterCloneSimilarityTest {
+
+    @Test
+    void hashedSimilarityMatchesStringShingleSimilarityForIdenticalTokens() {
+        var tokens = List.of("ID", "OP:=", "NUM", "OP:+", "ID");
+        var weights = new IAnalyzer.CloneSmellWeights(1, 1, 2, 1, 70);
+
+        assertSimilarityMatchesStringShingles(tokens, tokens, weights);
+    }
+
+    @Test
+    void hashedSimilarityMatchesStringShingleSimilarityForPartialOverlap() {
+        var left = List.of("ID", "OP:=", "NUM", "OP:+", "ID", "OP:;", "return", "ID");
+        var right = List.of("ID", "OP:=", "NUM", "OP:-", "ID", "OP:;", "return", "NUM");
+        var weights = new IAnalyzer.CloneSmellWeights(1, 1, 2, 1, 70);
+
+        assertSimilarityMatchesStringShingles(left, right, weights);
+    }
+
+    @Test
+    void hashedSimilarityMatchesStringShingleSimilarityBelowMinSharedShingles() {
+        var left = List.of("ID", "OP:=", "NUM", "OP:+", "ID");
+        var right = List.of("return", "STR", "OP:;", "throw", "ID");
+        var weights = new IAnalyzer.CloneSmellWeights(1, 1, 2, 3, 70);
+
+        assertSimilarityMatchesStringShingles(left, right, weights);
+    }
+
+    @Test
+    void hashedSimilarityMatchesStringShingleSimilarityWhenTokenListIsShorterThanShingleSize() {
+        var left = List.of("ID", "OP:=");
+        var right = List.of("ID", "OP:=");
+        var weights = new IAnalyzer.CloneSmellWeights(1, 1, 3, 1, 70);
+
+        assertSimilarityMatchesStringShingles(left, right, weights);
+    }
+
+    private static void assertSimilarityMatchesStringShingles(
+            List<String> left, List<String> right, IAnalyzer.CloneSmellWeights weights) {
+        int expected = stringShingleSimilarity(left, right, weights);
+        int actual = TreeSitterAnalyzer.computeCloneTokenSimilarity(
+                TreeSitterAnalyzer.hashedShingles(left, weights.shingleSize()),
+                TreeSitterAnalyzer.hashedShingles(right, weights.shingleSize()),
+                weights);
+        assertEquals(expected, actual);
+    }
+
+    private static int stringShingleSimilarity(
+            List<String> left, List<String> right, IAnalyzer.CloneSmellWeights weights) {
+        Set<String> leftShingles = stringShingles(left, weights.shingleSize());
+        Set<String> rightShingles = stringShingles(right, weights.shingleSize());
+        if (leftShingles.size() < weights.minSharedShingles() || rightShingles.size() < weights.minSharedShingles()) {
+            return 0;
+        }
+        var intersection = new LinkedHashSet<>(leftShingles);
+        intersection.retainAll(rightShingles);
+        if (intersection.size() < weights.minSharedShingles()) {
+            return 0;
+        }
+        var union = new LinkedHashSet<>(leftShingles);
+        union.addAll(rightShingles);
+        if (union.isEmpty()) {
+            return 0;
+        }
+        return (int) Math.round((intersection.size() * 100.0) / union.size());
+    }
+
+    private static Set<String> stringShingles(List<String> tokens, int shingleSize) {
+        int k = Math.max(1, shingleSize);
+        if (tokens.size() < k) {
+            return Set.of();
+        }
+        var shingles = new LinkedHashSet<String>();
+        for (int i = 0; i <= tokens.size() - k; i++) {
+            shingles.add(String.join("|", tokens.subList(i, i + k)));
+        }
+        return shingles;
+    }
+}

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/JavaCloneDetectionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/JavaCloneDetectionSmellTest.java
@@ -1,5 +1,6 @@
 package ai.brokk.analyzer.code_quality;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -157,5 +158,53 @@ public class JavaCloneDetectionSmellTest extends AbstractCloneDetectionSmellTest
         assertTrue(findings.stream()
                 .anyMatch(f -> f.enclosingFqName().contains("Alpha.compute")
                         && f.peerEnclosingFqName().contains("Beta.calculate")));
+    }
+
+    @Test
+    void keepsStableResultsWithMultiplePeerFunctions() {
+        String requested =
+                """
+                package com.example;
+                class Alpha {
+                    int compute(int input) {
+                        int total = input + 1;
+                        if (total > 10) {
+                            return total * 2;
+                        }
+                        return total - 3;
+                    }
+                }
+                """;
+        String peers =
+                """
+                package com.example;
+                class Beta {
+                    int calculate(int seed) {
+                        int amount = seed + 1;
+                        if (amount > 10) {
+                            return amount * 2;
+                        }
+                        return amount - 3;
+                    }
+
+                    int unrelated(int seed) {
+                        while (seed > 0) {
+                            seed--;
+                        }
+                        return seed;
+                    }
+                }
+                """;
+
+        var findings = analyze("com/example/Alpha.java", requested, "com/example/Beta.java", peers);
+        var matching = findings.stream()
+                .filter(f -> f.enclosingFqName().contains("Alpha.compute"))
+                .filter(f -> f.peerEnclosingFqName().contains("Beta.calculate"))
+                .toList();
+
+        assertEquals(1, matching.size());
+        assertTrue(findings.stream()
+                .noneMatch(f -> f.enclosingFqName().contains("Alpha.compute")
+                        && f.peerEnclosingFqName().contains("Beta.unrelated")));
     }
 }


### PR DESCRIPTION
## Summary
- Precompute per-candidate hashed shingles in `TreeSitterAnalyzer` and reuse them across pair comparisons.
- Replace repeated string-join shingle construction with an internal hashed representation and keep the Jaccard-style score behavior intact.
- Add regression coverage for hashed similarity equivalence and a multi-peer clone detection case.

## Testing
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.TreeSitterCloneSimilarityTest --tests ai.brokk.analyzer.code_quality.JavaCloneDetectionSmellTest --tests ai.brokk.analyzer.code_quality.PythonCloneDetectionSmellTest --tests ai.brokk.analyzer.code_quality.JsTsCloneDetectionSmellTest --tests ai.brokk.analyzer.MultiAnalyzerCapabilityTest`
- `./gradlew fix tidy`
- `./gradlew analyze`