### PR TITLE
ACP: tests proving brokk-code --jar bypasses jbang

### DIFF
--- a/brokk-code/tests/test_cli_modes.py
+++ b/brokk-code/tests/test_cli_modes.py
@@ -326,6 +326,64 @@ def test_main_acp_native_alias_warns_and_routes(monkeypatch, tmp_path, capsys) -
     assert "deprecated" in capsys.readouterr().err.lower()
 
 
+def test_main_acp_with_jar_forwards_jar_and_skips_jbang(monkeypatch, tmp_path) -> None:
+    """`brokk acp --jar <path>` must forward jar_path verbatim and never touch jbang.
+
+    End-to-end dispatch contract: the only thing main() does on the acp branch
+    is call run_native_acp_server with the resolved jar_path. No ensure_jbang_ready,
+    no install prefetch, no release-jar URL machinery.
+    """
+    captured: dict[str, Any] = {}
+    jar_path = tmp_path / "brokk.jar"
+    jar_path.write_text("dummy")
+
+    def fake_run_native_acp_server(**kwargs: Any) -> None:
+        captured["kwargs"] = kwargs
+
+    def boom_jbang() -> str:
+        raise AssertionError("ensure_jbang_ready must not be called on the acp dispatch path")
+
+    def boom_resolve_jbang() -> str | None:
+        raise AssertionError("resolve_jbang_binary must not be called on the acp dispatch path")
+
+    def boom_prefetch(_commands: list) -> None:
+        raise AssertionError("_run_install_prefetch must not be called on the acp dispatch path")
+
+    monkeypatch.setattr(main_module, "run_native_acp_server", fake_run_native_acp_server)
+    monkeypatch.setattr(main_module, "ensure_jbang_ready", boom_jbang)
+    monkeypatch.setattr(main_module, "resolve_jbang_binary", boom_resolve_jbang)
+    monkeypatch.setattr(main_module, "_run_install_prefetch", boom_prefetch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "brokk",
+            "acp",
+            "--workspace",
+            str(tmp_path),
+            "--jar",
+            str(jar_path),
+            "--executor-version",
+            "9.9.9",
+        ],
+    )
+
+    main_module.main()
+
+    kwargs = captured["kwargs"]
+    assert kwargs["workspace_dir"] == tmp_path.resolve()
+    assert kwargs["jar_path"] == jar_path.resolve()
+    assert kwargs["executor_version"] == "9.9.9"
+    passthrough = kwargs["passthrough_args"]
+    assert "--workspace-dir" in passthrough
+    assert str(tmp_path.resolve()) in passthrough
+    # Nothing in the forwarded kwargs should reference jbang or the release CDN.
+    for value in kwargs.values():
+        rendered = str(value)
+        assert "jbang" not in rendered.lower()
+        assert "brokk-releases" not in rendered
+
+
 def test_main_mcp_routes_to_launcher(monkeypatch, tmp_path) -> None:
     captured: dict[str, Any] = {}
     jar_path = tmp_path / "brokk.jar"

--- a/brokk-code/tests/test_mcp_launcher.py
+++ b/brokk-code/tests/test_mcp_launcher.py
@@ -508,3 +508,110 @@ def test_run_mcp_core_server_reports_missing_runtime(monkeypatch, tmp_path, caps
 
     assert exc.value.code == 1
     assert "Unable to launch MCP core runtime" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# ACP launcher: --jar must fully bypass jbang and the dev-jar fallback
+# ---------------------------------------------------------------------------
+
+
+def test_run_acp_server_with_jar_bypasses_jbang_and_dev_jar(monkeypatch, tmp_path) -> None:
+    """`brokk acp --jar <path>` must launch `java -cp <path>` directly.
+
+    With --jar provided, the launcher must not consult find_dev_jar, must not
+    call ensure_jbang_ready, must not invoke a jbang binary, and must not
+    construct any release-jar URL pointing at brokk-releases.
+    """
+    captured: dict[str, object] = {}
+    dummy_jar = tmp_path / "brokk.jar"
+    dummy_jar.write_text("dummy")
+
+    def boom_dev_jar(*_args, **_kwargs) -> None:
+        raise AssertionError("find_dev_jar must not be called when --jar is provided")
+
+    def boom_jbang() -> str:
+        raise AssertionError("ensure_jbang_ready must not be called when --jar is provided")
+
+    def fake_chdir(path: Path) -> None:
+        captured["cwd"] = path
+
+    def fake_execvpe(binary: str, command: list[str], env: dict[str, str]) -> None:
+        captured["binary"] = binary
+        captured["command"] = command
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "chdir", fake_chdir)
+    monkeypatch.setattr(os, "execvpe", fake_execvpe)
+    monkeypatch.setattr(mcp_launcher, "git_toplevel_for", lambda _path: None)
+    monkeypatch.setattr(mcp_launcher, "find_dev_jar", boom_dev_jar)
+    monkeypatch.setattr(mcp_launcher, "ensure_jbang_ready", boom_jbang)
+
+    with pytest.raises(RuntimeError, match="stop"):
+        mcp_launcher.run_acp_server(
+            workspace_dir=tmp_path,
+            jar_path=dummy_jar,
+            executor_version=None,
+            passthrough_args=["--workspace-dir", str(tmp_path)],
+        )
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert captured["binary"] == "java"
+    assert command[0] == "java"
+    assert "-cp" in command
+    assert str(dummy_jar) in command
+    assert "ai.brokk.acp.AcpServerMain" in command
+    # No jbang token anywhere in the command (binary path or arg).
+    assert not any("jbang" in part.lower() for part in command)
+    # No release-jar URL constructed (that would point at the executor release).
+    assert not any("brokk-releases" in part for part in command)
+    # passthrough args appended without the JBang `--` separator.
+    assert "--" not in command
+    assert command[-2:] == ["--workspace-dir", str(tmp_path)]
+
+
+def test_run_acp_server_passthrough_with_explicit_executor_version_still_uses_jar(
+    monkeypatch, tmp_path
+) -> None:
+    """An explicit --executor-version must not override --jar back onto jbang."""
+    captured: dict[str, object] = {}
+    dummy_jar = tmp_path / "brokk.jar"
+    dummy_jar.write_text("dummy")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "chdir", lambda _path: None)
+    monkeypatch.setattr(
+        os,
+        "execvpe",
+        lambda binary, command, _env: captured.update(binary=binary, command=command)
+        or (_ for _ in ()).throw(RuntimeError("stop")),
+    )
+    monkeypatch.setattr(mcp_launcher, "git_toplevel_for", lambda _path: None)
+    monkeypatch.setattr(
+        mcp_launcher,
+        "find_dev_jar",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("find_dev_jar must not be called when --jar is provided")
+        ),
+    )
+    monkeypatch.setattr(
+        mcp_launcher,
+        "ensure_jbang_ready",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("ensure_jbang_ready must not be called when --jar is provided")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="stop"):
+        mcp_launcher.run_acp_server(
+            workspace_dir=tmp_path,
+            jar_path=dummy_jar,
+            executor_version="9.9.9",
+        )
+
+    command = captured["command"]
+    assert captured["binary"] == "java"
+    assert str(dummy_jar) in command
+    assert not any("9.9.9" in part for part in command)
+    assert not any("brokk-releases" in part for part in command)


### PR DESCRIPTION
## Summary

- Lock in the contract that `brokk acp --jar <path>` launches the Java ACP server directly (`java -cp <jar> ai.brokk.acp.AcpServerMain`) and never resolves jbang, never calls `ensure_jbang_ready`, never consults `find_dev_jar`, and never constructs a `brokk-releases` JAR URL.
- Two layers of coverage: launcher-unit tests in `tests/test_mcp_launcher.py` (covering `mcp_launcher._resolve_mcp_command`'s `if jar_path: return ...` short-circuit) and a dispatch-unit test in `tests/test_cli_modes.py` (covering `main()`'s `args.command == "acp"` branch).
- The launcher-unit tests use a booby-trap pattern: `find_dev_jar` and `ensure_jbang_ready` are monkeypatched to raise, so any call from the `--jar` path fails loudly with a self-describing `AssertionError`.
- The dispatch test drives `main()` end-to-end with `brokk acp --workspace ... --jar ... --executor-version 9.9.9` and asserts `run_native_acp_server` receives the resolved `jar_path` verbatim while `ensure_jbang_ready`, `resolve_jbang_binary`, and `_run_install_prefetch` stay untouched.

No production code is modified — the contract these tests assert was already true; this PR makes it falsifiable.

## Negative-control verification

I temporarily deleted the `if jar_path: return _build_direct_mcp_command(...)` short-circuit in `brokk_code/mcp_launcher.py:_resolve_mcp_command` and confirmed both launcher tests fail with `AssertionError: find_dev_jar must not be called when --jar is provided`, then restored the source. Full 145-test suite (`tests/test_cli_modes.py` + `tests/test_mcp_launcher.py`) passes again.

## Test plan

- [x] `uv run pytest tests/test_mcp_launcher.py -k acp` — 2/2 passing
- [x] `uv run pytest tests/test_cli_modes.py -k acp` — 5/5 passing (incl. existing 4)
- [x] `uv run pytest tests/test_cli_modes.py tests/test_mcp_launcher.py` — 145/145 passing
- [x] Negative control: removing the `--jar` short-circuit in `mcp_launcher._resolve_mcp_command` makes both new launcher tests fail with the booby-trap `AssertionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)