### PR TITLE
Generalize comment density file reports

### DIFF
--- a/app/src/main/java/ai/brokk/tools/AGENTS.md
+++ b/app/src/main/java/ai/brokk/tools/AGENTS.md
@@ -1,0 +1,3 @@
+# Tools Package Guidance
+
+- Do not hard-code analyzer language extensions in tool-level capability checks. The active analyzer owns supported-file filtering and should signal unsupported files by returning empty results, `Optional.empty()`, or the existing unavailable path as appropriate.

--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -529,7 +529,7 @@ public class CodeQualityTools {
 
     @Tool(
             """
-            Java comment density tables for the given source files: one section per file and one row per top-level declaration.
+            Comment density tables for the given source files: one section per file and one row per top-level declaration.
             Includes own and rolled-up header/inline line counts. Bounded by maxFiles and maxTopLevelRows total across all files.""")
     public String reportCommentDensityForFiles(
             @P("File paths relative to the project root.") List<String> filePaths,
@@ -556,13 +556,6 @@ public class CodeQualityTools {
             ProjectFile file = contextManager.toFile(path);
             if (!file.exists()) {
                 lines.add("- Missing file (skipped): `" + path + "`");
-                filesShown++;
-                continue;
-            }
-            if (!"java".equals(file.extension())) {
-                lines.add("### `" + path + "`");
-                lines.add("(not a Java file; skipped)");
-                lines.add("");
                 filesShown++;
                 continue;
             }

--- a/app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java
+++ b/app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java
@@ -7,6 +7,8 @@ import ai.brokk.testutil.InlineTestProjectCreator;
 import ai.brokk.testutil.TestConsoleIO;
 import ai.brokk.testutil.TestContextManager;
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class CodeQualityToolsCommentDensityJsTsTest {
@@ -26,8 +28,7 @@ class CodeQualityToolsCommentDensityJsTsTest {
                 """,
                         "src/sample.js")
                 .build()) {
-            var contextManager =
-                    new TestContextManager(project, new TestConsoleIO(), java.util.Set.of(), project.getAnalyzer());
+            var contextManager = new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer());
             var tools = new CodeQualityTools(contextManager);
 
             String documentedReport = tools.reportCommentDensityForCodeUnit("src.documented", 120);
@@ -52,8 +53,7 @@ class CodeQualityToolsCommentDensityJsTsTest {
                 """,
                         "src/sample.ts")
                 .build()) {
-            var contextManager =
-                    new TestContextManager(project, new TestConsoleIO(), java.util.Set.of(), project.getAnalyzer());
+            var contextManager = new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer());
             var tools = new CodeQualityTools(contextManager);
 
             String report = tools.reportCommentDensityForCodeUnit("src.typed", 120);
@@ -61,6 +61,112 @@ class CodeQualityToolsCommentDensityJsTsTest {
             assertTrue(report.contains("`src.typed`"), report);
             assertTrue(report.contains("Own: header 1, inline 1"), report);
             assertFalse(report.contains("unavailable"), report);
+        }
+    }
+
+    @Test
+    void reportCommentDensityForCodeUnit_supportsPython() throws IOException {
+        try (var project = InlineTestProjectCreator.code(
+                        """
+                # header docs
+                def documented(value):
+                    return value + 1  # inline docs
+                """,
+                        "src/sample.py")
+                .build()) {
+            var contextManager = new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer());
+            var tools = new CodeQualityTools(contextManager);
+
+            String report = tools.reportCommentDensityForCodeUnit("src.sample.documented", 120);
+            assertTrue(report.contains("## Comment density"), report);
+            assertTrue(report.contains("`src.sample.documented`"), report);
+            assertTrue(report.contains("Own: header 1, inline 1"), report);
+            assertFalse(report.contains("unavailable"), report);
+        }
+    }
+
+    @Test
+    void reportCommentDensityForFiles_usesAnalyzerCapabilityForJavaScript() throws IOException {
+        try (var project = InlineTestProjectCreator.code(
+                        """
+                // header docs
+                function documented(value) {
+                    return value + 1; // inline docs
+                }
+                """,
+                        "src/sample.js")
+                .build()) {
+            var contextManager = new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer());
+            var tools = new CodeQualityTools(contextManager);
+
+            String report = tools.reportCommentDensityForFiles(List.of("src/sample.js"), 60, 25);
+            assertTrue(report.contains("## Comment density by file"), report);
+            assertTrue(report.contains("### `src/sample.js`"), report);
+            assertTrue(report.contains("| `src.documented` | 1 | 1 |"), report);
+            assertFalse(report.contains("not a Java file"), report);
+            assertFalse(report.contains("unavailable"), report);
+        }
+    }
+
+    @Test
+    void reportCommentDensityForFiles_usesAnalyzerCapabilityForTypeScript() throws IOException {
+        try (var project = InlineTestProjectCreator.code(
+                        """
+                // header docs
+                function typed(value: number): number {
+                    return value + 1; // inline docs
+                }
+                """,
+                        "src/sample.ts")
+                .build()) {
+            var contextManager = new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer());
+            var tools = new CodeQualityTools(contextManager);
+
+            String report = tools.reportCommentDensityForFiles(List.of("src/sample.ts"), 60, 25);
+            assertTrue(report.contains("## Comment density by file"), report);
+            assertTrue(report.contains("### `src/sample.ts`"), report);
+            assertTrue(report.contains("| `src.typed` | 1 | 1 |"), report);
+            assertFalse(report.contains("not a Java file"), report);
+            assertFalse(report.contains("unavailable"), report);
+        }
+    }
+
+    @Test
+    void reportCommentDensityForFiles_usesAnalyzerCapabilityForPython() throws IOException {
+        try (var project = InlineTestProjectCreator.code(
+                        """
+                # header docs
+                def documented(value):
+                    return value + 1  # inline docs
+                """,
+                        "src/sample.py")
+                .build()) {
+            var contextManager = new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer());
+            var tools = new CodeQualityTools(contextManager);
+
+            String report = tools.reportCommentDensityForFiles(List.of("src/sample.py"), 60, 25);
+            assertTrue(report.contains("## Comment density by file"), report);
+            assertTrue(report.contains("### `src/sample.py`"), report);
+            assertTrue(report.contains("| `src.sample.documented` | 1 | 1 |"), report);
+            assertFalse(report.contains("not a Java file"), report);
+            assertFalse(report.contains("unavailable"), report);
+        }
+    }
+
+    @Test
+    void reportCommentDensityForFiles_reportsUnavailableForUnsupportedAnalyzerResult() throws IOException {
+        try (var project = InlineTestProjectCreator.code(
+                        """
+                Plain text.
+                """, "notes/readme.txt")
+                .build()) {
+            var contextManager = new TestContextManager(project, new TestConsoleIO(), Set.of(), project.getAnalyzer());
+            var tools = new CodeQualityTools(contextManager);
+
+            String report = tools.reportCommentDensityForFiles(List.of("notes/readme.txt"), 60, 25);
+            assertTrue(report.contains("### `notes/readme.txt`"), report);
+            assertTrue(report.contains("Comment density is unavailable"), report);
+            assertFalse(report.contains("not a Java file"), report);
         }
     }
 }


### PR DESCRIPTION
### Description
Generalizes comment-density file reporting so CodeQualityTools delegates supported-file decisions to the active analyzer instead of hard-coding Java-only behavior. Adds tool-level coverage for Python code-unit reports, JavaScript/TypeScript/Python file reports, and unsupported analyzer results.

Resolves #3303
Resolves #3304
Resolves #3305
Resolves #3306

**Key Changes**:
- Removed the Java-only skip path from reportCommentDensityForFiles and kept the existing unavailable message for empty analyzer results.
- Added tools package guidance documenting that analyzers own language/file capability filtering.
- Expanded CodeQualityTools comment-density tests across Python, JavaScript, and TypeScript.

**Touch Points**:
- app/src/main/java/ai/brokk/tools/CodeQualityTools.java
- app/src/main/java/ai/brokk/tools/AGENTS.md
- app/src/test/java/ai/brokk/tools/CodeQualityToolsCommentDensityJsTsTest.java