### PR TITLE
ACP: explicit status APIs + earlier callCodeAgent/context/model/title fixes

### DIFF
--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -36,6 +36,7 @@ import ai.brokk.gui.Chrome;
 import ai.brokk.project.AbstractProject;
 import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
+import ai.brokk.project.ModelProperties;
 import ai.brokk.prompts.SummarizerPrompts;
 import ai.brokk.tasks.TaskList;
 import ai.brokk.tools.*;
@@ -774,6 +775,11 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
     @Override
     public AbstractService getService() {
         return serviceProvider.get();
+    }
+
+    @Override
+    public StreamingChatModel getCodeModel() {
+        return getService().getModel(ModelProperties.ModelType.CODE);
     }
 
     @Override

--- a/app/src/main/java/ai/brokk/IConsoleIO.java
+++ b/app/src/main/java/ai/brokk/IConsoleIO.java
@@ -5,6 +5,7 @@ import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.context.Context;
 import ai.brokk.gui.InstructionsPanel;
 import ai.brokk.tools.ApprovalResult;
+import ai.brokk.tools.ExplanationRenderer;
 import ai.brokk.tools.ToolExecutionResult;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.ChatMessage;
@@ -66,6 +67,29 @@ public interface IConsoleIO {
     }
 
     void llmOutput(String token, ChatMessageType type, LlmOutputMeta meta);
+
+    /**
+     * Emit a structured status banner — a headline plus key/value details — to the user. The
+     * default implementation renders the banner via {@link ExplanationRenderer} and emits it
+     * through {@link #llmOutput} as an AI-typed chunk, preserving the legacy text-stream shape
+     * for GUI consoles. Consoles that support structured tool calls may override to emit a
+     * synthetic tool call directly, which avoids relying on downstream pattern matching of
+     * banner-shaped prose.
+     */
+    default void showStatusBanner(String headline, Map<String, Object> details) {
+        var formatted = ExplanationRenderer.renderExplanation(headline, details);
+        llmOutput(formatted, ChatMessageType.AI, LlmOutputMeta.newMessage());
+    }
+
+    /**
+     * Emit a compact, single-line status update (e.g. {@code "Code Agent finished — message"}).
+     * Default implementation forwards through {@link #llmOutput} as a CUSTOM chunk so the GUI
+     * keeps its existing rendering. Consoles that support structured tool calls may override
+     * to emit a title-only tool_call with empty content for an unobtrusive single-line display.
+     */
+    default void showStatusLine(String message) {
+        llmOutput("\n" + message + "\n", ChatMessageType.CUSTOM, LlmOutputMeta.newMessage());
+    }
 
     /**
      * default implementation just forwards to systemOutput but the Chrome GUI implementation wraps JOptionPane;

--- a/app/src/main/java/ai/brokk/SessionManager.java
+++ b/app/src/main/java/ai/brokk/SessionManager.java
@@ -337,7 +337,8 @@ public class SessionManager implements AutoCloseable {
                 String currentName = info.name();
                 boolean isDefaultName = currentName.equals("TUI Session")
                         || currentName.equals("New Session")
-                        || currentName.equals("Session");
+                        || currentName.equals("Session")
+                        || currentName.equals("ACP Session");
 
                 if (isDefaultName) {
                     String derived = deriveSessionName(taskInput);

--- a/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
+++ b/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.JOptionPane;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -36,6 +38,8 @@ import org.jetbrains.annotations.Nullable;
  * <p>Constructed per-prompt-turn and set as the active console on ContextManager.
  */
 public class AcpConsoleIO extends MemoryConsole {
+    private static final Logger logger = LogManager.getLogger(AcpConsoleIO.class);
+
     private final AcpPromptContext context;
     private final String sessionId;
 
@@ -47,6 +51,18 @@ public class AcpConsoleIO extends MemoryConsole {
 
     /** Tracks tool call ID for commandStart/commandResult lifecycle. */
     private volatile @Nullable String activeCommandToolCallId;
+
+    /**
+     * Per-stream state for suppressing SEARCH/REPLACE block content from agent_message_chunk.
+     * The canonical edit visualization is delivered via {@link #afterFileEdits}'s
+     * tool_call_update with structured diff content; the raw SR prose duplicates that.
+     */
+    private final StringBuilder lineBuffer = new StringBuilder();
+
+    private boolean inSrBlock = false;
+
+    private static final String SR_START_PREFIX = "<<<<<<< SEARCH";
+    private static final String SR_END_PREFIX = ">>>>>>> REPLACE";
 
     /**
      * Tools whose result text is the agent's user-facing answer and is also streamed via
@@ -130,8 +146,55 @@ public class AcpConsoleIO extends MemoryConsole {
                 emitSyntheticToolCall(banner.get(), AcpSchema.ToolKind.THINK);
                 return;
             }
+            var filtered = filterSearchReplaceTokens(token);
+            if (!filtered.isEmpty()) {
+                context.sendMessage(filtered);
+            }
+            return;
         }
         context.sendMessage(token);
+    }
+
+    /**
+     * Strip SEARCH/REPLACE block content from a streamed AI token. State is held across calls
+     * via {@link #lineBuffer} and {@link #inSrBlock}.
+     *
+     * <p>Detection is line-based: a line starting with {@link #SR_START_PREFIX} opens the block;
+     * a line starting with {@link #SR_END_PREFIX} closes it. Lines between (and the marker
+     * lines themselves) are dropped. No placeholder is emitted; the structured edit visualization
+     * comes from {@link #afterFileEdits}'s tool_call_update.
+     *
+     * <p>Prose outside SR blocks streams through char-by-char, except a partial line starting
+     * with {@code '<'} or {@code '>'} is buffered until newline so a forming SR marker isn't
+     * accidentally emitted.
+     */
+    private synchronized String filterSearchReplaceTokens(String token) {
+        var out = new StringBuilder();
+        for (int i = 0; i < token.length(); i++) {
+            char c = token.charAt(i);
+            if (c == '\n') {
+                String line = lineBuffer.toString();
+                lineBuffer.setLength(0);
+                String trimmed = line.stripTrailing();
+                if (!inSrBlock && trimmed.startsWith(SR_START_PREFIX)) {
+                    inSrBlock = true;
+                } else if (inSrBlock && trimmed.startsWith(SR_END_PREFIX)) {
+                    inSrBlock = false;
+                } else if (!inSrBlock) {
+                    out.append(line).append('\n');
+                }
+            } else {
+                lineBuffer.append(c);
+                if (!inSrBlock) {
+                    char first = lineBuffer.charAt(0);
+                    if (first != '<' && first != '>') {
+                        out.append(lineBuffer);
+                        lineBuffer.setLength(0);
+                    }
+                }
+            }
+        }
+        return out.toString();
     }
 
     /**
@@ -193,10 +256,31 @@ public class AcpConsoleIO extends MemoryConsole {
             if (!approved) {
                 pendingToolKinds.remove(toolCallId);
                 pendingToolTitles.remove(toolCallId);
+                emitDeniedToolCallUpdate(toolCallId, title, kind);
             }
             return approved ? ApprovalResult.APPROVED : ApprovalResult.DENIED;
         }
         return ApprovalResult.APPROVED;
+    }
+
+    /**
+     * Emit a terminal {@code tool_call_update} with status FAILED so the client has a signal that
+     * the originally-requested tool call won't proceed. Clients that bind a permission dialog to
+     * the tool-call lifecycle can dismiss the dialog on this update.
+     */
+    private void emitDeniedToolCallUpdate(String toolCallId, String title, AcpSchema.ToolKind kind) {
+        var failed = new AcpSchema.ToolCallUpdateNotification(
+                "tool_call_update",
+                toolCallId,
+                title,
+                kind,
+                AcpSchema.ToolCallStatus.FAILED,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null);
+        context.sendUpdate(sessionId, failed);
     }
 
     @Override
@@ -223,6 +307,7 @@ public class AcpConsoleIO extends MemoryConsole {
         if (!approved) {
             pendingToolKinds.remove(toolCallId);
             pendingToolTitles.remove(toolCallId);
+            emitDeniedToolCallUpdate(toolCallId, title, AcpSchema.ToolKind.EXECUTE);
         }
         return approved ? ApprovalResult.APPROVED : ApprovalResult.DENIED;
     }
@@ -288,6 +373,12 @@ public class AcpConsoleIO extends MemoryConsole {
                 ? AcpSchema.ToolCallStatus.COMPLETED
                 : AcpSchema.ToolCallStatus.FAILED;
         var toolId = result.toolId();
+        if (toolId == null) {
+            // Without a correlation id we have nothing to update, and ConcurrentHashMap operations
+            // below would NPE on a null key.
+            logger.warn("afterToolOutput called with null toolId for tool '{}' status={}", result.toolName(), status);
+            return;
+        }
         var kind = pendingToolKinds.getOrDefault(toolId, AcpSchema.ToolKind.OTHER);
         pendingToolKinds.remove(toolId);
         var title = pendingToolTitles.getOrDefault(toolId, displayTitle(result.toolName(), null));

--- a/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
+++ b/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
@@ -1,10 +1,12 @@
 package ai.brokk.acp;
 
 import ai.brokk.LlmOutputMeta;
+import ai.brokk.TaskEntry;
 import ai.brokk.agents.BlitzForge;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.cli.MemoryConsole;
 import ai.brokk.tools.ApprovalResult;
+import ai.brokk.tools.ExplanationRenderer;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.util.Json;
 import com.agentclientprotocol.sdk.spec.AcpSchema;
@@ -16,7 +18,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.UUID;
@@ -119,6 +120,18 @@ public class AcpConsoleIO extends MemoryConsole {
 
     // ---- Core LLM output ----
 
+    /**
+     * No-op: the user's prompt is already known to the client via the JSON-RPC
+     * {@code session/prompt} request. The default implementation re-emits the prompt as a
+     * CUSTOM-typed {@code <task sequence=N>...</task>} blob, which the synthetic tool_call
+     * path then renders with an XML-tag title that the client strips, producing an empty
+     * checkmark card.
+     */
+    @Override
+    public void setLlmAndHistoryOutput(List<TaskEntry> history, TaskEntry taskEntry) {
+        // intentionally empty
+    }
+
     @Override
     public void llmOutput(String token, ChatMessageType type, LlmOutputMeta meta) {
         super.llmOutput(token, type, meta);
@@ -133,19 +146,6 @@ public class AcpConsoleIO extends MemoryConsole {
             return;
         }
         if (type == ChatMessageType.AI) {
-            // Brokk's agents emit "**Brokk Context Engine** analyzing…" /
-            // "`Adding context to workspace`\n```yaml\n…" status banners as full-message AI
-            // emissions. Detect them by *complete* `**Header**` or `` `Header` `` shape with
-            // content after — this excludes streaming tokens (partial markers) and bare bold
-            // emphasis (no content after the closing marker), and catches banners regardless
-            // of the LlmOutputMeta.newMessage flag (which Brokk doesn't set consistently).
-            // Final-answer text from terminal-answer tools is emitted as `# Answer\n\n…`
-            // (h1, not bold/backtick), so it doesn't match and continues flowing to chat.
-            var banner = tryDetectBanner(token);
-            if (banner.isPresent()) {
-                emitSyntheticToolCall(banner.get(), AcpSchema.ToolKind.THINK);
-                return;
-            }
             var filtered = filterSearchReplaceTokens(token);
             if (!filtered.isEmpty()) {
                 context.sendMessage(filtered);
@@ -203,25 +203,35 @@ public class AcpConsoleIO extends MemoryConsole {
      * Empty when the text is normal chat content (incl. streaming tokens that are partial
      * markers, bare bold/code emphasis with no body, or h1/plain text).
      */
-    private static Optional<HeaderAndBody> tryDetectBanner(String text) {
-        var trimmed = text.strip();
-        Matcher m = BOLD_HEADER.matcher(trimmed);
-        if (m.matches()) {
-            var header = m.group(1).strip();
-            var rest = m.group(2).stripLeading();
-            if (!header.isBlank() && !rest.isBlank()) {
-                return Optional.of(new HeaderAndBody(header, rest));
-            }
-        }
-        m = BACKTICK_HEADER.matcher(trimmed);
-        if (m.matches()) {
-            var header = m.group(1).strip();
-            var rest = m.group(2).stripLeading();
-            if (!header.isBlank() && !rest.isBlank()) {
-                return Optional.of(new HeaderAndBody(header, rest));
-            }
-        }
-        return Optional.empty();
+    @Override
+    public void showStatusBanner(String headline, Map<String, Object> details) {
+        var body = "```yaml\n" + ExplanationRenderer.toYaml(details) + "```";
+        emitSyntheticToolCall(new HeaderAndBody(headline, body), AcpSchema.ToolKind.THINK);
+    }
+
+    @Override
+    public void showStatusLine(String message) {
+        emitCompactStatus(message, AcpSchema.ToolKind.THINK);
+    }
+
+    /**
+     * Emit a single completed {@link AcpSchema.ToolCall} carrying just a title — no body. The
+     * client renders this as a one-line entry alongside its peers (matching how
+     * {@code projectFinished} appears as a compact "Project complete" line).
+     */
+    private void emitCompactStatus(String title, AcpSchema.ToolKind kind) {
+        var toolCall = new AcpSchema.ToolCall(
+                "tool_call",
+                UUID.randomUUID().toString(),
+                title,
+                kind,
+                AcpSchema.ToolCallStatus.COMPLETED,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                Map.of("brokk", Map.of("synthetic", true)));
+        context.sendUpdate(sessionId, toolCall);
     }
 
     // ---- Tool call hooks ----
@@ -421,7 +431,7 @@ public class AcpConsoleIO extends MemoryConsole {
         if (role == NotificationRole.COST) {
             return;
         }
-        emitSyntheticToolCall(new HeaderAndBody("Notification", message), AcpSchema.ToolKind.OTHER);
+        emitCompactStatus(message, AcpSchema.ToolKind.OTHER);
     }
 
     @Override
@@ -440,6 +450,8 @@ public class AcpConsoleIO extends MemoryConsole {
 
     @Override
     public void toolError(String msg, String title) {
+        // Errors keep a body — the message can be multi-line stack traces or actionable detail
+        // that's harder to fit in a title alone.
         emitSyntheticToolCall(new HeaderAndBody("Error: " + title, msg), AcpSchema.ToolKind.OTHER);
     }
 
@@ -751,10 +763,31 @@ public class AcpConsoleIO extends MemoryConsole {
         if (unwrapped != null) {
             return truncate(unwrapped, MAX_RENDERED_BODY_BYTES);
         }
+        // Unwrap {"explanation": "<text>"} envelopes — the wrapping JSON is internal
+        // bookkeeping; the chat should show the explanation prose.
+        var explanation = unwrapExplanation(parsed);
+        if (explanation != null) {
+            return truncate(explanation, MAX_RENDERED_BODY_BYTES);
+        }
         if (parsed.isArray() && (kind == AcpSchema.ToolKind.SEARCH || kind == AcpSchema.ToolKind.READ)) {
             return renderArrayAsBullets(parsed);
         }
         return renderJsonAsCodeBlock(parsed);
+    }
+
+    /**
+     * If {@code node} matches {@code {"explanation": "<text>"}} (an object with a single
+     * textual {@code explanation} field), return the text; otherwise null.
+     */
+    private static @Nullable String unwrapExplanation(JsonNode node) {
+        if (!node.isObject() || node.size() != 1) {
+            return null;
+        }
+        var explanation = node.get("explanation");
+        if (explanation == null || !explanation.isTextual()) {
+            return null;
+        }
+        return explanation.asText();
     }
 
     private static @Nullable JsonNode tryParseJson(String text) {

--- a/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
@@ -107,12 +107,26 @@ final class AcpRequestContext implements AcpPromptContext {
                                         + "Treating as denied. Request: {}",
                                 PERMISSION_TIMEOUT,
                                 request);
-                        sendMessage("\n**Permission request timed out** after "
+                        // Compose the notification into the Mono chain — calling sendMessage()
+                        // here would invoke .block() on Reactor's parallel scheduler thread,
+                        // which Reactor forbids and would replace the timeout error with an
+                        // IllegalStateException.
+                        var timeoutText = "\n**Permission request timed out** after "
                                 + PERMISSION_TIMEOUT.toSeconds()
                                 + "s without a response from the client. Treating this tool call as denied. "
                                 + "If you did click Allow, the IDE may have failed to deliver the response — "
-                                + "check `~/.brokk/debug.log` for the `acp-agent-inbound` thread.\n");
-                        return Mono.just(new AcpSchema.RequestPermissionResponse(new AcpSchema.PermissionCancelled()));
+                                + "check `~/.brokk/debug.log` for the `acp-agent-inbound` thread.\n";
+                        var update = new AcpSchema.AgentMessageChunk(
+                                "agent_message_chunk", new AcpSchema.TextContent(timeoutText));
+                        return session.sendNotification(
+                                        AcpSchema.METHOD_SESSION_UPDATE,
+                                        new AcpSchema.SessionNotification(sessionId, update))
+                                .onErrorResume(t -> {
+                                    logger.warn("Failed to deliver timeout notification: {}", t.getMessage());
+                                    return Mono.empty();
+                                })
+                                .thenReturn(
+                                        new AcpSchema.RequestPermissionResponse(new AcpSchema.PermissionCancelled()));
                     })
                     .block());
         } finally {

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -1,5 +1,6 @@
 package ai.brokk.acp;
 
+import ai.brokk.AbstractService;
 import ai.brokk.BuildInfo;
 import ai.brokk.ContextManager;
 import ai.brokk.IAppContextManager;
@@ -15,6 +16,7 @@ import ai.brokk.mcpclient.HttpMcpServer;
 import ai.brokk.mcpclient.McpServer;
 import ai.brokk.mcpclient.McpUtils;
 import ai.brokk.mcpclient.StdioMcpServer;
+import ai.brokk.project.ModelProperties;
 import ai.brokk.tasks.TaskList;
 import ai.brokk.util.Messages;
 import com.agentclientprotocol.sdk.spec.AcpSchema;
@@ -54,6 +56,10 @@ public class BrokkAcpAgent {
     private static final String DEFAULT_REASONING_LEVEL = "medium";
     private static final String DEFAULT_REASONING_LEVEL_CODE = "disable";
     private static final Set<String> REASONING_LEVEL_IDS = Set.of("low", "medium", "high", "disable", "default");
+
+    private static final int MODEL_DISCOVERY_INITIAL_ATTEMPTS = 3;
+    private static final int MODEL_DISCOVERY_RECOVERY_ATTEMPTS = 2;
+    private static final long MODEL_DISCOVERY_INITIAL_BACKOFF_MS = 200;
     private static final Path ACP_SETTINGS_PATH =
             Path.of(System.getProperty("user.home"), ".brokk", "acp_settings.json");
 
@@ -94,6 +100,7 @@ public class BrokkAcpAgent {
     // Per-session state
     private final Map<String, String> modeBySession = new ConcurrentHashMap<>();
     private final Map<String, String> modelBySession = new ConcurrentHashMap<>();
+    private final Set<String> sessionsOnFallbackCatalog = ConcurrentHashMap.newKeySet();
     private final Map<String, String> reasoningBySession = new ConcurrentHashMap<>();
     private final Map<String, String> activeJobBySession = new ConcurrentHashMap<>();
     private final Map<String, Map<String, PermissionVerdict>> stickyPermissionsBySession = new ConcurrentHashMap<>();
@@ -256,6 +263,7 @@ public class BrokkAcpAgent {
         rejectedMcpServersBySession.clear();
         lastTaskListBySession.clear();
         pendingPlanBySession.clear();
+        sessionsOnFallbackCatalog.clear();
         bundleBySession.clear();
     }
 
@@ -485,6 +493,7 @@ public class BrokkAcpAgent {
         modelBySession.remove(sessionId);
         reasoningBySession.remove(sessionId);
         stickyPermissionsBySession.remove(sessionId);
+        sessionsOnFallbackCatalog.remove(sessionId);
         permissionModeBySession.remove(sessionId);
         mcpServersBySession.remove(sessionId);
         rejectedMcpServersBySession.remove(sessionId);
@@ -565,7 +574,8 @@ public class BrokkAcpAgent {
         var bundle = bundleOpt.get();
 
         // Handle slash commands
-        if (text.strip().toLowerCase(Locale.ROOT).startsWith("/context")) {
+        var firstWord = text.strip().split("\\s+", 2)[0].toLowerCase(Locale.ROOT);
+        if (firstWord.equals("/context")) {
             handleContextCommand(bundle, promptContext);
             return AcpSchema.PromptResponse.endTurn();
         }
@@ -580,6 +590,16 @@ public class BrokkAcpAgent {
             return AcpSchema.PromptResponse.endTurn();
         }
         bundle.cm().switchSessionAsync(target.get().id()).join();
+
+        // Best-effort auto-rename for sessions still on a placeholder name; uses the user's prompt.
+        try {
+            bundle.cm()
+                    .getProject()
+                    .getSessionManager()
+                    .autoRenameIfDefault(target.get().id(), text);
+        } catch (Exception e) {
+            logger.warn("Failed to auto-rename ACP session {}: {}", sessionId, e.getMessage());
+        }
 
         // Materialize @-mentioned files (resource_link / embedded resource blocks) into the
         // workspace so every mode -- especially ASK, which has no tool loop -- can see them.
@@ -803,7 +823,26 @@ public class BrokkAcpAgent {
         // Persist updated defaults
         saveAcpDefaults(parsed.baseModel, reasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL));
 
+        refreshCatalogIfFallback(sessionId);
+
         return new AcpSchema.SetSessionModelResponse();
+    }
+
+    /**
+     * If {@code sessionId} was last seen on the {@code BASE_MODEL_IDS} fallback catalog, re-attempts
+     * live discovery. Clears the fallback flag on success so the next {@link #buildModelState}
+     * returns the real catalog. Best-effort: silently no-ops if discovery still fails.
+     */
+    private void refreshCatalogIfFallback(String sessionId) {
+        if (!sessionsOnFallbackCatalog.contains(sessionId)) {
+            return;
+        }
+        var service = bundleForSession(sessionId).cm().getService();
+        var fresh = discoverModelsWithRetry(service, MODEL_DISCOVERY_RECOVERY_ATTEMPTS);
+        if (!fresh.isEmpty()) {
+            sessionsOnFallbackCatalog.remove(sessionId);
+            logger.info("Model catalog recovered for session {} after fallback ({} models)", sessionId, fresh.size());
+        }
     }
 
     /**
@@ -965,7 +1004,15 @@ public class BrokkAcpAgent {
 
     private AcpSchema.SessionModelState buildModelState(String sessionId) {
         var service = bundleForSession(sessionId).cm().getService();
-        var availableModels = service.getAvailableModels();
+        var availableModels = discoverModelsWithRetry(service, MODEL_DISCOVERY_INITIAL_ATTEMPTS);
+
+        if (availableModels.isEmpty()) {
+            availableModels = ModelProperties.BASE_MODEL_IDS.stream().collect(Collectors.toMap(id -> id, id -> id));
+            sessionsOnFallbackCatalog.add(sessionId);
+            logger.warn("Model discovery returned no models; using BASE_MODEL_IDS fallback for session {}", sessionId);
+        } else {
+            sessionsOnFallbackCatalog.remove(sessionId);
+        }
 
         // Build model list with reasoning variants (model/low, model/medium, model/high, etc.)
         var models = new ArrayList<AcpSchema.ModelInfo>();
@@ -975,10 +1022,6 @@ public class BrokkAcpAgent {
                 models.add(new AcpSchema.ModelInfo(name + "/" + level, name + " (" + level + ")", null));
             }
         });
-
-        if (models.isEmpty()) {
-            models.add(new AcpSchema.ModelInfo("default", "Default Model", null));
-        }
 
         // Resolve current model, preferring persisted default for new sessions
         var baseModel = modelBySession.getOrDefault(sessionId, defaultModelId);
@@ -994,6 +1037,32 @@ public class BrokkAcpAgent {
         var currentModelId = formatModelIdWithVariant(baseModel, reasoning);
 
         return new AcpSchema.SessionModelState(currentModelId, List.copyOf(models));
+    }
+
+    /**
+     * Calls {@code service.getAvailableModels()} with bounded exponential backoff. Returns the
+     * first non-empty result, or an empty map if all attempts return empty. Backoff sequence is
+     * {@link #MODEL_DISCOVERY_INITIAL_BACKOFF_MS} doubling per retry.
+     */
+    private static Map<String, String> discoverModelsWithRetry(AbstractService service, int attempts) {
+        long backoff = MODEL_DISCOVERY_INITIAL_BACKOFF_MS;
+        Map<String, String> latest = Map.of();
+        for (int i = 0; i < attempts; i++) {
+            latest = service.getAvailableModels();
+            if (!latest.isEmpty()) {
+                return latest;
+            }
+            if (i < attempts - 1) {
+                try {
+                    Thread.sleep(backoff);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return latest;
+                }
+                backoff *= 2;
+            }
+        }
+        return latest;
     }
 
     private Map<String, Object> buildVariantMeta(String sessionId) {

--- a/app/src/main/java/ai/brokk/agents/CodeAgent.java
+++ b/app/src/main/java/ai/brokk/agents/CodeAgent.java
@@ -744,16 +744,13 @@ public class CodeAgent {
 
     void report(String message) {
         logger.debug(message);
-        io.llmOutput("\n" + message, ChatMessageType.CUSTOM, LlmOutputMeta.newMessage());
+        io.showStatusLine(message);
     }
 
     void reportComplete(TaskResult.StopReason reason, String message) {
         logger.debug(message);
         var badge = StatusBadge.badgeFor(reason);
-        io.llmOutput(
-                "\n## Code Agent Finished\n" + badge + "\n\n**Reason:** " + message,
-                ChatMessageType.CUSTOM,
-                LlmOutputMeta.newMessage());
+        io.showStatusLine(badge + " Code Agent finished — " + message);
     }
 
     Step parsePhase(

--- a/app/src/main/java/ai/brokk/agents/LutzAgent.java
+++ b/app/src/main/java/ai/brokk/agents/LutzAgent.java
@@ -31,7 +31,6 @@ import ai.brokk.prompts.SearchPrompts.Objective;
 import ai.brokk.prompts.SearchPrompts.Terminal;
 import ai.brokk.tools.DependencyTools;
 import ai.brokk.tools.Destructive;
-import ai.brokk.tools.ExplanationRenderer;
 import ai.brokk.tools.ParallelSearch;
 import ai.brokk.tools.SearchTools;
 import ai.brokk.tools.ToolExecutionHelper;
@@ -772,8 +771,7 @@ public class LutzAgent {
             details.put("fragments", descriptions);
         }
 
-        var explanation = ExplanationRenderer.renderExplanation("Adding context to workspace", details);
-        io.llmOutput(explanation, ChatMessageType.AI, LlmOutputMeta.DEFAULT);
+        io.showStatusBanner("Adding context to workspace", details);
     }
 
     // public for ToolRegistry
@@ -1860,9 +1858,6 @@ public class LutzAgent {
     void reportComplete(TaskResult.StopReason reason, String message) {
         logger.debug("SearchAgent completed: {}: {}", reason, message);
         var badge = StatusBadge.badgeFor(reason);
-        io.llmOutput(
-                "\n## Search Agent Finished\n" + badge + "\n\n**Reason:** " + message,
-                ChatMessageType.CUSTOM,
-                LlmOutputMeta.DEFAULT);
+        io.showStatusLine(badge + " Search Agent finished — " + message);
     }
 }

--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -537,7 +537,9 @@ public class SearchAgent {
 
         var details = jsonWithFragmentIds(List.copyOf(acceptedIds));
         var stopDetails = new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, details);
-        io.llmOutput(details, ChatMessageType.AI, LlmOutputMeta.newMessage());
+        // The wrapping workspaceComplete tool_call_update already produces a compact
+        // "Workspace ready" card via displayTitle — emitting an extra banner here just
+        // duplicates the entry with a verbose body.
         return new TerminalStopOutput(details, stopDetails);
     }
 

--- a/app/src/main/java/ai/brokk/project/ModelProperties.java
+++ b/app/src/main/java/ai/brokk/project/ModelProperties.java
@@ -33,6 +33,9 @@ public final class ModelProperties {
     public static final String GPT_5_1_CODEX_MINI_OAUTH = "gpt-5.1-codex-mini-oauth";
     public static final String GPT_5_3_CODEX_OAUTH = "gpt-5.3-codex-oauth";
 
+    /** Hardcoded fallback used when live model-catalog discovery returns empty (e.g., startup races). */
+    public static final List<String> BASE_MODEL_IDS = List.of(GPT_5_3_CODEX, FLASH_3);
+
     // Common configurations. Note that we override thinking levels in some cases for speed.
     private static final ModelConfig gpt5_4NanoLow = new ModelConfig(GPT_54_NANO, ReasoningLevel.LOW);
     private static final ModelConfig gpt5_4NanoHigh = new ModelConfig(GPT_54_NANO, ReasoningLevel.HIGH);

--- a/app/src/main/java/ai/brokk/tools/ExplanationRenderer.java
+++ b/app/src/main/java/ai/brokk/tools/ExplanationRenderer.java
@@ -34,7 +34,7 @@ public class ExplanationRenderer {
      * @param details Map to render
      * @return YAML-formatted string
      */
-    private static String toYaml(Map<String, Object> details) {
+    public static String toYaml(Map<String, Object> details) {
         var sb = new StringBuilder();
         for (var entry : details.entrySet()) {
             var key = entry.getKey();

--- a/app/src/main/java/ai/brokk/tools/ToolExecutionResult.java
+++ b/app/src/main/java/ai/brokk/tools/ToolExecutionResult.java
@@ -103,7 +103,7 @@ public final class ToolExecutionResult {
         return request.name();
     }
 
-    public String toolId() {
+    public @Nullable String toolId() {
         return request.id();
     }
 

--- a/app/src/main/java/ai/brokk/util/BuildTools.java
+++ b/app/src/main/java/ai/brokk/util/BuildTools.java
@@ -15,6 +15,7 @@ import ai.brokk.project.IProject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -233,12 +234,20 @@ public class BuildTools {
         context.put("fqclasses", MustacheTemplates.toStringElementList(fqClasses));
         context.put("classes", MustacheTemplates.toStringElementList(classes));
 
-        MustacheFactory mf = new DefaultMustacheFactory();
-        Mustache mustache = mf.compile(new StringReader(template), "dynamic_template");
-
-        StringWriter writer = new StringWriter();
-        mustache.execute(writer, context);
-        String result = writer.toString();
+        String result;
+        try {
+            MustacheFactory mf = new DefaultMustacheFactory();
+            Mustache mustache = mf.compile(new StringReader(template), "dynamic_template");
+            StringWriter writer = new StringWriter();
+            mustache.execute(writer, context);
+            result = writer.toString();
+        } catch (MustacheException e) {
+            // A malformed template (typically from a corrupted BuildDetails entry) must not abort
+            // the surrounding architect/code-agent run. Skip this command and let the verification
+            // step proceed without it.
+            logger.warn("Skipping malformed Mustache template: {} (template={})", e.getMessage(), template);
+            return "";
+        }
 
         if (result.isBlank() || (template.contains("{{") && result.equals(template))) {
             return "";
@@ -344,16 +353,19 @@ public class BuildTools {
     public static String interpolateMustacheTemplate(
             String template, List<String> items, String listKey, @Nullable String pythonVersion) {
         if (template.isEmpty()) return "";
-        // Use unified interpolation logic compatible with BuildAgent
-        MustacheFactory mf = new DefaultMustacheFactory();
-        Mustache mustache = mf.compile(new StringReader(template), "dynamic_template");
         Map<String, Object> context = new HashMap<>();
         context.put(listKey, MustacheTemplates.toStringElementList(items));
         context.put("pyver", pythonVersion == null ? "" : pythonVersion);
 
-        StringWriter writer = new StringWriter();
-        mustache.execute(writer, context);
-
-        return writer.toString();
+        try {
+            MustacheFactory mf = new DefaultMustacheFactory();
+            Mustache mustache = mf.compile(new StringReader(template), "dynamic_template");
+            StringWriter writer = new StringWriter();
+            mustache.execute(writer, context);
+            return writer.toString();
+        } catch (MustacheException e) {
+            logger.warn("Skipping malformed Mustache template: {} (template={})", e.getMessage(), template);
+            return "";
+        }
     }
 }

--- a/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
+++ b/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
@@ -312,7 +312,7 @@ class AcpConsoleIOTest {
     }
 
     @Test
-    void showNotificationEmitsSyntheticToolCallNotChat() {
+    void showNotificationEmitsCompactToolCall() {
         var ctx = new RecordingPromptContext();
         var io = new AcpConsoleIO(ctx);
 
@@ -324,8 +324,10 @@ class AcpConsoleIOTest {
                 .map(AcpSchema.ToolCall.class::cast)
                 .findFirst()
                 .orElseThrow();
-        assertEquals("Notification", call.title());
+        // Title carries the message; body stays empty so the IDE renders a single-line entry.
+        assertEquals("build started", call.title());
         assertEquals(AcpSchema.ToolCallStatus.COMPLETED, call.status());
+        assertTrue(call.content().isEmpty(), "compact notifications must have empty content");
     }
 
     @Test
@@ -340,45 +342,31 @@ class AcpConsoleIOTest {
     }
 
     @Test
-    void aiBoldBannerWrapsAsSyntheticToolCall() {
+    void aiBoldBannerShapedTokenFlowsAsChat() {
         var ctx = new RecordingPromptContext();
         var io = new AcpConsoleIO(ctx);
 
-        io.llmOutput(
-                "\n**Brokk Context Engine** analyzing repository context…\n",
-                ChatMessageType.AI,
-                LlmOutputMeta.newMessage());
+        // After removing the AI-stream banner-detection heuristic, banner-shaped text in the
+        // AI prose stream is treated as plain prose. Agents that want a synthetic tool_call
+        // must call showStatusBanner directly.
+        var token = "\n**Brokk Context Engine** analyzing repository context\n";
+        io.llmOutput(token, ChatMessageType.AI, LlmOutputMeta.newMessage());
 
-        assertTrue(ctx.messages.isEmpty(), "Bold-banner AI emissions must not flow to chat");
-        var call = ctx.updates.stream()
-                .filter(AcpSchema.ToolCall.class::isInstance)
-                .map(AcpSchema.ToolCall.class::cast)
-                .findFirst()
-                .orElseThrow();
-        assertEquals("Brokk Context Engine", call.title());
-        assertEquals(AcpSchema.ToolKind.THINK, call.kind());
+        assertEquals(List.of(token), ctx.messages);
+        assertTrue(ctx.updates.isEmpty(), "AI prose must not be auto-promoted to a synthetic tool_call");
     }
 
     @Test
-    void aiBacktickBannerWithDefaultMetaStillWraps() {
+    void aiBacktickBannerShapedTokenFlowsAsChat() {
         var ctx = new RecordingPromptContext();
         var io = new AcpConsoleIO(ctx);
 
-        // LutzAgent.emitContextAddedExplanation emits the YAML-bodied banner with
-        // LlmOutputMeta.DEFAULT (not newMessage), so banner detection must be shape-driven,
-        // not meta-driven. The full `Header` + body pattern marks this as a banner regardless
-        // of the newMessage flag.
         var explanation =
                 "`Adding context to workspace`\n```yaml\nfragmentCount: 2\nfragments:\n  - foo\n  - bar\n```\n";
         io.llmOutput(explanation, ChatMessageType.AI, LlmOutputMeta.DEFAULT);
 
-        assertTrue(ctx.messages.isEmpty(), "shape-detected banners must not flow to chat regardless of meta");
-        var call = ctx.updates.stream()
-                .filter(AcpSchema.ToolCall.class::isInstance)
-                .map(AcpSchema.ToolCall.class::cast)
-                .findFirst()
-                .orElseThrow();
-        assertEquals("Adding context to workspace", call.title());
+        assertEquals(List.of(explanation), ctx.messages);
+        assertTrue(ctx.updates.isEmpty(), "Backtick-shaped AI prose must not be auto-promoted");
     }
 
     @Test
@@ -397,21 +385,22 @@ class AcpConsoleIOTest {
     }
 
     @Test
-    void aiBacktickBannerWithNewMessageWrapsAsSyntheticToolCall() {
+    void showStatusBannerEmitsSyntheticToolCall() {
         var ctx = new RecordingPromptContext();
         var io = new AcpConsoleIO(ctx);
 
-        var explanation =
-                "`Adding context to workspace`\n```yaml\nfragmentCount: 2\nfragments:\n  - foo\n  - bar\n```\n";
-        io.llmOutput(explanation, ChatMessageType.AI, LlmOutputMeta.newMessage());
+        io.showStatusBanner(
+                "Adding context to workspace",
+                java.util.Map.of("fragmentCount", 2, "fragments", List.of("foo", "bar")));
 
-        assertTrue(ctx.messages.isEmpty(), "backtick banners with newMessage must be wrapped");
+        assertTrue(ctx.messages.isEmpty(), "showStatusBanner must not flow to chat");
         var call = ctx.updates.stream()
                 .filter(AcpSchema.ToolCall.class::isInstance)
                 .map(AcpSchema.ToolCall.class::cast)
                 .findFirst()
                 .orElseThrow();
         assertEquals("Adding context to workspace", call.title());
+        assertEquals(AcpSchema.ToolKind.THINK, call.kind());
         var block = (AcpSchema.ToolCallContentBlock) call.content().getFirst();
         var text = ((AcpSchema.TextContent) block.content()).text();
         assertTrue(text.contains("fragmentCount"), "yaml body should be carried into content");


### PR DESCRIPTION
## Summary

Bundles three commits already landed on this branch:

- **ACP: replace banner-shape detection with explicit status APIs** (this commit) — Add `IConsoleIO.showStatusBanner` / `showStatusLine`. `AcpConsoleIO` overrides both to emit synthetic tool_calls (banner with YAML body; compact title-only line). Drop the regex `tryDetectBanner` heuristic from the AI stream, convert `CodeAgent`/`LutzAgent` call sites, remove a duplicate `workspaceComplete` banner from `SearchAgent`, no-op `setLlmAndHistoryOutput` on ACP (the prompt is already known to the client via `session/prompt`), and unwrap `{"explanation": "..."}` envelopes when rendering tool-call bodies.
- **ACP: malformed-template handling, permission-timeout fix, SR-block suppression, denied dialog signal** (`ec6b443c5`).
- **ACP: callCodeAgent fix, /context first-word match, model-catalog fallback, session auto-rename** (`1b3abdfcf`) — addresses #3419, #3420, #3422, #3427 (see plan in worktree).

## Test plan

- [ ] `./gradlew :app:test --tests "ai.brokk.acp.AcpConsoleIOTest"`
- [ ] `./gradlew :app:test --tests "ai.brokk.acp.BrokkAcpAgentTest"`
- [ ] `./gradlew :app:check`
- [ ] In Zed: run a LUTZ flow that emits the "Adding context to workspace" banner and a Code Agent run — confirm both render as compact tool_call cards (not as duplicated chat prose).
- [ ] Confirm a final-answer reply still flows as chat (the h1 final-answer shape was never touched by the dropped heuristic, but verify after the refactor).
- [ ] Confirm Code/Search Agent completion lines render as one-line entries instead of multi-line "## Code Agent Finished" blocks.
- [ ] GUI smoke: confirm `showStatusBanner` / `showStatusLine` defaults still produce the legacy text rendering in the Brokk GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)