### PR TITLE
brokk-acp-rust: stream timeout, persistence error propagation, prompt-state snapshot

### DIFF
--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -18,7 +18,7 @@ use agent_client_protocol::{
 };
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::llm_client::{ChatMessage, LlmBackend};
+use crate::llm_client::LlmBackend;
 use crate::session::{ConversationTurn, PermissionMode, SessionMode, SessionStore};
 
 /// Stable ids for our `SessionConfigOption` selectors. We expose both
@@ -295,9 +295,20 @@ pub async fn run_agent(
                     return responder.respond(PromptResponse::new(StopReason::EndTurn));
                 }
 
-                // Get session state (prompt doesn't carry cwd, so use current dir as fallback)
+                // Get session state (prompt doesn't carry cwd, so use current dir as fallback).
+                // Build the full prompt state -- cwd, mode, model, permission mode, and
+                // the ChatMessage list including system prompt and the new user turn --
+                // under one read lock, so we never clone the conversation history twice.
                 let fallback_cwd = std::env::current_dir().unwrap_or_default();
-                let session = match sessions_prompt.get_session(&session_id, &fallback_cwd).await {
+                let prompt_state = match sessions_prompt
+                    .build_prompt_state(
+                        &session_id,
+                        &fallback_cwd,
+                        prompt_text.clone(),
+                        |mode, cwd| build_system_prompt(&mode, cwd),
+                    )
+                    .await
+                {
                     Some(s) => s,
                     None => {
                         send_message(&cx, &session_id, "Error: unknown session");
@@ -306,20 +317,12 @@ pub async fn run_agent(
                 };
 
                 // Validate model is configured
-                if session.model.is_empty() {
+                if prompt_state.model.is_empty() {
                     send_message(&cx, &session_id, "Error: no model configured. Start the server with --default-model or ensure the LLM endpoint is reachable for model discovery.");
                     return responder.respond(PromptResponse::new(StopReason::EndTurn));
                 }
 
-                // Build conversation messages from history
-                let mut messages = vec![
-                    ChatMessage::system(build_system_prompt(&session.mode, &session.cwd)),
-                ];
-                for turn in &session.history {
-                    messages.push(ChatMessage::user(turn.user_prompt.clone()));
-                    messages.push(ChatMessage::assistant(turn.agent_response.clone()));
-                }
-                messages.push(ChatMessage::user(prompt_text.clone()));
+                let messages = prompt_state.messages;
 
                 // Create a cancellation token for this prompt
                 let cancel = sessions_prompt.start_prompt(&session_id).await;
@@ -328,7 +331,7 @@ pub async fn run_agent(
                 let registry = sessions_prompt
                     .get_or_create_registry(
                         &session_id,
-                        session.cwd.clone(),
+                        prompt_state.cwd,
                         bifrost_binary_prompt.as_deref(),
                     )
                     .await;
@@ -342,7 +345,7 @@ pub async fn run_agent(
                 let cx_for_loop = cx.clone();
                 let session_id_for_loop = session_id.clone();
                 let prompt_text_for_turn = prompt_text;
-                let model_for_loop = session.model.clone();
+                let model_for_loop = prompt_state.model;
 
                 cx.spawn(async move {
                     use futures::FutureExt;

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -18,7 +18,7 @@ use agent_client_protocol::{
 };
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::llm_client::LlmBackend;
+use crate::llm_client::{ChatMessage, LlmBackend};
 use crate::session::{ConversationTurn, PermissionMode, SessionMode, SessionStore};
 
 /// Stable ids for our `SessionConfigOption` selectors. We expose both
@@ -296,17 +296,12 @@ pub async fn run_agent(
                 }
 
                 // Get session state (prompt doesn't carry cwd, so use current dir as fallback).
-                // Build the full prompt state -- cwd, mode, model, permission mode, and
-                // the ChatMessage list including system prompt and the new user turn --
-                // under one read lock, so we never clone the conversation history twice.
+                // The snapshot clones the conversation history exactly once under the
+                // read lock; we then consume it via `.into_iter()` to build ChatMessages
+                // without further string copies.
                 let fallback_cwd = std::env::current_dir().unwrap_or_default();
-                let prompt_state = match sessions_prompt
-                    .build_prompt_state(
-                        &session_id,
-                        &fallback_cwd,
-                        prompt_text.clone(),
-                        |mode, cwd| build_system_prompt(&mode, cwd),
-                    )
+                let snap = match sessions_prompt
+                    .snapshot(&session_id, &fallback_cwd)
                     .await
                 {
                     Some(s) => s,
@@ -317,12 +312,18 @@ pub async fn run_agent(
                 };
 
                 // Validate model is configured
-                if prompt_state.model.is_empty() {
+                if snap.model.is_empty() {
                     send_message(&cx, &session_id, "Error: no model configured. Start the server with --default-model or ensure the LLM endpoint is reachable for model discovery.");
                     return responder.respond(PromptResponse::new(StopReason::EndTurn));
                 }
 
-                let messages = prompt_state.messages;
+                let mut messages = Vec::with_capacity(snap.history.len() * 2 + 2);
+                messages.push(ChatMessage::system(build_system_prompt(&snap.mode, &snap.cwd)));
+                for turn in snap.history {
+                    messages.push(ChatMessage::user(turn.user_prompt));
+                    messages.push(ChatMessage::assistant(turn.agent_response));
+                }
+                messages.push(ChatMessage::user(prompt_text.clone()));
 
                 // Create a cancellation token for this prompt
                 let cancel = sessions_prompt.start_prompt(&session_id).await;
@@ -331,7 +332,7 @@ pub async fn run_agent(
                 let registry = sessions_prompt
                     .get_or_create_registry(
                         &session_id,
-                        prompt_state.cwd,
+                        snap.cwd,
                         bifrost_binary_prompt.as_deref(),
                     )
                     .await;
@@ -345,7 +346,7 @@ pub async fn run_agent(
                 let cx_for_loop = cx.clone();
                 let session_id_for_loop = session_id.clone();
                 let prompt_text_for_turn = prompt_text;
-                let model_for_loop = prompt_state.model;
+                let model_for_loop = snap.model;
 
                 cx.spawn(async move {
                     use futures::FutureExt;
@@ -385,9 +386,6 @@ pub async fn run_agent(
                     .catch_unwind()
                     .await;
 
-                    // Clean up cancellation token even on panic.
-                    sessions_for_loop.finish_prompt(&session_id_for_loop).await;
-
                     let response_text = match loop_result {
                         Ok(text) => text,
                         Err(panic) => {
@@ -400,8 +398,13 @@ pub async fn run_agent(
                         }
                     };
 
-                    // Save conversation turn (best effort -- logged on failure inside the store).
-                    sessions_for_loop
+                    // Persist the conversation turn BEFORE finish_prompt so the
+                    // per-session cancel token is held during the rewrite -- this
+                    // is the locking that makes `add_turn`'s rollback safe (see
+                    // the concurrency note on `SessionStore::add_turn`). On
+                    // failure, surface the error to the client so the user
+                    // knows their last turn isn't on disk.
+                    let persist_result = sessions_for_loop
                         .add_turn(
                             &session_id_for_loop,
                             ConversationTurn {
@@ -410,6 +413,20 @@ pub async fn run_agent(
                             },
                         )
                         .await;
+
+                    if let Err(e) = persist_result {
+                        send_message(
+                            &cx_for_loop,
+                            &session_id_for_loop,
+                            &format!(
+                                "\n**Warning:** failed to save this conversation turn to disk; \
+                                 it will not survive a session reload: {e}\n"
+                            ),
+                        );
+                    }
+
+                    // Clean up cancellation token even on panic / persistence failure.
+                    sessions_for_loop.finish_prompt(&session_id_for_loop).await;
 
                     if let Err(e) = responder.respond(PromptResponse::new(StopReason::EndTurn)) {
                         tracing::warn!(

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
+use crate::llm_client::ChatMessage;
 use crate::tools::ToolRegistry;
 
 // ---------------------------------------------------------------------------
@@ -171,6 +172,16 @@ impl Session {
             always_allow_tools: HashSet::new(),
         }
     }
+}
+
+/// Snapshot of the per-session data needed to start a prompt turn, with the
+/// full `ChatMessage` list pre-built so the caller doesn't have to clone the
+/// conversation history.
+#[derive(Debug)]
+pub struct PromptState {
+    pub cwd: PathBuf,
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
 }
 
 // ---------------------------------------------------------------------------
@@ -375,31 +386,28 @@ fn write_new_session_zip(zip_path: &Path, manifest: &SessionManifest) {
 }
 
 /// Update manifest.json and add a conversation turn to an existing session zip.
-fn append_turn_to_zip(zip_path: &Path, manifest: &SessionManifest, turn: &ConversationTurn) {
+///
+/// Failures of the framing operations (open, archive read, finalize, rename) are
+/// surfaced to the caller so the in-memory `add_turn` can roll back and keep
+/// `memory == disk`. Per-entry write failures inside the zip are still logged
+/// only; if any of those occur the temp zip is incomplete and the rename step
+/// will fail downstream, so callers still see the error.
+fn append_turn_to_zip(
+    zip_path: &Path,
+    manifest: &SessionManifest,
+    turn: &ConversationTurn,
+) -> anyhow::Result<()> {
+    use anyhow::Context;
+
     // Read the existing zip, rebuild with new content
-    let file = match std::fs::File::open(zip_path) {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::warn!("failed to open session zip for update: {e}");
-            return;
-        }
-    };
-    let mut archive = match zip::ZipArchive::new(file) {
-        Ok(a) => a,
-        Err(e) => {
-            tracing::warn!("failed to read session zip: {e}");
-            return;
-        }
-    };
+    let file = std::fs::File::open(zip_path)
+        .with_context(|| format!("opening session zip {} for update", zip_path.display()))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .with_context(|| format!("reading session zip {}", zip_path.display()))?;
 
     let tmp = zip_path.with_extension("tmp");
-    let out_file = match std::fs::File::create(&tmp) {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::warn!("failed to create temp zip: {e}");
-            return;
-        }
-    };
+    let out_file = std::fs::File::create(&tmp)
+        .with_context(|| format!("creating temp zip {}", tmp.display()))?;
 
     let mut zip_writer = zip::ZipWriter::new(out_file);
     let options = zip::write::SimpleFileOptions::default()
@@ -564,10 +572,12 @@ fn append_turn_to_zip(zip_path: &Path, manifest: &SessionManifest, turn: &Conver
         let _ = zip_writer.write_all(turn.agent_response.as_bytes());
     }
 
-    let _ = zip_writer.finish();
-    if let Err(e) = std::fs::rename(&tmp, zip_path) {
-        tracing::warn!("failed to rename updated session zip: {e}");
-    }
+    zip_writer
+        .finish()
+        .with_context(|| format!("finalizing temp zip {}", tmp.display()))?;
+    std::fs::rename(&tmp, zip_path)
+        .with_context(|| format!("renaming {} to {}", tmp.display(), zip_path.display()))?;
+    Ok(())
 }
 
 /// Replace manifest.json in an existing session zip, copying all other entries as-is.
@@ -727,21 +737,36 @@ impl SessionStore {
     }
 
     /// Get session from memory, or load from disk if it exists.
+    ///
+    /// Note: this clones the full `Session` (including the conversation history
+    /// vec). Callers on the hot prompt path should prefer `build_prompt_state`,
+    /// which constructs the message list under the read lock without copying
+    /// the history twice.
     pub async fn get_session(&self, id: &str, cwd: &Path) -> Option<Session> {
-        // Check memory first
-        if let Some(s) = self.sessions.read().await.get(id).cloned() {
-            return Some(s);
+        if !self.load_into_memory_if_cold(id, cwd).await {
+            return None;
         }
-        // Try to load from executor's session zip on disk (on a blocking worker).
+        self.sessions.read().await.get(id).cloned()
+    }
+
+    /// Ensure the session is in memory, loading it from disk if needed.
+    /// Returns true iff the session ends up loaded.
+    async fn load_into_memory_if_cold(&self, id: &str, cwd: &Path) -> bool {
+        if self.sessions.read().await.contains_key(id) {
+            return true;
+        }
         let zip_path = session_zip_path(cwd, id);
-        let (manifest, history) = tokio::task::spawn_blocking(move || {
+        let loaded = tokio::task::spawn_blocking(move || {
             let manifest = read_manifest_from_zip(&zip_path)?;
             let history = read_history_from_zip(&zip_path);
             Some((manifest, history))
         })
         .await
         .ok()
-        .flatten()?;
+        .flatten();
+        let Some((manifest, history)) = loaded else {
+            return false;
+        };
 
         // Prefer persisted mode/model; fall back to server defaults.
         let mode = manifest
@@ -768,11 +793,48 @@ impl SessionStore {
             permission_mode: PermissionMode::Default,
             always_allow_tools: HashSet::new(),
         };
-        self.sessions
-            .write()
-            .await
-            .insert(id.to_string(), session.clone());
-        Some(session)
+        let mut sessions = self.sessions.write().await;
+        // Re-check under the write lock in case another task loaded it concurrently.
+        sessions.entry(id.to_string()).or_insert(session);
+        true
+    }
+
+    /// Build the per-prompt context (cwd, mode, model, permission mode, and
+    /// the full ChatMessage list including system prompt and the new user
+    /// turn) without cloning the session's conversation history twice.
+    ///
+    /// `system_prompt_for` runs under the read lock, given the persisted mode
+    /// and cwd, so the caller controls system-prompt content without leaking
+    /// session internals. The closure runs synchronously and is dropped
+    /// before the lock is released.
+    pub async fn build_prompt_state<F>(
+        &self,
+        id: &str,
+        fallback_cwd: &Path,
+        new_user_prompt: String,
+        system_prompt_for: F,
+    ) -> Option<PromptState>
+    where
+        F: FnOnce(SessionMode, &Path) -> String,
+    {
+        if !self.load_into_memory_if_cold(id, fallback_cwd).await {
+            return None;
+        }
+        let sessions = self.sessions.read().await;
+        let s = sessions.get(id)?;
+        let system_prompt = system_prompt_for(s.mode, &s.cwd);
+        let mut messages = Vec::with_capacity(s.history.len() * 2 + 2);
+        messages.push(ChatMessage::system(system_prompt));
+        for turn in &s.history {
+            messages.push(ChatMessage::user(turn.user_prompt.clone()));
+            messages.push(ChatMessage::assistant(turn.agent_response.clone()));
+        }
+        messages.push(ChatMessage::user(new_user_prompt));
+        Some(PromptState {
+            cwd: s.cwd.clone(),
+            model: s.model.clone(),
+            messages,
+        })
     }
 
     pub async fn update_cwd(&self, id: &str, cwd: PathBuf) {
@@ -851,12 +913,21 @@ impl SessionStore {
     }
 
     /// Add a conversation turn and persist it to the session zip.
+    ///
+    /// On persistence failure the in-memory turn is rolled back so memory and
+    /// disk stay in sync: the next prompt either succeeds (with both written)
+    /// or surfaces the same error again deterministically. The error is logged
+    /// at `error!` level. The atomic temp-then-rename in `append_turn_to_zip`
+    /// guarantees the on-disk zip is unchanged on any failure path, so the
+    /// rollback restores a consistent state.
     pub async fn add_turn(&self, id: &str, turn: ConversationTurn) {
         // Mutate in-memory state first, then release the lock BEFORE blocking I/O.
+        // Capture pre-mutation `modified` so we can reverse the bump on failure.
         let snapshot = {
             let mut sessions = self.sessions.write().await;
             match sessions.get_mut(id) {
                 Some(session) => {
+                    let prev_modified = session.manifest.modified;
                     session.history.push(turn.clone());
                     let now = std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
@@ -866,16 +937,40 @@ impl SessionStore {
                     Some((
                         session_zip_path(&session.cwd, &session.id),
                         session.manifest.clone(),
+                        prev_modified,
                     ))
                 }
                 None => None,
             }
         };
-        if let Some((zip_path, manifest)) = snapshot {
-            let _ = tokio::task::spawn_blocking(move || {
-                append_turn_to_zip(&zip_path, &manifest, &turn)
-            })
-            .await;
+        let Some((zip_path, manifest, prev_modified)) = snapshot else {
+            return;
+        };
+
+        let turn_for_zip = turn.clone();
+        let join_result = tokio::task::spawn_blocking(move || {
+            append_turn_to_zip(&zip_path, &manifest, &turn_for_zip)
+        })
+        .await;
+
+        let persist_result = match join_result {
+            Ok(r) => r,
+            Err(join_err) => Err(anyhow::anyhow!(
+                "session persistence task panicked: {join_err}"
+            )),
+        };
+
+        if let Err(e) = persist_result {
+            tracing::error!(
+                session_id = %id,
+                "failed to persist conversation turn; rolling back in-memory state: {e:#}"
+            );
+            // A session has at most one in-flight prompt at a time, so the
+            // turn we just pushed is still the last entry.
+            if let Some(session) = self.sessions.write().await.get_mut(id) {
+                session.history.pop();
+                session.manifest.modified = prev_modified;
+            }
         }
     }
 

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-use crate::llm_client::ChatMessage;
 use crate::tools::ToolRegistry;
 
 // ---------------------------------------------------------------------------
@@ -174,14 +173,20 @@ impl Session {
     }
 }
 
-/// Snapshot of the per-session data needed to start a prompt turn, with the
-/// full `ChatMessage` list pre-built so the caller doesn't have to clone the
-/// conversation history.
+/// Snapshot of the per-session data needed to start a prompt turn. The
+/// conversation history is cloned exactly once under the read lock; callers
+/// consume it (via `.into_iter()`) when constructing protocol-specific
+/// message types, so no further string clones happen on the prompt path.
+///
+/// This intentionally exposes raw `ConversationTurn` rather than a
+/// pre-built `Vec<ChatMessage>` so `session.rs` doesn't depend on the LLM
+/// transport layer — message assembly belongs at the call site.
 #[derive(Debug)]
-pub struct PromptState {
+pub struct SessionSnapshot {
     pub cwd: PathBuf,
+    pub mode: SessionMode,
     pub model: String,
-    pub messages: Vec<ChatMessage>,
+    pub history: Vec<ConversationTurn>,
 }
 
 // ---------------------------------------------------------------------------
@@ -751,6 +756,11 @@ impl SessionStore {
 
     /// Ensure the session is in memory, loading it from disk if needed.
     /// Returns true iff the session ends up loaded.
+    ///
+    /// Note: if a session is already in memory, this is a no-op and the
+    /// disk copy is NOT re-read. Live in-memory state (e.g. an updated
+    /// `permission_mode` or pushed history turn) takes precedence over
+    /// whatever is on disk.
     async fn load_into_memory_if_cold(&self, id: &str, cwd: &Path) -> bool {
         if self.sessions.read().await.contains_key(id) {
             return true;
@@ -794,46 +804,31 @@ impl SessionStore {
             always_allow_tools: HashSet::new(),
         };
         let mut sessions = self.sessions.write().await;
-        // Re-check under the write lock in case another task loaded it concurrently.
+        // Race window: another task may have inserted under the same id while
+        // we read from disk. `or_insert` keeps the existing in-memory entry
+        // (which may carry mutations not yet persisted, like a newer
+        // `permission_mode` or pushed turn) and silently drops our freshly
+        // loaded copy. The on-disk zip is read-only on this path so no
+        // information is lost.
         sessions.entry(id.to_string()).or_insert(session);
         true
     }
 
-    /// Build the per-prompt context (cwd, mode, model, permission mode, and
-    /// the full ChatMessage list including system prompt and the new user
-    /// turn) without cloning the session's conversation history twice.
-    ///
-    /// `system_prompt_for` runs under the read lock, given the persisted mode
-    /// and cwd, so the caller controls system-prompt content without leaking
-    /// session internals. The closure runs synchronously and is dropped
-    /// before the lock is released.
-    pub async fn build_prompt_state<F>(
-        &self,
-        id: &str,
-        fallback_cwd: &Path,
-        new_user_prompt: String,
-        system_prompt_for: F,
-    ) -> Option<PromptState>
-    where
-        F: FnOnce(SessionMode, &Path) -> String,
-    {
+    /// Snapshot the per-session data needed to start a prompt turn,
+    /// cloning the conversation history exactly once (under the read lock).
+    /// Callers consume `history` to build protocol-specific message types
+    /// without further string copies.
+    pub async fn snapshot(&self, id: &str, fallback_cwd: &Path) -> Option<SessionSnapshot> {
         if !self.load_into_memory_if_cold(id, fallback_cwd).await {
             return None;
         }
         let sessions = self.sessions.read().await;
         let s = sessions.get(id)?;
-        let system_prompt = system_prompt_for(s.mode, &s.cwd);
-        let mut messages = Vec::with_capacity(s.history.len() * 2 + 2);
-        messages.push(ChatMessage::system(system_prompt));
-        for turn in &s.history {
-            messages.push(ChatMessage::user(turn.user_prompt.clone()));
-            messages.push(ChatMessage::assistant(turn.agent_response.clone()));
-        }
-        messages.push(ChatMessage::user(new_user_prompt));
-        Some(PromptState {
+        Some(SessionSnapshot {
             cwd: s.cwd.clone(),
+            mode: s.mode,
             model: s.model.clone(),
-            messages,
+            history: s.history.clone(),
         })
     }
 
@@ -914,13 +909,25 @@ impl SessionStore {
 
     /// Add a conversation turn and persist it to the session zip.
     ///
-    /// On persistence failure the in-memory turn is rolled back so memory and
-    /// disk stay in sync: the next prompt either succeeds (with both written)
-    /// or surfaces the same error again deterministically. The error is logged
-    /// at `error!` level. The atomic temp-then-rename in `append_turn_to_zip`
-    /// guarantees the on-disk zip is unchanged on any failure path, so the
-    /// rollback restores a consistent state.
-    pub async fn add_turn(&self, id: &str, turn: ConversationTurn) {
+    /// Returns `Ok(())` on successful persistence, or `Err` if the zip
+    /// rewrite failed. On error the in-memory turn is rolled back so memory
+    /// and disk stay in sync: the next prompt either succeeds (with both
+    /// written) or surfaces the same error again deterministically. The
+    /// atomic temp-then-rename in `append_turn_to_zip` guarantees the
+    /// on-disk zip is unchanged on any failure path.
+    ///
+    /// Concurrency: callers must serialize `add_turn` per session. The agent
+    /// achieves this by holding the per-session cancellation token via
+    /// `start_prompt`/`finish_prompt` for the entire prompt-plus-persistence
+    /// window — `finish_prompt` runs *after* `add_turn` returns. Without
+    /// that ordering, a second `session/prompt` could push a new turn
+    /// between this turn's push and its rollback `pop()`, removing the
+    /// wrong entry.
+    pub async fn add_turn(
+        &self,
+        id: &str,
+        turn: ConversationTurn,
+    ) -> anyhow::Result<()> {
         // Mutate in-memory state first, then release the lock BEFORE blocking I/O.
         // Capture pre-mutation `modified` so we can reverse the bump on failure.
         let snapshot = {
@@ -944,7 +951,9 @@ impl SessionStore {
             }
         };
         let Some((zip_path, manifest, prev_modified)) = snapshot else {
-            return;
+            // Session is unknown -- no in-memory state to roll back, nothing
+            // to persist. Treat as a no-op success.
+            return Ok(());
         };
 
         let turn_for_zip = turn.clone();
@@ -965,13 +974,13 @@ impl SessionStore {
                 session_id = %id,
                 "failed to persist conversation turn; rolling back in-memory state: {e:#}"
             );
-            // A session has at most one in-flight prompt at a time, so the
-            // turn we just pushed is still the last entry.
             if let Some(session) = self.sessions.write().await.get_mut(id) {
                 session.history.pop();
                 session.manifest.modified = prev_modified;
             }
+            return Err(e);
         }
+        Ok(())
     }
 
     /// List sessions from disk, filtered by cwd.
@@ -999,5 +1008,76 @@ impl SessionStore {
 
     pub async fn finish_prompt(&self, session_id: &str) {
         self.cancel_tokens.write().await.remove(session_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an in-memory session that has NEVER been written to disk, then
+    /// call `add_turn`. The append step must fail (because the zip file
+    /// doesn't exist), and the in-memory state must be rolled back so
+    /// `history` is empty and `manifest.modified` matches the pre-call value.
+    #[tokio::test]
+    async fn add_turn_rolls_back_on_persistence_failure() {
+        let store = SessionStore::new("test-model".to_string());
+
+        // Hand-construct a session and inject it into the in-memory map without
+        // ever calling `create_session` (which would write a zip on disk).
+        let id = "rollback-test".to_string();
+        let cwd = std::env::temp_dir().join(format!("brokk-acp-rust-rollback-{}", id));
+        let session = Session::new(id.clone(), cwd, "test-model".to_string(), "test".into());
+        let pre_modified = session.manifest.modified;
+        store
+            .sessions
+            .write()
+            .await
+            .insert(id.clone(), session);
+
+        let result = store
+            .add_turn(
+                &id,
+                ConversationTurn {
+                    user_prompt: "hello".into(),
+                    agent_response: "world".into(),
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "add_turn should fail when the session zip doesn't exist on disk"
+        );
+
+        let sessions = store.sessions.read().await;
+        let s = sessions.get(&id).expect("session still in memory");
+        assert!(
+            s.history.is_empty(),
+            "rollback should have popped the optimistically-pushed turn, got {:?}",
+            s.history
+        );
+        assert_eq!(
+            s.manifest.modified, pre_modified,
+            "rollback should restore the pre-call manifest.modified timestamp"
+        );
+    }
+
+    /// Sanity check that `add_turn` on an unknown session id is a no-op
+    /// success rather than an error -- callers may race between session
+    /// removal (none today, but reserved) and turn persistence.
+    #[tokio::test]
+    async fn add_turn_unknown_session_is_noop_success() {
+        let store = SessionStore::new("test-model".to_string());
+        let result = store
+            .add_turn(
+                "no-such-session",
+                ConversationTurn {
+                    user_prompt: "x".into(),
+                    agent_response: "y".into(),
+                },
+            )
+            .await;
+        assert!(result.is_ok());
     }
 }

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -923,11 +923,7 @@ impl SessionStore {
     /// that ordering, a second `session/prompt` could push a new turn
     /// between this turn's push and its rollback `pop()`, removing the
     /// wrong entry.
-    pub async fn add_turn(
-        &self,
-        id: &str,
-        turn: ConversationTurn,
-    ) -> anyhow::Result<()> {
+    pub async fn add_turn(&self, id: &str, turn: ConversationTurn) -> anyhow::Result<()> {
         // Mutate in-memory state first, then release the lock BEFORE blocking I/O.
         // Capture pre-mutation `modified` so we can reverse the bump on failure.
         let snapshot = {
@@ -1029,11 +1025,7 @@ mod tests {
         let cwd = std::env::temp_dir().join(format!("brokk-acp-rust-rollback-{}", id));
         let session = Session::new(id.clone(), cwd, "test-model".to_string(), "test".into());
         let pre_modified = session.manifest.modified;
-        store
-            .sessions
-            .write()
-            .await
-            .insert(id.clone(), session);
+        store.sessions.write().await.insert(id.clone(), session);
 
         let result = store
             .add_turn(

--- a/brokk-acp-rust/src/tool_loop.rs
+++ b/brokk-acp-rust/src/tool_loop.rs
@@ -25,6 +25,13 @@ const MAX_TOOL_RESULT_BYTES: usize = 50_000;
 /// and spawned task parked indefinitely with no operator-visible signal.
 const PERMISSION_REQUEST_TIMEOUT: Duration = Duration::from_secs(900);
 
+/// Cap on a single LLM streaming turn. The reqwest HTTP client has its own
+/// overall request timeout, but a stream that produces occasional bytes
+/// without meaningful progress can keep the connection alive past it; this
+/// bounds the loop's per-turn wait so a stuck server can't park the prompt
+/// handler indefinitely.
+const STREAM_CHAT_TIMEOUT: Duration = Duration::from_secs(600);
+
 /// Tools that must NEVER pick up an in-session "Always allow" — every call
 /// re-prompts. Today this is just the shell; even with prefix-scoped allow
 /// keys the danger surface is too wide without an OS sandbox (tracked in
@@ -188,15 +195,24 @@ pub(crate) async fn run(
             }
         });
 
-        let response = llm
-            .stream_chat(
+        let response = match tokio::time::timeout(
+            STREAM_CHAT_TIMEOUT,
+            llm.stream_chat(
                 model,
                 messages.clone(),
                 turn_tools,
                 on_token,
                 cancel.clone(),
-            )
-            .await;
+            ),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => Err(anyhow::anyhow!(
+                "LLM stream did not complete within {}s",
+                STREAM_CHAT_TIMEOUT.as_secs()
+            )),
+        };
 
         match response {
             Ok(LlmResponse::Text(text)) => {

--- a/brokk-acp-rust/src/tool_loop.rs
+++ b/brokk-acp-rust/src/tool_loop.rs
@@ -25,13 +25,6 @@ const MAX_TOOL_RESULT_BYTES: usize = 50_000;
 /// and spawned task parked indefinitely with no operator-visible signal.
 const PERMISSION_REQUEST_TIMEOUT: Duration = Duration::from_secs(900);
 
-/// Cap on a single LLM streaming turn. The reqwest HTTP client has its own
-/// overall request timeout, but a stream that produces occasional bytes
-/// without meaningful progress can keep the connection alive past it; this
-/// bounds the loop's per-turn wait so a stuck server can't park the prompt
-/// handler indefinitely.
-const STREAM_CHAT_TIMEOUT: Duration = Duration::from_secs(600);
-
 /// Tools that must NEVER pick up an in-session "Always allow" — every call
 /// re-prompts. Today this is just the shell; even with prefix-scoped allow
 /// keys the danger surface is too wide without an OS sandbox (tracked in
@@ -195,24 +188,21 @@ pub(crate) async fn run(
             }
         });
 
-        let response = match tokio::time::timeout(
-            STREAM_CHAT_TIMEOUT,
-            llm.stream_chat(
+        // Wall-clock bound on this stream is enforced by the reqwest client's
+        // own `.timeout(...)` (see `OpenAiClient::new`); duplicating it here
+        // would fire at ~the same moment with no added value. The original
+        // concern in #3366 -- streams that drip occasional bytes -- is
+        // genuinely about per-chunk inactivity, which a wall-clock timeout
+        // doesn't catch. Tracked as a separate fix in #3453.
+        let response = llm
+            .stream_chat(
                 model,
                 messages.clone(),
                 turn_tools,
                 on_token,
                 cancel.clone(),
-            ),
-        )
-        .await
-        {
-            Ok(r) => r,
-            Err(_) => Err(anyhow::anyhow!(
-                "LLM stream did not complete within {}s",
-                STREAM_CHAT_TIMEOUT.as_secs()
-            )),
-        };
+            )
+            .await;
 
         match response {
             Ok(LlmResponse::Text(text)) => {


### PR DESCRIPTION
## Summary

Bundles two improvements to brokk-acp-rust (a third change addressing #3366 was reverted during review — see below):

- **#3410 — propagate persistence errors and roll back.** `append_turn_to_zip` now returns `anyhow::Result<()>` and propagates the four critical framing failures (open / archive read / finish / rename). `add_turn` returns `Result`; on failure it logs at `error!` and rolls back the in-memory turn + manifest `modified` bump. Because the function uses atomic temp-then-rename, a failure leaves the on-disk zip untouched, so the rollback restores `memory == disk`. The agent surfaces the failure to the ACP client via a `**Warning:**` agent_message_chunk so the user knows their turn isn't on disk.
- **#3369 — avoid full Session clone on the prompt path.** New `SessionStore::snapshot` clones the conversation history exactly once under the read lock and returns raw fields (`cwd`, `mode`, `model`, `history`). The agent consumes `history` via `.into_iter()` to build `ChatMessage`s without further string copies. Halves per-turn string clones on the hot path.

`get_session` is preserved for the cold-path callers (`session/load`, `session/resume`, `set_config_option`), now sharing a `load_into_memory_if_cold` helper with `snapshot` so the load logic can't drift.

### What about #3366?

The first iteration of this PR wrapped `LlmBackend::stream_chat` in `tokio::time::timeout(600s)` to address #3366. Review found that `OpenAiClient`'s reqwest client already has `.timeout(600s)` covering the full request, so the outer wrap was a no-op. The original concern (streams that drip occasional bytes) is genuinely per-chunk inactivity, not wall-clock — that is tracked as a proper follow-up in #3453 (idle-byte detection). The wall-clock wrapper has been removed in this PR; #3366 should be closed in favor of #3453.

### Concurrency note (added in review)

`add_turn` now runs *before* `finish_prompt` so the per-session cancel token is held during the zip rewrite. This is the locking discipline that makes the rollback `pop()` safe — without that ordering, a second `session/prompt` could push a new turn between this turn's optimistic push and its rollback `pop()`, removing the wrong entry.

## Closes
- Closes #3410
- Closes #3369

## Follow-ups (filed during review)
- #3451 — bifrost handshake test silently skips when binary missing.
- #3452 — factor temp-then-rename + entry-copy zip pattern (3 open-coded variants).
- #3453 — detect idle LLM streams via per-chunk timeout (proper fix for #3366).
- #3454 — `Session::from_persisted` constructor to centralize security defaults.

## Test plan
- [x] `cargo check` clean, no warnings.
- [x] `cargo clippy -W clippy::all` clean.
- [x] `cargo test` passes 40/41 (the 41st is the pre-existing bifrost handshake failure tracked in PR #3447).
- [x] New unit tests: `add_turn_rolls_back_on_persistence_failure`, `add_turn_unknown_session_is_noop_success`.
- [x] Existing `tool_loop` permission-gate unit tests still pass.
- [ ] Manual: run a long-history session through `session/prompt` end-to-end, observe no behavior change.
- [ ] Manual: simulate a persistence failure (read-only sessions dir) and confirm the in-memory rollback + `**Warning:**` user-visible message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)