### PR TITLE
LUTZ: promote callShellAgent in the planner directive

### DIFF
--- a/app/src/main/java/ai/brokk/prompts/SearchPrompts.java
+++ b/app/src/main/java/ai/brokk/prompts/SearchPrompts.java
@@ -59,10 +59,11 @@ public class SearchPrompts {
         },
         LUTZ(
                 "query_or_instructions",
-                "Your goal is to gather enough context to either answer the question, produce a task list, or invoke the Code Agent for a small change.",
-                "one of: answer, task list, or Code Agent invocation",
+                "Your goal is to gather enough context to either answer the question, run a shell task, produce a task list, or invoke the Code Agent for a small change.",
+                "one of: answer, shell delegation, task list, or Code Agent invocation",
                 """
                 - Prefer answer(String) when no code changes are needed and the Workspace already justifies the answer (or the question is codebase-independent).
+                - When the request is a shell/CLI operation (installing tools, managing git worktrees, running scripts, environment setup, or any other "run this command" task), call callShellAgent(String task) to delegate to the Shell Agent, then summarize the result with answer(String). Delegating to the Shell Agent is NOT writing code; it is operating the user's system on their behalf, with their per-command approval. Do NOT respond with instructions for the user to run the command themselves, and do NOT propose adding a new tool to this codebase to perform the operation.
                 - Prefer callCodeAgent(String instructions, boolean deferBuild) if the requested change is small.
                 - Otherwise, decompose the problem with createOrReplaceTaskList(String explanation, List<TaskListEntry> tasks); do not attempt to write code yet.
                 """,


### PR DESCRIPTION
## Summary
- The LUTZ planner's Objective taskInstructions previously only enumerated `answer`, `callCodeAgent`, and `createOrReplaceTaskList`, so the registered `callShellAgent` tool was effectively invisible at the system-prompt level.
- Result: shell-flavored prompts in the Java ACP server (e.g. "create a git worktree", "install golangci-lint") got rationalized as "let me add a feature to this codebase" instead of being delegated to the Shell Agent.
- This patch surfaces `callShellAgent` as a peer option in `Objective.LUTZ` (mission, deliverable, and task-instruction bullets), with explicit guards against the two observed failure modes (telling the user to run the command themselves; proposing to add a new Brokk tool).

## Test plan
- [ ] Run an ACP session against the Java server (default LUTZ mode).
- [ ] Send a shell-flavored initial prompt (e.g. "create a git worktree at /tmp/foo from master") and confirm the planner invokes `callShellAgent` rather than producing a chatbot-style refusal or feature-add proposal.
- [ ] Verify a non-shell prompt still routes to `callCodeAgent` / `createOrReplaceTaskList` as before.
- [ ] `./gradlew :app:compileJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)