### PR TITLE
brokk-code-pypi: bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/brokk-code-pypi.yml
+++ b/.github/workflows/brokk-code-pypi.yml
@@ -13,22 +13,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Build distributions
         working-directory: brokk-code
         run: uv build
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: brokk-code-dist
           path: brokk-code/dist/
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: brokk-code-dist
           path: dist/


### PR DESCRIPTION
## Summary
- GitHub is deprecating Node.js 20 in Actions runners (default flips 2026-06-02, removed 2026-09-16).
- Bumps `actions/checkout` v4->v6, `actions/setup-python` v5->v6, `actions/upload-artifact` v4->v7, `actions/download-artifact` v4->v7.
- SHA-pins `astral-sh/setup-uv` to v8.1.0 per the action's README recommendation.

## Test plan
- [ ] Tag a `brokk-code-*` release (or run `workflow_dispatch`) and confirm Build + Publish jobs succeed without Node 20 deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)