### PR TITLE
ACP: thread JobSpec.codeModel through LutzAgent.callCodeAgent (#3429)

### DIFF
--- a/app/src/main/java/ai/brokk/agents/LutzAgent.java
+++ b/app/src/main/java/ai/brokk/agents/LutzAgent.java
@@ -114,6 +114,16 @@ public class LutzAgent {
     private static final int MAX_TOTAL_TURNS = 20;
     private final IAppContextManager cm;
     private final StreamingChatModel model;
+
+    /**
+     * Code model used when {@code callCodeAgent} fires. When {@code null}, callers fall back to
+     * {@link IAppContextManager#getCodeModel()} -- the user's project-level CODE setting.
+     * JobSpec-driven entry points (ACP via {@code JobRunner} -> {@code LutzExecutor}) inject the
+     * resolved {@code JobSpec.codeModel()} here so the per-job selection is honored (bug #3429);
+     * GUI/CLI/legacy callers pass {@code null} and keep the project-level fallback.
+     */
+    private final @Nullable StreamingChatModel codeModel;
+
     private final ContextManager.TaskScope scope;
     private final Llm llm;
     private final Llm scanLlm;
@@ -204,9 +214,30 @@ public class LutzAgent {
             ContextManager.TaskScope scope,
             IConsoleIO io,
             ScanConfig scanConfig) {
+        this(initialContext, goal, model, null, objective, scope, io, scanConfig);
+    }
+
+    /**
+     * Primary constructor.
+     *
+     * @param codeModel the code model to use when {@code callCodeAgent} fires. When {@code null},
+     *     {@link IAppContextManager#getCodeModel()} is consulted instead -- matching legacy
+     *     GUI/CLI behavior. JobSpec-driven entry points should pass an explicit value resolved
+     *     from {@code JobSpec.codeModel()} (bug #3429).
+     */
+    public LutzAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            @Nullable StreamingChatModel codeModel,
+            Objective objective,
+            ContextManager.TaskScope scope,
+            IConsoleIO io,
+            ScanConfig scanConfig) {
         this.goal = goal;
         this.cm = initialContext.getContextManager();
         this.model = model;
+        this.codeModel = codeModel;
         this.scope = scope;
 
         this.io = io;
@@ -745,13 +776,24 @@ public class LutzAgent {
     }
 
     /**
+     * Resolves the code model used by {@link #callCodeAgent(String)} and the {@code callCodeAgent}
+     * {@code @Tool} inside the LUTZ turn loop. Prefers the explicit {@link #codeModel} injected
+     * via constructor (e.g. from {@code JobSpec.codeModel()}); falls back to
+     * {@link IAppContextManager#getCodeModel()} for callers that do not thread one through
+     * (GUI, CLI, {@code IssueExecutor.runReviewFixTasks}). See bug #3429.
+     */
+    private StreamingChatModel effectiveCodeModel() {
+        return codeModel != null ? codeModel : cm.getCodeModel();
+    }
+
+    /**
      * Invokes the Code Agent to implement instructions using the current SearchState.
      * This is intended for internal/legacy callers and does not advance the SearchAgent's turn loop.
      */
     @Blocking
     public TaskResult callCodeAgent(String instructions) throws InterruptedException {
         ArchitectAgent architect =
-                new ArchitectAgent(cm, model, cm.getCodeModel(), instructions, scope, currentState.context());
+                new ArchitectAgent(cm, model, effectiveCodeModel(), instructions, scope, currentState.context());
 
         return architect.execute();
     }
@@ -1372,7 +1414,7 @@ public class LutzAgent {
             var architect = new ArchitectAgent(
                     agent.cm,
                     agent.model,
-                    agent.cm.getCodeModel(),
+                    agent.effectiveCodeModel(),
                     instructions,
                     agent.scope,
                     agent.resetPinsToOriginal(context));

--- a/app/src/main/java/ai/brokk/executor/jobs/LutzExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/LutzExecutor.java
@@ -40,7 +40,10 @@ public final class LutzExecutor {
             ContextManager.TaskScope scope)
             throws InterruptedException {
         // Phase 1: Search
-        runSearchPhase(taskInput, plannerModel, scope);
+        // Thread the JobSpec-resolved codeModel through so that callCodeAgent fired during the
+        // LUTZ search loop honors the per-job selection (bug #3429). Null preserves legacy
+        // fallback to cm.getCodeModel() for callers that do not specify a JobSpec code model.
+        runSearchPhase(taskInput, plannerModel, codeModel, scope);
 
         // Phase 2: Execution Loop
         LutzContext adapter = new LutzContext() {
@@ -61,10 +64,22 @@ public final class LutzExecutor {
     }
 
     @Blocking
-    private void runSearchPhase(String taskInput, StreamingChatModel plannerModel, ContextManager.TaskScope scope)
+    private void runSearchPhase(
+            String taskInput,
+            StreamingChatModel plannerModel,
+            @Nullable StreamingChatModel codeModel,
+            ContextManager.TaskScope scope)
             throws InterruptedException {
         var context = cm.liveContext();
-        var searchAgent = new LutzAgent(context, taskInput, plannerModel, SearchPrompts.Objective.LUTZ, scope);
+        var searchAgent = new LutzAgent(
+                context,
+                taskInput,
+                plannerModel,
+                codeModel,
+                SearchPrompts.Objective.LUTZ,
+                scope,
+                context.getContextManager().getIo(),
+                LutzAgent.ScanConfig.defaults());
         var taskListResult = searchAgent.execute();
         scope.append(taskListResult);
     }

--- a/app/src/test/java/ai/brokk/agents/LutzAgentTest.java
+++ b/app/src/test/java/ai/brokk/agents/LutzAgentTest.java
@@ -3,6 +3,8 @@ package ai.brokk.agents;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.AbstractService.OfflineStreamingModel;
@@ -290,6 +292,73 @@ class LutzAgentTest {
         assertTrue(noAppend.autoScan(), "noAppend() should have autoScan=true");
         assertNull(noAppend.scanModel(), "noAppend() should have scanModel=null");
         assertFalse(noAppend.appendToScope(), "noAppend() should have appendToScope=false");
+    }
+
+    @Test
+    void callCodeAgent_withoutExplicitCodeModel_fallsBackToCmGetCodeModel() throws InterruptedException {
+        // GUI/CLI/legacy callers (IssueExecutor.runReviewFixTasks, BprCli, InstructionsPanel,
+        // IssueRewriterAgent) construct LutzAgent without an explicit codeModel; callCodeAgent
+        // must then consult cm.getCodeModel() so the user's project-level CODE setting is honored.
+        // We prove the fallback path by making cm.getCodeModel() throw a sentinel and observing
+        // the throw propagate out of callCodeAgent. Eager left-to-right arg evaluation in
+        //     new ArchitectAgent(cm, model, effectiveCodeModel(), instructions, scope, currentState.context())
+        // means the third-arg throw fires before ArchitectAgent's body or the heavier args run.
+        //
+        // Pairs with callCodeAgent_withExplicitCodeModel_doesNotConsultCm_regressesBug3429,
+        // which verifies the JobSpec-driven path bypasses cm.getCodeModel().
+        var sentinel = new RuntimeException("FALLBACK_PROBE");
+        var cm = new TestContextManager(tempDir, new NoOpConsoleIO()) {
+            @Override
+            public StreamingChatModel getCodeModel() {
+                throw sentinel;
+            }
+        };
+
+        LutzAgent agent = newAgent(cm, new OfflineStreamingModel());
+
+        var thrown = assertThrows(RuntimeException.class, () -> agent.callCodeAgent("test instructions"));
+        assertSame(
+                sentinel,
+                thrown,
+                "Without an explicit codeModel, callCodeAgent must fall back to cm.getCodeModel().");
+    }
+
+    @Test
+    void callCodeAgent_withExplicitCodeModel_doesNotConsultCm_regressesBug3429() throws InterruptedException {
+        // Bug #3429 regression: when LutzAgent receives an explicit codeModel via constructor
+        // (e.g. from JobSpec.codeModel() threaded by JobRunner -> LutzExecutor for the ACP
+        // path), callCodeAgent must use that model and must NOT consult cm.getCodeModel().
+        // We prove the bypass by making cm.getCodeModel() throw an AssertionError; if the
+        // bug regresses, the AssertionError propagates and fails the test. Whatever happens
+        // after (ArchitectAgent execute against an OfflineStreamingModel typically fails) is
+        // outside the scope of this contract -- swallow Exceptions so only AssertionError
+        // (an Error, not an Exception) signals failure.
+        var explicitCodeModel = new OfflineStreamingModel();
+        var cm = new TestContextManager(tempDir, new NoOpConsoleIO()) {
+            @Override
+            public StreamingChatModel getCodeModel() {
+                throw new AssertionError(
+                        "Regression #3429: cm.getCodeModel() must not be consulted when an explicit codeModel is supplied");
+            }
+        };
+
+        LutzAgent agent = new LutzAgent(
+                cm.liveContext(),
+                "goal",
+                new OfflineStreamingModel(),
+                explicitCodeModel,
+                ai.brokk.prompts.SearchPrompts.Objective.WORKSPACE_ONLY,
+                null,
+                new NoOpConsoleIO(),
+                LutzAgent.ScanConfig.disabled());
+
+        try {
+            agent.callCodeAgent("test instructions");
+        } catch (Exception expected) {
+            // ArchitectAgent setup/execute legitimately fails with OfflineStreamingModel + no scope; ignore.
+        }
+        // If cm.getCodeModel() was wrongly consulted, the AssertionError it threw will have
+        // already failed the test (AssertionError is an Error and bypasses the catch above).
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/agents/LutzAgentTest.java
+++ b/app/src/test/java/ai/brokk/agents/LutzAgentTest.java
@@ -318,9 +318,7 @@ class LutzAgentTest {
 
         var thrown = assertThrows(RuntimeException.class, () -> agent.callCodeAgent("test instructions"));
         assertSame(
-                sentinel,
-                thrown,
-                "Without an explicit codeModel, callCodeAgent must fall back to cm.getCodeModel().");
+                sentinel, thrown, "Without an explicit codeModel, callCodeAgent must fall back to cm.getCodeModel().");
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/testutil/TestContextManager.java
+++ b/app/src/test/java/ai/brokk/testutil/TestContextManager.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  * triggering expensive analyzer build logic while satisfying callers (CodeAgent) that expect an AnalyzerWrapper to
  * exist and support pause()/resume()/get().
  */
-public final class TestContextManager implements IAppContextManager {
+public class TestContextManager implements IAppContextManager {
     private final IProject project;
     private final AtomicReference<IAnalyzer> analyzerRef;
     private final IGitRepo repo;


### PR DESCRIPTION
## Summary

- `LutzAgent.callCodeAgent` and its `@Tool` counterpart in `SingleTurnAgent` both passed `cm.getCodeModel()` to `ArchitectAgent`, which returns the user's project-level CODE setting and ignored any JobSpec-supplied code model.
- On the ACP path this silently overrode `JobSpec.codeModel` (computed by `BrokkAcpAgent.prompt` and resolved by `JobRunner`) with whatever the user had configured in the GUI -- a contract violation in the headless API and a cost/quality surprise for ACP users with customized CODE settings.
- Adds an optional `@Nullable StreamingChatModel codeModel` field to `LutzAgent` (settable via a new 8-arg ctor) and routes both call sites through a shared `effectiveCodeModel()` helper: prefer the explicit value, fall back to `cm.getCodeModel()` for legacy callers.
- Threads the JobSpec-resolved codeModel through `LutzExecutor.execute` -> `runSearchPhase` -> `LutzAgent`.

Other call sites (`BprCli`, `IssueExecutor`, `IssueRewriterAgent`, `InstructionsPanel`, `JobRunner` non-LUTZ paths) keep the project-level fallback unchanged.

Closes #3429.

## Why this matters in production

Concrete user impact for any ACP user with a non-default project CODE model (`DEFAULT_CODE_MODEL = "gemini-3-flash-preview"`):

| Project CODE setting | What ACP intended | What ran before | Symptom |
|---|---|---|---|
| `claude-opus-4.6` | gemini-3-flash-preview | claude-opus-4.6 | ~10x cost per code change, silent |
| `gpt-5-nano` | gemini-3-flash-preview | gpt-5-nano | quality regression blamed on ACP |
| flipped mid-session in GUI | gemini-3-flash-preview | new value | ACP behavior changes from an unrelated GUI click |

GUI users see no change (the project-level setting was always the right source for them).

## Test plan

- [x] `LutzAgentTest.callCodeAgent_withoutExplicitCodeModel_fallsBackToCmGetCodeModel` -- pins the fallback contract for legacy GUI/CLI callers
- [x] `LutzAgentTest.callCodeAgent_withExplicitCodeModel_doesNotConsultCm_regressesBug3429` -- pins the new JobSpec-driven contract; an `AssertionError` from `cm.getCodeModel()` would fail the test if the bug regresses
- [x] All other `LutzAgentTest` cases pass unchanged
- [x] `executor.jobs.*` test suite green (`JobRunnerTest`, `JobRunnerIssueModeTest`, etc.)
- [x] `acp.*` test suite green
- [x] `:app:compileJava` and `:app:compileTestJava` clean

## Notes for reviewers

- `TestContextManager` is now non-final so test-local anonymous subclasses can override `getCodeModel()` to make the call observable. It's a test utility; no production effect.
- The new 8-arg `LutzAgent` constructor inserts `@Nullable StreamingChatModel codeModel` as the 4th positional parameter (between `model` and `objective`). Existing constructors delegate with `codeModel = null` to preserve all current call-site behavior.
- Both `callCodeAgent` paths share `effectiveCodeModel()`, so future changes to either path can't drift from the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)