### PR TITLE
optimize selectFilesForDisplay

### DIFF
--- a/app/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/app/src/main/java/ai/brokk/tools/SearchTools.java
@@ -1011,9 +1011,12 @@ public class SearchTools {
         if (truncated) {
             result.append("### WARNING: Result limit reached (max ")
                     .append(effectiveLimit)
-                    .append(" files). Showing first ")
+                    .append(" files). Showing ")
                     .append(effectiveLimit)
-                    .append(" files. Retrying the same tool call will return the same results.\n\n");
+                    .append(" of ")
+                    .append(fileGroups.size())
+                    .append(" files selected by recent activity when available. Results are displayed alphabetically. "
+                            + "Retrying the same tool call will return the same results.\n\n");
         }
 
         filesToRender.forEach(file -> {
@@ -1562,8 +1565,10 @@ public class SearchTools {
         }
         String prefix = "";
         if (truncated) {
-            prefix = "### WARNING: Result limit reached (max " + effectiveLimit + " files). Showing first "
-                    + effectiveLimit + " matches. " + "Retrying the same tool call will return the same results.\n\n";
+            prefix = "### WARNING: Result limit reached (max " + effectiveLimit + " files). Showing "
+                    + effectiveLimit + " of " + searchResult.matches().size()
+                    + " matches selected by recent activity when available. Results are displayed alphabetically. "
+                    + "Retrying the same tool call will return the same results.\n\n";
         }
 
         var matchingStrings = matchingFilenames.stream()
@@ -2363,8 +2368,10 @@ public class SearchTools {
 
         String prefix = "";
         if (truncated) {
-            prefix = "### WARNING: Result limit reached (max " + effectiveLimit + " filenames). Showing first "
-                    + effectiveLimit + " matches. " + "Retrying the same tool call will return the same results.\n\n";
+            prefix = "### WARNING: Result limit reached (max " + effectiveLimit + " filenames). Showing "
+                    + effectiveLimit + " of " + allMatches.size()
+                    + " matches selected by recent activity when available. Results are displayed alphabetically. "
+                    + "Retrying the same tool call will return the same results.\n\n";
         }
 
         return recordResearchTokens(
@@ -2592,9 +2599,12 @@ public class SearchTools {
         if (truncatedByFileLimit) {
             prefix.append("### WARNING: Result limit reached (max ")
                     .append(FILE_SKIM_LIMIT)
-                    .append(" files). Showing first ")
+                    .append(" files). Showing ")
                     .append(FILE_SKIM_LIMIT)
-                    .append(" files. Retrying the same tool call will return the same results.\n\n");
+                    .append(" of ")
+                    .append(projectFiles.size())
+                    .append(" files selected by recent activity when available. Results are displayed alphabetically. "
+                            + "Retrying the same tool call will return the same results.\n\n");
         }
 
         String fullSkim = selectedBlocks.stream()

--- a/app/src/test/java/ai/brokk/analyzer/ranking/GitDistanceMostImportantTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/ranking/GitDistanceMostImportantTest.java
@@ -6,6 +6,7 @@ import ai.brokk.analyzer.BrokkFile;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.git.CommitInfo;
 import ai.brokk.git.GitDistance;
 import ai.brokk.git.GitRepo;
 import ai.brokk.git.IGitRepo;
@@ -14,8 +15,11 @@ import ai.brokk.testutil.TestProject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -103,6 +107,59 @@ public class GitDistanceMostImportantTest {
         assertEquals(userService, results.get(0), "UserService should be most important");
         assertEquals(user, results.get(1), "User should be second");
         assertEquals(userRepo, results.get(2), "UserRepository should be third");
+    }
+
+    @Test
+    public void testSortByImportanceUsesBoundedRecentCommitScores() throws InterruptedException {
+        var low = new ProjectFile(testProject.getRoot(), "Low.java");
+        var high = new ProjectFile(testProject.getRoot(), "High.java");
+        var newest = new CommitInfo("newest", "Update high", "Test", Instant.parse("2025-01-02T00:00:00Z"));
+        var older = new CommitInfo("older", "Update low", "Test", Instant.parse("2025-01-01T00:00:00Z"));
+
+        IGitRepo repo = new IGitRepo() {
+            @Override
+            public Set<ProjectFile> getTrackedFiles() {
+                return Set.of(low, high);
+            }
+
+            @Override
+            public void add(Collection<ProjectFile> files) {}
+
+            @Override
+            public void add(ProjectFile file) {}
+
+            @Override
+            public void remove(ProjectFile file) {}
+
+            @Override
+            public String getCurrentBranch() {
+                return "main";
+            }
+
+            @Override
+            public List<CommitInfo> listCommitsDetailed(String branchName, int maxResults) {
+                assertEquals(1_000, maxResults, "sortByImportance should use the bounded recent-commit window");
+                return List.of(newest, older);
+            }
+
+            @Override
+            public List<ModifiedFile> listFilesChangedInCommit(String commitId) {
+                return switch (commitId) {
+                    case "newest" -> List.of(new ModifiedFile(high, ModificationType.MODIFIED));
+                    case "older" -> List.of(new ModifiedFile(low, ModificationType.MODIFIED));
+                    default -> List.of();
+                };
+            }
+
+            @Override
+            public List<CommitInfo> getFileHistories(Collection<ProjectFile> files, int maxResults) {
+                throw new AssertionError("sortByImportance should not collect per-file histories");
+            }
+        };
+
+        var results = GitDistance.sortByImportance(List.of(low, high), repo);
+
+        assertEquals(high, results.getFirst(), "Newer recent history should make High.java more important");
     }
 
     @Test

--- a/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
@@ -986,9 +986,12 @@ public class SearchTools {
         if (truncated) {
             result.append("### WARNING: Result limit reached (max ")
                     .append(effectiveLimit)
-                    .append(" files). Showing first ")
+                    .append(" files). Showing ")
                     .append(effectiveLimit)
-                    .append(" files. Retrying the same tool call will return the same results.\n\n");
+                    .append(" of ")
+                    .append(fileGroups.size())
+                    .append(" files selected by recent activity when available. Results are displayed alphabetically. "
+                            + "Retrying the same tool call will return the same results.\n\n");
         }
 
         filesToRender.forEach(file -> {
@@ -1494,8 +1497,10 @@ public class SearchTools {
         }
         String prefix = "";
         if (truncated) {
-            prefix = "### WARNING: Result limit reached (max " + effectiveLimit + " files). Showing first "
-                    + effectiveLimit + " matches. " + "Retrying the same tool call will return the same results.\n\n";
+            prefix = "### WARNING: Result limit reached (max " + effectiveLimit + " files). Showing "
+                    + effectiveLimit + " of " + searchResult.matches().size()
+                    + " matches selected by recent activity when available. Results are displayed alphabetically. "
+                    + "Retrying the same tool call will return the same results.\n\n";
         }
 
         var matchingStrings = matchingFilenames.stream()
@@ -2210,8 +2215,10 @@ public class SearchTools {
 
         String prefix = "";
         if (truncated) {
-            prefix = "### WARNING: Result limit reached (max " + effectiveLimit + " filenames). Showing first "
-                    + effectiveLimit + " matches. " + "Retrying the same tool call will return the same results.\n\n";
+            prefix = "### WARNING: Result limit reached (max " + effectiveLimit + " filenames). Showing "
+                    + effectiveLimit + " of " + allMatches.size()
+                    + " matches selected by recent activity when available. Results are displayed alphabetically. "
+                    + "Retrying the same tool call will return the same results.\n\n";
         }
 
         return recordResearchTokens(
@@ -2417,9 +2424,12 @@ public class SearchTools {
         if (truncatedByFileLimit) {
             prefix.append("### WARNING: Result limit reached (max ")
                     .append(FILE_SKIM_LIMIT)
-                    .append(" files). Showing first ")
+                    .append(" files). Showing ")
                     .append(FILE_SKIM_LIMIT)
-                    .append(" files. Retrying the same tool call will return the same results.\n\n");
+                    .append(" of ")
+                    .append(projectFiles.size())
+                    .append(" files selected by recent activity when available. Results are displayed alphabetically. "
+                            + "Retrying the same tool call will return the same results.\n\n");
         }
 
         String fullSkim = selectedBlocks.stream()

--- a/brokk-shared/src/main/java/ai/brokk/git/GitDistance.java
+++ b/brokk-shared/src/main/java/ai/brokk/git/GitDistance.java
@@ -188,7 +188,7 @@ public final class GitDistance {
             throws InterruptedException {
         Map<ProjectFile, Double> scores;
         try {
-            var commits = repo.getFileHistories(files, Integer.MAX_VALUE);
+            var commits = repo.listCommitsDetailed(repo.getCurrentBranch(), COMMITS_TO_PROCESS);
             scores = computeImportanceScores(repo, commits);
             logger.trace("Computed importance scores for sortByImportance: {}", scores);
         } catch (UnsupportedOperationException e) {


### PR DESCRIPTION
- Bounded `GitDistance.sortByImportance` to `COMMITS_TO_PROCESS` via `listCommitsDetailed(..., 1_000)` instead of expensive per-file history collection.
- Updated truncation warning copy in both app and brokk-core to avoid “Showing first N” and clarify ranked selection plus alphabetical display.
- Added the regression test proving the bounded path is used and `getFileHistories` is not called.