### PR TITLE
fix: brokk-core MCP scanUsages drops field usage results

### DIFF
--- a/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
@@ -16,6 +16,10 @@ import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.analyzer.RelaxedSourceLookupResolver;
 import ai.brokk.analyzer.RelaxedSourceLookupResolver.RelaxedSourceLookup;
 import ai.brokk.analyzer.TestDetectionProvider;
+import ai.brokk.analyzer.usages.JdtUsageAnalyzerStrategy;
+import ai.brokk.analyzer.usages.RegexUsageAnalyzer;
+import ai.brokk.analyzer.usages.UsageAnalyzer;
+import ai.brokk.analyzer.usages.UsageRenderer;
 import ai.brokk.concurrent.LoggingFuture;
 import ai.brokk.git.CommitInfo;
 import ai.brokk.git.GitRepo;
@@ -1056,7 +1060,7 @@ public class SearchTools {
         return hit.lineNumber() > 0 ? "%d: %s".formatted(hit.lineNumber(), hit.signature()) : hit.signature();
     }
 
-    public String scanUsages(List<String> symbols, boolean includeTests) {
+    public String scanUsages(List<String> symbols, boolean includeTests) throws InterruptedException {
         // Sanitize symbols: remove potential `(params)` suffix from LLM.
         symbols = stripParams(symbols);
         if (symbols.isEmpty()) {
@@ -1064,6 +1068,9 @@ public class SearchTools {
         }
 
         var analyzer = getAnalyzer();
+        var candidates = codeIntelligence.getProject().getAllFiles().stream()
+                .filter(file -> includeTests || !isTestFile(file, analyzer))
+                .collect(Collectors.toSet());
         List<String> results = new ArrayList<>();
         for (String symbol : symbols) {
             if (symbol.isBlank()) continue;
@@ -1075,11 +1082,13 @@ public class SearchTools {
             var filteredDefs = definitions.stream()
                     .filter(cu -> includeTests || !isTestFile(cu.source(), analyzer))
                     .toList();
+            if (filteredDefs.isEmpty()) continue;
 
-            var processed = AnalyzerUtil.processUsages(analyzer, filteredDefs);
-            String text = AnalyzerUtil.CodeWithSource.text(analyzer, processed);
-            if (!text.isEmpty()) {
-                results.add(text);
+            var usageAnalyzer = usageAnalyzerFor(filteredDefs.getFirst(), analyzer);
+            var usageResult = usageAnalyzer.findUsages(filteredDefs, candidates, 500);
+            var rendered = UsageRenderer.render(analyzer, symbol, filteredDefs, usageResult, UsageRenderer.Mode.SAMPLE);
+            if (rendered.hasUsages() && !rendered.text().isEmpty()) {
+                results.add(rendered.text());
             }
         }
 
@@ -1087,6 +1096,14 @@ public class SearchTools {
             return "No usages found for: " + String.join(", ", symbols);
         }
         return recordResearchTokens(String.join("\n\n", results));
+    }
+
+    private UsageAnalyzer usageAnalyzerFor(CodeUnit target, IAnalyzer analyzer) {
+        var language = Languages.fromExtension(target.source().extension());
+        if (language.contains(Languages.JAVA)) {
+            return new JdtUsageAnalyzerStrategy(codeIntelligence.getProject());
+        }
+        return new RegexUsageAnalyzer(analyzer);
     }
 
     public String getClassSources(List<String> classNames) {

--- a/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
@@ -16,9 +16,7 @@ import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.analyzer.RelaxedSourceLookupResolver;
 import ai.brokk.analyzer.RelaxedSourceLookupResolver.RelaxedSourceLookup;
 import ai.brokk.analyzer.TestDetectionProvider;
-import ai.brokk.analyzer.usages.JdtUsageAnalyzerStrategy;
-import ai.brokk.analyzer.usages.RegexUsageAnalyzer;
-import ai.brokk.analyzer.usages.UsageAnalyzer;
+import ai.brokk.analyzer.usages.UsageAnalyzerSelector;
 import ai.brokk.analyzer.usages.UsageRenderer;
 import ai.brokk.concurrent.LoggingFuture;
 import ai.brokk.git.CommitInfo;
@@ -1068,9 +1066,7 @@ public class SearchTools {
         }
 
         var analyzer = getAnalyzer();
-        var candidates = codeIntelligence.getProject().getAllFiles().stream()
-                .filter(file -> includeTests || !isTestFile(file, analyzer))
-                .collect(Collectors.toSet());
+        @Nullable Set<ProjectFile> candidates = null;
         List<String> results = new ArrayList<>();
         for (String symbol : symbols) {
             if (symbol.isBlank()) continue;
@@ -1084,10 +1080,19 @@ public class SearchTools {
                     .toList();
             if (filteredDefs.isEmpty()) continue;
 
-            var usageAnalyzer = usageAnalyzerFor(filteredDefs.getFirst(), analyzer);
-            var usageResult = usageAnalyzer.findUsages(filteredDefs, candidates, 500);
+            if (candidates == null) {
+                candidates = codeIntelligence.getProject().getAllFiles().stream()
+                        .filter(file -> includeTests || !isTestFile(file, analyzer))
+                        .collect(Collectors.toSet());
+            }
+
+            var usageAnalyzer =
+                    UsageAnalyzerSelector.forTarget(filteredDefs.getFirst(), analyzer, codeIntelligence.getProject());
+            var usageResult = UsageAnalyzerSelector.findUsages(usageAnalyzer, analyzer, filteredDefs, candidates);
             var rendered = UsageRenderer.render(analyzer, symbol, filteredDefs, usageResult, UsageRenderer.Mode.SAMPLE);
-            if (rendered.hasUsages() && !rendered.text().isEmpty()) {
+            if (rendered.hasUsages()
+                    && rendered.hitCount() > 0
+                    && !rendered.text().isEmpty()) {
                 results.add(rendered.text());
             }
         }
@@ -1096,14 +1101,6 @@ public class SearchTools {
             return "No usages found for: " + String.join(", ", symbols);
         }
         return recordResearchTokens(String.join("\n\n", results));
-    }
-
-    private UsageAnalyzer usageAnalyzerFor(CodeUnit target, IAnalyzer analyzer) {
-        var language = Languages.fromExtension(target.source().extension());
-        if (language.contains(Languages.JAVA)) {
-            return new JdtUsageAnalyzerStrategy(codeIntelligence.getProject());
-        }
-        return new RegexUsageAnalyzer(analyzer);
     }
 
     public String getClassSources(List<String> classNames) {

--- a/brokk-core/src/test/java/ai/brokk/tools/SearchToolsTest.java
+++ b/brokk-core/src/test/java/ai/brokk/tools/SearchToolsTest.java
@@ -175,6 +175,84 @@ class SearchToolsTest {
     }
 
     @Test
+    void scanUsages_FindsJavaFieldUsagesThroughJdt() throws Exception {
+        Path projectRoot = initRepo();
+        commitTrackedFiles(
+                projectRoot,
+                Map.of(
+                        "src/main/java/com/example/Target.java",
+                        """
+                        package com.example;
+
+                        public class Target {
+                            public String field;
+                        }
+                        """
+                                .stripIndent(),
+                        "src/main/java/com/consumer/Consumer.java",
+                        """
+                        package com.consumer;
+
+                        import com.example.Target;
+
+                        public class Consumer {
+                            public void use(Target target) {
+                                target.field = "value";
+                                System.out.println(target.field);
+                            }
+                        }
+                        """
+                                .stripIndent()),
+                Instant.parse("2025-01-01T00:00:00Z"),
+                "Add Java field usage");
+
+        project = new CoreProject(projectRoot);
+        IAnalyzer analyzer = Languages.JAVA.createAnalyzer(project);
+        SearchTools tools = new SearchTools(new StandaloneCodeIntelligence(project, analyzer));
+
+        String result = tools.scanUsages(List.of("com.example.Target.field"), true);
+
+        assertTrue(result.contains("# Usages of com.example.Target.field"), "Should render Java field usages");
+        assertTrue(result.contains("Consumer.java"), "Should include the Java consumer file");
+        assertTrue(result.contains("target.field"), "Should include source examples with the field access");
+        assertFalse(result.contains("No usages found"), "Should not miss Java field usages");
+    }
+
+    @Test
+    void scanUsages_SkipsSuccessfulResultsWithNoHits() throws Exception {
+        Path projectRoot = initRepo();
+        commitTrackedFiles(
+                projectRoot,
+                Map.of(
+                        "go.mod",
+                        """
+                        module example.com/test
+
+                        go 1.21
+                        """
+                                .stripIndent(),
+                        "model/album.go",
+                        """
+                        package model
+
+                        type Album struct {
+                            ImageFiles string
+                        }
+                        """
+                                .stripIndent()),
+                Instant.parse("2025-01-01T00:00:00Z"),
+                "Add unused Go field");
+
+        project = new CoreProject(projectRoot);
+        IAnalyzer analyzer = Languages.GO.createAnalyzer(project);
+        SearchTools tools = new SearchTools(new StandaloneCodeIntelligence(project, analyzer));
+
+        String result = tools.scanUsages(List.of("model.Album.ImageFiles"), true);
+
+        assertEquals("No usages found for: model.Album.ImageFiles", result);
+    }
+
+    @Test
     void searchFileContents_ReadsMatchingFileOnce() throws Exception {
         Path projectRoot = initRepo();
         Path filePath = projectRoot.resolve("counted.txt");

--- a/brokk-core/src/test/java/ai/brokk/tools/SearchToolsTest.java
+++ b/brokk-core/src/test/java/ai/brokk/tools/SearchToolsTest.java
@@ -10,6 +10,7 @@ import ai.brokk.analyzer.DisabledAnalyzer;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.IAnalyzer.Range;
 import ai.brokk.analyzer.Language;
+import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.git.CommitInfo;
 import ai.brokk.git.IGitRepo;
@@ -120,6 +121,57 @@ class SearchToolsTest {
         assertTrue(result.contains("## Related Content"), "Should include related content header");
         assertTrue(relatedSection.contains("B.java"), "Should include a related file");
         assertFalse(relatedSection.contains("A.java"), "Should not echo the seed file");
+    }
+
+    @Test
+    void scanUsages_FindsGoStructFieldUsages() throws Exception {
+        Path projectRoot = initRepo();
+        commitTrackedFiles(
+                projectRoot,
+                Map.of(
+                        "go.mod",
+                        """
+                        module example.com/test
+
+                        go 1.21
+                        """
+                                .stripIndent(),
+                        "model/album.go",
+                        """
+                        package model
+
+                        type Album struct {
+                            ImageFiles string
+                        }
+                        """
+                                .stripIndent(),
+                        "core/reader.go",
+                        """
+                        package core
+
+                        import "example.com/test/model"
+
+                        func Read(album model.Album) string {
+                            if album.ImageFiles != "" {
+                                return album.ImageFiles
+                            }
+                            return ""
+                        }
+                        """
+                                .stripIndent()),
+                Instant.parse("2025-01-01T00:00:00Z"),
+                "Add Go field usage");
+
+        project = new CoreProject(projectRoot);
+        IAnalyzer analyzer = Languages.GO.createAnalyzer(project);
+        SearchTools tools = new SearchTools(new StandaloneCodeIntelligence(project, analyzer));
+
+        String result = tools.scanUsages(List.of("model.Album.ImageFiles"), true);
+
+        assertTrue(result.contains("# Usages of model.Album.ImageFiles"), "Should render usage results");
+        assertTrue(result.contains("core/reader.go"), "Should include the file containing the field accesses");
+        assertTrue(result.contains("ImageFiles"), "Should include source examples with the field access");
+        assertFalse(result.contains("No usages found"), "Should not drop field symbols from usage results");
     }
 
     @Test

--- a/brokk-shared/src/main/java/ai/brokk/AnalyzerUtil.java
+++ b/brokk-shared/src/main/java/ai/brokk/AnalyzerUtil.java
@@ -37,6 +37,13 @@ public class AnalyzerUtil {
             }
         }
 
+        var fieldUses = uses.stream().filter(CodeUnit::isField).sorted().toList();
+        for (var field : fieldUses) {
+            analyzer.parentOf(field)
+                    .flatMap(analyzer::getSkeletonHeader)
+                    .ifPresent(header -> results.add(new CodeWithSource(header, field)));
+        }
+
         return results;
     }
 

--- a/brokk-shared/src/main/java/ai/brokk/AnalyzerUtil.java
+++ b/brokk-shared/src/main/java/ai/brokk/AnalyzerUtil.java
@@ -39,9 +39,13 @@ public class AnalyzerUtil {
 
         var fieldUses = uses.stream().filter(CodeUnit::isField).sorted().toList();
         for (var field : fieldUses) {
-            analyzer.parentOf(field)
-                    .flatMap(analyzer::getSkeletonHeader)
-                    .ifPresent(header -> results.add(new CodeWithSource(header, field)));
+            var parentOpt = analyzer.parentOf(field);
+            if (parentOpt.isEmpty()) {
+                continue;
+            }
+
+            var parent = parentOpt.get();
+            analyzer.getSkeletonHeader(parent).ifPresent(header -> results.add(new CodeWithSource(header, parent)));
         }
 
         return results;

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageAnalyzerSelector.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageAnalyzerSelector.java
@@ -1,0 +1,52 @@
+package ai.brokk.analyzer.usages;
+
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.Languages;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.project.ICoreProject;
+import java.util.List;
+import java.util.Set;
+
+/** Selects the usage analyzer strategy shared by context fragments and MCP tools. */
+public final class UsageAnalyzerSelector {
+    public static final int DEFAULT_MAX_USAGES = 500;
+
+    private UsageAnalyzerSelector() {}
+
+    public static UsageAnalyzer forTarget(CodeUnit target, IAnalyzer analyzer, ICoreProject project) {
+        var language = Languages.fromExtension(target.source().extension());
+        if (language.contains(Languages.JAVA)) {
+            return new JdtUsageAnalyzerStrategy(project);
+        }
+        if (language.contains(Languages.JAVASCRIPT) || language.contains(Languages.TYPESCRIPT)) {
+            var graph = new JsTsExportUsageGraphStrategy(analyzer);
+            if (graph.canHandle(target)) {
+                return graph;
+            }
+        }
+        return new RegexUsageAnalyzer(analyzer);
+    }
+
+    public static FuzzyResult findUsages(
+            UsageAnalyzer usageAnalyzer, IAnalyzer analyzer, List<CodeUnit> overloads, Set<ProjectFile> candidates)
+            throws InterruptedException {
+        var result = usageAnalyzer.findUsages(overloads, candidates, DEFAULT_MAX_USAGES);
+        if (shouldFallbackToRegex(result, usageAnalyzer)) {
+            return new RegexUsageAnalyzer(analyzer).findUsages(overloads, candidates, DEFAULT_MAX_USAGES);
+        }
+        return result;
+    }
+
+    public static boolean shouldFallbackToRegex(FuzzyResult result, UsageAnalyzer usageAnalyzer) {
+        if (!(usageAnalyzer instanceof JsTsExportUsageGraphStrategy)) {
+            return false;
+        }
+        return switch (result) {
+            case FuzzyResult.Success success -> success.hits().isEmpty();
+            case FuzzyResult.Ambiguous ambiguous -> ambiguous.hits().isEmpty();
+            case FuzzyResult.Failure ignored -> true;
+            case FuzzyResult.TooManyCallsites ignored -> false;
+        };
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageRenderer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageRenderer.java
@@ -18,7 +18,7 @@ public final class UsageRenderer {
         SAMPLE
     }
 
-    public record Output(String text, Set<ProjectFile> files, boolean hasUsages) {}
+    public record Output(String text, Set<ProjectFile> files, boolean hasUsages, int hitCount) {}
 
     public static Output render(
             IAnalyzer analyzer, String targetIdentifier, List<CodeUnit> overloads, FuzzyResult result, Mode mode) {
@@ -28,7 +28,7 @@ public final class UsageRenderer {
 
         var either = result.toEither();
         if (!either.hasUsages()) {
-            return new Output(either.getErrorMessage(), Set.of(), false);
+            return new Output(either.getErrorMessage(), Set.of(), false, 0);
         }
 
         CodeUnit definingOwner = analyzer.parentOf(overloads.getFirst()).orElse(overloads.getFirst());
@@ -59,12 +59,16 @@ public final class UsageRenderer {
                                         .toList());
                 };
         var sourceText = sources.stream().map(AnalyzerUtil.CodeWithSource::code).collect(Collectors.joining("\n\n"));
-        var examplesHeader = mode == Mode.SAMPLE ? "\n\nExamples:\n\n" : "\n\n";
+        var sourcePrefix =
+                switch (mode) {
+                    case SAMPLE -> "\n\nExamples:\n\n";
+                    case FULL -> sourceText.isEmpty() ? "" : "\n";
+                };
         var files = hits.stream().map(UsageHit::file).collect(Collectors.toSet());
         var text = "# Usages of %s\n\nCall sites (%d):\n%s%s%s"
-                .formatted(targetIdentifier, hits.size(), callSites, examplesHeader, sourceText)
+                .formatted(targetIdentifier, hits.size(), callSites, sourcePrefix, sourceText)
                 .trim();
 
-        return new Output(text, files, true);
+        return new Output(text, files, true, hits.size());
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageRenderer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageRenderer.java
@@ -1,0 +1,70 @@
+package ai.brokk.analyzer.usages;
+
+import ai.brokk.AnalyzerUtil;
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Formats usage-analysis results for context fragments and MCP search tools. */
+public final class UsageRenderer {
+    private UsageRenderer() {}
+
+    public enum Mode {
+        FULL,
+        SAMPLE
+    }
+
+    public record Output(String text, Set<ProjectFile> files, boolean hasUsages) {}
+
+    public static Output render(
+            IAnalyzer analyzer, String targetIdentifier, List<CodeUnit> overloads, FuzzyResult result, Mode mode) {
+        if (overloads.isEmpty()) {
+            throw new IllegalArgumentException("overloads must not be empty");
+        }
+
+        var either = result.toEither();
+        if (!either.hasUsages()) {
+            return new Output(either.getErrorMessage(), Set.of(), false);
+        }
+
+        CodeUnit definingOwner = analyzer.parentOf(overloads.getFirst()).orElse(overloads.getFirst());
+        var hits = either.getUsages().stream()
+                .filter(hit -> {
+                    var owner = analyzer.parentOf(hit.enclosing()).orElse(hit.enclosing());
+                    return !owner.equals(definingOwner);
+                })
+                .sorted(Comparator.comparing((UsageHit hit) -> hit.enclosing().fqName())
+                        .thenComparing(hit -> hit.file().toString())
+                        .thenComparingInt(UsageHit::line))
+                .toList();
+
+        var callSites = hits.stream()
+                .map(hit -> "- `%s` (%s:%d)"
+                        .formatted(hit.enclosing().fqName(), hit.file().getRelPath(), hit.line()))
+                .collect(Collectors.joining("\n"));
+
+        List<AnalyzerUtil.CodeWithSource> sources =
+                switch (mode) {
+                    case SAMPLE -> AnalyzerUtil.sampleUsages(analyzer, hits);
+                    case FULL ->
+                        AnalyzerUtil.processUsages(
+                                analyzer,
+                                hits.stream()
+                                        .map(UsageHit::enclosing)
+                                        .distinct()
+                                        .toList());
+                };
+        var sourceText = sources.stream().map(AnalyzerUtil.CodeWithSource::code).collect(Collectors.joining("\n\n"));
+        var examplesHeader = mode == Mode.SAMPLE ? "\n\nExamples:\n\n" : "\n\n";
+        var files = hits.stream().map(UsageHit::file).collect(Collectors.toSet());
+        var text = "# Usages of %s\n\nCall sites (%d):\n%s%s%s"
+                .formatted(targetIdentifier, hits.size(), callSites, examplesHeader, sourceText)
+                .trim();
+
+        return new Output(text, files, true);
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageRenderer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageRenderer.java
@@ -4,6 +4,7 @@ import ai.brokk.AnalyzerUtil;
 import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.util.PathNormalizer;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -43,8 +44,7 @@ public final class UsageRenderer {
                 .toList();
 
         var callSites = hits.stream()
-                .map(hit -> "- `%s` (%s:%d)"
-                        .formatted(hit.enclosing().fqName(), hit.file().getRelPath(), hit.line()))
+                .map(hit -> "- `%s` (%s:%d)".formatted(hit.enclosing().fqName(), displayPath(hit.file()), hit.line()))
                 .collect(Collectors.joining("\n"));
 
         List<AnalyzerUtil.CodeWithSource> sources =
@@ -70,5 +70,9 @@ public final class UsageRenderer {
                 .trim();
 
         return new Output(text, files, true, hits.size());
+    }
+
+    private static String displayPath(ProjectFile file) {
+        return PathNormalizer.canonicalizeForProject(file.getRelPath().toString(), file.getRoot());
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/context/ContextFragments.java
+++ b/brokk-shared/src/main/java/ai/brokk/context/ContextFragments.java
@@ -20,6 +20,7 @@ import ai.brokk.analyzer.usages.JdtUsageAnalyzerStrategy;
 import ai.brokk.analyzer.usages.JsTsExportUsageGraphStrategy;
 import ai.brokk.analyzer.usages.RegexUsageAnalyzer;
 import ai.brokk.analyzer.usages.UsageAnalyzer;
+import ai.brokk.analyzer.usages.UsageRenderer;
 import ai.brokk.concurrent.ComputedValue;
 import ai.brokk.concurrent.ExecutorsUtil;
 import ai.brokk.concurrent.LoggingExecutorService;
@@ -45,7 +46,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -1511,8 +1511,6 @@ public class ContextFragments {
                     usageAnalyzer.getClass().getSimpleName(),
                     candidates.size());
 
-            CodeUnit definingOwner = analyzer.parentOf(overloads.getFirst()).orElse(overloads.getFirst());
-
             FuzzyResult result;
             try {
                 result = usageAnalyzer.findUsages(overloads, candidates, 500);
@@ -1530,56 +1528,18 @@ public class ContextFragments {
                         false);
             }
 
-            var either = result.toEither();
-            if (!either.hasUsages()) {
+            var rendered = UsageRenderer.render(
+                    analyzer,
+                    targetIdentifier,
+                    overloads,
+                    result,
+                    mode == UsageMode.SAMPLE ? UsageRenderer.Mode.SAMPLE : UsageRenderer.Mode.FULL);
+            if (!rendered.hasUsages()) {
                 logger.debug("UsageFragment found no usages for {} via {}", targetIdentifier, usageAnalyzer);
-                return new ContentSnapshot(either.getErrorMessage(), Set.of(), Set.of(), (List<Byte>) null, false);
+                return new ContentSnapshot(rendered.text(), Set.of(), Set.of(), (List<Byte>) null, false);
             }
 
-            var hits = either.getUsages().stream()
-                    .filter(hit -> {
-                        var owner = analyzer.parentOf(hit.enclosing()).orElse(hit.enclosing());
-                        return !owner.equals(definingOwner);
-                    })
-                    .sorted(Comparator.comparing((ai.brokk.analyzer.usages.UsageHit h) ->
-                                    h.enclosing().fqName())
-                            .thenComparing(h -> h.file().toString())
-                            .thenComparingInt(ai.brokk.analyzer.usages.UsageHit::line))
-                    .toList();
-
-            StringBuilder sb =
-                    new StringBuilder("# Usages of ").append(targetIdentifier).append("\n\n");
-            sb.append("Call sites (").append(hits.size()).append("):\n");
-            for (var hit : hits) {
-                sb.append("- `")
-                        .append(hit.enclosing().fqName())
-                        .append("` (")
-                        .append(hit.file().getRelPath())
-                        .append(":")
-                        .append(hit.line())
-                        .append(")\n");
-            }
-
-            List<AnalyzerUtil.CodeWithSource> sources;
-            if (mode == UsageMode.SAMPLE) {
-                sb.append("\nExamples:\n\n");
-                sources = AnalyzerUtil.sampleUsages(analyzer, hits);
-            } else {
-                sources = AnalyzerUtil.processUsages(
-                        analyzer,
-                        hits.stream()
-                                .map(ai.brokk.analyzer.usages.UsageHit::enclosing)
-                                .distinct()
-                                .toList());
-            }
-
-            for (var src : sources) {
-                sb.append(src.code()).append("\n\n");
-            }
-
-            var files =
-                    hits.stream().map(ai.brokk.analyzer.usages.UsageHit::file).collect(Collectors.toSet());
-            return new ContentSnapshot(sb.toString().trim(), Set.of(), files, (List<Byte>) null, true);
+            return new ContentSnapshot(rendered.text(), Set.of(), rendered.files(), (List<Byte>) null, true);
         }
 
         private static UsageAnalyzer usageAnalyzerFor(

--- a/brokk-shared/src/main/java/ai/brokk/context/ContextFragments.java
+++ b/brokk-shared/src/main/java/ai/brokk/context/ContextFragments.java
@@ -10,16 +10,10 @@ import ai.brokk.analyzer.CodeUnitType;
 import ai.brokk.analyzer.ExternalFile;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.ImportAnalysisProvider;
-import ai.brokk.analyzer.Language;
-import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.MultiAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.analyzer.TypeHierarchyProvider;
-import ai.brokk.analyzer.usages.FuzzyResult;
-import ai.brokk.analyzer.usages.JdtUsageAnalyzerStrategy;
-import ai.brokk.analyzer.usages.JsTsExportUsageGraphStrategy;
-import ai.brokk.analyzer.usages.RegexUsageAnalyzer;
-import ai.brokk.analyzer.usages.UsageAnalyzer;
+import ai.brokk.analyzer.usages.UsageAnalyzerSelector;
 import ai.brokk.analyzer.usages.UsageRenderer;
 import ai.brokk.concurrent.ComputedValue;
 import ai.brokk.concurrent.ExecutorsUtil;
@@ -1503,7 +1497,7 @@ public class ContextFragments {
                         false);
             }
 
-            var usageAnalyzer = usageAnalyzerFor(overloads.getFirst(), analyzer, project);
+            var usageAnalyzer = UsageAnalyzerSelector.forTarget(overloads.getFirst(), analyzer, project);
             logger.debug(
                     "UsageFragment analyzing {} with {} overloads using {} across {} candidate files",
                     targetIdentifier,
@@ -1511,13 +1505,20 @@ public class ContextFragments {
                     usageAnalyzer.getClass().getSimpleName(),
                     candidates.size());
 
-            FuzzyResult result;
             try {
-                result = usageAnalyzer.findUsages(overloads, candidates, 500);
-                if (shouldFallbackToRegex(result, usageAnalyzer)) {
-                    logger.debug("UsageFragment falling back to RegexUsageAnalyzer for {}", targetIdentifier);
-                    result = new RegexUsageAnalyzer(analyzer).findUsages(overloads, candidates, 500);
+                var result = UsageAnalyzerSelector.findUsages(usageAnalyzer, analyzer, overloads, candidates);
+                var rendered = UsageRenderer.render(
+                        analyzer,
+                        targetIdentifier,
+                        overloads,
+                        result,
+                        mode == UsageMode.SAMPLE ? UsageRenderer.Mode.SAMPLE : UsageRenderer.Mode.FULL);
+                if (!rendered.hasUsages()) {
+                    logger.debug("UsageFragment found no usages for {} via {}", targetIdentifier, usageAnalyzer);
+                    return new ContentSnapshot(rendered.text(), Set.of(), Set.of(), (List<Byte>) null, false);
                 }
+
+                return new ContentSnapshot(rendered.text(), Set.of(), rendered.files(), (List<Byte>) null, true);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return new ContentSnapshot(
@@ -1527,46 +1528,6 @@ public class ContextFragments {
                         (List<Byte>) null,
                         false);
             }
-
-            var rendered = UsageRenderer.render(
-                    analyzer,
-                    targetIdentifier,
-                    overloads,
-                    result,
-                    mode == UsageMode.SAMPLE ? UsageRenderer.Mode.SAMPLE : UsageRenderer.Mode.FULL);
-            if (!rendered.hasUsages()) {
-                logger.debug("UsageFragment found no usages for {} via {}", targetIdentifier, usageAnalyzer);
-                return new ContentSnapshot(rendered.text(), Set.of(), Set.of(), (List<Byte>) null, false);
-            }
-
-            return new ContentSnapshot(rendered.text(), Set.of(), rendered.files(), (List<Byte>) null, true);
-        }
-
-        private static UsageAnalyzer usageAnalyzerFor(
-                CodeUnit target, IAnalyzer analyzer, ai.brokk.project.ICoreProject project) {
-            Language lang = Languages.fromExtension(target.source().extension());
-            if (lang.contains(Languages.JAVA)) {
-                return new JdtUsageAnalyzerStrategy(project);
-            }
-            if (lang.contains(Languages.JAVASCRIPT) || lang.contains(Languages.TYPESCRIPT)) {
-                var graph = new JsTsExportUsageGraphStrategy(analyzer);
-                if (graph.canHandle(target)) {
-                    return graph;
-                }
-            }
-            return new RegexUsageAnalyzer(analyzer);
-        }
-
-        private static boolean shouldFallbackToRegex(FuzzyResult result, UsageAnalyzer usageAnalyzer) {
-            if (!(usageAnalyzer instanceof JsTsExportUsageGraphStrategy)) {
-                return false;
-            }
-            return switch (result) {
-                case FuzzyResult.Success success -> success.hits().isEmpty();
-                case FuzzyResult.Failure ignored -> true;
-                case FuzzyResult.Ambiguous ambiguous -> ambiguous.hits().isEmpty();
-                case FuzzyResult.TooManyCallsites ignored -> false;
-            };
         }
 
         @Override

--- a/brokk-shared/src/test/java/ai/brokk/AnalyzerUtilTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/AnalyzerUtilTest.java
@@ -7,10 +7,8 @@ import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.DisabledAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
 import java.nio.file.Path;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.SequencedSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -24,15 +22,6 @@ class AnalyzerUtilTest {
         var targetClass = CodeUnit.cls(file, "com.example", "Target");
         var targetField = CodeUnit.field(file, "com.example", "Target.field");
         var analyzer = new DisabledAnalyzer() {
-            @Override
-            public SequencedSet<CodeUnit> getDefinitions(String fqName) {
-                SequencedSet<CodeUnit> result = new LinkedHashSet<>();
-                if (targetClass.fqName().equals(fqName)) {
-                    result.add(targetClass);
-                }
-                return result;
-            }
-
             @Override
             public Optional<CodeUnit> parentOf(CodeUnit cu) {
                 if (targetField.equals(cu)) {
@@ -50,20 +39,14 @@ class AnalyzerUtilTest {
             }
         };
 
-        assertTrue(targetField.isField());
-        assertEquals(Optional.of(targetClass), analyzer.parentOf(targetField));
-        assertEquals(
-                Optional.of("public class Target { public String field; }"),
-                analyzer.parentOf(targetField).flatMap(analyzer::getSkeletonHeader));
-        assertEquals(
-                List.of(targetField),
-                List.of(targetField).stream().filter(CodeUnit::isField).toList());
         var rendered = AnalyzerUtil.processUsages(analyzer, List.of(targetField));
 
         assertEquals(1, rendered.size());
         assertEquals(
                 "public class Target { public String field; }",
                 rendered.getFirst().code());
-        assertEquals(targetField, rendered.getFirst().source());
+        assertEquals(targetClass, rendered.getFirst().source());
+        assertTrue(AnalyzerUtil.CodeWithSource.text(analyzer, rendered)
+                .contains("public class Target { public String field; }"));
     }
 }

--- a/brokk-shared/src/test/java/ai/brokk/AnalyzerUtilTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/AnalyzerUtilTest.java
@@ -1,0 +1,69 @@
+package ai.brokk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.DisabledAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.SequencedSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AnalyzerUtilTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void processUsages_RendersFieldParentSkeleton() {
+        var file = new ProjectFile(tempDir, "Target.java");
+        var targetClass = CodeUnit.cls(file, "com.example", "Target");
+        var targetField = CodeUnit.field(file, "com.example", "Target.field");
+        var analyzer = new DisabledAnalyzer() {
+            @Override
+            public SequencedSet<CodeUnit> getDefinitions(String fqName) {
+                SequencedSet<CodeUnit> result = new LinkedHashSet<>();
+                if (targetClass.fqName().equals(fqName)) {
+                    result.add(targetClass);
+                }
+                return result;
+            }
+
+            @Override
+            public Optional<CodeUnit> parentOf(CodeUnit cu) {
+                if (targetField.equals(cu)) {
+                    return Optional.of(targetClass);
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<String> getSkeletonHeader(CodeUnit classUnit) {
+                if (targetClass.equals(classUnit)) {
+                    return Optional.of("public class Target { public String field; }");
+                }
+                return Optional.empty();
+            }
+        };
+
+        assertTrue(targetField.isField());
+        assertEquals(Optional.of(targetClass), analyzer.parentOf(targetField));
+        assertEquals(
+                Optional.of("public class Target { public String field; }"),
+                analyzer.parentOf(targetField).flatMap(analyzer::getSkeletonHeader));
+        assertEquals(
+                List.of(targetField),
+                List.of(targetField).stream().filter(CodeUnit::isField).toList());
+        var rendered = AnalyzerUtil.processUsages(analyzer, List.of(targetField));
+
+        assertEquals(1, rendered.size());
+        assertEquals(
+                "public class Target { public String field; }",
+                rendered.getFirst().code());
+        assertEquals(targetField, rendered.getFirst().source());
+    }
+}

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/usages/UsageRendererTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/usages/UsageRendererTest.java
@@ -1,0 +1,34 @@
+package ai.brokk.analyzer.usages;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.DisabledAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class UsageRendererTest {
+
+    @TempDir
+    Path root;
+
+    @Test
+    void renderNormalizesUsagePaths() {
+        ProjectFile modelFile = new ProjectFile(root, Path.of("model\\album.go"));
+        ProjectFile readerFile = new ProjectFile(root, Path.of("core\\reader.go"));
+        CodeUnit target = CodeUnit.field(modelFile, "model", "Album.ImageFiles");
+        CodeUnit enclosing = CodeUnit.fn(readerFile, "core", "Read");
+        UsageHit hit = new UsageHit(readerFile, 7, 0, 10, enclosing, 1.0, "album.ImageFiles");
+        FuzzyResult result = new FuzzyResult.Success(Map.of(target, Set.of(hit)));
+
+        var output = UsageRenderer.render(
+                new DisabledAnalyzer(), "model.Album.ImageFiles", List.of(target), result, UsageRenderer.Mode.SAMPLE);
+
+        assertTrue(output.text().contains("core/reader.go:7"), output.text());
+    }
+}


### PR DESCRIPTION
Noticed while trying brokk-core mcp with simple agent; brokk-core `scanUsages` drops field usage results.

---

Detailed analysis by codex:

At iteration 12, the agent called:

- `mcp__brokk__scanUsages` for:
  `model.Album.ExternalInfoUpdatedAt`, `model.Artist.ExternalInfoUpdatedAt`, `model.Share.ExpiresAt`, `model.Share.LastVisitedAt`, `model.Album.ImageFiles`
- `mcp__brokk__getSymbolLocations` for the same symbols

The important part from `stats.json`: **Brokk did find the symbols as definitions**:

```text
model.Album.ExternalInfoUpdatedAt -> model/album.go
model.Artist.ExternalInfoUpdatedAt -> model/artist.go
model.Share.ExpiresAt -> model/share.go
model.Share.LastVisitedAt -> model/share.go
model.Album.ImageFiles -> model/album.go
```

What failed was **usage scanning**:

```text
No usages found for: model.Album.ExternalInfoUpdatedAt, ...
```

Root cause: `brokk-core`’s `scanUsages` implementation is not actually doing usage analysis there. It resolves definitions, then passes those definition `CodeUnit`s to `AnalyzerUtil.processUsages`:

[SearchTools.java](/home/dragan/br/brokk/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java:1059)

But `AnalyzerUtil.processUsages` only renders functions and classes. It drops fields entirely:

[AnalyzerUtil.java](/home/dragan/br/brokk/brokk-shared/src/main/java/ai/brokk/AnalyzerUtil.java:21)

So for field symbols, `scanUsages` resolves them, then discards them because they are `FIELD` code units, producing an empty result and the misleading “No usages found” message.

The agent then fell back to shell search: iteration 13 tried `rg`, but `rg` was unavailable in that workdir; iteration 14 used `grep -RInE` and found the field references.

So the short answer: **Brokk Core MCP did find the searched symbols; `getSymbolLocations` worked. The failure was that `scanUsages` in brokk-core mishandles field symbols by resolving definitions but never invoking real usage search, then filtering fields out of the rendered result.**

Also, the app-side `SearchTools.scanUsages` was not broken in the same way: before and at `1b969ebdb`, it used `ContextFragments.UsageFragment`, not `AnalyzerUtil.processUsages`. So this was a brokk-core porting/initial implementation bug, introduced when standalone brokk-core MCP was added.