### PR TITLE
ACP: add session-level PermissionMode dropdown (#3423)

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
+++ b/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
@@ -770,38 +770,7 @@ public class AcpConsoleIO extends MemoryConsole {
      * tool name prefixes to match the reference ACP implementation's categories.
      */
     private static AcpSchema.ToolKind classifyTool(String toolName, boolean destructive) {
-        if (destructive) {
-            return AcpSchema.ToolKind.EDIT;
-        }
-        return switch (toolName) {
-            case "shell" -> AcpSchema.ToolKind.EXECUTE;
-            case "searchAgent" -> AcpSchema.ToolKind.SEARCH;
-            case "createOrReplaceTaskList" -> AcpSchema.ToolKind.THINK;
-            default -> classifyByPrefix(toolName);
-        };
-    }
-
-    private static AcpSchema.ToolKind classifyByPrefix(String toolName) {
-        if (toolName.startsWith("search") || toolName.startsWith("find")) {
-            return AcpSchema.ToolKind.SEARCH;
-        }
-        if (toolName.startsWith("get")
-                || toolName.startsWith("list")
-                || toolName.startsWith("skim")
-                || toolName.startsWith("explain")
-                || toolName.startsWith("read")
-                || toolName.startsWith("scan")) {
-            return AcpSchema.ToolKind.READ;
-        }
-        if (toolName.startsWith("add")
-                || toolName.startsWith("drop")
-                || toolName.startsWith("replace")
-                || toolName.startsWith("edit")
-                || toolName.startsWith("write")
-                || toolName.startsWith("create")) {
-            return AcpSchema.ToolKind.EDIT;
-        }
-        return AcpSchema.ToolKind.OTHER;
+        return destructive ? AcpSchema.ToolKind.EDIT : PermissionGate.classify(toolName);
     }
 
     // ---- GUI-only methods: all no-op (inherited defaults from IConsoleIO) ----

--- a/app/src/main/java/ai/brokk/acp/AcpProtocol.java
+++ b/app/src/main/java/ai/brokk/acp/AcpProtocol.java
@@ -13,8 +13,94 @@ final class AcpProtocol {
     static final String METHOD_SESSION_RESUME = "session/resume";
     static final String METHOD_SESSION_CLOSE = "session/close";
     static final String METHOD_SESSION_FORK = "session/fork";
+    static final String METHOD_SESSION_SET_CONFIG_OPTION = "session/set_config_option";
 
     private AcpProtocol() {}
+
+    // ---- Session config options (dropdowns) ----
+    //
+    // Mirrors {@code agent-client-protocol-schema-0.12.0::SessionConfigOption} so the JSON we put
+    // on the wire matches what Zed and other ACP clients expect from the Rust reference server.
+    // The SDK at 0.10.0 has none of these types; once it gains them we can drop these records.
+
+    /**
+     * A single dropdown selector advertised by the agent. Serializes as a flat JSON object with
+     * {@code type: "select"} and the select-specific fields ({@code currentValue}, {@code options})
+     * promoted to the top level (matching the {@code #[serde(flatten)]} on the Rust enum).
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record SessionConfigOption(
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("description") @Nullable String description,
+            @JsonProperty("category") @Nullable String category,
+            @JsonProperty("type") String type,
+            @JsonProperty("currentValue") String currentValue,
+            @JsonProperty("options") List<SessionConfigSelectOption> options) {
+
+        /** Builds a "select" (single-value dropdown) option with the standard {@code mode} category. */
+        static SessionConfigOption select(
+                String id,
+                String name,
+                @Nullable String description,
+                String currentValue,
+                List<SessionConfigSelectOption> options) {
+            return select(id, name, description, "mode", currentValue, options);
+        }
+
+        /** Builds a "select" option with an explicit category (e.g. {@code "model"}). */
+        static SessionConfigOption select(
+                String id,
+                String name,
+                @Nullable String description,
+                String category,
+                String currentValue,
+                List<SessionConfigSelectOption> options) {
+            return new SessionConfigOption(id, name, description, category, "select", currentValue, options);
+        }
+    }
+
+    /** A single value within a {@link SessionConfigOption} dropdown. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record SessionConfigSelectOption(
+            @JsonProperty("value") String value,
+            @JsonProperty("name") String name,
+            @JsonProperty("description") @Nullable String description) {}
+
+    /** Request body for {@code session/set_config_option}. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record SetSessionConfigOptionRequest(
+            @JsonProperty("sessionId") String sessionId,
+            @JsonProperty("configId") String configId,
+            @JsonProperty("value") String value,
+            @JsonProperty("_meta") @Nullable Map<String, Object> meta) {}
+
+    /** Response to {@code session/set_config_option}: the full set after the change. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record SetSessionConfigOptionResponse(
+            @JsonProperty("configOptions") List<SessionConfigOption> configOptions,
+            @JsonProperty("_meta") @Nullable Map<String, Object> meta) {}
+
+    // ---- Extended session-creation responses ----
+    //
+    // The SDK's NewSessionResponse and LoadSessionResponse don't carry {@code configOptions}; we
+    // wrap them here so the agent can advertise the permission/behavior dropdowns. Field order
+    // mirrors the SDK records so the wire JSON is a strict superset.
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record NewSessionResponseExt(
+            @JsonProperty("sessionId") String sessionId,
+            @JsonProperty("modes") AcpSchema.SessionModeState modes,
+            @JsonProperty("models") AcpSchema.SessionModelState models,
+            @JsonProperty("configOptions") @Nullable List<SessionConfigOption> configOptions,
+            @JsonProperty("_meta") @Nullable Map<String, Object> meta) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record LoadSessionResponseExt(
+            @JsonProperty("modes") AcpSchema.SessionModeState modes,
+            @JsonProperty("models") AcpSchema.SessionModelState models,
+            @JsonProperty("configOptions") @Nullable List<SessionConfigOption> configOptions,
+            @JsonProperty("_meta") @Nullable Map<String, Object> meta) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     record InitializeResponse(
@@ -83,6 +169,7 @@ final class AcpProtocol {
     record ResumeSessionResponse(
             @JsonProperty("modes") AcpSchema.SessionModeState modes,
             @JsonProperty("models") AcpSchema.SessionModelState models,
+            @JsonProperty("configOptions") @Nullable List<SessionConfigOption> configOptions,
             @JsonProperty("_meta") @Nullable Map<String, Object> meta) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -104,5 +191,6 @@ final class AcpProtocol {
             @JsonProperty("sessionId") String sessionId,
             @JsonProperty("modes") AcpSchema.SessionModeState modes,
             @JsonProperty("models") AcpSchema.SessionModelState models,
+            @JsonProperty("configOptions") @Nullable List<SessionConfigOption> configOptions,
             @JsonProperty("_meta") @Nullable Map<String, Object> meta) {}
 }

--- a/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
@@ -208,6 +208,33 @@ final class AcpRequestContext implements AcpPromptContext {
     public boolean askPermission(String action, String toolName) {
         boolean cacheable = !NON_CACHEABLE_TOOL_NAMES.contains(toolName);
         var cache = cacheable ? agent : null;
+
+        // Session-level PermissionMode is consulted BEFORE the sticky cache so READ_ONLY can deny
+        // even tools the user previously approved, and BYPASS_PERMISSIONS can short-circuit before
+        // any user-facing prompt fires. Mirrors brokk-acp-rust/src/tool_loop.rs:pure_gate_decision.
+        if (agent != null) {
+            var mode = agent.permissionModeFor(sessionId);
+            var kind = PermissionGate.classify(toolName);
+            boolean alwaysAllowed = cache != null
+                    && cache.stickyPermissionFor(sessionId, toolName)
+                            .filter(v -> v == BrokkAcpAgent.PermissionVerdict.ALLOW)
+                            .isPresent();
+            switch (PermissionGate.decide(mode, kind, toolName, alwaysAllowed)) {
+                case ALLOW -> {
+                    return true;
+                }
+                case REJECT -> {
+                    sendMessage("\n**" + toolName + " denied:** " + PermissionGate.READ_ONLY_REJECTION + "\n");
+                    return false;
+                }
+                case PROMPT -> {
+                    // Fall through to the legacy sticky-cache + prompt path. We still need the
+                    // sticky cache on the deny side (a previous reject_always must continue to deny
+                    // without a round-trip), which gateDecision didn't consult.
+                }
+            }
+        }
+
         if (cache != null) {
             var sticky = cache.stickyPermissionFor(sessionId, toolName);
             if (sticky.isPresent()) {

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -97,6 +97,7 @@ public class BrokkAcpAgent {
     private final Map<String, String> reasoningBySession = new ConcurrentHashMap<>();
     private final Map<String, String> activeJobBySession = new ConcurrentHashMap<>();
     private final Map<String, Map<String, PermissionVerdict>> stickyPermissionsBySession = new ConcurrentHashMap<>();
+    private final Map<String, PermissionMode> permissionModeBySession = new ConcurrentHashMap<>();
     private final Map<String, List<McpServer>> mcpServersBySession = new ConcurrentHashMap<>();
     private static final InheritableThreadLocal<List<McpServer>> SESSION_MCP_SCOPE = new InheritableThreadLocal<>();
     private final Map<String, TaskList.TaskListData> lastTaskListBySession = new ConcurrentHashMap<>();
@@ -250,6 +251,7 @@ public class BrokkAcpAgent {
         reasoningBySession.clear();
         activeJobBySession.clear();
         stickyPermissionsBySession.clear();
+        permissionModeBySession.clear();
         mcpServersBySession.clear();
         rejectedMcpServersBySession.clear();
         lastTaskListBySession.clear();
@@ -362,7 +364,7 @@ public class BrokkAcpAgent {
         return new AcpSchema.AuthenticateResponse();
     }
 
-    public AcpSchema.NewSessionResponse newSession(AcpSchema.NewSessionRequest request) {
+    public AcpProtocol.NewSessionResponseExt newSession(AcpSchema.NewSessionRequest request) {
         logger.info("ACP new session, cwd={}", request.cwd());
         var bundle = bundleFor(request.cwd());
 
@@ -373,18 +375,20 @@ public class BrokkAcpAgent {
 
         modeBySession.put(sessionId, "LUTZ");
         reasoningBySession.put(sessionId, defaultReasoningLevel);
+        permissionModeBySession.put(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
         var modeState = new AcpSchema.SessionModeState("LUTZ", AVAILABLE_MODES);
         var modelState = buildModelState(sessionId);
         var meta = buildVariantMeta(sessionId);
+        var configOptions = buildConfigOptions(sessionId);
 
         scheduleAvailableCommandsUpdate(sessionId);
 
-        return new AcpSchema.NewSessionResponse(sessionId, modeState, modelState, meta);
+        return new AcpProtocol.NewSessionResponseExt(sessionId, modeState, modelState, configOptions, meta);
     }
 
-    public AcpSchema.LoadSessionResponse loadSession(AcpSchema.LoadSessionRequest request) {
+    public AcpProtocol.LoadSessionResponseExt loadSession(AcpSchema.LoadSessionRequest request) {
         logger.info("ACP load session {} cwd={}", request.sessionId(), request.cwd());
         var sessionId = request.sessionId();
         var bundle = bundleFor(request.cwd());
@@ -400,17 +404,19 @@ public class BrokkAcpAgent {
 
         modeBySession.putIfAbsent(sessionId, "LUTZ");
         reasoningBySession.putIfAbsent(sessionId, defaultReasoningLevel);
+        permissionModeBySession.putIfAbsent(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
         var modeState = new AcpSchema.SessionModeState(modeBySession.getOrDefault(sessionId, "LUTZ"), AVAILABLE_MODES);
         var modelState = buildModelState(sessionId);
         var meta = buildVariantMeta(sessionId);
+        var configOptions = buildConfigOptions(sessionId);
 
         // Schedule conversation replay and commands advertisement after response is sent
         scheduleConversationReplay(sessionId);
         scheduleAvailableCommandsUpdate(sessionId);
 
-        return new AcpSchema.LoadSessionResponse(modeState, modelState, meta);
+        return new AcpProtocol.LoadSessionResponseExt(modeState, modelState, configOptions, meta);
     }
 
     public AcpProtocol.ResumeSessionResponse resumeSession(AcpProtocol.ResumeSessionRequest request) {
@@ -422,14 +428,16 @@ public class BrokkAcpAgent {
 
         modeBySession.putIfAbsent(sessionId, "LUTZ");
         reasoningBySession.putIfAbsent(sessionId, defaultReasoningLevel);
+        permissionModeBySession.putIfAbsent(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
         var modeState = new AcpSchema.SessionModeState(modeBySession.getOrDefault(sessionId, "LUTZ"), AVAILABLE_MODES);
         var modelState = buildModelState(sessionId);
         var meta = buildVariantMeta(sessionId);
+        var configOptions = buildConfigOptions(sessionId);
 
         scheduleAvailableCommandsUpdate(sessionId);
-        return new AcpProtocol.ResumeSessionResponse(modeState, modelState, meta);
+        return new AcpProtocol.ResumeSessionResponse(modeState, modelState, configOptions, meta);
     }
 
     public AcpProtocol.ListSessionsResponse listSessions(AcpProtocol.ListSessionsRequest request) {
@@ -477,6 +485,7 @@ public class BrokkAcpAgent {
         modelBySession.remove(sessionId);
         reasoningBySession.remove(sessionId);
         stickyPermissionsBySession.remove(sessionId);
+        permissionModeBySession.remove(sessionId);
         mcpServersBySession.remove(sessionId);
         rejectedMcpServersBySession.remove(sessionId);
         lastTaskListBySession.remove(sessionId);
@@ -510,6 +519,9 @@ public class BrokkAcpAgent {
             }
             reasoningBySession.put(
                     forkSessionId, reasoningBySession.getOrDefault(request.sessionId(), defaultReasoningLevel));
+            permissionModeBySession.put(
+                    forkSessionId,
+                    permissionModeBySession.getOrDefault(request.sessionId(), PermissionMode.DEFAULT));
             // Inherit MCP servers from parent unless the fork request supplies a fresh list.
             if (request.mcpServers() != null) {
                 applySessionMcpServers(forkSessionId, request.mcpServers());
@@ -524,9 +536,10 @@ public class BrokkAcpAgent {
                     new AcpSchema.SessionModeState(modeBySession.getOrDefault(forkSessionId, "LUTZ"), AVAILABLE_MODES);
             var modelState = buildModelState(forkSessionId);
             var meta = buildVariantMeta(forkSessionId);
+            var configOptions = buildConfigOptions(forkSessionId);
 
             scheduleAvailableCommandsUpdate(forkSessionId);
-            return new AcpProtocol.ForkSessionResponse(forkSessionId, modeState, modelState, meta);
+            return new AcpProtocol.ForkSessionResponse(forkSessionId, modeState, modelState, configOptions, meta);
         } catch (Exception e) {
             throw new RuntimeException("Failed to fork session " + request.sessionId(), e);
         }
@@ -641,6 +654,137 @@ public class BrokkAcpAgent {
         }
 
         return new AcpSchema.SetSessionModeResponse();
+    }
+
+    /** Returns the active permission mode for {@code sessionId}, defaulting to {@code DEFAULT}. */
+    public PermissionMode permissionModeFor(String sessionId) {
+        return permissionModeBySession.getOrDefault(sessionId, PermissionMode.DEFAULT);
+    }
+
+    /**
+     * Handler for {@code session/set_config_option}. Routes on {@code configId} to either the
+     * permission-mode store or the existing {@link #setMode} logic for behavior modes. Returns the
+     * updated set of dropdowns so clients can refresh their UI.
+     */
+    public AcpProtocol.SetSessionConfigOptionResponse setSessionConfigOption(
+            AcpProtocol.SetSessionConfigOptionRequest request) {
+        var sessionId = request.sessionId();
+        var configId = request.configId();
+        var value = request.value();
+        logger.info("ACP set config_option session={} config={} value={}", sessionId, configId, value);
+
+        switch (configId) {
+            case "permission_mode" -> {
+                var parsed = PermissionMode.parse(value);
+                if (parsed.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "Unknown permission mode '" + value
+                                    + "'. Supported: default, acceptEdits, readOnly, bypassPermissions");
+                }
+                permissionModeBySession.put(sessionId, parsed.get());
+            }
+            case "behavior_mode" -> {
+                var validMode = AVAILABLE_MODES.stream().anyMatch(m -> m.id().equals(value));
+                if (!validMode) {
+                    throw new IllegalArgumentException("Unknown behavior mode '" + value
+                            + "'. Supported: "
+                            + AVAILABLE_MODES.stream().map(AcpSchema.SessionMode::id).toList());
+                }
+                setMode(new AcpSchema.SetSessionModeRequest(sessionId, value));
+            }
+            case "model_selection" -> setModel(new AcpSchema.SetSessionModelRequest(sessionId, value));
+            default ->
+                throw new IllegalArgumentException(
+                        "Unknown configId '" + configId
+                                + "'. Supported: permission_mode, behavior_mode, model_selection");
+        }
+        return new AcpProtocol.SetSessionConfigOptionResponse(buildConfigOptions(sessionId), null);
+    }
+
+    /**
+     * Builds the dropdown advertisement for one session. Behavior, permission, and a flat
+     * model+reasoning dropdown are emitted via {@code configOptions} — IntelliJ hides the legacy
+     * {@code modes} / {@code models} channels once anything appears here, so every selector must
+     * come through this channel or it vanishes from the UI.
+     *
+     * <p>Model and reasoning are presented as a single flat list of {@code name/variant} entries
+     * because IntelliJ doesn't render the spec'd {@code thought_level} category yet. When it does,
+     * we should split this into two adjacent dropdowns to match the legacy two-picker UX.
+     */
+    private List<AcpProtocol.SessionConfigOption> buildConfigOptions(String sessionId) {
+        var currentBehavior = modeBySession.getOrDefault(sessionId, "LUTZ");
+        return List.of(
+                behaviorConfigOption(currentBehavior),
+                permissionConfigOption(permissionModeFor(sessionId)),
+                modelConfigOption(sessionId));
+    }
+
+    private AcpProtocol.SessionConfigOption modelConfigOption(String sessionId) {
+        var service = bundleForSession(sessionId).cm().getService();
+        var availableModels = service.getAvailableModels();
+
+        var options = new ArrayList<AcpProtocol.SessionConfigSelectOption>();
+        availableModels.keySet().stream().sorted().forEach(name -> {
+            options.add(new AcpProtocol.SessionConfigSelectOption(name, name, null));
+            for (var level : List.of("low", "medium", "high", "disable")) {
+                options.add(new AcpProtocol.SessionConfigSelectOption(
+                        name + "/" + level, name + " (" + level + ")", null));
+            }
+        });
+        if (options.isEmpty()) {
+            options.add(new AcpProtocol.SessionConfigSelectOption("default", "Default Model", null));
+        }
+
+        var baseModel = modelBySession.getOrDefault(sessionId, defaultModelId);
+        var modelNames = availableModels.keySet();
+        if (!baseModel.isEmpty() && !modelNames.contains(baseModel) && !modelNames.isEmpty()) {
+            baseModel = modelNames.stream().sorted().findFirst().orElse(baseModel);
+        }
+        var reasoning = reasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL);
+        var currentValue = formatModelIdWithVariant(baseModel, reasoning);
+        if (currentValue.isBlank()) {
+            currentValue = options.getFirst().value();
+        }
+
+        return AcpProtocol.SessionConfigOption.select(
+                "model_selection",
+                "Model",
+                "Selects the LLM and reasoning effort for this session.",
+                "model",
+                currentValue,
+                List.copyOf(options));
+    }
+
+    private static AcpProtocol.SessionConfigOption behaviorConfigOption(String currentValue) {
+        var options = AVAILABLE_MODES.stream()
+                .map(m -> new AcpProtocol.SessionConfigSelectOption(m.id(), m.name(), m.description()))
+                .toList();
+        return AcpProtocol.SessionConfigOption.select(
+                "behavior_mode",
+                "Mode",
+                "Controls Brokk's overall behavior style for this session.",
+                currentValue,
+                options);
+    }
+
+    private static AcpProtocol.SessionConfigOption permissionConfigOption(PermissionMode current) {
+        var options = List.of(
+                new AcpProtocol.SessionConfigSelectOption(
+                        "default", "Default", "Ask for permission before each tool call"),
+                new AcpProtocol.SessionConfigSelectOption(
+                        "acceptEdits", "Accept Edits", "Auto-allow edits; ask for everything else"),
+                new AcpProtocol.SessionConfigSelectOption(
+                        "readOnly", "Read-only", "Refuse every edit, deletion, move, or shell command"),
+                new AcpProtocol.SessionConfigSelectOption(
+                        "bypassPermissions",
+                        "Bypass Permissions",
+                        "Allow all tool calls without prompting (use with care)"));
+        return AcpProtocol.SessionConfigOption.select(
+                "permission_mode",
+                "Permission",
+                "Controls which tool calls require user approval.",
+                current.asString(),
+                options);
     }
 
     public AcpSchema.SetSessionModelResponse setModel(AcpSchema.SetSessionModelRequest request) {

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -520,8 +520,7 @@ public class BrokkAcpAgent {
             reasoningBySession.put(
                     forkSessionId, reasoningBySession.getOrDefault(request.sessionId(), defaultReasoningLevel));
             permissionModeBySession.put(
-                    forkSessionId,
-                    permissionModeBySession.getOrDefault(request.sessionId(), PermissionMode.DEFAULT));
+                    forkSessionId, permissionModeBySession.getOrDefault(request.sessionId(), PermissionMode.DEFAULT));
             // Inherit MCP servers from parent unless the fork request supplies a fresh list.
             if (request.mcpServers() != null) {
                 applySessionMcpServers(forkSessionId, request.mcpServers());
@@ -677,9 +676,8 @@ public class BrokkAcpAgent {
             case "permission_mode" -> {
                 var parsed = PermissionMode.parse(value);
                 if (parsed.isEmpty()) {
-                    throw new IllegalArgumentException(
-                            "Unknown permission mode '" + value
-                                    + "'. Supported: default, acceptEdits, readOnly, bypassPermissions");
+                    throw new IllegalArgumentException("Unknown permission mode '" + value
+                            + "'. Supported: default, acceptEdits, readOnly, bypassPermissions");
                 }
                 permissionModeBySession.put(sessionId, parsed.get());
             }
@@ -688,15 +686,16 @@ public class BrokkAcpAgent {
                 if (!validMode) {
                     throw new IllegalArgumentException("Unknown behavior mode '" + value
                             + "'. Supported: "
-                            + AVAILABLE_MODES.stream().map(AcpSchema.SessionMode::id).toList());
+                            + AVAILABLE_MODES.stream()
+                                    .map(AcpSchema.SessionMode::id)
+                                    .toList());
                 }
                 setMode(new AcpSchema.SetSessionModeRequest(sessionId, value));
             }
             case "model_selection" -> setModel(new AcpSchema.SetSessionModelRequest(sessionId, value));
             default ->
-                throw new IllegalArgumentException(
-                        "Unknown configId '" + configId
-                                + "'. Supported: permission_mode, behavior_mode, model_selection");
+                throw new IllegalArgumentException("Unknown configId '" + configId
+                        + "'. Supported: permission_mode, behavior_mode, model_selection");
         }
         return new AcpProtocol.SetSessionConfigOptionResponse(buildConfigOptions(sessionId), null);
     }
@@ -727,8 +726,8 @@ public class BrokkAcpAgent {
         availableModels.keySet().stream().sorted().forEach(name -> {
             options.add(new AcpProtocol.SessionConfigSelectOption(name, name, null));
             for (var level : List.of("low", "medium", "high", "disable")) {
-                options.add(new AcpProtocol.SessionConfigSelectOption(
-                        name + "/" + level, name + " (" + level + ")", null));
+                options.add(
+                        new AcpProtocol.SessionConfigSelectOption(name + "/" + level, name + " (" + level + ")", null));
             }
         });
         if (options.isEmpty()) {

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpRuntime.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpRuntime.java
@@ -79,6 +79,10 @@ final class BrokkAcpRuntime implements AutoCloseable {
             var request = unmarshal(params, new TypeRef<AcpSchema.SetSessionModelRequest>() {});
             return Mono.fromCallable(() -> agent.setModel(request));
         });
+        handlers.put(AcpProtocol.METHOD_SESSION_SET_CONFIG_OPTION, params -> {
+            var request = unmarshal(params, new TypeRef<AcpProtocol.SetSessionConfigOptionRequest>() {});
+            return Mono.fromCallable(() -> agent.setSessionConfigOption(request));
+        });
         return handlers;
     }
 

--- a/app/src/main/java/ai/brokk/acp/PermissionGate.java
+++ b/app/src/main/java/ai/brokk/acp/PermissionGate.java
@@ -1,0 +1,120 @@
+package ai.brokk.acp;
+
+import com.agentclientprotocol.sdk.spec.AcpSchema;
+
+/**
+ * Pure permission-gate logic. Given a session's {@link PermissionMode} and the kind/name of the
+ * tool being invoked, decides whether to auto-allow, auto-reject, or escalate to a per-call prompt.
+ * Mirrors {@code brokk-acp-rust/src/tool_loop.rs:pure_gate_decision}.
+ *
+ * <p>The decision is intentionally separate from {@link AcpRequestContext#askPermission} so it can
+ * be unit-tested without spinning up a transport.
+ */
+final class PermissionGate {
+    private PermissionGate() {}
+
+    /** Outcome returned by {@link #decide}. */
+    enum Outcome {
+        ALLOW,
+        REJECT,
+        PROMPT
+    }
+
+    /** Reason text shown to the user when {@code READ_ONLY} rejects a call. */
+    static final String READ_ONLY_REJECTION =
+            """
+            Tool use denied: read-only mode forbids edits, deletions, moves, shell execution, \
+            and any tool not classified as read/search/think/fetch. \
+            Switch the Permission menu to 'default' or 'acceptEdits' to run this tool.""";
+
+    /**
+     * Tools that must always escalate per call regardless of the always-allow cache. {@code "shell"}
+     * is here because the cache key is the literal string "shell" and one approval would otherwise
+     * blanket-allow every future shell command in the session.
+     */
+    private static boolean requiresPerCallPrompt(String toolName) {
+        return "shell".equals(toolName);
+    }
+
+    /**
+     * Returns the gate's outcome for the given mode/kind/tool/cache-state combination.
+     *
+     * @param isAlwaysAllowed {@code true} iff the user has previously chosen "Always allow" for
+     *     this tool in this session (i.e. the sticky cache holds an ALLOW verdict).
+     */
+    static Outcome decide(PermissionMode mode, AcpSchema.ToolKind kind, String toolName, boolean isAlwaysAllowed) {
+        // BYPASS_PERMISSIONS: trust everything. Explicit user opt-out of the gate.
+        if (mode == PermissionMode.BYPASS_PERMISSIONS) {
+            return Outcome.ALLOW;
+        }
+
+        // READ_ONLY: only allow strictly informational kinds. OTHER (Bifrost-loaded tools we
+        // haven't classified) is refused so the user-visible "no edits/exec" promise actually
+        // holds. Also refused even if always-allow was set, because READ_ONLY is a hard brake.
+        if (mode == PermissionMode.READ_ONLY && !isReadOnlyKind(kind)) {
+            return Outcome.REJECT;
+        }
+
+        // Mode-independent auto-allow: pure-info kinds never mutate.
+        if (isReadOnlyKind(kind)) {
+            return Outcome.ALLOW;
+        }
+
+        // ACCEPT_EDITS auto-allows EDIT but still gates EXECUTE/OTHER.
+        if (mode == PermissionMode.ACCEPT_EDITS && kind == AcpSchema.ToolKind.EDIT) {
+            return Outcome.ALLOW;
+        }
+
+        // In-session "Always allow" cache, except for tools where one approval would be carte
+        // blanche (currently {@code "shell"}).
+        if (!requiresPerCallPrompt(toolName) && isAlwaysAllowed) {
+            return Outcome.ALLOW;
+        }
+
+        return Outcome.PROMPT;
+    }
+
+    private static boolean isReadOnlyKind(AcpSchema.ToolKind kind) {
+        return kind == AcpSchema.ToolKind.READ
+                || kind == AcpSchema.ToolKind.SEARCH
+                || kind == AcpSchema.ToolKind.THINK
+                || kind == AcpSchema.ToolKind.FETCH;
+    }
+
+    /**
+     * Classifies a Brokk tool name into an {@link AcpSchema.ToolKind}. Mirrors the categorization
+     * already used by {@link AcpConsoleIO} for {@code tool_call} notifications, so the gate and the
+     * UI agree on a tool's nature.
+     */
+    static AcpSchema.ToolKind classify(String toolName) {
+        return switch (toolName) {
+            case "shell" -> AcpSchema.ToolKind.EXECUTE;
+            case "searchAgent" -> AcpSchema.ToolKind.SEARCH;
+            case "createOrReplaceTaskList" -> AcpSchema.ToolKind.THINK;
+            default -> classifyByPrefix(toolName);
+        };
+    }
+
+    private static AcpSchema.ToolKind classifyByPrefix(String toolName) {
+        if (toolName.startsWith("search") || toolName.startsWith("find")) {
+            return AcpSchema.ToolKind.SEARCH;
+        }
+        if (toolName.startsWith("get")
+                || toolName.startsWith("list")
+                || toolName.startsWith("skim")
+                || toolName.startsWith("explain")
+                || toolName.startsWith("read")
+                || toolName.startsWith("scan")) {
+            return AcpSchema.ToolKind.READ;
+        }
+        if (toolName.startsWith("add")
+                || toolName.startsWith("drop")
+                || toolName.startsWith("replace")
+                || toolName.startsWith("edit")
+                || toolName.startsWith("write")
+                || toolName.startsWith("create")) {
+            return AcpSchema.ToolKind.EDIT;
+        }
+        return AcpSchema.ToolKind.OTHER;
+    }
+}

--- a/app/src/main/java/ai/brokk/acp/PermissionMode.java
+++ b/app/src/main/java/ai/brokk/acp/PermissionMode.java
@@ -1,0 +1,38 @@
+package ai.brokk.acp;
+
+import java.util.Optional;
+
+/**
+ * Per-session permission policy. Mirrors {@code claude-agent-acp}'s four reference modes and
+ * Brokk's Rust ACP server (see {@code brokk-acp-rust/src/session.rs:54-83}); the Java agent
+ * surfaces it to clients as a {@code SessionConfigOption} dropdown independent of {@code SessionMode}.
+ *
+ * <p>{@link #READ_ONLY} is renamed from the reference's "plan" to avoid colliding with Brokk's PLAN
+ * behavior mode (LUTZ/CODE/ASK/PLAN), which is a separate dropdown.
+ */
+enum PermissionMode {
+    DEFAULT("default"),
+    ACCEPT_EDITS("acceptEdits"),
+    READ_ONLY("readOnly"),
+    BYPASS_PERMISSIONS("bypassPermissions");
+
+    private final String wireId;
+
+    PermissionMode(String wireId) {
+        this.wireId = wireId;
+    }
+
+    /** Wire id, matching {@code session/set_config_option} value strings the Rust server uses. */
+    String asString() {
+        return wireId;
+    }
+
+    static Optional<PermissionMode> parse(String s) {
+        for (var mode : values()) {
+            if (mode.wireId.equals(s)) {
+                return Optional.of(mode);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -741,8 +741,7 @@ class BrokkAcpAgentTest {
     void gateBypassAllowsEverything() {
         assertEquals(
                 PermissionGate.Outcome.ALLOW,
-                PermissionGate.decide(
-                        PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EDIT, "editFile", false));
+                PermissionGate.decide(PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EDIT, "editFile", false));
         assertEquals(
                 PermissionGate.Outcome.ALLOW,
                 PermissionGate.decide(PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EXECUTE, "shell", false));
@@ -880,8 +879,8 @@ class BrokkAcpAgentTest {
         var captured = new ArrayList<AcpSchema.SessionUpdate>();
         agent.setSessionUpdateSender((sessionId, update) -> captured.add(update));
 
-        var resp = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
-                created.sessionId(), "behavior_mode", "ASK", null));
+        var resp = agent.setSessionConfigOption(
+                new AcpProtocol.SetSessionConfigOptionRequest(created.sessionId(), "behavior_mode", "ASK", null));
 
         // Existing setMode logic must have stored the new mode and emitted current_mode_update.
         var modeUpdates = captured.stream()

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -700,7 +700,7 @@ class BrokkAcpAgentTest {
                     AcpSchema.METHOD_SESSION_NEW,
                     "new",
                     Map.of("cwd", projectRoot.toString(), "mcpServers", List.of()));
-            var newSessionResult = assertInstanceOf(AcpSchema.NewSessionResponse.class, newSession.result());
+            var newSessionResult = assertInstanceOf(AcpProtocol.NewSessionResponseExt.class, newSession.result());
 
             var list =
                     transport.exchange(AcpProtocol.METHOD_SESSION_LIST, "list", Map.of("cwd", projectRoot.toString()));
@@ -723,6 +723,336 @@ class BrokkAcpAgentTest {
                     "fork",
                     Map.of("sessionId", newSessionResult.sessionId(), "cwd", projectRoot.toString()));
             assertInstanceOf(AcpProtocol.ForkSessionResponse.class, fork.result());
+        }
+    }
+
+    // ---- PermissionMode and gate ----
+
+    @Test
+    void permissionModeParseRoundTrip() {
+        for (var mode : PermissionMode.values()) {
+            assertEquals(mode, PermissionMode.parse(mode.asString()).orElseThrow());
+        }
+        assertTrue(PermissionMode.parse("not-a-mode").isEmpty());
+        assertTrue(PermissionMode.parse("").isEmpty());
+    }
+
+    @Test
+    void gateBypassAllowsEverything() {
+        assertEquals(
+                PermissionGate.Outcome.ALLOW,
+                PermissionGate.decide(
+                        PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EDIT, "editFile", false));
+        assertEquals(
+                PermissionGate.Outcome.ALLOW,
+                PermissionGate.decide(PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EXECUTE, "shell", false));
+        assertEquals(
+                PermissionGate.Outcome.ALLOW,
+                PermissionGate.decide(PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.OTHER, "weird", false));
+    }
+
+    @Test
+    void gateReadOnlyRejectsEditExecuteAndOther() {
+        assertEquals(
+                PermissionGate.Outcome.REJECT,
+                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EDIT, "editFile", false));
+        assertEquals(
+                PermissionGate.Outcome.REJECT,
+                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EXECUTE, "shell", false));
+        assertEquals(
+                PermissionGate.Outcome.REJECT,
+                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.OTHER, "weird", false));
+        // Always-allow does not lift the read-only brake.
+        assertEquals(
+                PermissionGate.Outcome.REJECT,
+                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EDIT, "editFile", true));
+    }
+
+    @Test
+    void gateReadOnlyAllowsInformationalKinds() {
+        for (var k : List.of(
+                AcpSchema.ToolKind.READ,
+                AcpSchema.ToolKind.SEARCH,
+                AcpSchema.ToolKind.THINK,
+                AcpSchema.ToolKind.FETCH)) {
+            assertEquals(
+                    PermissionGate.Outcome.ALLOW,
+                    PermissionGate.decide(PermissionMode.READ_ONLY, k, "anything", false),
+                    "READ_ONLY must allow " + k);
+        }
+    }
+
+    @Test
+    void gateAcceptEditsAllowsEditButPromptsExecute() {
+        assertEquals(
+                PermissionGate.Outcome.ALLOW,
+                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.EDIT, "editFile", false));
+        assertEquals(
+                PermissionGate.Outcome.PROMPT,
+                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.EXECUTE, "shell", false));
+        assertEquals(
+                PermissionGate.Outcome.PROMPT,
+                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.OTHER, "weird", false));
+    }
+
+    @Test
+    void gateDefaultPromptsExceptForReadOnlyKinds() {
+        assertEquals(
+                PermissionGate.Outcome.ALLOW,
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.READ, "readFile", false));
+        assertEquals(
+                PermissionGate.Outcome.PROMPT,
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EDIT, "editFile", false));
+        assertEquals(
+                PermissionGate.Outcome.PROMPT,
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EXECUTE, "shell", false));
+    }
+
+    @Test
+    void gateAlwaysAllowSkipsPromptExceptForShell() {
+        // Always-allow short-circuits the prompt for cacheable tools…
+        assertEquals(
+                PermissionGate.Outcome.ALLOW,
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EDIT, "editFile", true));
+        // …but never for shell, where one approval would blanket-allow every future shell command.
+        assertEquals(
+                PermissionGate.Outcome.PROMPT,
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EXECUTE, "shell", true));
+    }
+
+    @Test
+    void gateClassifiesBrokkToolNames() {
+        assertEquals(AcpSchema.ToolKind.EXECUTE, PermissionGate.classify("shell"));
+        assertEquals(AcpSchema.ToolKind.SEARCH, PermissionGate.classify("searchAgent"));
+        assertEquals(AcpSchema.ToolKind.SEARCH, PermissionGate.classify("findFiles"));
+        assertEquals(AcpSchema.ToolKind.READ, PermissionGate.classify("getSummaries"));
+        assertEquals(AcpSchema.ToolKind.READ, PermissionGate.classify("listFiles"));
+        assertEquals(AcpSchema.ToolKind.EDIT, PermissionGate.classify("addFiles"));
+        assertEquals(AcpSchema.ToolKind.EDIT, PermissionGate.classify("replaceText"));
+        assertEquals(AcpSchema.ToolKind.THINK, PermissionGate.classify("createOrReplaceTaskList"));
+        assertEquals(AcpSchema.ToolKind.OTHER, PermissionGate.classify("totallyUnknown"));
+    }
+
+    // ---- session/set_config_option handler ----
+
+    @Test
+    void newSessionAdvertisesBothDropdowns() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        assertNotNull(created.configOptions());
+        // All three selectors must come through configOptions. IntelliJ hides legacy `modes` and
+        // `models` channels once configOptions is non-empty, so dropping any of these would make
+        // the corresponding toolbar element vanish.
+        assertEquals(
+                List.of("behavior_mode", "permission_mode", "model_selection"),
+                created.configOptions().stream()
+                        .map(AcpProtocol.SessionConfigOption::id)
+                        .toList());
+
+        var behavior = created.configOptions().stream()
+                .filter(o -> "behavior_mode".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("LUTZ", behavior.currentValue());
+        assertEquals("select", behavior.type());
+        assertEquals(
+                List.of("LUTZ", "CODE", "ASK", "PLAN"),
+                behavior.options().stream()
+                        .map(AcpProtocol.SessionConfigSelectOption::value)
+                        .toList());
+
+        var permission = created.configOptions().stream()
+                .filter(o -> "permission_mode".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("default", permission.currentValue());
+        assertEquals("select", permission.type());
+        assertEquals(
+                List.of("default", "acceptEdits", "readOnly", "bypassPermissions"),
+                permission.options().stream()
+                        .map(AcpProtocol.SessionConfigSelectOption::value)
+                        .toList());
+    }
+
+    @Test
+    void setSessionConfigOptionRoutesBehaviorMode() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var captured = new ArrayList<AcpSchema.SessionUpdate>();
+        agent.setSessionUpdateSender((sessionId, update) -> captured.add(update));
+
+        var resp = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "behavior_mode", "ASK", null));
+
+        // Existing setMode logic must have stored the new mode and emitted current_mode_update.
+        var modeUpdates = captured.stream()
+                .filter(AcpSchema.CurrentModeUpdate.class::isInstance)
+                .map(AcpSchema.CurrentModeUpdate.class::cast)
+                .toList();
+        assertEquals(1, modeUpdates.size());
+        assertEquals("ASK", modeUpdates.getFirst().currentModeId());
+
+        var behavior = resp.configOptions().stream()
+                .filter(o -> "behavior_mode".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("ASK", behavior.currentValue());
+    }
+
+    @Test
+    void newSessionAdvertisesModelDropdownWithModelCategory() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var model = created.configOptions().stream()
+                .filter(o -> "model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("model", model.category());
+        assertEquals("select", model.type());
+        assertNotNull(model.currentValue());
+        assertFalse(model.options().isEmpty());
+    }
+
+    @Test
+    void setSessionConfigOptionRejectsUnknownBehaviorMode() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                        created.sessionId(), "behavior_mode", "BOGUS", null)));
+    }
+
+    @Test
+    void setSessionConfigOptionStoresPermissionMode() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        var resp = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "permission_mode", "acceptEdits", null));
+
+        assertEquals(PermissionMode.ACCEPT_EDITS, agent.permissionModeFor(created.sessionId()));
+        var permission = resp.configOptions().stream()
+                .filter(o -> "permission_mode".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("acceptEdits", permission.currentValue());
+    }
+
+    @Test
+    void setSessionConfigOptionRejectsUnknownValue() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var ex = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                        created.sessionId(), "permission_mode", "bogus", null)));
+        assertTrue(ex.getMessage().contains("Unknown permission mode"));
+    }
+
+    @Test
+    void setSessionConfigOptionRejectsUnknownConfigId() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                        created.sessionId(), "made_up", "default", null)));
+    }
+
+    @Test
+    void runtimeRoutesSetSessionConfigOption() {
+        var transport = new FakeTransport();
+        try (var runtime = new BrokkAcpRuntime(transport, agent)) {
+            transport.exchange(AcpSchema.METHOD_INITIALIZE, "init", Map.of("protocolVersion", 1));
+            var newSession = transport.exchange(
+                    AcpSchema.METHOD_SESSION_NEW,
+                    "new",
+                    Map.of("cwd", projectRoot.toString(), "mcpServers", List.of()));
+            var sessionId = ((AcpProtocol.NewSessionResponseExt) newSession.result()).sessionId();
+
+            var setConfig = transport.exchange(
+                    AcpProtocol.METHOD_SESSION_SET_CONFIG_OPTION,
+                    "setcfg",
+                    Map.of("sessionId", sessionId, "configId", "permission_mode", "value", "readOnly"));
+            assertNull(setConfig.error());
+            var result = assertInstanceOf(AcpProtocol.SetSessionConfigOptionResponse.class, setConfig.result());
+            assertEquals(
+                    "readOnly",
+                    result.configOptions().stream()
+                            .filter(o -> "permission_mode".equals(o.id()))
+                            .findFirst()
+                            .orElseThrow()
+                            .currentValue());
+            assertEquals(PermissionMode.READ_ONLY, agent.permissionModeFor(sessionId));
+        }
+    }
+
+    // ---- askPermission honors PermissionMode ----
+
+    @Test
+    void askPermissionShortCircuitsUnderBypass() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "permission_mode", "bypassPermissions", null));
+
+        try (var fixture = new PermissionFixture()) {
+            var calls = new java.util.concurrent.atomic.AtomicInteger();
+            fixture.transport.respondTo(AcpSchema.METHOD_SESSION_REQUEST_PERMISSION, params -> {
+                calls.incrementAndGet();
+                return new AcpSchema.RequestPermissionResponse(
+                        new AcpSchema.PermissionSelected("selected", "reject_once"));
+            });
+
+            var ctx = fixture.contextFor(created.sessionId());
+            assertTrue(ctx.askPermission("Allow editFile?", "editFile"));
+            assertTrue(ctx.askPermission("Allow shell?", "shell"));
+            assertEquals(0, calls.get(), "BYPASS must not round-trip to client");
+        }
+    }
+
+    @Test
+    void askPermissionRejectsEditsUnderReadOnly() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "permission_mode", "readOnly", null));
+
+        try (var fixture = new PermissionFixture()) {
+            var calls = new java.util.concurrent.atomic.AtomicInteger();
+            fixture.transport.respondTo(AcpSchema.METHOD_SESSION_REQUEST_PERMISSION, params -> {
+                calls.incrementAndGet();
+                return new AcpSchema.RequestPermissionResponse(
+                        new AcpSchema.PermissionSelected("selected", "allow_once"));
+            });
+
+            var ctx = fixture.contextFor(created.sessionId());
+            assertFalse(ctx.askPermission("Allow editFile?", "editFile"));
+            assertFalse(ctx.askPermission("Allow shell?", "shell"));
+            assertTrue(ctx.askPermission("Allow readFile?", "readFile"));
+            assertEquals(0, calls.get(), "READ_ONLY must decide locally without round-tripping");
+
+            var sawDenialMessage = fixture.transport.sessionUpdates().stream()
+                    .anyMatch(n -> n.update() instanceof AcpSchema.AgentMessageChunk a
+                            && a.content() instanceof AcpSchema.TextContent t
+                            && t.text().contains("denied"));
+            assertTrue(sawDenialMessage, "user must see a denial chat message under READ_ONLY");
+        }
+    }
+
+    @Test
+    void askPermissionAutoAllowsEditsUnderAcceptEdits() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "permission_mode", "acceptEdits", null));
+
+        try (var fixture = new PermissionFixture()) {
+            var calls = new java.util.concurrent.atomic.AtomicInteger();
+            fixture.transport.respondTo(AcpSchema.METHOD_SESSION_REQUEST_PERMISSION, params -> {
+                calls.incrementAndGet();
+                return new AcpSchema.RequestPermissionResponse(
+                        new AcpSchema.PermissionSelected("selected", "allow_once"));
+            });
+
+            var ctx = fixture.contextFor(created.sessionId());
+            assertTrue(ctx.askPermission("Allow editFile?", "editFile"));
+            assertEquals(0, calls.get(), "ACCEPT_EDITS must not prompt for edits");
+
+            assertTrue(ctx.askPermission("Allow shell?", "shell"));
+            assertEquals(1, calls.get(), "ACCEPT_EDITS must still prompt for shell");
         }
     }
 


### PR DESCRIPTION
## Summary
- Mirrors the Rust ACP server's per-session permission policy on the native Java server (`PermissionMode`: default / acceptEdits / readOnly / bypassPermissions).
- Pure `PermissionGate.decide(mode, kind, toolName, alwaysAllowed)` consulted in `AcpRequestContext.askPermission` *before* the sticky cache, so `READ_ONLY` hard-rejects edits/exec even for previously-approved tools and `BYPASS_PERMISSIONS` skips the client round-trip entirely. Tool kind classification is shared with `AcpConsoleIO` via `PermissionGate.classify`.
- New `session/set_config_option` JSON-RPC handler routes `permission_mode`, `behavior_mode`, and `model_selection` to the right setter. Session responses now expose those three as `SessionConfigOption` dropdowns; clients (IntelliJ, Zed) hide the legacy `modes`/`models` channels once `configOptions` is non-empty, so all three selectors come through the new channel.
- `setModel` semantics unchanged from master.

Closes #3423.

## Test plan
- [x] 50+ ACP tests pass (`./gradlew :app:test --tests ai.brokk.acp.BrokkAcpAgentTest`), including new coverage for the `PermissionGate` decision matrix, parse round-trip, dropdown advertisement, and `askPermission` enforcement under each mode.
- [x] Smoke-tested in JetBrains: behavior, permission, and model dropdowns render and persist selections.
- [ ] Verify in Zed (mode/permission/model dropdowns visible).
- [x] Verified `READ_ONLY` in JetBrains: a `callCodeAgent` invocation was hard-rejected by the gate (`Terminal tool 'callCodeAgent' failed with status REQUEST_ERROR: Tool call 'callCodeAgent' was denied by user.`) — no permission prompt fired, the gate denied server-side as designed.
- [ ] Verify `BYPASS_PERMISSIONS` skips prompts during a destructive tool run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
