### PR TITLE
OpenAI Codex OAuth: refresh defaults and Codex API compat

### DIFF
--- a/app/src/main/java/ai/brokk/AbstractService.java
+++ b/app/src/main/java/ai/brokk/AbstractService.java
@@ -387,8 +387,7 @@ public abstract class AbstractService implements ExceptionReporter.ReportingServ
                 .filter(name -> !UNAVAILABLE.equals(name))
                 .filter(name -> !ModelProperties.SYSTEM_ONLY_MODELS.contains(name))
                 .filter(name -> codexConnected || !isCodexModel(name))
-                .filter(name -> !restrictToOauth
-                        || (name.endsWith("-oauth") && !name.startsWith("gpt-5.1-")))
+                .filter(name -> !restrictToOauth || (name.endsWith("-oauth") && !name.startsWith("gpt-5.1-")))
                 .collect(Collectors.toMap(name -> name, name -> modelLocations.getOrDefault(name, name)));
     }
 

--- a/app/src/main/java/ai/brokk/AbstractService.java
+++ b/app/src/main/java/ai/brokk/AbstractService.java
@@ -382,10 +382,13 @@ public abstract class AbstractService implements ExceptionReporter.ReportingServ
      */
     public Map<String, String> getAvailableModels() {
         boolean codexConnected = MainProject.isOpenAiCodexOauthConnected();
+        boolean restrictToOauth = codexConnected && MainProject.isRestrictToOauthModelsWhenConnected();
         return modelInfoMap.keySet().stream()
                 .filter(name -> !UNAVAILABLE.equals(name))
                 .filter(name -> !ModelProperties.SYSTEM_ONLY_MODELS.contains(name))
                 .filter(name -> codexConnected || !isCodexModel(name))
+                .filter(name -> !restrictToOauth
+                        || (name.endsWith("-oauth") && !name.startsWith("gpt-5.1-")))
                 .collect(Collectors.toMap(name -> name, name -> modelLocations.getOrDefault(name, name)));
     }
 
@@ -612,8 +615,11 @@ public abstract class AbstractService implements ExceptionReporter.ReportingServ
         if (!supportsReasoningEffort(nameOf(model))) {
             level = ReasoningLevel.DEFAULT;
         }
+        // DEFAULT omits reasoning_effort entirely. For OpenAI gpt-5.2-5.4 the model's own
+        // default reasoning is disable-equivalent and they reject the literal "disable" string,
+        // so omitting the parameter is the correct way to honor DISABLE intent on those models.
         if (!supportsReasoningDisable(nameOf(model)) && level == ReasoningLevel.DISABLE) {
-            level = ReasoningLevel.LOW;
+            level = ReasoningLevel.DEFAULT;
         }
 
         var config = ModelConfig.from(model, this);

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -1915,8 +1915,8 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
                 var imageContent = ImageContent.from(l4jImage);
 
                 // Create prompt messages for the LLM
-                var systemMessage = new SystemMessage(
-                        "You describe pasted images in a few words for use as a fragment label.");
+                var systemMessage =
+                        new SystemMessage("You describe pasted images in a few words for use as a fragment label.");
                 var textContent = TextContent.from(
                         "Briefly describe this image in a few words (e.g., 'screenshot of code', 'diagram of system').");
                 var userMessage = UserMessage.from(textContent, imageContent);

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -1915,10 +1915,12 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
                 var imageContent = ImageContent.from(l4jImage);
 
                 // Create prompt messages for the LLM
+                var systemMessage = new SystemMessage(
+                        "You describe pasted images in a few words for use as a fragment label.");
                 var textContent = TextContent.from(
                         "Briefly describe this image in a few words (e.g., 'screenshot of code', 'diagram of system').");
                 var userMessage = UserMessage.from(textContent, imageContent);
-                List<ChatMessage> messages = List.of(userMessage);
+                List<ChatMessage> messages = List.of(systemMessage, userMessage);
 
                 Llm.StreamingResult result = getLlm(
                                 serviceProvider.get().summarizeModel(),

--- a/app/src/main/java/ai/brokk/DescribePasteWorker.java
+++ b/app/src/main/java/ai/brokk/DescribePasteWorker.java
@@ -6,6 +6,7 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolContext;
 import dev.langchain4j.agent.tool.ToolSpecifications;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import java.util.ArrayList;
@@ -59,14 +60,13 @@ public class DescribePasteWorker {
                         var toolContext = new ToolContext(List.of(toolSpec), ToolChoice.REQUIRED, tr);
 
                         var messages = new ArrayList<ChatMessage>();
-                        var prompt =
-                                "Describe the following content in 12 words or fewer, and identify its syntax style by calling the 'describePasteContents' tool. "
-                                        + "The syntaxStyle parameter must be one of the following values: "
+                        messages.add(new SystemMessage(
+                                "Describe pasted content in 12 words or fewer and identify its syntax style "
+                                        + "by calling the 'describePasteContents' tool. The syntaxStyle parameter "
+                                        + "must be one of: "
                                         + String.join(", ", syntaxStyles)
-                                        + ".\n\n"
-                                        + "Content:\n\n"
-                                        + content;
-                        messages.add(new UserMessage(prompt));
+                                        + "."));
+                        messages.add(new UserMessage("Content:\n\n" + content));
 
                         var llm = cm.getLlm(
                                 cm.getService().quickestModel(), "Describe pasted text", TaskResult.Type.SUMMARIZE);

--- a/app/src/main/java/ai/brokk/agents/CodeAgent.java
+++ b/app/src/main/java/ai/brokk/agents/CodeAgent.java
@@ -258,8 +258,7 @@ public class CodeAgent {
 
     public CodeAgent(IAppContextManager contextManager, StreamingChatModel model, IConsoleIO io) {
         this.contextManager = contextManager;
-        var service = contextManager.getService();
-        this.model = service.withReasoning(model, AbstractService.ReasoningLevel.DISABLE);
+        this.model = model;
         this.io = io;
 
         @Nullable String rawAttempts = System.getenv("BRK_CODE_BUILD_ATTEMPTS");

--- a/app/src/main/java/ai/brokk/agents/ReferenceAgent.java
+++ b/app/src/main/java/ai/brokk/agents/ReferenceAgent.java
@@ -13,6 +13,7 @@ import ai.brokk.git.GitDistance;
 import ai.brokk.project.ModelProperties;
 import ai.brokk.util.Json;
 import ai.brokk.util.Lines;
+import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
@@ -195,8 +196,10 @@ public class ReferenceAgent {
                         .jsonSchema(schema)
                         .build());
 
-        String prompt = buildReferenceClassificationPrompt(goal, conversationHistory, candidates);
-        var result = llm.sendRequest(List.of(new UserMessage(prompt)), requestOptions);
+        String userPrompt = buildReferenceClassificationUserPrompt(goal, conversationHistory, candidates);
+        var result = llm.sendRequest(
+                List.of(new SystemMessage(REFERENCE_CLASSIFICATION_SYSTEM_PROMPT), new UserMessage(userPrompt)),
+                requestOptions);
         if (result.error() != null) {
             return Set.of();
         }
@@ -207,13 +210,8 @@ public class ReferenceAgent {
         return relevant;
     }
 
-    private static String buildReferenceClassificationPrompt(
-            String goal, String conversationHistory, List<String> references) {
-        var mapper = Json.getMapper();
-        var valuesArray = mapper.createArrayNode();
-        references.forEach(valuesArray::add);
-
-        return """
+    private static final String REFERENCE_CLASSIFICATION_SYSTEM_PROMPT =
+            """
           You are filtering candidate references extracted from the user's request.
 
           Your task is to keep the references that are plausibly useful as initial anchors for later
@@ -235,6 +233,22 @@ public class ReferenceAgent {
           - The goal is not to find the minimum perfect set; the goal is to avoid missing anchors that would help the next search step start in the right place.
           - ... While avoiding junk and noise.
 
+          Output JSON with a single field:
+          - "relevant": array of reference strings chosen from the candidate list.
+
+          Requirements:
+          - Return only strings from the provided candidate list.
+          - Preserve exact spelling.
+          - No commentary.
+          """;
+
+    private static String buildReferenceClassificationUserPrompt(
+            String goal, String conversationHistory, List<String> references) {
+        var mapper = Json.getMapper();
+        var valuesArray = mapper.createArrayNode();
+        references.forEach(valuesArray::add);
+
+        return """
           <conversation_history>
           %s
           </conversation_history>
@@ -245,14 +259,6 @@ public class ReferenceAgent {
 
           References:
           %s
-
-          Output JSON with a single field:
-          - "relevant": array of reference strings chosen from the candidate list.
-
-          Requirements:
-          - Return only strings from the provided candidate list.
-          - Preserve exact spelling.
-          - No commentary.
           """
                 .formatted(conversationHistory, goal, valuesArray);
     }

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsAdvancedPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsAdvancedPanel.java
@@ -896,8 +896,7 @@ public class SettingsAdvancedPanel extends JPanel implements ThemeAware {
         defaultsRolesButton.addActionListener(e -> {
             boolean codexConnected = MainProject.isOpenAiCodexOauthConnected();
 
-            otherModelsVendorCombo.setSelectedItem(
-                    codexConnected ? "OpenAI - Codex" : ModelProperties.DEFAULT_VENDOR);
+            otherModelsVendorCombo.setSelectedItem(codexConnected ? "OpenAI - Codex" : ModelProperties.DEFAULT_VENDOR);
 
             // OAuth-connected: use the Codex OAuth preset; else fall back to ModelProperties defaults.
             var architectConfig = codexConnected

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsAdvancedPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsAdvancedPanel.java
@@ -212,10 +212,6 @@ public class SettingsAdvancedPanel extends JPanel implements ThemeAware {
     public boolean applySettings() {
         AdvancedValues values = collectAdvancedValues();
 
-        String previousVendorPref = MainProject.getOtherModelsVendorPreference();
-        String previousVendorSelection =
-                previousVendorPref.isBlank() ? ModelProperties.DEFAULT_VENDOR : previousVendorPref;
-
         // JVM memory
         MainProject.setJvmMemorySettings(values.jvmMemorySettings());
         JDeploySettingsUtil.updateJvmMemorySettings(values.jvmMemorySettings());
@@ -272,11 +268,9 @@ public class SettingsAdvancedPanel extends JPanel implements ThemeAware {
         }
         MainProject.setOtherModelsVendorPreference(normalizedVendorPref);
 
-        String currentVendorSelection =
-                normalizedVendorPref.isBlank() ? ModelProperties.DEFAULT_VENDOR : normalizedVendorPref;
-        if (!previousVendorSelection.equals(currentVendorSelection)) {
-            chrome.getContextManager().reloadService();
-        }
+        // Reload so freshly persisted role configs and favorites are picked up by the live Service;
+        // any model selected via getModelConfig(ModelType.*) above won't otherwise refresh in-memory.
+        chrome.getContextManager().reloadService();
 
         // Watch service implementation preference
         MainProject.setWatchServiceImplPreference(values.watchServiceImplPreference());
@@ -767,7 +761,9 @@ public class SettingsAdvancedPanel extends JPanel implements ThemeAware {
                 quickModelsTable.getCellEditor().stopCellEditing();
             }
 
-            var defaultFavorites = new ArrayList<>(MainProject.DEFAULT_FAVORITE_MODELS);
+            var defaultFavorites = MainProject.isOpenAiCodexOauthConnected()
+                    ? new ArrayList<>(ModelProperties.CODEX_OAUTH_FAVORITES)
+                    : new ArrayList<>(MainProject.DEFAULT_FAVORITE_MODELS);
 
             quickModelsTableModel.setFavorites(defaultFavorites);
             if (!defaultFavorites.isEmpty()) {
@@ -898,11 +894,18 @@ public class SettingsAdvancedPanel extends JPanel implements ThemeAware {
         rolesPanel.add(rolesButtonsPanel, gbcRoles);
 
         defaultsRolesButton.addActionListener(e -> {
-            otherModelsVendorCombo.setSelectedItem(ModelProperties.DEFAULT_VENDOR);
+            boolean codexConnected = MainProject.isOpenAiCodexOauthConnected();
 
-            // Get preferred defaults from ModelProperties
-            var architectConfig = ModelProperties.ModelType.ARCHITECT.defaultConfig();
-            var codeConfig = ModelProperties.ModelType.CODE.defaultConfig();
+            otherModelsVendorCombo.setSelectedItem(
+                    codexConnected ? "OpenAI - Codex" : ModelProperties.DEFAULT_VENDOR);
+
+            // OAuth-connected: use the Codex OAuth preset; else fall back to ModelProperties defaults.
+            var architectConfig = codexConnected
+                    ? ModelProperties.CODEX_OAUTH_ARCHITECT_CONFIG
+                    : ModelProperties.ModelType.ARCHITECT.defaultConfig();
+            var codeConfig = codexConnected
+                    ? ModelProperties.CODEX_OAUTH_CODE_CONFIG
+                    : ModelProperties.ModelType.CODE.defaultConfig();
 
             // Restore primary model to ARCHITECT default
             boolean foundPrimary = false;

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -2,7 +2,6 @@ package ai.brokk.gui.dialogs;
 
 import static java.util.Objects.requireNonNull;
 
-import ai.brokk.AbstractService;
 import ai.brokk.Service;
 import ai.brokk.SettingsChangeListener;
 import ai.brokk.gui.Chrome;

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -93,6 +93,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
     private JLabel openAiStatusLabel = new JLabel();
     private MaterialButton openAiConnectButton = new MaterialButton("Connect");
     private MaterialButton openAiDisconnectButton = new MaterialButton("Disconnect");
+    private JCheckBox restrictToOauthCheckbox = new JCheckBox("Show only OAuth-compatible models");
 
     // Connections section: paid-only components and upgrade link
     private JPanel connectionsPaidPanel = new JPanel();
@@ -472,11 +473,23 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
         connectionsPaidPanel.add(openAiPanel, paidGbc);
 
+        restrictToOauthCheckbox = new JCheckBox("Show only OAuth-compatible models");
+        restrictToOauthCheckbox.setToolTipText(
+                "When connected via ChatGPT OAuth, hide non-OAuth models from selectors. "
+                        + "Disable to also see API-key models alongside OAuth models.");
+        restrictToOauthCheckbox.setSelected(MainProject.isRestrictToOauthModelsWhenConnected());
+        restrictToOauthCheckbox.addActionListener(e -> {
+            MainProject.setRestrictToOauthModelsWhenConnected(restrictToOauthCheckbox.isSelected());
+            chrome.getContextManager().reloadService();
+        });
+        paidGbc.gridy = 1;
+        connectionsPaidPanel.add(restrictToOauthCheckbox, paidGbc);
+
         var providerKeysUrl = joinUrl(MainProject.getFrontendUrl(), "/dashboard/provider-keys");
         providerKeysLabel = new BrowserLabel(providerKeysUrl, "Set LLM Provider API Keys");
         providerKeysLabel.setToolTipText(
                 "Configure your own provider API keys for Brokk to use in upstream LLM requests.");
-        paidGbc.gridy = 1;
+        paidGbc.gridy = 2;
         connectionsPaidPanel.add(providerKeysLabel, paidGbc);
 
         gbc.gridx = 1;
@@ -2389,6 +2402,8 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
         }
         openAiConnectButton.setVisible(!connected);
         openAiDisconnectButton.setVisible(connected);
+        restrictToOauthCheckbox.setVisible(connected);
+        restrictToOauthCheckbox.setSelected(MainProject.isRestrictToOauthModelsWhenConnected());
     }
 
     /**
@@ -2468,30 +2483,12 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
                 }
             }
 
-            var codeModelConfig = new Service.ModelConfig(
-                    ModelProperties.GPT_5_3_CODEX_OAUTH, AbstractService.ReasoningLevel.DISABLE);
-            var architectModelConfig =
-                    new Service.ModelConfig(ModelProperties.GPT_5_3_CODEX_OAUTH, AbstractService.ReasoningLevel.LOW);
-
-            // Replace favorites list with only Codex OAuth models
-            var codexFavorites = List.of(
-                    new Service.FavoriteModel(
-                            "5.3 Codex instant",
-                            new Service.ModelConfig(
-                                    ModelProperties.GPT_5_3_CODEX_OAUTH, AbstractService.ReasoningLevel.DISABLE)),
-                    new Service.FavoriteModel(
-                            "5.3 Codex low",
-                            new Service.ModelConfig(
-                                    ModelProperties.GPT_5_3_CODEX_OAUTH, AbstractService.ReasoningLevel.LOW)),
-                    new Service.FavoriteModel(
-                            "5.3 Codex high",
-                            new Service.ModelConfig(
-                                    ModelProperties.GPT_5_3_CODEX_OAUTH, AbstractService.ReasoningLevel.HIGH)));
-            MainProject.saveFavoriteModels(codexFavorites);
+            MainProject.saveFavoriteModels(ModelProperties.CODEX_OAUTH_FAVORITES);
             logger.info("Replaced favorites list with Codex OAuth models");
 
-            mainProject.setModelConfig(ModelProperties.ModelType.CODE, codeModelConfig);
-            mainProject.setModelConfig(ModelProperties.ModelType.ARCHITECT, architectModelConfig);
+            mainProject.setModelConfig(ModelProperties.ModelType.CODE, ModelProperties.CODEX_OAUTH_CODE_CONFIG);
+            mainProject.setModelConfig(
+                    ModelProperties.ModelType.ARCHITECT, ModelProperties.CODEX_OAUTH_ARCHITECT_CONFIG);
 
             chrome.getContextManager().reloadService();
 

--- a/app/src/main/java/ai/brokk/project/MainProject.java
+++ b/app/src/main/java/ai/brokk/project/MainProject.java
@@ -128,6 +128,7 @@ public final class MainProject extends AbstractProject {
     private static final String AUTO_UPDATE_LOCAL_DEPENDENCIES_KEY = "autoUpdateLocalDependencies";
     private static final String AUTO_UPDATE_GIT_DEPENDENCIES_KEY = "autoUpdateGitDependencies";
     private static final String OPENAI_CODEX_OAUTH_CONNECTED_KEY = "openAiCodexOauthConnected";
+    private static final String RESTRICT_TO_OAUTH_MODELS_KEY = "restrictToOauthModelsWhenConnected";
 
     private static final List<SettingsChangeListener> settingsChangeListeners = new CopyOnWriteArrayList<>();
 
@@ -375,10 +376,13 @@ public final class MainProject extends AbstractProject {
                     storedVersion,
                     ModelProperties.MODEL_SETTINGS_VERSION);
 
-            // Remove keys to force fallback to current defaults in ModelProperties
+            // Remove keys to force fallback to current defaults in ModelProperties.
+            // Clears all role configs so any model that's been retired (e.g., 5.1-family OAuth
+            // variants) is replaced by the active vendor map on next read.
             props.remove(ModelProperties.FAVORITE_MODELS_KEY);
-            props.remove(ModelType.CODE.propertyKey);
-            props.remove(ModelType.ARCHITECT.propertyKey);
+            for (ModelType type : ModelType.values()) {
+                props.remove(type.propertyKey);
+            }
 
             props.setProperty(
                     ModelProperties.MODEL_SETTINGS_VERSION_KEY, String.valueOf(ModelProperties.MODEL_SETTINGS_VERSION));
@@ -1112,6 +1116,20 @@ public final class MainProject extends AbstractProject {
             }
             saveGlobalProperties(props);
             notifyOpenAiOauthConnectionChanged();
+        }
+    }
+
+    public static boolean isRestrictToOauthModelsWhenConnected() {
+        var props = loadGlobalProperties();
+        return Boolean.parseBoolean(props.getProperty(RESTRICT_TO_OAUTH_MODELS_KEY, "true"));
+    }
+
+    public static void setRestrictToOauthModelsWhenConnected(boolean restrict) {
+        var props = loadGlobalProperties();
+        boolean currentValue = Boolean.parseBoolean(props.getProperty(RESTRICT_TO_OAUTH_MODELS_KEY, "true"));
+        if (currentValue != restrict) {
+            props.setProperty(RESTRICT_TO_OAUTH_MODELS_KEY, Boolean.toString(restrict));
+            saveGlobalProperties(props);
         }
     }
 

--- a/app/src/main/java/ai/brokk/project/ModelProperties.java
+++ b/app/src/main/java/ai/brokk/project/ModelProperties.java
@@ -30,8 +30,9 @@ public final class ModelProperties {
     private static final String HAIKU_4_5 = "claude-haiku-4-5";
     public static final String GPT_5_3_CODEX = "gpt-5.3-codex";
 
-    public static final String GPT_5_1_CODEX_MINI_OAUTH = "gpt-5.1-codex-mini-oauth";
     public static final String GPT_5_3_CODEX_OAUTH = "gpt-5.3-codex-oauth";
+    public static final String GPT_5_2_OAUTH = "gpt-5.2-oauth";
+    public static final String GPT_5_4_OAUTH = "gpt-5.4-oauth";
 
     /** Hardcoded fallback used when live model-catalog discovery returns empty (e.g., startup races). */
     public static final List<String> BASE_MODEL_IDS = List.of(GPT_5_3_CODEX, FLASH_3);
@@ -41,9 +42,9 @@ public final class ModelProperties {
     private static final ModelConfig gpt5_4NanoHigh = new ModelConfig(GPT_54_NANO, ReasoningLevel.HIGH);
     private static final ModelConfig codex5_3 = new ModelConfig(GPT_5_3_CODEX, ReasoningLevel.DISABLE);
 
-    private static final ModelConfig gpt5_1CodexMiniOauth =
-            new ModelConfig(GPT_5_1_CODEX_MINI_OAUTH, ReasoningLevel.LOW);
     private static final ModelConfig gpt5_3CodexOauth = new ModelConfig(GPT_5_3_CODEX_OAUTH, ReasoningLevel.DISABLE);
+    private static final ModelConfig gpt5_3CodexOauthDefault =
+            new ModelConfig(GPT_5_3_CODEX_OAUTH, ReasoningLevel.DEFAULT);
 
     private static final ModelConfig haiku4_5 = new ModelConfig(HAIKU_4_5);
     private static final ModelConfig sonnet4_6 = new ModelConfig(SONNET_4_6, ReasoningLevel.DISABLE);
@@ -71,7 +72,7 @@ public final class ModelProperties {
      * Current version for model settings. Increment this to force a reset of favorite models,
      * code model, and architect model to their current defaults on the next app upgrade.
      */
-    public static final int MODEL_SETTINGS_VERSION = 1;
+    public static final int MODEL_SETTINGS_VERSION = 3;
 
     public static final String MODEL_SETTINGS_VERSION_KEY = "modelSettingsVersion";
 
@@ -83,6 +84,22 @@ public final class ModelProperties {
             new Service.FavoriteModel("GPT-5.3 Codex", codex5_3),
             new Service.FavoriteModel("Flash 3", flash3),
             new Service.FavoriteModel("Gemini 3.1 Pro", g31p));
+
+    /** Code/Architect role configs applied when Codex OAuth is the active vendor. */
+    public static final ModelConfig CODEX_OAUTH_CODE_CONFIG =
+            new ModelConfig(GPT_5_3_CODEX_OAUTH, ReasoningLevel.DISABLE);
+
+    public static final ModelConfig CODEX_OAUTH_ARCHITECT_CONFIG =
+            new ModelConfig(GPT_5_4_OAUTH, ReasoningLevel.MEDIUM);
+
+    /** Favorites preset installed by Codex OAuth auto-setup and the OAuth-aware Defaults buttons. */
+    public static final List<Service.FavoriteModel> CODEX_OAUTH_FAVORITES = List.of(
+            new Service.FavoriteModel(
+                    "5.3 Codex instant", new ModelConfig(GPT_5_3_CODEX_OAUTH, ReasoningLevel.DISABLE)),
+            new Service.FavoriteModel("5.3 Codex low", new ModelConfig(GPT_5_3_CODEX_OAUTH, ReasoningLevel.LOW)),
+            new Service.FavoriteModel("5.3 Codex high", new ModelConfig(GPT_5_3_CODEX_OAUTH, ReasoningLevel.HIGH)),
+            new Service.FavoriteModel("5.4 medium", new ModelConfig(GPT_5_4_OAUTH, ReasoningLevel.MEDIUM)),
+            new Service.FavoriteModel("5.2 Instant", new ModelConfig(GPT_5_2_OAUTH, ReasoningLevel.DEFAULT)));
 
     /**
      * Enum representing the different model configuration slots persisted in global properties.
@@ -174,15 +191,15 @@ public final class ModelProperties {
             map.put(
                     "OpenAI - Codex",
                     Map.of(
-                            ModelType.SUMMARIZE, gpt5_1CodexMiniOauth,
-                            ModelType.USAGES, gpt5_1CodexMiniOauth,
-                            ModelType.QUICK_EDIT, gpt5_1CodexMiniOauth,
-                            ModelType.QUICKEST, gpt5_1CodexMiniOauth,
-                            ModelType.COMMIT_MESSAGE, gpt5_1CodexMiniOauth,
+                            ModelType.SUMMARIZE, gpt5_3CodexOauthDefault,
+                            ModelType.USAGES, gpt5_3CodexOauthDefault,
+                            ModelType.QUICK_EDIT, gpt5_3CodexOauthDefault,
+                            ModelType.QUICKEST, gpt5_3CodexOauthDefault,
+                            ModelType.COMMIT_MESSAGE, gpt5_3CodexOauthDefault,
                             ModelType.REFERENCES, gpt5_3CodexOauth,
                             ModelType.SCAN, gpt5_3CodexOauth,
                             ModelType.SEARCH, gpt5_3CodexOauth,
-                            ModelType.BUILD_PROCESSOR, gpt5_1CodexMiniOauth));
+                            ModelType.BUILD_PROCESSOR, gpt5_3CodexOauthDefault));
 
             // Validate that all vendors have configurations for all internal ModelTypes
             for (var entry : map.entrySet()) {

--- a/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
+++ b/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
@@ -59,20 +59,31 @@ class ServiceCodexGatingTest {
         // Setup models
         service.addModel("Normal Model", "normal-loc", false);
         service.addModel("Codex Model", "codex-loc", true);
+        service.addModel("gpt-5.4-oauth", "oauth-loc", false);
 
         // 1. Not connected
         MainProject.setOpenAiCodexOauthConnected(false);
         var available = service.getAvailableModels();
         assertTrue(available.containsKey("Normal Model"));
         assertFalse(available.containsKey("Codex Model"));
+        assertTrue(available.containsKey("gpt-5.4-oauth"));
         assertFalse(service.isCodexModel("Normal Model"));
         assertTrue(service.isCodexModel("Codex Model"));
 
-        // 2. Connected
+        // 2. Connected with OAuth restriction disabled: all models visible
         MainProject.setOpenAiCodexOauthConnected(true);
+        MainProject.setRestrictToOauthModelsWhenConnected(false);
         available = service.getAvailableModels();
         assertTrue(available.containsKey("Normal Model"));
         assertTrue(available.containsKey("Codex Model"));
+        assertTrue(available.containsKey("gpt-5.4-oauth"));
+
+        // 3. Connected with OAuth restriction enabled (default): only -oauth-suffixed models visible
+        MainProject.setRestrictToOauthModelsWhenConnected(true);
+        available = service.getAvailableModels();
+        assertFalse(available.containsKey("Normal Model"));
+        assertFalse(available.containsKey("Codex Model"));
+        assertTrue(available.containsKey("gpt-5.4-oauth"));
     }
 
     /**

--- a/brokk-code/brokk_code/rust_acp_install.py
+++ b/brokk-code/brokk_code/rust_acp_install.py
@@ -219,8 +219,7 @@ def _download_bifrost(version: str) -> Path:
             actual_sha = _file_sha256(archive_path)
             if expected_sha != actual_sha:
                 raise BifrostInstallError(
-                    f"Checksum mismatch for {asset_name}: "
-                    f"expected {expected_sha}, got {actual_sha}"
+                    f"Checksum mismatch for {asset_name}: expected {expected_sha}, got {actual_sha}"
                 )
 
             extracted_dir = tmp_path / "extracted"
@@ -284,9 +283,7 @@ def _find_extracted_binary(root: Path) -> Path:
     expected = _bifrost_binary_filename()
     matches = [p for p in root.rglob(expected) if p.is_file()]
     if not matches:
-        raise BifrostInstallError(
-            f"No '{expected}' found inside extracted archive at {root}"
-        )
+        raise BifrostInstallError(f"No '{expected}' found inside extracted archive at {root}")
     # Prefer the shallowest match if multiple (release archives ship one binary at root).
     matches.sort(key=lambda p: len(p.parts))
     return matches[0]

--- a/brokk-code/brokk_code/zed_config.py
+++ b/brokk-code/brokk_code/zed_config.py
@@ -187,9 +187,7 @@ def loads_json_or_jsonc(text: str) -> Any:
         return json.loads(cleaned)
 
 
-def brokk_code_entry_name(
-    *, native: bool = False, rust_paths: RustAcpPaths | None = None
-) -> str:
+def brokk_code_entry_name(*, native: bool = False, rust_paths: RustAcpPaths | None = None) -> str:
     """Returns the agent_servers key for a given install variant.
 
     Distinct keys per variant let the default, --native, and --rust installs

--- a/brokk-code/tests/test_bifrost_launcher.py
+++ b/brokk-code/tests/test_bifrost_launcher.py
@@ -10,9 +10,7 @@ import pytest
 from brokk_code import bifrost_launcher, mcp_launcher, rust_acp_install
 
 
-def test_run_bifrost_server_uses_override_and_execs_searchtools(
-    monkeypatch, tmp_path
-) -> None:
+def test_run_bifrost_server_uses_override_and_execs_searchtools(monkeypatch, tmp_path) -> None:
     captured: dict[str, object] = {}
 
     binary = tmp_path / "bifrost"
@@ -179,9 +177,7 @@ def test_parse_sha256_rejects_malformed(tmp_path) -> None:
 def test_download_bifrost_extracts_and_caches(monkeypatch, tmp_path) -> None:
     """End-to-end exercise of _download_bifrost with a stubbed httpx layer."""
     cache_root = tmp_path / "cache"
-    monkeypatch.setattr(
-        "brokk_code.rust_acp_install.get_global_cache_dir", lambda: cache_root
-    )
+    monkeypatch.setattr("brokk_code.rust_acp_install.get_global_cache_dir", lambda: cache_root)
     monkeypatch.setattr(rust_acp_install.platform, "system", lambda: "Linux")
     monkeypatch.setattr(rust_acp_install.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(sys, "platform", "linux")


### PR DESCRIPTION
## Summary

Fixes a cluster of issues hit when running Brokk with the OpenAI Codex OAuth (ChatGPT account) vendor selected.

### Model defaults

- Drop retired `gpt-5.1-codex-mini-oauth`. Add `gpt-5.2-oauth` and `gpt-5.4-oauth` ids and `CODEX_OAUTH_CODE_CONFIG` / `ARCHITECT_CONFIG` / `FAVORITES` preset constants.
- Route OpenAI-Codex lower roles (SUMMARIZE / USAGES / QUICK_EDIT / QUICKEST / COMMIT_MESSAGE / BUILD_PROCESSOR) to `gpt-5.3-codex-oauth` with DEFAULT reasoning. `gpt-5.2-codex` is rejected by the Codex/ChatGPT account API.
- Bump `MODEL_SETTINGS_VERSION` to 3 and clear *all* role configs on migration so retired model ids get replaced by the active vendor map.

### OAuth restriction toggle

- New `restrictToOauthModelsWhenConnected` setting (default on) and checkbox in the Connections section.
- Filters `getAvailableModels` to `*-oauth` (excluding `5.1-`) when Codex OAuth is connected.

### Reasoning honors user config

- `CodeAgent` no longer overrides reasoning to DISABLE in its constructor; the user-configured level for the CODE role is honored as-is. Curated role defaults already specify DISABLE in `ModelProperties` where appropriate.
- `AbstractService.withReasoning` fallback for non-disable-capable models is now DEFAULT, not LOW. OpenAI gpt-5.2-5.4 reject the literal `disable` string and the proxy doesn't translate it; omitting the parameter matches the model's own default.

### Codex API SystemMessage compat

The Codex Responses API requires a top-level `instructions` field and rejects user-only requests with `Instructions are required`. Audited every `llm.sendRequest` call site and fixed three that built user-only message lists:

- `ReferenceAgent` — split persona / criteria / output-format into `SystemMessage`; data inputs (conversation_history, goal, references) into `UserMessage`.
- `ContextManager.submitSummarizePastedImage` — prepended `SystemMessage`.
- `DescribePasteWorker` — split tool-call instructions into `SystemMessage`; pasted content into `UserMessage`.

### Settings apply path

- `SettingsAdvancedPanel.applySettings` now always reloads the service.
- The previous guard only reloaded on vendor change, missing cases like the Defaults button rewriting role configs while keeping the same vendor selected — which left the live `Service` holding stale model assignments after a config rewrite.

## Test plan

- [x] Connect Codex OAuth on a fresh install; verify auto-setup populates roles with `gpt-5.3-codex-oauth` and `gpt-5.4-oauth`, no `gpt-5.2-codex-oauth` anywhere in `brokk.properties`.
- [x] On an existing install (modelSettingsVersion < 3), launch Brokk and verify migration clears the old role configs and re-applies the new defaults.
- [x] Toggle "Show only OAuth-compatible models" off/on and confirm `getAvailableModels` widens/narrows accordingly while Codex OAuth is connected.
- [x] Trigger workflows that hit the previously broken roles under Codex vendor: paste an image (SUMMARIZE), describe pasted text (QUICKEST), reference search (REFERENCES). All should complete without `The 'gpt-5.2-codex' model is not supported` or `Instructions are required` errors.
- [ ] Pick a non-default reasoning level (e.g. LOW) for the CODE role and confirm `CodeAgent` honors it instead of forcing DISABLE.
- [x] Click Settings -> Defaults + OK without changing vendor; verify the live service immediately resolves to the new role configs without requiring a Brokk restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)