### PR TITLE
brokk-code: add `jetbrains` alias for `install intellij`

### DIFF
--- a/brokk-code/brokk_code/__main__.py
+++ b/brokk-code/brokk_code/__main__.py
@@ -938,8 +938,8 @@ def _build_parser() -> argparse.ArgumentParser:
     install_parser = subparsers.add_parser("install", help="Install integration settings")
     install_parser.add_argument(
         "target",
-        choices=["zed", "intellij", "nvim", "neovim", "mcp", "codex-plugin"],
-        help="Install target for integration settings",
+        choices=["zed", "intellij", "jetbrains", "nvim", "neovim", "mcp", "codex-plugin"],
+        help="Install target for integration settings (jetbrains is an alias for intellij)",
     )
     install_parser.add_argument(
         "--plugin",
@@ -1988,6 +1988,8 @@ def _main_dispatch(
 ) -> None:
     """Core command dispatch, extracted to support optional worktree wrapping."""
     if args.command == "install":
+        if args.target == "jetbrains":
+            args.target = "intellij"
         # Fast-fail validation before prompting for API keys
         if args.plugin and args.target not in {"nvim", "neovim"}:
             print("Error: --plugin is only valid for install targets nvim/neovim", file=sys.stderr)

--- a/brokk-code/tests/test_cli_modes.py
+++ b/brokk-code/tests/test_cli_modes.py
@@ -583,6 +583,30 @@ def test_main_install_intellij_routes_to_installer(monkeypatch, tmp_path, capsys
     assert "Configured IntelliJ ACP integration" in output
 
 
+def test_main_install_jetbrains_alias_routes_to_intellij_installer(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_configure_intellij_acp_settings(
+        *, force: bool = False, settings_path: Any = None, uvx_command: Any = None, **_kw
+    ):
+        captured["force"] = force
+        return tmp_path / "intellij-config"
+
+    _stub_install_warmup(monkeypatch)
+    monkeypatch.setattr(
+        main_module, "configure_intellij_acp_settings", fake_configure_intellij_acp_settings
+    )
+    monkeypatch.setattr(sys, "argv", ["brokk", "install", "jetbrains", "--force"])
+
+    main_module.main()
+
+    output = capsys.readouterr().out
+    assert captured["force"] is True
+    assert "Configured IntelliJ ACP integration" in output
+
+
 def test_main_install_nvim_routes_to_installer(monkeypatch, tmp_path, capsys) -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary

- Adds `jetbrains` as an alias for `intellij` in `brokk install`. Users on PyCharm/GoLand/WebStorm/RubyMine/etc. naturally look for a `jetbrains` target first; the JetBrains plugin runs in any of those IDEs and writes the same settings file regardless.
- One-line normalization at the top of the install dispatch (`if args.target == "jetbrains": args.target = "intellij"`) so every downstream check — the `--rust` allowlist, the dispatch arm, the `_build_install_prefetch_commands` call — keeps working unchanged.
- `intellij` continues to work indefinitely. No deprecation, no behavior change for existing users.

Closes #3439.

## Out of scope

- The deprecated `acp --ide` flag (`brokk_code/__main__.py:904`) is silently ignored at runtime, so adding `jetbrains` there has no practical effect.
- `executor.py:303` (`self.environment_type == "intellij"`) is a runtime environment classification set by the plugin, not a CLI target. Not affected by this alias.

## Test plan

- [x] `uv run pytest tests/test_cli_modes.py` — all 120 tests pass (one new alias-equivalence test plus the existing 4 intellij tests).
- [x] `uv run ruff check brokk_code/__main__.py tests/test_cli_modes.py` — clean.
- [ ] Manual: `brokk install jetbrains --force` produces the same `Configured IntelliJ ACP integration in <path>` output as `brokk install intellij --force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)