### PR TITLE
Add "God Object"/"Giant Method" Smell Tool

### DIFF
--- a/app/src/main/java/ai/brokk/executor/agents/AgentDefinition.java
+++ b/app/src/main/java/ai/brokk/executor/agents/AgentDefinition.java
@@ -50,6 +50,7 @@ public record AgentDefinition(
             "jq",
             "computeCyclomaticComplexity",
             "computeCognitiveComplexity",
+            "reportLongMethodAndGodObjectSmells",
             "reportCommentDensityForCodeUnit",
             "reportCommentDensityForFiles",
             "reportExceptionHandlingSmells",
@@ -86,6 +87,7 @@ public record AgentDefinition(
             "jq",
             "computeCyclomaticComplexity",
             "computeCognitiveComplexity",
+            "reportLongMethodAndGodObjectSmells",
             "reportCommentDensityForCodeUnit",
             "reportCommentDensityForFiles",
             "reportExceptionHandlingSmells",
@@ -138,6 +140,7 @@ public record AgentDefinition(
             // CodeQualityTools
             "computeCyclomaticComplexity",
             "computeCognitiveComplexity",
+            "reportLongMethodAndGodObjectSmells",
             "reportCommentDensityForCodeUnit",
             "reportCommentDensityForFiles",
             "reportExceptionHandlingSmells",

--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
@@ -133,6 +134,85 @@ public class CodeQualityTools {
         contextManager.getIo().showNotification(IConsoleIO.NotificationRole.INFO, finding);
         lines.add("- " + cu.fqName() + ": " + complexity);
         return true;
+    }
+
+    @Tool(
+            """
+            Reports long methods/functions, god objects/modules, and helper sprawl in the given files.
+            Uses analyzer code-unit hierarchy and declaration ranges, then ranks bounded findings by maintainability impact.
+            Includes file path, symbol, line range, size/responsibility signals, and concise rationale.""")
+    public String reportLongMethodAndGodObjectSmells(
+            @P("File paths relative to the project root.") List<String> filePaths,
+            @P("Maximum findings to return; values <= 0 default to 20.") int maxFindings,
+            @P("Maximum existing files to analyze; values <= 0 default to 25.") int maxFiles,
+            @P("Long method/function line threshold; values <= 0 use default.") int longMethodSpanLines,
+            @P("High cyclomatic complexity threshold; values <= 0 use default.") int highComplexityThreshold,
+            @P("God object/module line threshold; values <= 0 use default.") int godObjectSpanLines,
+            @P("God object/module direct-child threshold; values <= 0 use default.") int godObjectDirectChildren,
+            @P("God object/module function-count threshold; values <= 0 use default.") int godObjectFunctions,
+            @P("Helper-sprawl function-count threshold; values <= 0 use default.") int helperSprawlFunctions,
+            @P("Helper-sprawl workflow line threshold; values <= 0 use default.") int helperSprawlWorkflowLines) {
+
+        int cap = maxFindings > 0 ? maxFindings : 20;
+        int fileCap = maxFiles > 0 ? maxFiles : 25;
+        var defaults = IAnalyzer.MaintainabilitySizeSmellWeights.defaults();
+        var weights = new IAnalyzer.MaintainabilitySizeSmellWeights(
+                pickPositive(longMethodSpanLines, defaults.longMethodSpanLines()),
+                pickPositive(highComplexityThreshold, defaults.highComplexityThreshold()),
+                pickPositive(godObjectSpanLines, defaults.godObjectSpanLines()),
+                pickPositive(godObjectDirectChildren, defaults.godObjectDirectChildren()),
+                pickPositive(godObjectFunctions, defaults.godObjectFunctions()),
+                pickPositive(helperSprawlFunctions, defaults.helperSprawlFunctions()),
+                pickPositive(helperSprawlWorkflowLines, defaults.helperSprawlWorkflowLines()),
+                defaults.fileModuleLeewayMultiplier());
+        IAnalyzer analyzer = contextManager.getAnalyzerUninterrupted();
+        var files = filePaths.stream()
+                .map(contextManager::toFile)
+                .filter(ProjectFile::exists)
+                .limit(fileCap)
+                .toList();
+        var selectedFiles = new HashSet<>(files);
+        var findings = files.stream()
+                .flatMap(file -> analyzer.findLongMethodAndGodObjectSmells(file, weights).stream())
+                .filter(smell -> selectedFiles.contains(smell.codeUnit().source()))
+                .sorted(IAnalyzer.maintainabilitySizeSmellComparator())
+                .limit(cap)
+                .toList();
+
+        var lines = new ArrayList<String>();
+        lines.add("Long method and god object smells (max findings: " + cap + "):");
+        lines.add("- Files analyzed cap: " + fileCap);
+        lines.add("- Weights: " + formatWeights(weights));
+        if (findings.isEmpty()) {
+            lines.add("");
+            lines.add("No long method or god object smells found.");
+            return String.join("\n", lines);
+        }
+
+        for (var smell : findings) {
+            CodeUnit cu = smell.codeUnit();
+            var range = smell.range();
+            int displayStartLine = range.startLine() + 1;
+            int displayEndLine = range.endLine() + 1;
+            String finding = "%s Maintainability size smell: %s (score: %d) in %s:%d-%d"
+                    .formatted(
+                            FINDING_PREFIX, cu.fqName(), smell.score(), cu.source(), displayStartLine, displayEndLine);
+            contextManager.getIo().showNotification(IConsoleIO.NotificationRole.INFO, finding);
+            lines.add("- `%s` in `%s:%d-%d` [score %d]"
+                    .formatted(cu.fqName(), cu.source(), displayStartLine, displayEndLine, smell.score()));
+            lines.add(
+                    "  - Signals: own %d lines, descendants %d lines, direct children %d, functions %d, nested types %d, max function %d lines, max CC %d"
+                            .formatted(
+                                    smell.ownSpanLines(),
+                                    smell.descendantSpanLines(),
+                                    smell.directChildCount(),
+                                    smell.functionCount(),
+                                    smell.nestedTypeCount(),
+                                    smell.maxFunctionSpanLines(),
+                                    smell.maxCyclomaticComplexity()));
+            lines.add("  - Rationale: " + String.join("; ", smell.reasons()));
+        }
+        return String.join("\n", lines);
     }
 
     @Tool(
@@ -612,8 +692,27 @@ public class CodeQualityTools {
         return candidate >= 0 ? candidate : fallback;
     }
 
+    private static int pickPositive(int candidate, int fallback) {
+        return candidate > 0 ? candidate : fallback;
+    }
+
     private static String sanitizeTableCell(String value) {
         return value.replace("|", "\\|");
+    }
+
+    private static String formatWeights(IAnalyzer.MaintainabilitySizeSmellWeights w) {
+        return "longMethodSpan=%d, highComplexity=%d, godObjectSpan=%d, directChildren=%d, functions=%d,"
+                        .formatted(
+                                w.longMethodSpanLines(),
+                                w.highComplexityThreshold(),
+                                w.godObjectSpanLines(),
+                                w.godObjectDirectChildren(),
+                                w.godObjectFunctions())
+                + " helperFunctions=%d, helperWorkflowLines=%d, fileModuleLeewayMultiplier=%d"
+                        .formatted(
+                                w.helperSprawlFunctions(),
+                                w.helperSprawlWorkflowLines(),
+                                w.fileModuleLeewayMultiplier());
     }
 
     private static String formatWeights(IAnalyzer.ExceptionSmellWeights w) {

--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -163,8 +163,7 @@ public class CodeQualityTools {
                 pickPositive(godObjectDirectChildren, defaults.godObjectDirectChildren()),
                 pickPositive(godObjectFunctions, defaults.godObjectFunctions()),
                 pickPositive(helperSprawlFunctions, defaults.helperSprawlFunctions()),
-                pickPositive(helperSprawlWorkflowLines, defaults.helperSprawlWorkflowLines()),
-                defaults.fileModuleLeewayMultiplier());
+                pickPositive(helperSprawlWorkflowLines, defaults.helperSprawlWorkflowLines()));
         IAnalyzer analyzer = contextManager.getAnalyzerUninterrupted();
         var files = filePaths.stream()
                 .map(contextManager::toFile)
@@ -188,7 +187,6 @@ public class CodeQualityTools {
             lines.add("No long method or god object smells found.");
             return String.join("\n", lines);
         }
-
         for (var smell : findings) {
             CodeUnit cu = smell.codeUnit();
             var range = smell.range();
@@ -701,18 +699,14 @@ public class CodeQualityTools {
     }
 
     private static String formatWeights(IAnalyzer.MaintainabilitySizeSmellWeights w) {
-        return "longMethodSpan=%d, highComplexity=%d, godObjectSpan=%d, directChildren=%d, functions=%d,"
+        return "longMethodLines=%d, highComplexity=%d, godObjectLines=%d, godObjectDirectChildren=%d,"
                         .formatted(
                                 w.longMethodSpanLines(),
                                 w.highComplexityThreshold(),
                                 w.godObjectSpanLines(),
-                                w.godObjectDirectChildren(),
-                                w.godObjectFunctions())
-                + " helperFunctions=%d, helperWorkflowLines=%d, fileModuleLeewayMultiplier=%d"
-                        .formatted(
-                                w.helperSprawlFunctions(),
-                                w.helperSprawlWorkflowLines(),
-                                w.fileModuleLeewayMultiplier());
+                                w.godObjectDirectChildren())
+                + " godObjectFunctions=%d, helperSprawlFunctions=%d, helperSprawlWorkflowLines=%d"
+                        .formatted(w.godObjectFunctions(), w.helperSprawlFunctions(), w.helperSprawlWorkflowLines());
     }
 
     private static String formatWeights(IAnalyzer.ExceptionSmellWeights w) {

--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -163,7 +163,8 @@ public class CodeQualityTools {
                 pickPositive(godObjectDirectChildren, defaults.godObjectDirectChildren()),
                 pickPositive(godObjectFunctions, defaults.godObjectFunctions()),
                 pickPositive(helperSprawlFunctions, defaults.helperSprawlFunctions()),
-                pickPositive(helperSprawlWorkflowLines, defaults.helperSprawlWorkflowLines()));
+                pickPositive(helperSprawlWorkflowLines, defaults.helperSprawlWorkflowLines()),
+                defaults.fileModuleLeewayMultiplier());
         IAnalyzer analyzer = contextManager.getAnalyzerUninterrupted();
         var files = filePaths.stream()
                 .map(contextManager::toFile)
@@ -705,8 +706,12 @@ public class CodeQualityTools {
                                 w.highComplexityThreshold(),
                                 w.godObjectSpanLines(),
                                 w.godObjectDirectChildren())
-                + " godObjectFunctions=%d, helperSprawlFunctions=%d, helperSprawlWorkflowLines=%d"
-                        .formatted(w.godObjectFunctions(), w.helperSprawlFunctions(), w.helperSprawlWorkflowLines());
+                + " godObjectFunctions=%d, helperSprawlFunctions=%d, helperSprawlWorkflowLines=%d, fileModuleLeeway=%dx"
+                        .formatted(
+                                w.godObjectFunctions(),
+                                w.helperSprawlFunctions(),
+                                w.helperSprawlWorkflowLines(),
+                                w.fileModuleLeewayMultiplier());
     }
 
     private static String formatWeights(IAnalyzer.ExceptionSmellWeights w) {

--- a/app/src/test/java/ai/brokk/executor/agents/AgentDefinitionTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/AgentDefinitionTest.java
@@ -116,6 +116,7 @@ class AgentDefinitionTest {
                         "getFileContents",
                         "computeCyclomaticComplexity",
                         "computeCognitiveComplexity",
+                        "reportLongMethodAndGodObjectSmells",
                         "reportExceptionHandlingSmells",
                         "reportStructuralCloneSmells",
                         "reportSecretLikeCode",

--- a/app/src/test/java/ai/brokk/tools/CodeQualityToolsLongMethodAndGodObjectTest.java
+++ b/app/src/test/java/ai/brokk/tools/CodeQualityToolsLongMethodAndGodObjectTest.java
@@ -1,0 +1,90 @@
+package ai.brokk.tools;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.testutil.InlineTestProjectCreator;
+import ai.brokk.testutil.TestConsoleIO;
+import ai.brokk.testutil.TestContextManager;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class CodeQualityToolsLongMethodAndGodObjectTest {
+
+    @Test
+    void reportLongMethodAndGodObjectSmellsReturnsBoundedMarkdown() throws IOException {
+        String source =
+                """
+                package com.example;
+                public class GeneratedController {
+                    public void executeWorkflow() {
+                %s
+                    }
+                %s
+                }
+                """
+                        .formatted(statements(85), helpers(16));
+
+        try (var project = InlineTestProjectCreator.code(source, "src/main/java/com/example/GeneratedController.java")
+                .build()) {
+            var tools = new CodeQualityTools(
+                    new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer()));
+
+            String report = tools.reportLongMethodAndGodObjectSmells(
+                    List.of("src/main/java/com/example/GeneratedController.java", "missing/Missing.java"), 1);
+
+            assertTrue(report.contains("Long method and god object smells"), report);
+            assertTrue(report.contains("`com.example.GeneratedController"), report);
+            assertTrue(report.contains("Signals: own"), report);
+            assertTrue(report.contains("Rationale:"), report);
+            assertFalse(
+                    report.contains("executeWorkflow"), "maxFindings should limit output to one finding: " + report);
+        }
+    }
+
+    @Test
+    void reportLongMethodAndGodObjectSmellsReturnsEmptyMessage() throws IOException {
+        String source =
+                """
+                package com.example;
+                public class Small {
+                    public int add(int left, int right) {
+                        return left + right;
+                    }
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.code(source, "src/main/java/com/example/Small.java")
+                .build()) {
+            var tools = new CodeQualityTools(
+                    new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer()));
+
+            String report = tools.reportLongMethodAndGodObjectSmells(
+                    List.of("src/main/java/com/example/Small.java", "missing/Missing.java"), 20);
+
+            assertTrue(report.contains("No long method or god object smells found."), report);
+        }
+    }
+
+    private static String statements(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> "        int value" + i + " = " + i + ";")
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static String helpers(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i ->
+                        """
+                            private int helper%s(int value) {
+                                return value + %s;
+                            }
+                        """
+                                .formatted(i, i))
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/app/src/test/java/ai/brokk/tools/CodeQualityToolsLongMethodAndGodObjectTest.java
+++ b/app/src/test/java/ai/brokk/tools/CodeQualityToolsLongMethodAndGodObjectTest.java
@@ -34,10 +34,15 @@ class CodeQualityToolsLongMethodAndGodObjectTest {
             var tools = new CodeQualityTools(
                     new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer()));
 
-            String report = tools.reportLongMethodAndGodObjectSmells(
-                    List.of("src/main/java/com/example/GeneratedController.java", "missing/Missing.java"), 1);
+            String report = reportWithDefaults(
+                    tools,
+                    List.of("src/main/java/com/example/GeneratedController.java", "missing/Missing.java"),
+                    1,
+                    25);
 
             assertTrue(report.contains("Long method and god object smells"), report);
+            assertTrue(report.contains("Files analyzed cap: 25"), report);
+            assertTrue(report.contains("Weights: longMethodLines=80"), report);
             assertTrue(report.contains("`com.example.GeneratedController"), report);
             assertTrue(report.contains("Signals: own"), report);
             assertTrue(report.contains("Rationale:"), report);
@@ -63,11 +68,94 @@ class CodeQualityToolsLongMethodAndGodObjectTest {
             var tools = new CodeQualityTools(
                     new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer()));
 
-            String report = tools.reportLongMethodAndGodObjectSmells(
-                    List.of("src/main/java/com/example/Small.java", "missing/Missing.java"), 20);
+            String report = reportWithDefaults(
+                    tools, List.of("src/main/java/com/example/Small.java", "missing/Missing.java"), 20, 25);
 
             assertTrue(report.contains("No long method or god object smells found."), report);
+            assertTrue(report.contains("Weights: longMethodLines=80"), report);
         }
+    }
+
+    @Test
+    void reportLongMethodAndGodObjectSmellsSupportsThresholdOverrides() throws IOException {
+        String source =
+                """
+                package com.example;
+                public class Tunable {
+                    public void smallerWorkflow() {
+                %s
+                    }
+                }
+                """
+                        .formatted(statements(12));
+
+        try (var project = InlineTestProjectCreator.code(source, "src/main/java/com/example/Tunable.java")
+                .build()) {
+            var tools = new CodeQualityTools(
+                    new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer()));
+
+            String permissive = tools.reportLongMethodAndGodObjectSmells(
+                    List.of("src/main/java/com/example/Tunable.java"), 20, 25, 10, 0, 0, 0, 0, 0, 0);
+            String strict = tools.reportLongMethodAndGodObjectSmells(
+                    List.of("src/main/java/com/example/Tunable.java"), 20, 25, 200, 0, 0, 0, 0, 0, 0);
+
+            assertTrue(permissive.contains("`com.example.Tunable.smallerWorkflow`"), permissive);
+            assertTrue(permissive.contains("Weights: longMethodLines=10"), permissive);
+            assertTrue(strict.contains("No long method or god object smells found."), strict);
+            assertTrue(strict.contains("Weights: longMethodLines=200"), strict);
+        }
+    }
+
+    @Test
+    void reportLongMethodAndGodObjectSmellsLimitsExistingFilesAnalyzed() throws IOException {
+        String firstSmelly =
+                """
+                package com.example;
+                public class FirstSmelly {
+                    public void generatedWorkflow() {
+                %s
+                    }
+                }
+                """
+                        .formatted(statements(85));
+        String secondSmelly =
+                """
+                package com.example;
+                public class SecondSmelly {
+                    public void generatedWorkflow() {
+                %s
+                    }
+                }
+                """
+                        .formatted(statements(85));
+
+        try (var project = InlineTestProjectCreator.empty()
+                .addFileContents(firstSmelly, "src/main/java/com/example/FirstSmelly.java")
+                .addFileContents(secondSmelly, "src/main/java/com/example/SecondSmelly.java")
+                .build()) {
+            var tools = new CodeQualityTools(
+                    new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer()));
+
+            String report = reportWithDefaults(
+                    tools,
+                    List.of(
+                            "missing/Missing.java",
+                            "src/main/java/com/example/FirstSmelly.java",
+                            "src/main/java/com/example/SecondSmelly.java"),
+                    20,
+                    1);
+
+            assertTrue(report.contains("Files analyzed cap: 1"), report);
+            assertTrue(
+                    report.contains("FirstSmelly.generatedWorkflow")
+                            ^ report.contains("SecondSmelly.generatedWorkflow"),
+                    report);
+        }
+    }
+
+    private static String reportWithDefaults(
+            CodeQualityTools tools, List<String> paths, int maxFindings, int maxFiles) {
+        return tools.reportLongMethodAndGodObjectSmells(paths, maxFindings, maxFiles, 0, 0, 0, 0, 0, 0, 0);
     }
 
     private static String statements(int count) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
@@ -135,6 +135,15 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
             "qcritical");
 
     @Override
+    public boolean isFileLevelModule(CodeUnit cu, boolean topLevel) {
+        return topLevel
+                && cu.isModule()
+                && parentOf(cu).isEmpty()
+                && languages().stream().anyMatch(language -> language.getExtensions()
+                        .contains(cu.source().extension()));
+    }
+
+    @Override
     public Optional<String> extractCallReceiver(String reference) {
         return ClassNameExtractor.extractForCpp(reference);
     }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -39,6 +39,15 @@ import org.treesitter.TreeSitterGo;
 public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisProvider {
     static final Logger log = LoggerFactory.getLogger(GoAnalyzer.class); // Changed to package-private
 
+    @Override
+    public boolean isFileLevelModule(CodeUnit cu, boolean topLevel) {
+        return topLevel
+                && cu.isModule()
+                && parentOf(cu).isEmpty()
+                && languages().stream().anyMatch(language -> language.getExtensions()
+                        .contains(cu.source().extension()));
+    }
+
     // Pattern to match both double-quoted and backtick-quoted import paths
     private static final Pattern IMPORT_PATH_PATTERN = Pattern.compile("\"([^\"]+)\"|`([^`]+)`");
 

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
@@ -4,6 +4,7 @@ import ai.brokk.AnalyzerUtil;
 import ai.brokk.project.ICoreProject;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -11,6 +12,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SequencedSet;
@@ -403,6 +405,19 @@ public interface IAnalyzer {
             int assertionCount,
             List<String> reasons,
             String excerpt) {}
+
+    record MaintainabilitySizeSmell(
+            CodeUnit codeUnit,
+            Range range,
+            int score,
+            int ownSpanLines,
+            int descendantSpanLines,
+            int directChildCount,
+            int functionCount,
+            int nestedTypeCount,
+            int maxFunctionSpanLines,
+            int maxCyclomaticComplexity,
+            List<String> reasons) {}
 
     record Range(int startByte, int endByte, int startLine, int endLine, int commentStartByte) {
         public boolean isEmpty() {
@@ -843,6 +858,142 @@ public interface IAnalyzer {
             complexity++;
         }
         return complexity;
+    }
+
+    int LONG_METHOD_SPAN_LINES = 80;
+    int HIGH_COMPLEXITY_THRESHOLD = 10;
+    int GOD_OBJECT_SPAN_LINES = 300;
+    int GOD_OBJECT_DIRECT_CHILDREN = 20;
+    int GOD_OBJECT_FUNCTIONS = 15;
+    int HELPER_SPRAWL_FUNCTIONS = 10;
+    int HELPER_SPRAWL_WORKFLOW_LINES = 60;
+
+    /**
+     * Finds oversized functions, classes, and modules that are likely to carry generated-code maintainability debt.
+     */
+    default List<MaintainabilitySizeSmell> findLongMethodAndGodObjectSmells(ProjectFile file) {
+        var findings = new ArrayList<MaintainabilitySizeSmell>();
+        var visited = new HashSet<CodeUnit>();
+        for (CodeUnit cu : getTopLevelDeclarations(file)) {
+            collectMaintainabilitySizeSmells(cu, visited, findings);
+        }
+        return findings.stream()
+                .sorted(Comparator.comparingInt(MaintainabilitySizeSmell::score)
+                        .reversed()
+                        .thenComparing(smell -> smell.codeUnit().source().toString(), String.CASE_INSENSITIVE_ORDER)
+                        .thenComparing(smell -> smell.codeUnit().fqName(), String.CASE_INSENSITIVE_ORDER))
+                .toList();
+    }
+
+    private MaintainabilitySizeMetrics collectMaintainabilitySizeSmells(
+            CodeUnit cu, Set<CodeUnit> visited, List<MaintainabilitySizeSmell> findings) {
+        if (!visited.add(cu)) {
+            return MaintainabilitySizeMetrics.empty();
+        }
+
+        var range = primaryRangeOf(cu);
+        int ownSpanLines = spanLines(range);
+        int maxFunctionSpanLines = cu.isFunction() ? ownSpanLines : 0;
+        int maxCyclomaticComplexity = cu.isFunction() ? computeCyclomaticComplexity(cu) : 0;
+        int functionCount = cu.isFunction() ? 1 : 0;
+        int nestedTypeCount = cu.isClass() || cu.isModule() ? 1 : 0;
+        int descendantSpanLines = ownSpanLines;
+        var children = getDirectChildren(cu);
+
+        for (CodeUnit child : children) {
+            var childMetrics = collectMaintainabilitySizeSmells(child, visited, findings);
+            functionCount += childMetrics.functionCount();
+            nestedTypeCount += childMetrics.nestedTypeCount();
+            descendantSpanLines += childMetrics.descendantSpanLines();
+            maxFunctionSpanLines = Math.max(maxFunctionSpanLines, childMetrics.maxFunctionSpanLines());
+            maxCyclomaticComplexity = Math.max(maxCyclomaticComplexity, childMetrics.maxCyclomaticComplexity());
+        }
+
+        if (!range.isEmpty()) {
+            var reasons = new ArrayList<String>();
+            int score = 0;
+            if (cu.isFunction()) {
+                if (ownSpanLines >= LONG_METHOD_SPAN_LINES) {
+                    score += ownSpanLines - LONG_METHOD_SPAN_LINES + 25;
+                    reasons.add("long function spans " + ownSpanLines + " lines");
+                }
+                if (maxCyclomaticComplexity > HIGH_COMPLEXITY_THRESHOLD) {
+                    score += (maxCyclomaticComplexity - HIGH_COMPLEXITY_THRESHOLD) * 5;
+                    reasons.add("high cyclomatic complexity " + maxCyclomaticComplexity);
+                }
+            } else if (cu.isClass() || cu.isModule()) {
+                boolean responsibilityCluster = cu.isClass() || children.size() > 1;
+                if (ownSpanLines >= GOD_OBJECT_SPAN_LINES) {
+                    score += (ownSpanLines - GOD_OBJECT_SPAN_LINES) / 4 + 20;
+                    reasons.add(
+                            "large " + cu.kind().name().toLowerCase(Locale.ROOT) + " spans " + ownSpanLines + " lines");
+                }
+                if (responsibilityCluster && children.size() >= GOD_OBJECT_DIRECT_CHILDREN) {
+                    score += (children.size() - GOD_OBJECT_DIRECT_CHILDREN) * 2 + 15;
+                    reasons.add("many direct members (" + children.size() + ")");
+                }
+                if (responsibilityCluster && functionCount >= GOD_OBJECT_FUNCTIONS) {
+                    score += (functionCount - GOD_OBJECT_FUNCTIONS) * 2 + 15;
+                    reasons.add("many functions in one responsibility cluster (" + functionCount + ")");
+                }
+                if (responsibilityCluster
+                        && functionCount >= HELPER_SPRAWL_FUNCTIONS
+                        && maxFunctionSpanLines >= HELPER_SPRAWL_WORKFLOW_LINES) {
+                    score += functionCount + maxFunctionSpanLines / 4;
+                    reasons.add("helper sprawl around a " + maxFunctionSpanLines + "-line workflow");
+                }
+                if (maxCyclomaticComplexity > HIGH_COMPLEXITY_THRESHOLD) {
+                    score += (maxCyclomaticComplexity - HIGH_COMPLEXITY_THRESHOLD) * 3;
+                    reasons.add("contains high-complexity workflow (CC " + maxCyclomaticComplexity + ")");
+                }
+                if (score > 0 && nestedTypeCount > 1) {
+                    reasons.add("nested type/module cluster (" + nestedTypeCount + ")");
+                }
+            }
+
+            if (score > 0) {
+                findings.add(new MaintainabilitySizeSmell(
+                        cu,
+                        range,
+                        score,
+                        ownSpanLines,
+                        descendantSpanLines,
+                        children.size(),
+                        functionCount,
+                        nestedTypeCount,
+                        maxFunctionSpanLines,
+                        maxCyclomaticComplexity,
+                        List.copyOf(reasons)));
+            }
+        }
+
+        return new MaintainabilitySizeMetrics(
+                descendantSpanLines, functionCount, nestedTypeCount, maxFunctionSpanLines, maxCyclomaticComplexity);
+    }
+
+    private Range primaryRangeOf(CodeUnit cu) {
+        return rangesOf(cu).stream()
+                .filter(range -> !range.isEmpty())
+                .max(Comparator.comparingInt(IAnalyzer::spanLines))
+                .orElse(new Range(0, 0, 0, 0, 0));
+    }
+
+    private static int spanLines(Range range) {
+        if (range.isEmpty()) {
+            return 0;
+        }
+        return Math.max(1, range.endLine() - range.startLine() + 1);
+    }
+
+    record MaintainabilitySizeMetrics(
+            int descendantSpanLines,
+            int functionCount,
+            int nestedTypeCount,
+            int maxFunctionSpanLines,
+            int maxCyclomaticComplexity) {
+        static MaintainabilitySizeMetrics empty() {
+            return new MaintainabilitySizeMetrics(0, 0, 0, 0, 0);
+        }
     }
 
     /**

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
@@ -413,7 +413,8 @@ public interface IAnalyzer {
             int godObjectDirectChildren,
             int godObjectFunctions,
             int helperSprawlFunctions,
-            int helperSprawlWorkflowLines) {
+            int helperSprawlWorkflowLines,
+            int fileModuleLeewayMultiplier) {
 
         public static MaintainabilitySizeSmellWeights defaults() {
             return new MaintainabilitySizeSmellWeights(
@@ -423,7 +424,8 @@ public interface IAnalyzer {
                     20, // Many direct members suggest mixed responsibilities.
                     15, // Many functions under one parent suggest a god object/module.
                     10, // Helper sprawl threshold around a larger workflow.
-                    60 // Workflow size large enough to make surrounding helpers suspicious.
+                    60, // Workflow size large enough to make surrounding helpers suspicious.
+                    2 // JS/TS modules and Python files are expected to be broader than class-like units.
                     );
         }
     }
@@ -897,7 +899,7 @@ public interface IAnalyzer {
         var findings = new ArrayList<MaintainabilitySizeSmell>();
         var visited = new HashSet<CodeUnit>();
         for (CodeUnit cu : getTopLevelDeclarations(file)) {
-            collectMaintainabilitySizeSmells(cu, weights, visited, findings);
+            collectMaintainabilitySizeSmells(cu, weights, true, visited, findings);
         }
         return findings.stream().sorted(maintainabilitySizeSmellComparator()).toList();
     }
@@ -912,6 +914,7 @@ public interface IAnalyzer {
     private MaintainabilitySizeMetrics collectMaintainabilitySizeSmells(
             CodeUnit cu,
             MaintainabilitySizeSmellWeights weights,
+            boolean topLevel,
             Set<CodeUnit> visited,
             List<MaintainabilitySizeSmell> findings) {
         if (!visited.add(cu)) {
@@ -931,7 +934,7 @@ public interface IAnalyzer {
                 children.stream().filter(child -> !child.isSynthetic()).toList();
 
         for (CodeUnit child : children) {
-            var childMetrics = collectMaintainabilitySizeSmells(child, weights, visited, findings);
+            var childMetrics = collectMaintainabilitySizeSmells(child, weights, false, visited, findings);
             functionCount += childMetrics.functionCount();
             nestedTypeCount += childMetrics.nestedTypeCount();
             descendantSpanLines += childMetrics.descendantSpanLines();
@@ -952,22 +955,27 @@ public interface IAnalyzer {
                     reasons.add("high cyclomatic complexity " + maxCyclomaticComplexity);
                 }
             } else if (cu.isClass() || cu.isModule()) {
+                int moduleLeewayMultiplier = isFileLevelModule(cu, topLevel) ? weights.fileModuleLeewayMultiplier() : 1;
+                int godObjectSpanLines = weights.godObjectSpanLines() * moduleLeewayMultiplier;
+                int godObjectDirectChildren = weights.godObjectDirectChildren() * moduleLeewayMultiplier;
+                int godObjectFunctions = weights.godObjectFunctions() * moduleLeewayMultiplier;
+                int helperSprawlFunctions = weights.helperSprawlFunctions() * moduleLeewayMultiplier;
                 boolean responsibilityCluster = cu.isClass() || nonSyntheticChildren.size() > 1;
-                if (ownSpanLines >= weights.godObjectSpanLines()) {
-                    score += (ownSpanLines - weights.godObjectSpanLines()) / 4 + 20;
+                if (ownSpanLines >= godObjectSpanLines) {
+                    score += (ownSpanLines - godObjectSpanLines) / 4 + 20;
                     reasons.add(
                             "large " + cu.kind().name().toLowerCase(Locale.ROOT) + " spans " + ownSpanLines + " lines");
                 }
-                if (responsibilityCluster && nonSyntheticChildren.size() >= weights.godObjectDirectChildren()) {
-                    score += (nonSyntheticChildren.size() - weights.godObjectDirectChildren()) * 2 + 15;
+                if (responsibilityCluster && nonSyntheticChildren.size() >= godObjectDirectChildren) {
+                    score += (nonSyntheticChildren.size() - godObjectDirectChildren) * 2 + 15;
                     reasons.add("many direct members (" + nonSyntheticChildren.size() + ")");
                 }
-                if (responsibilityCluster && functionCount >= weights.godObjectFunctions()) {
-                    score += (functionCount - weights.godObjectFunctions()) * 2 + 15;
+                if (responsibilityCluster && functionCount >= godObjectFunctions) {
+                    score += (functionCount - godObjectFunctions) * 2 + 15;
                     reasons.add("many functions in one responsibility cluster (" + functionCount + ")");
                 }
                 if (responsibilityCluster
-                        && functionCount >= weights.helperSprawlFunctions()
+                        && functionCount >= helperSprawlFunctions
                         && maxFunctionSpanLines >= weights.helperSprawlWorkflowLines()) {
                     score += functionCount + maxFunctionSpanLines / 4;
                     reasons.add("helper sprawl around a " + maxFunctionSpanLines + "-line workflow");
@@ -999,6 +1007,10 @@ public interface IAnalyzer {
 
         return new MaintainabilitySizeMetrics(
                 descendantSpanLines, functionCount, nestedTypeCount, maxFunctionSpanLines, maxCyclomaticComplexity);
+    }
+
+    default boolean isFileLevelModule(CodeUnit cu, boolean topLevel) {
+        return false;
     }
 
     private Range primaryRangeOf(CodeUnit cu) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
@@ -406,6 +406,28 @@ public interface IAnalyzer {
             List<String> reasons,
             String excerpt) {}
 
+    record MaintainabilitySizeSmellWeights(
+            int longMethodSpanLines,
+            int highComplexityThreshold,
+            int godObjectSpanLines,
+            int godObjectDirectChildren,
+            int godObjectFunctions,
+            int helperSprawlFunctions,
+            int helperSprawlWorkflowLines) {
+
+        public static MaintainabilitySizeSmellWeights defaults() {
+            return new MaintainabilitySizeSmellWeights(
+                    80, // Long generated workflows become difficult to review.
+                    10, // Matches the default cyclomatic complexity review threshold.
+                    300, // Large class/module bodies are worth triage even before counting members.
+                    20, // Many direct members suggest mixed responsibilities.
+                    15, // Many functions under one parent suggest a god object/module.
+                    10, // Helper sprawl threshold around a larger workflow.
+                    60 // Workflow size large enough to make surrounding helpers suspicious.
+                    );
+        }
+    }
+
     record MaintainabilitySizeSmell(
             CodeUnit codeUnit,
             Range range,
@@ -860,48 +882,56 @@ public interface IAnalyzer {
         return complexity;
     }
 
-    int LONG_METHOD_SPAN_LINES = 80;
-    int HIGH_COMPLEXITY_THRESHOLD = 10;
-    int GOD_OBJECT_SPAN_LINES = 300;
-    int GOD_OBJECT_DIRECT_CHILDREN = 20;
-    int GOD_OBJECT_FUNCTIONS = 15;
-    int HELPER_SPRAWL_FUNCTIONS = 10;
-    int HELPER_SPRAWL_WORKFLOW_LINES = 60;
-
     /**
      * Finds oversized functions, classes, and modules that are likely to carry generated-code maintainability debt.
      */
     default List<MaintainabilitySizeSmell> findLongMethodAndGodObjectSmells(ProjectFile file) {
+        return findLongMethodAndGodObjectSmells(file, MaintainabilitySizeSmellWeights.defaults());
+    }
+
+    /**
+     * Finds oversized functions, classes, and modules using configurable maintainability-size thresholds.
+     */
+    default List<MaintainabilitySizeSmell> findLongMethodAndGodObjectSmells(
+            ProjectFile file, MaintainabilitySizeSmellWeights weights) {
         var findings = new ArrayList<MaintainabilitySizeSmell>();
         var visited = new HashSet<CodeUnit>();
         for (CodeUnit cu : getTopLevelDeclarations(file)) {
-            collectMaintainabilitySizeSmells(cu, visited, findings);
+            collectMaintainabilitySizeSmells(cu, weights, visited, findings);
         }
-        return findings.stream()
-                .sorted(Comparator.comparingInt(MaintainabilitySizeSmell::score)
-                        .reversed()
-                        .thenComparing(smell -> smell.codeUnit().source().toString(), String.CASE_INSENSITIVE_ORDER)
-                        .thenComparing(smell -> smell.codeUnit().fqName(), String.CASE_INSENSITIVE_ORDER))
-                .toList();
+        return findings.stream().sorted(maintainabilitySizeSmellComparator()).toList();
+    }
+
+    static Comparator<MaintainabilitySizeSmell> maintainabilitySizeSmellComparator() {
+        return Comparator.comparingInt(MaintainabilitySizeSmell::score)
+                .reversed()
+                .thenComparing(smell -> smell.codeUnit().source().toString(), String.CASE_INSENSITIVE_ORDER)
+                .thenComparing(smell -> smell.codeUnit().fqName(), String.CASE_INSENSITIVE_ORDER);
     }
 
     private MaintainabilitySizeMetrics collectMaintainabilitySizeSmells(
-            CodeUnit cu, Set<CodeUnit> visited, List<MaintainabilitySizeSmell> findings) {
+            CodeUnit cu,
+            MaintainabilitySizeSmellWeights weights,
+            Set<CodeUnit> visited,
+            List<MaintainabilitySizeSmell> findings) {
         if (!visited.add(cu)) {
             return MaintainabilitySizeMetrics.empty();
         }
 
         var range = primaryRangeOf(cu);
-        int ownSpanLines = spanLines(range);
-        int maxFunctionSpanLines = cu.isFunction() ? ownSpanLines : 0;
-        int maxCyclomaticComplexity = cu.isFunction() ? computeCyclomaticComplexity(cu) : 0;
-        int functionCount = cu.isFunction() ? 1 : 0;
-        int nestedTypeCount = cu.isClass() || cu.isModule() ? 1 : 0;
+        boolean synthetic = cu.isSynthetic();
+        int ownSpanLines = synthetic ? 0 : spanLines(range);
+        int maxFunctionSpanLines = !synthetic && cu.isFunction() ? ownSpanLines : 0;
+        int maxCyclomaticComplexity = !synthetic && cu.isFunction() ? computeCyclomaticComplexity(cu) : 0;
+        int functionCount = !synthetic && cu.isFunction() ? 1 : 0;
+        int nestedTypeCount = !synthetic && (cu.isClass() || cu.isModule()) ? 1 : 0;
         int descendantSpanLines = ownSpanLines;
         var children = getDirectChildren(cu);
+        var nonSyntheticChildren =
+                children.stream().filter(child -> !child.isSynthetic()).toList();
 
         for (CodeUnit child : children) {
-            var childMetrics = collectMaintainabilitySizeSmells(child, visited, findings);
+            var childMetrics = collectMaintainabilitySizeSmells(child, weights, visited, findings);
             functionCount += childMetrics.functionCount();
             nestedTypeCount += childMetrics.nestedTypeCount();
             descendantSpanLines += childMetrics.descendantSpanLines();
@@ -909,41 +939,41 @@ public interface IAnalyzer {
             maxCyclomaticComplexity = Math.max(maxCyclomaticComplexity, childMetrics.maxCyclomaticComplexity());
         }
 
-        if (!range.isEmpty()) {
+        if (!synthetic && !range.isEmpty()) {
             var reasons = new ArrayList<String>();
             int score = 0;
             if (cu.isFunction()) {
-                if (ownSpanLines >= LONG_METHOD_SPAN_LINES) {
-                    score += ownSpanLines - LONG_METHOD_SPAN_LINES + 25;
+                if (ownSpanLines >= weights.longMethodSpanLines()) {
+                    score += ownSpanLines - weights.longMethodSpanLines() + 25;
                     reasons.add("long function spans " + ownSpanLines + " lines");
                 }
-                if (maxCyclomaticComplexity > HIGH_COMPLEXITY_THRESHOLD) {
-                    score += (maxCyclomaticComplexity - HIGH_COMPLEXITY_THRESHOLD) * 5;
+                if (maxCyclomaticComplexity > weights.highComplexityThreshold()) {
+                    score += (maxCyclomaticComplexity - weights.highComplexityThreshold()) * 5;
                     reasons.add("high cyclomatic complexity " + maxCyclomaticComplexity);
                 }
             } else if (cu.isClass() || cu.isModule()) {
-                boolean responsibilityCluster = cu.isClass() || children.size() > 1;
-                if (ownSpanLines >= GOD_OBJECT_SPAN_LINES) {
-                    score += (ownSpanLines - GOD_OBJECT_SPAN_LINES) / 4 + 20;
+                boolean responsibilityCluster = cu.isClass() || nonSyntheticChildren.size() > 1;
+                if (ownSpanLines >= weights.godObjectSpanLines()) {
+                    score += (ownSpanLines - weights.godObjectSpanLines()) / 4 + 20;
                     reasons.add(
                             "large " + cu.kind().name().toLowerCase(Locale.ROOT) + " spans " + ownSpanLines + " lines");
                 }
-                if (responsibilityCluster && children.size() >= GOD_OBJECT_DIRECT_CHILDREN) {
-                    score += (children.size() - GOD_OBJECT_DIRECT_CHILDREN) * 2 + 15;
-                    reasons.add("many direct members (" + children.size() + ")");
+                if (responsibilityCluster && nonSyntheticChildren.size() >= weights.godObjectDirectChildren()) {
+                    score += (nonSyntheticChildren.size() - weights.godObjectDirectChildren()) * 2 + 15;
+                    reasons.add("many direct members (" + nonSyntheticChildren.size() + ")");
                 }
-                if (responsibilityCluster && functionCount >= GOD_OBJECT_FUNCTIONS) {
-                    score += (functionCount - GOD_OBJECT_FUNCTIONS) * 2 + 15;
+                if (responsibilityCluster && functionCount >= weights.godObjectFunctions()) {
+                    score += (functionCount - weights.godObjectFunctions()) * 2 + 15;
                     reasons.add("many functions in one responsibility cluster (" + functionCount + ")");
                 }
                 if (responsibilityCluster
-                        && functionCount >= HELPER_SPRAWL_FUNCTIONS
-                        && maxFunctionSpanLines >= HELPER_SPRAWL_WORKFLOW_LINES) {
+                        && functionCount >= weights.helperSprawlFunctions()
+                        && maxFunctionSpanLines >= weights.helperSprawlWorkflowLines()) {
                     score += functionCount + maxFunctionSpanLines / 4;
                     reasons.add("helper sprawl around a " + maxFunctionSpanLines + "-line workflow");
                 }
-                if (maxCyclomaticComplexity > HIGH_COMPLEXITY_THRESHOLD) {
-                    score += (maxCyclomaticComplexity - HIGH_COMPLEXITY_THRESHOLD) * 3;
+                if (maxCyclomaticComplexity > weights.highComplexityThreshold()) {
+                    score += (maxCyclomaticComplexity - weights.highComplexityThreshold()) * 3;
                     reasons.add("contains high-complexity workflow (CC " + maxCyclomaticComplexity + ")");
                 }
                 if (score > 0 && nestedTypeCount > 1) {
@@ -958,7 +988,7 @@ public interface IAnalyzer {
                         score,
                         ownSpanLines,
                         descendantSpanLines,
-                        children.size(),
+                        nonSyntheticChildren.size(),
                         functionCount,
                         nestedTypeCount,
                         maxFunctionSpanLines,

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
@@ -94,6 +94,15 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
         super(project, language, state, listener, cache);
     }
 
+    @Override
+    public boolean isFileLevelModule(CodeUnit cu, boolean topLevel) {
+        return topLevel
+                && cu.isModule()
+                && parentOf(cu).isEmpty()
+                && languages().stream().anyMatch(language -> language.getExtensions()
+                        .contains(cu.source().extension()));
+    }
+
     public TSLanguage tsLanguage() {
         return getTSLanguage();
     }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
@@ -39,6 +39,15 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
     // Python's "last wins" behavior is handled by TreeSitterAnalyzer's addTopLevelCodeUnit().
 
     @Override
+    public boolean isFileLevelModule(CodeUnit cu, boolean topLevel) {
+        return topLevel
+                && cu.isModule()
+                && parentOf(cu).isEmpty()
+                && languages().stream().anyMatch(language -> language.getExtensions()
+                        .contains(cu.source().extension()));
+    }
+
+    @Override
     public Optional<String> extractCallReceiver(String reference) {
         return ClassNameExtractor.extractForPython(reference);
     }
@@ -1959,7 +1968,13 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
         CodeUnit targetCu = (existing != null && existing.isModule()) ? existing : moduleCu;
 
         if (existing == null) {
-            acc.addLookupKey(targetCu.fqName(), targetCu);
+            var moduleRange = new Range(
+                    rootNode.getStartByte(),
+                    rootNode.getEndByte(),
+                    rootNode.getStartPoint().getRow(),
+                    rootNode.getEndPoint().getRow(),
+                    rootNode.getStartByte());
+            acc.addTopLevel(targetCu).addRange(targetCu, moduleRange);
         }
 
         acc.addSignature(targetCu, "# module " + modulePackageName)

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/PythonAnalyzer.java
@@ -3,6 +3,7 @@ package ai.brokk.analyzer;
 import static ai.brokk.analyzer.python.Constants.*;
 import static org.treesitter.PythonNodeType.*;
 
+import ai.brokk.AnalyzerUtil;
 import ai.brokk.analyzer.cache.AnalyzerCache;
 import ai.brokk.analyzer.python.CognitiveComplexityAnalysis;
 import ai.brokk.project.ICoreProject;
@@ -45,6 +46,31 @@ public final class PythonAnalyzer extends TreeSitterAnalyzer implements ImportAn
                 && parentOf(cu).isEmpty()
                 && languages().stream().anyMatch(language -> language.getExtensions()
                         .contains(cu.source().extension()));
+    }
+
+    @Override
+    public Map<CodeUnit, String> getSkeletons(ProjectFile file) {
+        return super.getSkeletons(file).entrySet().stream()
+                .filter(entry -> !isFileLevelModule(entry.getKey(), true))
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, Map.Entry::getValue, (left, right) -> left, LinkedHashMap::new));
+    }
+
+    @Override
+    public Optional<String> getSkeleton(CodeUnit cu) {
+        if (isFileLevelModule(cu, true)) {
+            return Optional.empty();
+        }
+        return super.getSkeleton(cu);
+    }
+
+    @Override
+    public Set<CodeUnit> testFilesToCodeUnits(Collection<ProjectFile> files) {
+        var unitsInFiles = AnalyzerUtil.getTestDeclarationsWithLogging(this, files)
+                .filter(cu -> cu.isClass() || cu.isFunction())
+                .collect(Collectors.toSet());
+
+        return AnalyzerUtil.coalesceNestedUnits(this, unitsInFiles);
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/RustAnalyzer.java
@@ -28,6 +28,15 @@ import org.treesitter.RustNodeField;
 public final class RustAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisProvider {
     private static final Logger log = LoggerFactory.getLogger(RustAnalyzer.class);
 
+    @Override
+    public boolean isFileLevelModule(CodeUnit cu, boolean topLevel) {
+        return topLevel
+                && cu.isModule()
+                && parentOf(cu).isEmpty()
+                && languages().stream().anyMatch(language -> language.getExtensions()
+                        .contains(cu.source().extension()));
+    }
+
     private record AssertionSignal(
             String kind,
             int score,

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.testutil.InlineCoreProject;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
@@ -110,7 +112,7 @@ class LongMethodAndGodObjectSmellTest {
                 15, // Would trip if the synthetic constructor counted as a direct child.
                 15, // Would trip if the synthetic constructor counted as a function.
                 999, // Disable helper-sprawl scoring.
-                999);
+                999, 999);
 
         try (var project =
                 InlineCoreProject.code(source, "com/example/Boundary.java").build()) {
@@ -133,8 +135,8 @@ class LongMethodAndGodObjectSmellTest {
                 }
                 """
                         .formatted(statements(12));
-        var permissive = new IAnalyzer.MaintainabilitySizeSmellWeights(10, 999, 999, 999, 999, 999, 999);
-        var strict = new IAnalyzer.MaintainabilitySizeSmellWeights(200, 999, 999, 999, 999, 999, 999);
+        var permissive = new IAnalyzer.MaintainabilitySizeSmellWeights(10, 999, 999, 999, 999, 999, 999, 1);
+        var strict = new IAnalyzer.MaintainabilitySizeSmellWeights(200, 999, 999, 999, 999, 999, 999, 1);
 
         try (var project =
                 InlineCoreProject.code(source, "com/example/Tunable.java").build()) {
@@ -149,10 +151,268 @@ class LongMethodAndGodObjectSmellTest {
         }
     }
 
+    @Test
+    void fileLevelModulePredicateAcceptsOnlyTopLevelModulesForOptInLanguages() {
+        assertFileLevelModulePredicate(Languages.JAVASCRIPT, "src/module.js", "src/wrong.java");
+        assertFileLevelModulePredicate(Languages.TYPESCRIPT, "src/module.ts", "src/wrong.java");
+        assertFileLevelModulePredicate(Languages.PYTHON, "src/module.py", "src/wrong.java");
+        assertFileLevelModulePredicate(Languages.C_CPP, "src/module.cpp", "src/wrong.java");
+        assertFileLevelModulePredicate(Languages.GO, "src/module.go", "src/wrong.java");
+        assertFileLevelModulePredicate(Languages.RUST, "src/module.rs", "src/wrong.java");
+    }
+
+    @Test
+    void defaultFileLevelModulePredicateRejectsJavaModules() {
+        try (var project = InlineCoreProject.empty()
+                .languages(Set.of(Languages.JAVA))
+                .addFile("package com.example; public class Sample {}\n", "src/Sample.java")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+            var module = CodeUnit.module(project.file("src/Sample.java"), "com.example", "Sample.java");
+
+            assertFalse(analyzer.isFileLevelModule(module, true));
+        }
+    }
+
+    @Test
+    void fileLevelModulePredicateRejectsNestedCppNamespace() {
+        String source =
+                """
+                namespace outer {
+                namespace inner {
+                int value = 1;
+                }
+                }
+                """;
+
+        try (var project = InlineCoreProject.empty()
+                .languages(Set.of(Languages.C_CPP))
+                .addFile(source, "src/nested.cpp")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+            var outer = analyzer.getTopLevelDeclarations(project.file("src/nested.cpp")).stream()
+                    .filter(CodeUnit::isModule)
+                    .filter(cu -> cu.identifier().equals("outer"))
+                    .findFirst()
+                    .orElseThrow();
+            var inner = analyzer.getDirectChildren(outer).stream()
+                    .filter(CodeUnit::isModule)
+                    .filter(cu -> cu.identifier().equals("inner"))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertTrue(analyzer.isFileLevelModule(outer, true));
+            assertTrue(analyzer.parentOf(inner).isPresent());
+            assertFalse(analyzer.isFileLevelModule(inner, false));
+            assertFalse(analyzer.isFileLevelModule(inner, true));
+        }
+    }
+
+    @Test
+    void fileLevelModulePredicateRejectsNestedRustModule() {
+        String source =
+                """
+                mod outer {
+                    mod inner {
+                        pub const VALUE: i32 = 1;
+                    }
+                }
+                """;
+
+        try (var project = InlineCoreProject.empty()
+                .languages(Set.of(Languages.RUST))
+                .addFile(source, "src/nested.rs")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+            var outer = analyzer.getTopLevelDeclarations(project.file("src/nested.rs")).stream()
+                    .filter(CodeUnit::isModule)
+                    .filter(cu -> cu.identifier().equals("outer"))
+                    .findFirst()
+                    .orElseThrow();
+            var nested = analyzer.getTopLevelDeclarations(project.file("src/nested.rs")).stream()
+                    .flatMap(cu -> nestedCodeUnits(analyzer, cu).stream())
+                    .toList();
+            var inner = nested.stream()
+                    .filter(cu -> !cu.equals(outer))
+                    .filter(CodeUnit::isModule)
+                    .filter(cu -> cu.fqName().contains("inner"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(nested.toString()));
+
+            assertTrue(analyzer.isFileLevelModule(outer, true));
+            assertTrue(analyzer.parentOf(inner).isPresent());
+            assertFalse(analyzer.isFileLevelModule(inner, false));
+            assertFalse(analyzer.isFileLevelModule(inner, true));
+        }
+    }
+
+    @Test
+    void javascriptModuleGetsFileLevelSizeLeewayButStillFlagsVeryLargeFiles() {
+        String moderateModule =
+                """
+                import { dep } from "./dep.js";
+                export const values = [
+                %s
+                ];
+                """
+                        .formatted(arrayElements(350));
+        String oversizedModule =
+                """
+                import { dep } from "./dep.js";
+                export const values = [
+                %s
+                ];
+                """
+                        .formatted(arrayElements(650));
+        String depModule = "export const dep = 1;\n";
+
+        try (var project = InlineCoreProject.empty()
+                .addFile(depModule, "src/dep.js")
+                .addFile(moderateModule, "src/moderate.js")
+                .addFile(oversizedModule, "src/oversized.js")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+
+            var moderateSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/moderate.js"));
+            var oversizedSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/oversized.js"));
+
+            assertTrue(
+                    moderateSmells.stream().noneMatch(smell -> smell.codeUnit().isModule()), moderateSmells.toString());
+            assertTrue(
+                    oversizedSmells.stream().anyMatch(smell -> smell.codeUnit().isModule()),
+                    oversizedSmells.toString());
+        }
+    }
+
+    @Test
+    void pythonFileModuleGetsFileLevelSizeLeewayButStillFlagsVeryLargeFiles() {
+        String moderateModule = """
+                VALUES = [
+                %s
+                ]
+                """
+                .formatted(arrayElements(350));
+        String oversizedModule = """
+                VALUES = [
+                %s
+                ]
+                """
+                .formatted(arrayElements(650));
+
+        try (var project = InlineCoreProject.empty()
+                .addFile(moderateModule, "src/moderate.py")
+                .addFile(oversizedModule, "src/oversized.py")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+
+            var moderateSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/moderate.py"));
+            var oversizedSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/oversized.py"));
+
+            assertTrue(
+                    moderateSmells.stream().noneMatch(smell -> smell.codeUnit().isModule()), moderateSmells.toString());
+            assertTrue(
+                    oversizedSmells.stream().anyMatch(smell -> smell.codeUnit().isModule()),
+                    oversizedSmells.toString());
+        }
+    }
+
+    @Test
+    void cppTopLevelNamespaceGetsLeewayButStillFlagsVeryLargeNamespaces() {
+        String moderateNamespace =
+                """
+                namespace generated {
+                int values[] = {
+                %s
+                };
+                }
+                """
+                        .formatted(arrayElements(350));
+        String oversizedNamespace =
+                """
+                namespace generated {
+                int values[] = {
+                %s
+                };
+                }
+                """
+                        .formatted(arrayElements(650));
+
+        try (var project = InlineCoreProject.empty()
+                .addFile(moderateNamespace, "src/moderate.cpp")
+                .addFile(oversizedNamespace, "src/oversized.cpp")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+
+            var moderateSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/moderate.cpp"));
+            var oversizedSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/oversized.cpp"));
+
+            assertTrue(
+                    moderateSmells.stream().noneMatch(smell -> smell.codeUnit().isModule()), moderateSmells.toString());
+            assertTrue(
+                    oversizedSmells.stream().anyMatch(smell -> smell.codeUnit().isModule()),
+                    oversizedSmells.toString());
+        }
+    }
+
+    @Test
+    void rustTopLevelModuleGetsLeewayButNestedModuleDoesNot() {
+        String topLevelModerate =
+                """
+                mod generated {
+                    pub const VALUES: &[i32] = &[
+                %s
+                    ];
+                }
+                """
+                        .formatted(arrayElements(350));
+        String topLevelOversized =
+                """
+                mod generated {
+                    pub const VALUES: &[i32] = &[
+                %s
+                    ];
+                }
+                """
+                        .formatted(arrayElements(650));
+        String nestedModerate =
+                """
+                mod outer {
+                    mod inner {
+                        pub const VALUES: &[i32] = &[
+                %s
+                        ];
+                    }
+                }
+                """
+                        .formatted(arrayElements(350));
+
+        try (var project = InlineCoreProject.empty()
+                .addFile(topLevelModerate, "src/moderate.rs")
+                .addFile(topLevelOversized, "src/oversized.rs")
+                .addFile(nestedModerate, "src/nested.rs")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+
+            var moderateSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/moderate.rs"));
+            var oversizedSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/oversized.rs"));
+            var nestedSmells = analyzer.findLongMethodAndGodObjectSmells(project.file("src/nested.rs"));
+
+            assertTrue(
+                    moderateSmells.stream().noneMatch(smell -> smell.codeUnit().isModule()), moderateSmells.toString());
+            assertTrue(
+                    oversizedSmells.stream().anyMatch(smell -> smell.codeUnit().isModule()),
+                    oversizedSmells.toString());
+            assertTrue(
+                    nestedSmells.stream()
+                            .anyMatch(smell -> smell.codeUnit().fqName().contains("inner")),
+                    nestedSmells.toString());
+        }
+    }
+
     private static String statements(int count) {
         return IntStream.range(0, count)
                 .mapToObj(i -> "        int value" + i + " = " + i + ";")
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
     }
 
     private static String helpers(int count) {
@@ -164,6 +424,37 @@ class LongMethodAndGodObjectSmellTest {
                             }
                         """
                                 .formatted(i, i))
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static String arrayElements(int count) {
+        return IntStream.range(0, count).mapToObj(i -> "    " + i + ",").collect(Collectors.joining("\n"));
+    }
+
+    private static java.util.List<CodeUnit> nestedCodeUnits(IAnalyzer analyzer, CodeUnit root) {
+        return java.util.stream.Stream.concat(
+                        java.util.stream.Stream.of(root),
+                        analyzer.getDirectChildren(root).stream()
+                                .flatMap(child -> nestedCodeUnits(analyzer, child).stream()))
+                .toList();
+    }
+
+    private static void assertFileLevelModulePredicate(
+            Language language, String modulePath, String wrongExtensionPath) {
+        try (var project = InlineCoreProject.empty()
+                .languages(Set.of(language))
+                .addFile("", modulePath)
+                .addFile("", wrongExtensionPath)
+                .build()) {
+            var analyzer = project.getAnalyzer();
+            var module = CodeUnit.module(project.file(modulePath), "", "module");
+            var function = CodeUnit.fn(project.file(modulePath), "", "function");
+            var wrongExtensionModule = CodeUnit.module(project.file(wrongExtensionPath), "", "module");
+
+            assertTrue(analyzer.isFileLevelModule(module, true), language.internalName());
+            assertFalse(analyzer.isFileLevelModule(module, false), language.internalName());
+            assertFalse(analyzer.isFileLevelModule(function, true), language.internalName());
+            assertFalse(analyzer.isFileLevelModule(wrongExtensionModule, true), language.internalName());
+        }
     }
 }

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java
@@ -93,6 +93,62 @@ class LongMethodAndGodObjectSmellTest {
         }
     }
 
+    @Test
+    void ignoresSyntheticConstructorAtThresholdBoundary() {
+        String source =
+                """
+                package com.example;
+                public class Boundary {
+                %s
+                }
+                """
+                        .formatted(helpers(14));
+        var weights = new IAnalyzer.MaintainabilitySizeSmellWeights(
+                999, // Disable long-method scoring.
+                999, // Disable high-complexity scoring.
+                999, // Disable span scoring.
+                15, // Would trip if the synthetic constructor counted as a direct child.
+                15, // Would trip if the synthetic constructor counted as a function.
+                999, // Disable helper-sprawl scoring.
+                999);
+
+        try (var project =
+                InlineCoreProject.code(source, "com/example/Boundary.java").build()) {
+            var smells = project.getAnalyzer()
+                    .findLongMethodAndGodObjectSmells(project.file("com/example/Boundary.java"), weights);
+
+            assertTrue(smells.isEmpty(), smells.toString());
+        }
+    }
+
+    @Test
+    void customWeightsCanLowerAndRaiseThresholds() {
+        String source =
+                """
+                package com.example;
+                public class Tunable {
+                    public void smallerWorkflow() {
+                %s
+                    }
+                }
+                """
+                        .formatted(statements(12));
+        var permissive = new IAnalyzer.MaintainabilitySizeSmellWeights(10, 999, 999, 999, 999, 999, 999);
+        var strict = new IAnalyzer.MaintainabilitySizeSmellWeights(200, 999, 999, 999, 999, 999, 999);
+
+        try (var project =
+                InlineCoreProject.code(source, "com/example/Tunable.java").build()) {
+            var file = project.file("com/example/Tunable.java");
+
+            assertFalse(project.getAnalyzer()
+                    .findLongMethodAndGodObjectSmells(file, permissive)
+                    .isEmpty());
+            assertTrue(project.getAnalyzer()
+                    .findLongMethodAndGodObjectSmells(file, strict)
+                    .isEmpty());
+        }
+    }
+
     private static String statements(int count) {
         return IntStream.range(0, count)
                 .mapToObj(i -> "        int value" + i + " = " + i + ";")

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java
@@ -1,0 +1,113 @@
+package ai.brokk.analyzer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.testutil.InlineCoreProject;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class LongMethodAndGodObjectSmellTest {
+
+    @Test
+    void flagsLongMethodWithRangeAndRationale() {
+        String source =
+                """
+                package com.example;
+                public class Workflow {
+                    public void generatedWorkflow() {
+                %s
+                    }
+                }
+                """
+                        .formatted(statements(85));
+
+        try (var project =
+                InlineCoreProject.code(source, "com/example/Workflow.java").build()) {
+            var smells =
+                    project.getAnalyzer().findLongMethodAndGodObjectSmells(project.file("com/example/Workflow.java"));
+
+            var longMethod = smells.stream()
+                    .filter(smell -> smell.codeUnit().fqName().equals("com.example.Workflow.generatedWorkflow"))
+                    .findFirst()
+                    .orElseThrow();
+            assertTrue(longMethod.ownSpanLines() >= 80, longMethod.toString());
+            assertFalse(longMethod.range().isEmpty(), longMethod.toString());
+            assertTrue(
+                    longMethod.reasons().stream().anyMatch(reason -> reason.contains("long function")),
+                    longMethod.toString());
+        }
+    }
+
+    @Test
+    void flagsGodObjectAndHelperSprawl() {
+        String source =
+                """
+                package com.example;
+                public class GeneratedController {
+                    public void executeWorkflow() {
+                %s
+                    }
+                %s
+                }
+                """
+                        .formatted(statements(65), helpers(16));
+
+        try (var project = InlineCoreProject.code(source, "com/example/GeneratedController.java")
+                .build()) {
+            var smells = project.getAnalyzer()
+                    .findLongMethodAndGodObjectSmells(project.file("com/example/GeneratedController.java"));
+
+            var godObject = smells.stream()
+                    .filter(smell -> smell.codeUnit().fqName().equals("com.example.GeneratedController"))
+                    .findFirst()
+                    .orElseThrow();
+            assertTrue(godObject.functionCount() >= 17, godObject.toString());
+            assertTrue(godObject.directChildCount() >= 17, godObject.toString());
+            assertTrue(godObject.maxFunctionSpanLines() >= 60, godObject.toString());
+            assertTrue(
+                    godObject.reasons().stream().anyMatch(reason -> reason.contains("helper sprawl")),
+                    godObject.toString());
+            assertEquals(godObject, smells.getFirst(), "god object should rank above its workflow helper");
+        }
+    }
+
+    @Test
+    void ignoresSmallCohesiveFile() {
+        String source =
+                """
+                package com.example;
+                public class Small {
+                    public int add(int left, int right) {
+                        return left + right;
+                    }
+                }
+                """;
+
+        try (var project =
+                InlineCoreProject.code(source, "com/example/Small.java").build()) {
+            var smells = project.getAnalyzer().findLongMethodAndGodObjectSmells(project.file("com/example/Small.java"));
+
+            assertTrue(smells.isEmpty(), smells.toString());
+        }
+    }
+
+    private static String statements(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> "        int value" + i + " = " + i + ";")
+                .collect(java.util.stream.Collectors.joining("\n"));
+    }
+
+    private static String helpers(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i ->
+                        """
+                            private int helper%s(int value) {
+                                return value + %s;
+                            }
+                        """
+                                .formatted(i, i))
+                .collect(java.util.stream.Collectors.joining("\n"));
+    }
+}

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.testutil.InlineCoreProject;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -247,6 +248,212 @@ class LongMethodAndGodObjectSmellTest {
     }
 
     @Test
+    void pythonFileModuleRemainsTopLevelParentButIsHiddenFromSkeletons() {
+        String source =
+                """
+                VALUE = 1
+
+                def helper():
+                    return VALUE
+
+                class Worker:
+                    def run(self):
+                        return helper()
+                """;
+
+        try (var project = InlineCoreProject.empty()
+                .languages(Set.of(Languages.PYTHON))
+                .addFile(source, "src/worker.py")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+            var file = project.file("src/worker.py");
+            var topLevel = analyzer.getTopLevelDeclarations(file);
+            var module =
+                    topLevel.stream().filter(CodeUnit::isModule).findFirst().orElseThrow();
+            var helper = topLevel.stream()
+                    .filter(CodeUnit::isFunction)
+                    .filter(cu -> cu.identifier().equals("helper"))
+                    .findFirst()
+                    .orElseThrow();
+            var worker = topLevel.stream()
+                    .filter(CodeUnit::isClass)
+                    .filter(cu -> cu.identifier().equals("Worker"))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertTrue(analyzer.isFileLevelModule(module, true));
+            assertTrue(analyzer.parentOf(helper).filter(module::equals).isPresent());
+            assertTrue(analyzer.parentOf(worker).filter(module::equals).isPresent());
+
+            var skeletons = analyzer.getSkeletons(file);
+            assertFalse(skeletons.containsKey(module), skeletons.toString());
+            assertTrue(skeletons.containsKey(helper), skeletons.toString());
+            assertTrue(skeletons.containsKey(worker), skeletons.toString());
+            assertTrue(analyzer.getSkeleton(module).isEmpty());
+        }
+    }
+
+    @Test
+    void javascriptImportModuleSkeletonDoesNotDuplicateTopLevelDeclarations() {
+        String source =
+                """
+                import { dep } from "./dep.js";
+
+                export function helper() {
+                    return dep;
+                }
+
+                export class Worker {
+                    run() {
+                        return helper();
+                    }
+                }
+                """;
+
+        try (var project = InlineCoreProject.empty()
+                .languages(Set.of(Languages.JAVASCRIPT))
+                .addFile("export const dep = 1;\n", "src/dep.js")
+                .addFile(source, "src/worker.js")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+            var file = project.file("src/worker.js");
+            var skeletons = analyzer.getSkeletons(file);
+            var module = analyzer.getTopLevelDeclarations(file).stream()
+                    .filter(CodeUnit::isModule)
+                    .findFirst()
+                    .orElseThrow();
+
+            assertTrue(analyzer.isFileLevelModule(module, true));
+            assertTrue(skeletons.containsKey(module), skeletons.toString());
+            assertFalse(skeletons.get(module).contains("helper"), skeletons.get(module));
+            assertFalse(skeletons.get(module).contains("Worker"), skeletons.get(module));
+            assertEquals(
+                    1,
+                    skeletons.values().stream()
+                            .filter(skeleton -> skeleton.contains("helper"))
+                            .count());
+            assertEquals(
+                    1,
+                    skeletons.values().stream()
+                            .filter(skeleton -> skeleton.contains("Worker"))
+                            .count());
+        }
+    }
+
+    @Test
+    void typescriptImportModuleSkeletonDoesNotDuplicateTopLevelDeclarations() {
+        String source =
+                """
+                import { dep } from "./dep";
+
+                export function helper(): number {
+                    return dep;
+                }
+
+                export class Worker {
+                    run(): number {
+                        return helper();
+                    }
+                }
+                """;
+
+        try (var project = InlineCoreProject.empty()
+                .languages(Set.of(Languages.TYPESCRIPT))
+                .addFile("export const dep = 1;\n", "src/dep.ts")
+                .addFile(source, "src/worker.ts")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+            var file = project.file("src/worker.ts");
+            var skeletons = analyzer.getSkeletons(file);
+            var module = analyzer.getTopLevelDeclarations(file).stream()
+                    .filter(CodeUnit::isModule)
+                    .findFirst()
+                    .orElseThrow();
+
+            assertTrue(analyzer.isFileLevelModule(module, true));
+            assertTrue(skeletons.containsKey(module), skeletons.toString());
+            assertFalse(skeletons.get(module).contains("helper"), skeletons.get(module));
+            assertFalse(skeletons.get(module).contains("Worker"), skeletons.get(module));
+            assertEquals(
+                    1,
+                    skeletons.values().stream()
+                            .filter(skeleton -> skeleton.contains("helper"))
+                            .count());
+            assertEquals(
+                    1,
+                    skeletons.values().stream()
+                            .filter(skeleton -> skeleton.contains("Worker"))
+                            .count());
+        }
+    }
+
+    @Test
+    void cppAndRustSyntaxModulesRemainSkeletonVisible() {
+        String cpp =
+                """
+                namespace generated {
+                int value = 1;
+                }
+                """;
+        String rust =
+                """
+                mod generated {
+                    pub const VALUE: i32 = 1;
+                }
+                """;
+
+        try (var cppProject = InlineCoreProject.empty()
+                        .languages(Set.of(Languages.C_CPP))
+                        .addFile(cpp, "src/generated.cpp")
+                        .build();
+                var rustProject = InlineCoreProject.empty()
+                        .languages(Set.of(Languages.RUST))
+                        .addFile(rust, "src/generated.rs")
+                        .build()) {
+            var cppAnalyzer = cppProject.getAnalyzer();
+            var cppFile = cppProject.file("src/generated.cpp");
+            var cppModule = cppAnalyzer.getTopLevelDeclarations(cppFile).stream()
+                    .filter(CodeUnit::isModule)
+                    .findFirst()
+                    .orElseThrow();
+            assertTrue(cppAnalyzer.isFileLevelModule(cppModule, true));
+            assertTrue(cppAnalyzer.getSkeletons(cppFile).containsKey(cppModule));
+
+            var rustAnalyzer = rustProject.getAnalyzer();
+            var rustFile = rustProject.file("src/generated.rs");
+            var rustModule = rustAnalyzer.getTopLevelDeclarations(rustFile).stream()
+                    .filter(CodeUnit::isModule)
+                    .findFirst()
+                    .orElseThrow();
+            assertTrue(rustAnalyzer.isFileLevelModule(rustModule, true));
+            assertTrue(rustAnalyzer.getSkeletons(rustFile).containsKey(rustModule));
+        }
+    }
+
+    @Test
+    void goDoesNotEmitExplicitFileModuleCodeUnit() {
+        String source =
+                """
+                package mypkg
+
+                const value = 1
+
+                func TestHelper() {}
+                """;
+
+        try (var project = InlineCoreProject.empty()
+                .languages(Set.of(Languages.GO))
+                .addFile(source, "mypkg/helper_test.go")
+                .build()) {
+            var analyzer = project.getAnalyzer();
+            var file = project.file("mypkg/helper_test.go");
+
+            assertTrue(analyzer.getTopLevelDeclarations(file).stream().noneMatch(CodeUnit::isModule));
+            assertTrue(analyzer.testFilesToCodeUnits(List.of(file)).stream().allMatch(CodeUnit::isFunction));
+        }
+    }
+
+    @Test
     void javascriptModuleGetsFileLevelSizeLeewayButStillFlagsVeryLargeFiles() {
         String moderateModule =
                 """
@@ -320,7 +527,7 @@ class LongMethodAndGodObjectSmellTest {
     void cppTopLevelNamespaceGetsLeewayButStillFlagsVeryLargeNamespaces() {
         String moderateNamespace =
                 """
-                namespace generated {
+                namespace moderate_generated {
                 int values[] = {
                 %s
                 };
@@ -329,7 +536,7 @@ class LongMethodAndGodObjectSmellTest {
                         .formatted(arrayElements(350));
         String oversizedNamespace =
                 """
-                namespace generated {
+                namespace oversized_generated {
                 int values[] = {
                 %s
                 };


### PR DESCRIPTION
### Description
Adds a code quality tool for identifying long methods, god objects/modules, and helper sprawl using analyzer CodeUnit traversal. The tool returns bounded, ranked findings with source ranges, size signals, and rationale for generated-code maintainability review.

**Key Changes**:
- Adds configurable maintainability-size smell detection in IAnalyzer, including defaults, centralized ordering, synthetic CodeUnit filtering, and bounded file analysis support from CodeQualityTools.
- Registers reportLongMethodAndGodObjectSmells as a known read-only, parallel-safe tool and covers analyzer/tool behavior with focused regression tests.

**Touch Points**:
- app/src/main/java/ai/brokk/tools/CodeQualityTools.java
- app/src/main/java/ai/brokk/executor/agents/AgentDefinition.java
- brokk-shared/src/main/java/ai/brokk/analyzer/IAnalyzer.java
- app/src/test/java/ai/brokk/tools/CodeQualityToolsLongMethodAndGodObjectTest.java
- brokk-shared/src/test/java/ai/brokk/analyzer/LongMethodAndGodObjectSmellTest.java