### PR TITLE
brokk-acp-rust: reject writeFile through symlinks pointing outside cwd

### DIFF
--- a/brokk-acp-rust/src/tools/mod.rs
+++ b/brokk-acp-rust/src/tools/mod.rs
@@ -433,11 +433,8 @@ mod tests {
     /// Allocate a fresh empty directory under the system temp dir for one test
     /// to scribble in. Caller is responsible for cleaning it up.
     fn fresh_tmp_dir(label: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "brokk-acp-rust-{}-{}",
-            label,
-            uuid::Uuid::new_v4()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("brokk-acp-rust-{}-{}", label, uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).expect("create tmp dir");
         dir
     }
@@ -452,11 +449,7 @@ mod tests {
         std::os::unix::fs::symlink(&outside, cwd.join("evil")).expect("create symlink");
 
         let result = safe_resolve_for_write(&cwd, "evil");
-        assert!(
-            result.is_err(),
-            "expected rejection, got Ok({:?})",
-            result
-        );
+        assert!(result.is_err(), "expected rejection, got Ok({:?})", result);
 
         std::fs::remove_dir_all(&cwd).ok();
         std::fs::remove_dir_all(outside.parent().unwrap()).ok();
@@ -475,11 +468,7 @@ mod tests {
         std::os::unix::fs::symlink(&outside_file, cwd.join("evil")).expect("create symlink");
 
         let result = safe_resolve_for_write(&cwd, "evil");
-        assert!(
-            result.is_err(),
-            "expected rejection, got Ok({:?})",
-            result
-        );
+        assert!(result.is_err(), "expected rejection, got Ok({:?})", result);
 
         std::fs::remove_dir_all(&cwd).ok();
         std::fs::remove_dir_all(&outside_dir).ok();
@@ -517,11 +506,7 @@ mod tests {
         std::os::unix::fs::symlink(&outside, cwd.join("escape")).expect("create symlink");
 
         let result = safe_resolve_for_write(&cwd, "escape/newfile.txt");
-        assert!(
-            result.is_err(),
-            "expected rejection, got Ok({:?})",
-            result
-        );
+        assert!(result.is_err(), "expected rejection, got Ok({:?})", result);
 
         std::fs::remove_dir_all(&cwd).ok();
         std::fs::remove_dir_all(&outside).ok();

--- a/brokk-acp-rust/src/tools/mod.rs
+++ b/brokk-acp-rust/src/tools/mod.rs
@@ -375,10 +375,15 @@ pub fn safe_resolve_for_write(cwd: &Path, requested: &str) -> Result<PathBuf, St
     let joined = cwd.join(requested);
 
     // Walk up to the first existing ancestor (including the target itself if it exists).
+    // Use symlink_metadata rather than exists(): exists() follows symlinks, so a dangling
+    // symlink at the leaf would be reported as non-existent and we'd skip past it,
+    // letting fs::write follow the link and write outside cwd. symlink_metadata reports
+    // the symlink itself as "existing" so the canonicalize step below either resolves it
+    // (rejecting if the target lies outside cwd) or errors on a dangling target.
     let mut tail: Vec<std::ffi::OsString> = Vec::new();
     let mut cursor: &Path = &joined;
     let existing = loop {
-        if cursor.exists() {
+        if cursor.symlink_metadata().is_ok() {
             break cursor.to_path_buf();
         }
         match (cursor.file_name(), cursor.parent()) {
@@ -419,4 +424,126 @@ pub fn safe_resolve_for_write(cwd: &Path, requested: &str) -> Result<PathBuf, St
     }
 
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Allocate a fresh empty directory under the system temp dir for one test
+    /// to scribble in. Caller is responsible for cleaning it up.
+    fn fresh_tmp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "brokk-acp-rust-{}-{}",
+            label,
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).expect("create tmp dir");
+        dir
+    }
+
+    /// Regression: a dangling symlink at the leaf must be rejected, not silently
+    /// followed by the eventual fs::write at the call site. See issue #3408.
+    #[cfg(unix)]
+    #[test]
+    fn safe_resolve_for_write_rejects_dangling_symlink_to_outside_cwd() {
+        let cwd = fresh_tmp_dir("dangling-symlink");
+        let outside = fresh_tmp_dir("dangling-target").join("does-not-exist-yet");
+        std::os::unix::fs::symlink(&outside, cwd.join("evil")).expect("create symlink");
+
+        let result = safe_resolve_for_write(&cwd, "evil");
+        assert!(
+            result.is_err(),
+            "expected rejection, got Ok({:?})",
+            result
+        );
+
+        std::fs::remove_dir_all(&cwd).ok();
+        std::fs::remove_dir_all(outside.parent().unwrap()).ok();
+    }
+
+    /// A symlink whose target *exists* but lies outside cwd must also be rejected.
+    /// This case worked before the fix; the test pins it down so a future change
+    /// doesn't regress it.
+    #[cfg(unix)]
+    #[test]
+    fn safe_resolve_for_write_rejects_live_symlink_to_outside_cwd() {
+        let cwd = fresh_tmp_dir("live-symlink");
+        let outside_dir = fresh_tmp_dir("live-target");
+        let outside_file = outside_dir.join("real");
+        std::fs::write(&outside_file, "hello").expect("seed outside file");
+        std::os::unix::fs::symlink(&outside_file, cwd.join("evil")).expect("create symlink");
+
+        let result = safe_resolve_for_write(&cwd, "evil");
+        assert!(
+            result.is_err(),
+            "expected rejection, got Ok({:?})",
+            result
+        );
+
+        std::fs::remove_dir_all(&cwd).ok();
+        std::fs::remove_dir_all(&outside_dir).ok();
+    }
+
+    /// A symlink that points back inside cwd should still be allowed: the
+    /// fix must not over-restrict legitimate intra-sandbox links.
+    #[cfg(unix)]
+    #[test]
+    fn safe_resolve_for_write_allows_symlink_pointing_inside_cwd() {
+        let cwd = fresh_tmp_dir("inside-symlink");
+        let real = cwd.join("real.txt");
+        std::fs::write(&real, "ok").expect("seed real file");
+        std::os::unix::fs::symlink(&real, cwd.join("link")).expect("create symlink");
+
+        let resolved = safe_resolve_for_write(&cwd, "link").expect("resolve must succeed");
+        let cwd_canonical = cwd.canonicalize().unwrap();
+        assert!(
+            resolved.starts_with(&cwd_canonical),
+            "resolved {:?} must stay under cwd {:?}",
+            resolved,
+            cwd_canonical
+        );
+
+        std::fs::remove_dir_all(&cwd).ok();
+    }
+
+    /// An intermediate directory that is a symlink to outside cwd must be
+    /// rejected even if the leaf is a not-yet-existing file.
+    #[cfg(unix)]
+    #[test]
+    fn safe_resolve_for_write_rejects_intermediate_symlink_escape() {
+        let cwd = fresh_tmp_dir("intermediate-symlink");
+        let outside = fresh_tmp_dir("intermediate-target");
+        std::os::unix::fs::symlink(&outside, cwd.join("escape")).expect("create symlink");
+
+        let result = safe_resolve_for_write(&cwd, "escape/newfile.txt");
+        assert!(
+            result.is_err(),
+            "expected rejection, got Ok({:?})",
+            result
+        );
+
+        std::fs::remove_dir_all(&cwd).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+
+    /// Happy path: writing to a not-yet-existing file in an existing,
+    /// symlink-free directory still resolves under cwd.
+    #[test]
+    fn safe_resolve_for_write_allows_new_file_in_existing_dir() {
+        let cwd = fresh_tmp_dir("new-file");
+
+        let resolved =
+            safe_resolve_for_write(&cwd, "subdir/new.txt").expect("resolve must succeed");
+        let cwd_canonical = cwd.canonicalize().unwrap();
+        assert!(
+            resolved.starts_with(&cwd_canonical),
+            "resolved {:?} must stay under cwd {:?}",
+            resolved,
+            cwd_canonical
+        );
+        assert!(resolved.ends_with("subdir/new.txt"));
+
+        std::fs::remove_dir_all(&cwd).ok();
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3408. `safe_resolve_for_write` used `Path::exists()` to find the first existing ancestor during walk-up, but `exists()` follows symlinks. A dangling symlink at the leaf returned `false`, so the walk-up stepped past it, validated only the parent directory, and then `std::fs::write` followed the link and created the target wherever it pointed -- escaping the sandbox in `default` and `acceptEdits` modes (the modes where the user has *not* opted out of containment).

The one-line behavioural change is `cursor.exists()` -> `cursor.symlink_metadata().is_ok()`. `symlink_metadata` does not traverse the final component, so the symlink itself is treated as "exists." The existing `canonicalize` step then either resolves the link (and rejects via `starts_with(cwd_canonical)` if it lands outside) or errors on a dangling target.

- Live symlink to outside cwd was already caught (covered by a new pinning test).
- Live symlink to inside cwd is still allowed (no over-restriction).
- Intermediate-directory symlink escapes were already caught and remain so.

## Test plan

- [x] `cargo test --bin brokk-acp safe_resolve` -- 5/5 new tests pass
- [x] `cargo test` for the full crate -- 46/46 pass, no regressions
- [x] `cargo clippy --all-targets -- -D warnings` -- clean

New tests (`#[cfg(unix)]` for the four symlink ones since `std::os::unix::fs::symlink` is unix-only):

- `safe_resolve_for_write_rejects_dangling_symlink_to_outside_cwd` -- the regression
- `safe_resolve_for_write_rejects_live_symlink_to_outside_cwd` -- pin the case that already worked
- `safe_resolve_for_write_allows_symlink_pointing_inside_cwd` -- guard against over-restriction
- `safe_resolve_for_write_rejects_intermediate_symlink_escape` -- intermediate-component symlink escape
- `safe_resolve_for_write_allows_new_file_in_existing_dir` -- happy path, cross-platform