### PR TITLE
ACP: validate persisted defaults against current catalog (#3421)

### DIFF
--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -1014,6 +1014,11 @@ public class BrokkAcpAgent {
             sessionsOnFallbackCatalog.remove(sessionId);
         }
 
+        // Re-validate persisted catalog-wide defaults against the live catalog (#3421).
+        // The internal guard skips when on fallback catalog so transient discovery failures
+        // do not overwrite user-configured defaults.
+        revalidatePersistedDefaults(sessionId, availableModels, service);
+
         // Build model list with reasoning variants (model/low, model/medium, model/high, etc.)
         var models = new ArrayList<AcpSchema.ModelInfo>();
         availableModels.keySet().stream().sorted().forEach(name -> {
@@ -1037,6 +1042,83 @@ public class BrokkAcpAgent {
         var currentModelId = formatModelIdWithVariant(baseModel, reasoning);
 
         return new AcpSchema.SessionModelState(currentModelId, List.copyOf(models));
+    }
+
+    /**
+     * Pure decision logic for reasoning-level sanitization. Returns {@code level} unchanged when
+     * it is a known id and supported by the model's capabilities; otherwise returns {@code "default"}.
+     * Decoupled from {@link AbstractService} so unit tests can exercise every combination cheaply.
+     * Mirrors the deleted Python bridge's {@code _sanitize_reasoning_level_for_model}. See #3421.
+     */
+    static String sanitizeReasoningLevel(String level, boolean supportsEffort, boolean supportsDisable) {
+        var normalized = REASONING_LEVEL_IDS.contains(level) ? level : "default";
+        if (!supportsEffort && !"default".equals(normalized)) {
+            return "default";
+        }
+        if ("disable".equals(normalized) && !supportsDisable) {
+            return "default";
+        }
+        return normalized;
+    }
+
+    /**
+     * Sanitizes a reasoning level against a model's reasoning capabilities. A blank model name
+     * short-circuits to enum-level normalization (no service lookup); useful when the persisted
+     * default has no chosen model yet. See #3421.
+     */
+    private static String sanitizeReasoningLevelForModel(String modelName, String level, AbstractService service) {
+        if (modelName.isBlank()) {
+            return REASONING_LEVEL_IDS.contains(level) ? level : "default";
+        }
+        return sanitizeReasoningLevel(
+                level, service.supportsReasoningEffort(modelName), service.supportsReasoningDisable(modelName));
+    }
+
+    /**
+     * Re-validates the persisted catalog-wide ACP defaults against the live catalog and the
+     * chosen model's reasoning capabilities. If a default is stale (model retired upstream,
+     * reasoning level not supported by the model), updates the in-memory default and re-persists
+     * to {@code ~/.brokk/acp_settings.json}. Mirrors the per-{@code new_session} validation in
+     * the deleted Python bridge. See #3421.
+     *
+     * <p>Skipped when the session is on the {@code BASE_MODEL_IDS} fallback catalog -- writing
+     * sanitized defaults based on a fallback would erase the user's configured choice as soon
+     * as live discovery comes back.
+     */
+    private void revalidatePersistedDefaults(
+            String sessionId, Map<String, String> availableModels, AbstractService service) {
+        if (sessionsOnFallbackCatalog.contains(sessionId) || availableModels.isEmpty()) {
+            return;
+        }
+
+        var modelChanged = false;
+        if (!defaultModelId.isEmpty() && !availableModels.containsKey(defaultModelId)) {
+            var fallback =
+                    availableModels.keySet().stream().sorted().findFirst().orElse(null);
+            if (fallback != null && !fallback.equals(defaultModelId)) {
+                logger.info(
+                        "Persisted ACP default model {} not in current catalog; falling back to {}",
+                        defaultModelId,
+                        fallback);
+                defaultModelId = fallback;
+                modelChanged = true;
+            }
+        }
+
+        var sanitized = sanitizeReasoningLevelForModel(defaultModelId, defaultReasoningLevel, service);
+        var reasoningChanged = !sanitized.equals(defaultReasoningLevel);
+        if (reasoningChanged) {
+            logger.info(
+                    "Persisted ACP reasoning {} invalid for model {}; falling back to {}",
+                    defaultReasoningLevel,
+                    defaultModelId,
+                    sanitized);
+            defaultReasoningLevel = sanitized;
+        }
+
+        if (modelChanged || reasoningChanged) {
+            saveAcpDefaults(defaultModelId, defaultReasoningLevel);
+        }
     }
 
     /**

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -114,6 +114,49 @@ class BrokkAcpAgentTest {
         assertEquals(second.sessionId(), contextManager.getCurrentSessionId().toString());
     }
 
+    // ---- #3421: sanitizeReasoningLevel pure decision logic -------------------------------
+
+    @Test
+    void sanitizeReasoningLevel_unknownLevelNormalizesToDefault() {
+        // Any id outside REASONING_LEVEL_IDS becomes "default" before capability checks.
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("ultra", true, true));
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("", true, true));
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("LOW", true, true)); // case-sensitive
+    }
+
+    @Test
+    void sanitizeReasoningLevel_modelLacksEffortSupport_anyNonDefaultBecomesDefault() {
+        // When the model does not advertise reasoning_effort, low/medium/high/disable are all unsupported.
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("low", false, false));
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("medium", false, false));
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("high", false, false));
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("disable", false, false));
+    }
+
+    @Test
+    void sanitizeReasoningLevel_modelSupportsEffort_lowMediumHighPassThrough() {
+        assertEquals("low", BrokkAcpAgent.sanitizeReasoningLevel("low", true, false));
+        assertEquals("medium", BrokkAcpAgent.sanitizeReasoningLevel("medium", true, false));
+        assertEquals("high", BrokkAcpAgent.sanitizeReasoningLevel("high", true, false));
+    }
+
+    @Test
+    void sanitizeReasoningLevel_disableRequiresExplicitDisableSupport() {
+        // supportsEffort=true, supportsDisable=false -> "disable" must drop to "default"
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("disable", true, false));
+        // both supported -> "disable" passes through
+        assertEquals("disable", BrokkAcpAgent.sanitizeReasoningLevel("disable", true, true));
+    }
+
+    @Test
+    void sanitizeReasoningLevel_defaultLevelAlwaysPassesRegardlessOfCapabilities() {
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("default", false, false));
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("default", true, false));
+        assertEquals("default", BrokkAcpAgent.sanitizeReasoningLevel("default", true, true));
+    }
+
+    // ---- end #3421 -----------------------------------------------------------------------
+
     @Test
     void closeSessionClearsAcpStateButDoesNotDeleteBrokkSession() {
         var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));


### PR DESCRIPTION
## Summary

When PR #3415 retired the Python ACP bridge in favor of the native Java server, two pieces of persisted-defaults validation didn't make it across:

1. **Stale model id**: the persisted `default_model` was never checked against the live catalog. If a model the user had selected was retired upstream, the dead id stayed in `~/.brokk/acp_settings.json` indefinitely. `buildModelState` did silently fall back to first-available per session, so things still worked, but the stale default kept resurfacing on every `newSession` round and the user got no signal.
2. **Stale reasoning level**: `loadAcpDefaults` only validated reasoning at the enum level (`low`/`medium`/`high`/`disable`/`default`). A persisted level like `"high"` against a model that doesn't advertise `reasoning_effort` would propagate through to API calls.

This PR ports the per-`new_session` validation that lived in the deleted `acp_server.py:1417-1471` and `_sanitize_reasoning_level_for_model` (line 237).

## Design

- **Pure helper** `BrokkAcpAgent.sanitizeReasoningLevel(level, supportsEffort, supportsDisable)` — boolean inputs only, decoupled from `AbstractService`. Exhaustively unit-testable.
- **Wrapper** `sanitizeReasoningLevelForModel(name, level, service)` — looks up `service.supportsReasoningEffort` / `supportsReasoningDisable` and delegates to the pure helper. Blank model name short-circuits to enum-level normalization.
- **Validator** `revalidatePersistedDefaults(sessionId, availableModels, service)`:
  - If `defaultModelId` is non-empty and not in the catalog → replace with first sorted available.
  - Sanitize `defaultReasoningLevel` against the (possibly updated) `defaultModelId`.
  - Re-persist via `saveAcpDefaults` exactly once per call if anything changed; log each fallback at `INFO`.
- **Wired into** `buildModelState` after the catalog-fetch / fallback decision.

## Subtle pitfall handled

The validator **skips when the session is on the `BASE_MODEL_IDS` fallback catalog**. Overwriting persisted defaults based on a fallback catalog would erase user-configured choices as soon as live discovery comes back online — a worse failure than the original bug. The `sessionsOnFallbackCatalog` flag (added in #3428 for catalog recovery) already tracks this; we just consult it.

Closes #3421.

## Test plan

Five table-driven unit tests pin `sanitizeReasoningLevel`'s pure decision logic:

- [x] `sanitizeReasoningLevel_unknownLevelNormalizesToDefault` — unknown ids and case-mismatches drop to `"default"`
- [x] `sanitizeReasoningLevel_modelLacksEffortSupport_anyNonDefaultBecomesDefault` — without `reasoning_effort` support, low/medium/high/disable all become `"default"`
- [x] `sanitizeReasoningLevel_modelSupportsEffort_lowMediumHighPassThrough` — happy path
- [x] `sanitizeReasoningLevel_disableRequiresExplicitDisableSupport` — `"disable"` needs both effort and disable; either missing → `"default"`
- [x] `sanitizeReasoningLevel_defaultLevelAlwaysPassesRegardlessOfCapabilities` — `"default"` is the safe identity

Plus:
- [x] Full `BrokkAcpAgentTest` suite still green
- [x] Full `executor.jobs.*` suite still green
- [x] `./gradlew spotlessApply` reports no changes (formatter clean)

## Notes for reviewers

- `sanitizeReasoningLevel` is package-private (not `private`) so the test in the same package can call it directly. This matches the prevailing pattern (e.g. `patchAcpDuplicateKeyBug` is similarly testable).
- I deliberately did **not** add an integration test that exercises the file-write path. `ACP_SETTINGS_PATH` is a `static final` derived from `user.home`, so testing the persistence side without redirecting `user.home` would touch the real user's settings. The wiring (one call to `revalidatePersistedDefaults` from `buildModelState`) is small and reviewable in the diff; if we want to harden persistence-path testing in the future, that's a separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)