### PR TITLE
Optimize dead-code smell analysis by batching usage scans

### DIFF
--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -30,6 +30,8 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.jetbrains.annotations.Blocking;
 
@@ -38,6 +40,7 @@ import org.jetbrains.annotations.Blocking;
  * Intended for {@link ai.brokk.executor.agents.CustomAgentExecutor custom agents} and similar tool loops.
  */
 public class CodeQualityTools {
+    private static final Logger logger = LogManager.getLogger(CodeQualityTools.class);
     private static final String FINDING_PREFIX = "[CODE_QUALITY]";
 
     private static final String COMMENT_DENSITY_UNAVAILABLE =
@@ -250,12 +253,14 @@ public class CodeQualityTools {
         int usageFileCap = maxUsageCandidateFiles > 0 ? maxUsageCandidateFiles : UsageFinder.DEFAULT_MAX_FILES;
         int usageCap = maxUsagesPerSymbol > 0 ? maxUsagesPerSymbol : 100;
 
+        long startedNanos = System.nanoTime();
         IAnalyzer analyzer = contextManager.getAnalyzerUninterrupted();
         var files = filePaths.stream()
                 .map(contextManager::toFile)
                 .filter(ProjectFile::exists)
                 .limit(inputFileCap)
                 .toList();
+        long inputFilesSelectedNanos = System.nanoTime();
         var selectedFiles = Set.copyOf(files);
         var findings = new ArrayList<DeadCodeFinding>();
         var skipped = new ArrayList<String>();
@@ -263,12 +268,14 @@ public class CodeQualityTools {
         CandidateFileProvider batchCandidateProvider = (target, analysis) -> analysis.getProject()
                 .getAnalyzableFiles(Languages.fromExtension(target.source().extension()));
         var candidateSelection = deadCodeCandidates(analyzer, files, fqNames, selectedFiles, candidateCap, skipped);
+        long candidatesSelectedNanos = System.nanoTime();
 
         for (CodeUnit candidate : candidateSelection.candidates()) {
             Optional<DeadCodeFinding> finding = analyzeDeadCodeCandidate(
                     analyzer, usageFinder, batchCandidateProvider, candidate, usageFileCap, usageCap, skipped);
             finding.filter(f -> f.score() >= threshold).ifPresent(findings::add);
         }
+        long usageScansFinishedNanos = System.nanoTime();
 
         var filtered = findings.stream()
                 .sorted(Comparator.comparingInt(DeadCodeFinding::totalUsageCount)
@@ -278,6 +285,19 @@ public class CodeQualityTools {
                         .thenComparing(DeadCodeFinding::symbol, String.CASE_INSENSITIVE_ORDER))
                 .limit(findingsCap)
                 .toList();
+        long reportFormattedNanos = System.nanoTime();
+
+        logger.debug(
+                "Dead-code smell analysis candidates={} inputFiles={} findings={} skipped={} elapsedMs={} inputMs={} candidateMs={} usageMs={} formatMs={}",
+                candidateSelection.candidates().size(),
+                files.size(),
+                findings.size(),
+                skipped.size(),
+                elapsedMs(startedNanos, reportFormattedNanos),
+                elapsedMs(startedNanos, inputFilesSelectedNanos),
+                elapsedMs(inputFilesSelectedNanos, candidatesSelectedNanos),
+                elapsedMs(candidatesSelectedNanos, usageScansFinishedNanos),
+                elapsedMs(usageScansFinishedNanos, reportFormattedNanos));
 
         var lines = new ArrayList<String>();
         lines.add("## Dead code and unused abstraction smells");
@@ -483,6 +503,10 @@ public class CodeQualityTools {
         }
         CodeUnit hitOwner = analyzer.parentOf(hit.enclosing()).orElse(hit.enclosing());
         return !hitOwner.equals(definingOwner.get());
+    }
+
+    private static long elapsedMs(long startNanos, long endNanos) {
+        return (endNanos - startNanos) / 1_000_000;
     }
 
     private record CandidateSelection(List<CodeUnit> candidates, boolean truncated) {}

--- a/app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java
+++ b/app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java
@@ -14,9 +14,16 @@ import ai.brokk.analyzer.usages.FuzzyResult;
 import ai.brokk.analyzer.usages.UsageAnalyzer;
 import ai.brokk.analyzer.usages.UsageHit;
 import ai.brokk.analyzer.usages.UsagePrompt;
+import ai.brokk.concurrent.ExecutorsUtil;
+import ai.brokk.concurrent.LoggingExecutorService;
 import ai.brokk.project.IProject;
+import ai.brokk.util.ConcurrencyUtil;
 import ai.brokk.util.FileUtil;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,8 +31,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -39,11 +50,20 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class LlmUsageAnalyzer implements UsageAnalyzer {
     private static final Logger logger = LogManager.getLogger(LlmUsageAnalyzer.class);
+    private static final int FUZZY_SCAN_PARALLELISM = ConcurrencyUtil.computeAdaptiveIoConcurrencyCap();
+    private static final LoggingExecutorService FUZZY_SCAN_EXECUTOR =
+            ExecutorsUtil.newVirtualThreadExecutor("fuzzy-usage-scan-", FUZZY_SCAN_PARALLELISM);
 
     private final IProject project;
     private final IAnalyzer analyzer;
     private final AbstractService service;
     private final @Nullable Llm llm;
+    private final Cache<ProjectFile, CachedFileScanInput> fileScanInputCache = Caffeine.newBuilder()
+            .maximumSize(2_048)
+            .expireAfterAccess(Duration.ofMinutes(10))
+            .build();
+    private final AtomicInteger fileReadCount = new AtomicInteger();
+    private final AtomicInteger lineStartComputationCount = new AtomicInteger();
 
     public LlmUsageAnalyzer(IProject project, IAnalyzer analyzer, AbstractService service, @Nullable Llm llm) {
         this.project = project;
@@ -64,6 +84,8 @@ public final class LlmUsageAnalyzer implements UsageAnalyzer {
         var searchPatterns = templates.stream()
                 .map(template -> template.replace("$ident", Pattern.quote(identifier)))
                 .collect(Collectors.toSet());
+        int fileReadsBefore = fileReadCount.get();
+        int lineStartComputationsBefore = lineStartComputationCount.get();
 
         var matchingCodeUnits =
                 analyzer.searchDefinitions("\\b%s\\b".formatted(Pattern.quote(identifier)), false).stream()
@@ -74,6 +96,14 @@ public final class LlmUsageAnalyzer implements UsageAnalyzer {
         var hits = extractUsageHits(candidateFiles, searchPatterns).stream()
                 .filter(h -> !h.enclosing().equals(target))
                 .collect(Collectors.toSet());
+        logger.debug(
+                "Fuzzy usage scan for {} considered {} candidate files, produced {} hits, fileReadsDelta={}, lineStartsDelta={}, cachedFiles={}",
+                target.fqName(),
+                candidateFiles.size(),
+                hits.size(),
+                fileReadCount.get() - fileReadsBefore,
+                lineStartComputationCount.get() - lineStartComputationsBefore,
+                fileScanInputCache.estimatedSize());
 
         if (hits.size() > maxUsages) {
             logger.debug("Too many usage hits for {}: {} > {}", target.fqName(), hits.size(), maxUsages);
@@ -146,53 +176,110 @@ public final class LlmUsageAnalyzer implements UsageAnalyzer {
         return new FuzzyResult.Ambiguous(target.shortName(), matchingCodeUnits, Map.of(target, hits));
     }
 
-    private Set<UsageHit> extractUsageHits(Set<ProjectFile> candidateFiles, Set<String> searchPatterns) {
+    private Set<UsageHit> extractUsageHits(Set<ProjectFile> candidateFiles, Set<String> searchPatterns)
+            throws InterruptedException {
         var hits = new ConcurrentHashMap<UsageHit, Boolean>();
         final var patterns = searchPatterns.stream().map(Pattern::compile).toList();
 
-        candidateFiles.parallelStream().forEach(file -> {
+        List<Callable<Void>> tasks = candidateFiles.stream()
+                .map(file -> (Callable<Void>) () -> {
+                    scanFileForUsageHits(file, patterns, hits);
+                    return null;
+                })
+                .toList();
+
+        var futures = FUZZY_SCAN_EXECUTOR.invokeAll(tasks);
+        for (var future : futures) {
             try {
-                if (!file.isText()) return;
-                var contentOpt = file.read();
-                if (contentOpt.isEmpty()) return;
-                var content = contentOpt.get();
-                if (content.isEmpty()) return;
+                future.get();
+            } catch (ExecutionException e) {
+                logger.warn("Failed to extract usage hits", e.getCause());
+            }
+        }
+        return Set.copyOf(hits.keySet());
+    }
 
-                var lines = content.split("\\R", -1);
-                var lineStarts = FileUtil.computeLineStarts(content);
+    private void scanFileForUsageHits(
+            ProjectFile file, List<Pattern> patterns, ConcurrentHashMap<UsageHit, Boolean> hits) {
+        try {
+            var scanInputOpt = scanInput(file);
+            if (scanInputOpt.isEmpty()) return;
+            var scanInput = scanInputOpt.get();
+            var content = scanInput.content();
 
-                for (var pattern : patterns) {
-                    var matcher = pattern.matcher(content);
-                    while (matcher.find()) {
-                        int start = matcher.start();
-                        int end = matcher.end();
-                        int startByte = content.substring(0, start).getBytes(StandardCharsets.UTF_8).length;
-                        int endByte = startByte + matcher.group().getBytes(StandardCharsets.UTF_8).length;
+            for (var pattern : patterns) {
+                var matcher = pattern.matcher(content);
+                while (matcher.find()) {
+                    int start = matcher.start();
+                    int end = matcher.end();
+                    int startByte = content.substring(0, start).getBytes(StandardCharsets.UTF_8).length;
+                    int endByte = startByte + matcher.group().getBytes(StandardCharsets.UTF_8).length;
 
-                        if (!analyzer.isAccessExpression(file, startByte, endByte)) continue;
+                    if (!analyzer.isAccessExpression(file, startByte, endByte)) continue;
 
-                        int lineIdx = FileUtil.findLineIndexForOffset(lineStarts, start);
-                        int startLine = Math.max(0, lineIdx - 3);
-                        int endLine = Math.min(lines.length - 1, lineIdx + 3);
-                        var snippet = IntStream.rangeClosed(startLine, endLine)
-                                .mapToObj(i -> lines[i])
-                                .collect(Collectors.joining("\n"));
+                    int lineIdx = FileUtil.findLineIndexForOffset(scanInput.lineStarts(), start);
+                    int startLine = Math.max(0, lineIdx - 3);
+                    int endLine = Math.min(scanInput.lines().length - 1, lineIdx + 3);
+                    var snippet = IntStream.rangeClosed(startLine, endLine)
+                            .<String>mapToObj(i -> scanInput.lines()[i])
+                            .collect(Collectors.joining("\n"));
 
-                        var range = new IAnalyzer.Range(startByte, endByte, lineIdx, lineIdx, lineIdx);
-                        var enclosingCodeUnit = analyzer.enclosingCodeUnit(file, range);
+                    var range = new IAnalyzer.Range(startByte, endByte, lineIdx, lineIdx, lineIdx);
+                    var enclosingCodeUnit = analyzer.enclosingCodeUnit(file, range);
 
-                        if (enclosingCodeUnit.isPresent()) {
-                            hits.put(
-                                    new UsageHit(file, lineIdx + 1, start, end, enclosingCodeUnit.get(), 1.0, snippet),
-                                    true);
-                        }
+                    if (enclosingCodeUnit.isPresent()) {
+                        hits.put(
+                                new UsageHit(file, lineIdx + 1, start, end, enclosingCodeUnit.get(), 1.0, snippet),
+                                true);
                     }
                 }
-            } catch (Exception e) {
-                logger.warn("Failed to extract usage hits from {}: {}", file, e.toString());
             }
-        });
-        return Set.copyOf(hits.keySet());
+        } catch (Exception e) {
+            logger.warn("Failed to extract usage hits from {}: {}", file, e.toString());
+        }
+    }
+
+    private Optional<CachedFileScanInput> scanInput(ProjectFile file) {
+        long mtime;
+        try {
+            mtime = file.mtime();
+        } catch (IOException e) {
+            logger.debug("Could not stat {} before usage scan; reading without caching", file, e);
+            return readScanInput(file, 0);
+        }
+
+        var cached = fileScanInputCache.getIfPresent(file);
+        if (cached != null && cached.mtime() == mtime) {
+            return Optional.of(cached);
+        }
+        if (cached != null) {
+            fileScanInputCache.invalidate(file);
+        }
+
+        var scanInput = readScanInput(file, mtime);
+        scanInput.ifPresent(input -> fileScanInputCache.put(file, input));
+        return scanInput;
+    }
+
+    private Optional<CachedFileScanInput> readScanInput(ProjectFile file, long mtime) {
+        if (!file.isText()) return Optional.empty();
+        fileReadCount.incrementAndGet();
+        var contentOpt = file.read();
+        if (contentOpt.isEmpty()) return Optional.empty();
+        var content = contentOpt.get();
+        if (content.isEmpty()) return Optional.empty();
+
+        lineStartComputationCount.incrementAndGet();
+        return Optional.of(
+                new CachedFileScanInput(mtime, content, content.split("\\R", -1), FileUtil.computeLineStarts(content)));
+    }
+
+    int cachedFileReadCount() {
+        return fileReadCount.get();
+    }
+
+    int cachedLineStartComputationCount() {
+        return lineStartComputationCount.get();
     }
 
     public static Map<CodeUnit, Set<UsageHit>> filterByConfidence(Map<CodeUnit, Set<UsageHit>> allHitsByOverload) {
@@ -204,5 +291,35 @@ public final class LlmUsageAnalyzer implements UsageAnalyzer {
                 .stream()
                 .filter(e -> !e.getValue().isEmpty())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static final class CachedFileScanInput {
+        private final long mtime;
+        private final String content;
+        private final String[] lines;
+        private final int[] lineStarts;
+
+        private CachedFileScanInput(long mtime, String content, String[] lines, int[] lineStarts) {
+            this.mtime = mtime;
+            this.content = content;
+            this.lines = lines;
+            this.lineStarts = lineStarts;
+        }
+
+        private long mtime() {
+            return mtime;
+        }
+
+        private String content() {
+            return content;
+        }
+
+        private String[] lines() {
+            return lines;
+        }
+
+        private int[] lineStarts() {
+            return lineStarts;
+        }
     }
 }

--- a/app/src/test/java/ai/brokk/usages/LlmUsageAnalyzerTest.java
+++ b/app/src/test/java/ai/brokk/usages/LlmUsageAnalyzerTest.java
@@ -1,0 +1,136 @@
+package ai.brokk.usages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.brokk.OfflineService;
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.CodeUnitType;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import ai.brokk.testutil.TestAnalyzer;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class LlmUsageAnalyzerTest {
+
+    @Test
+    void cachesFileScanInputAcrossSymbolQueries() throws IOException, InterruptedException {
+        String source =
+                """
+                package com.example;
+                class Caller {
+                    void call(Target target) {
+                        target.foo();
+                        target.bar();
+                    }
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.empty().build()) {
+            var file = new CountingProjectFile(project.getRoot(), "src/main/java/com/example/Caller.java");
+            Files.createDirectories(file.absPath().getParent());
+            Files.writeString(file.absPath(), source);
+
+            var caller = new CodeUnit(file, CodeUnitType.CLASS, "com.example", "Caller");
+            var foo = new CodeUnit(file, CodeUnitType.FUNCTION, "com.example", "Target.foo");
+            var bar = new CodeUnit(file, CodeUnitType.FUNCTION, "com.example", "Target.bar");
+
+            var analyzer = new TestAnalyzer(List.of(caller, foo, bar), java.util.Map.of(), project);
+            analyzer.setRanges(caller, List.of(new ai.brokk.analyzer.IAnalyzer.Range(0, source.length(), 1, 6, 6)));
+
+            var usageAnalyzer = new LlmUsageAnalyzer(project, analyzer, new OfflineService(project), null);
+            var candidateFiles = Set.<ProjectFile>of(file);
+
+            usageAnalyzer.findUsages(List.of(foo), candidateFiles, 100);
+            usageAnalyzer.findUsages(List.of(bar), candidateFiles, 100);
+
+            assertEquals(1, file.readCount());
+            assertEquals(1, usageAnalyzer.cachedFileReadCount());
+            assertEquals(1, usageAnalyzer.cachedLineStartComputationCount());
+        }
+    }
+
+    @Test
+    void invalidatesFileScanInputWhenMtimeChanges() throws IOException, InterruptedException {
+        String firstSource =
+                """
+                package com.example;
+                class Caller {
+                    void call(Target target) {
+                        target.foo();
+                    }
+                }
+                """;
+        String secondSource =
+                """
+                package com.example;
+                class Caller {
+                    void call(Target target) {
+                        target.bar();
+                    }
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.empty().build()) {
+            var file = new CountingProjectFile(project.getRoot(), "src/main/java/com/example/Caller.java");
+            Files.createDirectories(file.absPath().getParent());
+            Files.writeString(file.absPath(), firstSource);
+
+            var caller = new CodeUnit(file, CodeUnitType.CLASS, "com.example", "Caller");
+            var foo = new CodeUnit(file, CodeUnitType.FUNCTION, "com.example", "Target.foo");
+            var bar = new CodeUnit(file, CodeUnitType.FUNCTION, "com.example", "Target.bar");
+
+            var analyzer = new TestAnalyzer(List.of(caller, foo, bar), java.util.Map.of(), project);
+            analyzer.setRanges(
+                    caller, List.of(new ai.brokk.analyzer.IAnalyzer.Range(0, secondSource.length(), 1, 6, 6)));
+
+            var usageAnalyzer = new LlmUsageAnalyzer(project, analyzer, new OfflineService(project), null);
+            var candidateFiles = Set.<ProjectFile>of(file);
+
+            usageAnalyzer.findUsages(List.of(foo), candidateFiles, 100);
+
+            Files.writeString(file.absPath(), secondSource);
+            file.advanceMtime();
+
+            usageAnalyzer.findUsages(List.of(bar), candidateFiles, 100);
+
+            assertEquals(2, file.readCount());
+            assertEquals(2, usageAnalyzer.cachedFileReadCount());
+            assertEquals(2, usageAnalyzer.cachedLineStartComputationCount());
+        }
+    }
+
+    private static final class CountingProjectFile extends ProjectFile {
+        private final AtomicInteger readCount = new AtomicInteger();
+        private final AtomicInteger mtime = new AtomicInteger(1);
+
+        private CountingProjectFile(Path root, String relName) {
+            super(root, relName);
+        }
+
+        @Override
+        public Optional<String> read() {
+            readCount.incrementAndGet();
+            return super.read();
+        }
+
+        private int readCount() {
+            return readCount.get();
+        }
+
+        @Override
+        public long mtime() {
+            return mtime.get();
+        }
+
+        private void advanceMtime() {
+            mtime.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
### Description
- Cache fuzzy usage scan inputs with a bounded Caffeine cache keyed by `ProjectFile`, and invalidate cached entries when file `mtime` changes.
- Replace common-pool `parallelStream` scanning with a capped virtual-thread executor so dead-code analysis no longer competes with unrelated work.
- Add lightweight timing/counter logging for the dead-code path and regression coverage for cache reuse and invalidation.

**Key Changes**:
- `LlmUsageAnalyzer` now reuses scan inputs safely with explicit cache bounds and freshness checks, avoiding stale results after file edits.
- `CodeQualityTools` records phase timings for candidate discovery and usage scanning to help profile the bottleneck.
- New tests cover repeated symbol queries, mtime-based invalidation, and the existing dead-code report behavior.

**Touch Points**:
- `app/src/main/java/ai/brokk/tools/CodeQualityTools.java`
- `app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java`
- `app/src/test/java/ai/brokk/usages/LlmUsageAnalyzerTest.java`

### Testing
- `./gradlew fix tidy`
- `./gradlew :app:test --tests ai.brokk.usages.LlmUsageAnalyzerTest --tests ai.brokk.tools.CodeQualityToolsDeadCodeAndUnusedAbstractionTest`
- `./gradlew analyze`