### PR TITLE
MOP/ACP: stop emitting LLM message framing on display side

### DIFF
--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -1625,7 +1625,8 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
                 } else {
                     // add the post-task terminal output to the history
                     var log = new ContextOutputFragments.TaskOutputFragment(
-                            "Post-task verification output", Messages.format(getIo().getLlmRawMessages()));
+                            "Post-task verification output",
+                            Messages.formatForDisplay(getIo().getLlmRawMessages()));
                     var context2 = context.addHistoryEntry(log, null);
                     pushContext(ctx -> context2);
                 }
@@ -2349,7 +2350,7 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
         // prepare MOP
         var history = liveContext().getTaskHistory();
         var messages = List.<ChatMessage>of(new UserMessage(input));
-        var markdown = Messages.format(messages);
+        var markdown = Messages.formatForDisplay(messages);
         io.setLlmAndHistoryOutput(history, new TaskEntry(-1, input, markdown, null, null, null));
 
         // rename the session if needed

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -1625,8 +1625,7 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
                 } else {
                     // add the post-task terminal output to the history
                     var log = new ContextOutputFragments.TaskOutputFragment(
-                            "Post-task verification output",
-                            Messages.formatForDisplay(getIo().getLlmRawMessages()));
+                            "Post-task verification output", Messages.formatForDisplay(getIo().getLlmRawMessages()));
                     var context2 = context.addHistoryEntry(log, null);
                     pushContext(ctx -> context2);
                 }

--- a/app/src/main/java/ai/brokk/TaskEntry.java
+++ b/app/src/main/java/ai/brokk/TaskEntry.java
@@ -140,11 +140,11 @@ public final class TaskEntry {
             return this;
         }
 
-        // Best-effort: append rendered messages to the existing rendered Markdown.
-        // This is not "diff aware" but preserves the log for users/serialization.
-        String appended = Messages.format(List.copyOf(additionalMessages));
-        String newMopMarkdown = mopMarkdown + "\n\n" + appended;
-        String newLlmMarkdown = llmMarkdown == null ? null : (llmMarkdown + "\n\n" + appended);
+        var copied = List.<ChatMessage>copyOf(additionalMessages);
+        String mopAppended = Messages.formatForDisplay(copied);
+        String llmAppended = Messages.format(copied);
+        String newMopMarkdown = mopMarkdown + "\n\n" + mopAppended;
+        String newLlmMarkdown = llmMarkdown == null ? null : (llmMarkdown + "\n\n" + llmAppended);
         return new TaskEntry(sequence, description, newMopMarkdown, newLlmMarkdown, summary, meta);
     }
 

--- a/app/src/main/java/ai/brokk/context/Context.java
+++ b/app/src/main/java/ai/brokk/context/Context.java
@@ -1020,7 +1020,7 @@ public class Context {
             StreamingChatModel model,
             String instructions) {
         var mc = AbstractService.ModelConfig.from(model, contextManager.getService());
-        var mopMarkdown = Messages.format(mopMessages);
+        var mopMarkdown = Messages.formatForDisplay(mopMessages);
         var llmMarkdown = Messages.format(llmMessages);
         return addHistoryEntryInternal(new TaskEntry(
                 getTaskHistory().size(),

--- a/app/src/main/java/ai/brokk/context/DtoMapper.java
+++ b/app/src/main/java/ai/brokk/context/DtoMapper.java
@@ -254,7 +254,7 @@ public class DtoMapper {
             var messages = dto.messages().stream()
                     .map(msgDto -> fromChatMessageDto(msgDto, reader))
                     .toList();
-            markdown = Messages.format(messages);
+            markdown = Messages.formatForDisplay(messages);
         }
 
         boolean escapeHtml = dto.escapeHtml() == null || dto.escapeHtml();

--- a/app/src/main/java/ai/brokk/difftool/ui/BrokkDiffPanel.java
+++ b/app/src/main/java/ai/brokk/difftool/ui/BrokkDiffPanel.java
@@ -697,7 +697,8 @@ public class BrokkDiffPanel extends JPanel
         var resultingCtx = currentContext
                 .addFragments(contextManager.toPathFragments(changedFiles))
                 .addHistoryEntry(
-                        new ContextOutputFragments.TaskOutputFragment(actionDescription, Messages.format(messages)),
+                        new ContextOutputFragments.TaskOutputFragment(
+                                actionDescription, Messages.formatForDisplay(messages)),
                         null);
 
         var result = TaskResult.from(resultingCtx, TaskResult.StopReason.SUCCESS);

--- a/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
@@ -1644,7 +1644,7 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
 
     private void openOutputWindowStreaming() {
         List<ChatMessage> currentMessages = llmStreamArea.getRawMessages();
-        String currentMarkdown = Messages.format(currentMessages);
+        String currentMarkdown = Messages.formatForDisplay(currentMessages);
         var history = new ArrayList<>(contextManager.liveContext().getTaskHistory());
         history.add(new TaskEntry(-1, "Streaming Output...", currentMarkdown, currentMarkdown, null, null));
 

--- a/app/src/main/java/ai/brokk/gui/dialogs/BlitzForgeDialog.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/BlitzForgeDialog.java
@@ -1655,7 +1655,7 @@ public class BlitzForgeDialog extends BaseThemedDialog {
                 // Run the task
                 if (engineAction == Action.ASK) {
                     var fragment = new ContextOutputFragments.TaskOutputFragment(
-                            instructions, Messages.format(readOnlyMessages));
+                            instructions, Messages.formatForDisplay(readOnlyMessages));
                     var meta = new TaskResult.TaskMeta(
                             TaskResult.Type.ASK, Service.ModelConfig.from(model, cm.getService()));
                     var ctx = new Context(cm)

--- a/app/src/main/java/ai/brokk/gui/git/GitIssuesTab.java
+++ b/app/src/main/java/ai/brokk/gui/git/GitIssuesTab.java
@@ -1294,7 +1294,7 @@ public class GitIssuesTab extends JPanel implements SettingsChangeListener, Them
             IssueDetails details, List<ChatMessage> messages) {
         IssueHeader header = details.header();
         String description = String.format("Issue %s: %s", header.id(), header.title());
-        return new ContextOutputFragments.TaskOutputFragment(description, Messages.format(messages), false);
+        return new ContextOutputFragments.TaskOutputFragment(description, Messages.formatForDisplay(messages), false);
     }
 
     private List<ChatMessage> buildChatMessagesFromDtoComments(List<Comment> dtoComments) {
@@ -1315,7 +1315,8 @@ public class GitIssuesTab extends JPanel implements SettingsChangeListener, Them
             IssueDetails details, List<ChatMessage> commentMessages) {
         IssueHeader header = details.header();
         String description = String.format("Issue %s: Comments", header.id());
-        return new ContextOutputFragments.TaskOutputFragment(description, Messages.format(commentMessages), false);
+        return new ContextOutputFragments.TaskOutputFragment(
+                description, Messages.formatForDisplay(commentMessages), false);
     }
 
     private int processAndCaptureImagesFromDetails(IssueDetails details) {

--- a/app/src/main/java/ai/brokk/util/Messages.java
+++ b/app/src/main/java/ai/brokk/util/Messages.java
@@ -220,4 +220,56 @@ public class Messages {
                 })
                 .collect(Collectors.joining("\n"));
     }
+
+    public static String getReprForDisplay(ChatMessage message) {
+        return switch (message) {
+            case SystemMessage sm -> sm.text();
+            case CustomMessage cm -> requireNonNull(cm.attributes().get("text")).toString();
+            case AiMessage am -> {
+                var reasoning = am.reasoningContent();
+                var text = am.text();
+                var hasReasoning = reasoning != null && !reasoning.isBlank();
+                var hasText = text != null && !text.isBlank();
+                var hasTools = am.hasToolExecutionRequests();
+
+                var parts = new ArrayList<String>();
+                if (hasReasoning) {
+                    parts.add(reasoning);
+                }
+                if (hasText) {
+                    parts.add(text);
+                }
+                if (hasTools) {
+                    var toolText = am.toolExecutionRequests().stream()
+                            .map(Messages::getRedactedRepr)
+                            .collect(Collectors.joining("\n"));
+                    parts.add(toolText);
+                }
+                yield String.join("\n\n", parts);
+            }
+            case UserMessage um ->
+                um.contents().stream()
+                        .map(c -> {
+                            if (c instanceof TextContent textContent) {
+                                return textContent.text();
+                            } else if (c instanceof ImageContent) {
+                                return "[Image]";
+                            } else {
+                                throw new UnsupportedOperationException(
+                                        c.getClass().toString());
+                            }
+                        })
+                        .collect(Collectors.joining("\n"));
+            case ToolExecutionResultMessage tr -> "%s -> %s".formatted(tr.toolName(), tr.text());
+            default ->
+                throw new UnsupportedOperationException(message.getClass().toString());
+        };
+    }
+
+    public static String formatForDisplay(List<ChatMessage> messages) {
+        return messages.stream()
+                .map(Messages::getReprForDisplay)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.joining("\n\n"));
+    }
 }

--- a/app/src/test/java/ai/brokk/TaskEntryTest.java
+++ b/app/src/test/java/ai/brokk/TaskEntryTest.java
@@ -38,9 +38,9 @@ class TaskEntryTest {
         assertEquals("existing-summary", updated.summary());
         assertEquals("new-desc", updated.description());
 
-        assertEquals(md + "\n\n" + Messages.format(List.of(msg2)), updated.mopMarkdown());
+        assertEquals(md + "\n\n" + Messages.formatForDisplay(List.of(msg2)), updated.mopMarkdown());
 
-        // llmLog should be kept consistent when present
+        // llmLog should be kept consistent when present (still framed for LLM consumption)
         assertEquals(md + "\n\n" + Messages.format(List.of(msg2)), updated.llmMarkdown());
     }
 
@@ -55,7 +55,7 @@ class TaskEntryTest {
 
         var updated = entry.withAppendedMopMessages(List.of(msg2), "new-desc");
 
-        assertEquals(md + "\n\n" + Messages.format(List.of(msg2)), updated.mopMarkdown());
+        assertEquals(md + "\n\n" + Messages.formatForDisplay(List.of(msg2)), updated.mopMarkdown());
         assertEquals(md + "\n\n" + Messages.format(List.of(msg2)), updated.llmMarkdown());
     }
 
@@ -72,7 +72,7 @@ class TaskEntryTest {
 
         assertEquals(7, updated.sequence());
         assertEquals("new-desc", updated.description());
-        assertEquals(md + "\n\n" + Messages.format(List.of(msg2, msg3)), updated.mopMarkdown());
+        assertEquals(md + "\n\n" + Messages.formatForDisplay(List.of(msg2, msg3)), updated.mopMarkdown());
     }
 
     @Test


### PR DESCRIPTION
Fixes #3441.

## Summary

- `Messages.format` produces `<message type=...>` framed text intended for LLM-prompt replay; the same serializer was being used for display-side content, leaking framing + `Reasoning:` / `Tool calls:` text labels into the MOP and ACP transcript.
- Add `Messages.formatForDisplay` + `Messages.getReprForDisplay` (no envelope, no parser-style labels, `getRedactedRepr` for tool requests).
- Switch eight display-side callers; leave LLM-side fields (`llmMarkdown`, `Llm.java` debug log) on `format`.

## Files touched

- `Messages.java` -- new display companions.
- `Context.java`, `TaskEntry.java`, `ContextManager.java` (x2), `HistoryOutputPanel.java`, `BrokkDiffPanel.java`, `GitIssuesTab.java` (x2), `BlitzForgeDialog.java`, `DtoMapper.java` -- swap to `formatForDisplay` for display-side serialization only.
- `TaskEntryTest.java` -- updated three assertions where the old contract pinned the mop-side append to `format`. LLM-side appends still framed.

## Out of scope (deliberate, per issue body)

- Strip-on-read for legacy persisted sessions: `TaskEntry` derives a content-hash ID from `mopMarkdown`, so cleaning legacy blobs on read changes the ID and risks invalidating cached refs. Old sessions keep showing framing until next mutation; new sessions are clean.
- Whether to keep capturing the `**Brokk Context Engine** complete` status banner into history at all -- separate cleanup; this PR only changes how it's rendered.

## Test plan

- [x] `./gradlew :app:compileJava`
- [x] Targeted: `ContextCompressionTest`, `ContextSerializationTest`, `ContextHistoryTest`, `ContextDeltaTest`, `ContextTest`, `SessionManagerTest`, `HistoryIoTest`, `CodePromptsTest`, `PrReviewServiceTest`, `TaskEntryTest`
- [x] `./gradlew :app:test`
- [x] Manual: launched `:app:run` and verified MOP rendering on a fresh turn -- no `<message type=...>` tags, no bare `Reasoning:` / `Tool calls:` labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)