### PR TITLE
chore: drop claude-plugin tag pinning in codex installer

### DIFF
--- a/brokk-code/brokk_code/mcp_config.py
+++ b/brokk-code/brokk_code/mcp_config.py
@@ -4,7 +4,6 @@ import os
 import re
 import tempfile
 import tomllib
-import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -259,7 +258,6 @@ class InstalledCodexPlugin:
 
 
 _GITHUB_RAW_BASE = "https://raw.githubusercontent.com/BrokkAi/brokk"
-_CLAUDE_PLUGIN_VERSION = "0.4.1"
 
 _log = logging.getLogger(__name__)
 
@@ -298,24 +296,16 @@ _SKILL_AGENT_DEPS: dict[str, list[str]] = {
 
 
 def _fetch_github_file(path: str) -> str:
-    """Fetch a file from the brokk GitHub repo.
+    """Fetch a file from the brokk GitHub repo's master branch.
 
-    Tries the ``claude-plugin-{version}`` tag first, falls back to ``master``
-    if the tag does not exist (HTTP 404).
+    The plugin's ``version`` field in ``plugin.json`` is the upgrade signal;
+    fetching from master means installs always pick up the latest published
+    skills, agents, and manifest.
     """
-    tag_ref = f"claude-plugin-{_CLAUDE_PLUGIN_VERSION}"
-    for ref in (tag_ref, "master"):
-        url = f"{_GITHUB_RAW_BASE}/{ref}/{path}"
-        _log.info("Fetching %s", url)
-        try:
-            with urllib.request.urlopen(url, timeout=30) as resp:
-                return resp.read().decode("utf-8")
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404 and ref != "master":
-                _log.warning("Tag %s not found, falling back to master", tag_ref)
-                continue
-            raise
-    raise RuntimeError(f"Failed to fetch {path} from GitHub")
+    url = f"{_GITHUB_RAW_BASE}/master/{path}"
+    _log.info("Fetching %s", url)
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        return resp.read().decode("utf-8")
 
 
 def _fetch_codex_skills() -> dict[str, str]:


### PR DESCRIPTION
## Summary
- Drop `_CLAUDE_PLUGIN_VERSION` and the tag-fallback loop from `brokk-code/brokk_code/mcp_config.py`; fetch claude-plugin assets from `master` directly.
- `plugin.json#version` is now the single upgrade signal for the codex plugin install, matching the model claude marketplaces already use.
- Eliminates the silent-staleness bug where `_CLAUDE_PLUGIN_VERSION` lagged behind the actual `plugin.json#version` (currently 0.4.1 vs 0.4.2), causing codex installs to ship outdated skills/agents.

## Why
Two parallel "this changed" mechanisms (the git tag and the version field) means two numbers to bump on every release. When the tag-version was forgotten, the fallback to master was a 404 round-trip away, but only if the tag didn't exist at all -- if a stale tag existed, codex installs silently fetched stale content. Collapsing to one mechanism removes the drift class.

## Test plan
- [x] `uv run pytest tests/test_mcp_config.py` (22 passed)
- [x] `uv run ruff check brokk_code/mcp_config.py` (clean)
- [ ] CI green

## Notes
The existing `claude-plugin-*` git tags are now unused but harmless; left in place rather than doing a destructive tag deletion. If you want to stop creating new ones, that's a release-process change handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)