### PR TITLE
MOP/ACP: parse legacy <message type=...> framing on display-side replay

### DIFF
--- a/app/src/main/java/ai/brokk/TaskEntry.java
+++ b/app/src/main/java/ai/brokk/TaskEntry.java
@@ -262,8 +262,13 @@ public final class TaskEntry {
 
     public Collection<ChatMessage> mopMessages() {
         // Keep for call sites that still need ChatMessage collections (app-side only).
+        // Parse legacy <message type=X>...</message> framing back into per-segment messages so
+        // display-side renderers receive properly typed bubbles instead of one big CustomMessage
+        // whose text leaks framing tags to the user.
         if (mopMarkdown != null) {
-            return List.of(Messages.customSystem(mopMarkdown));
+            return Messages.parseLegacyFraming(mopMarkdown).stream()
+                    .map(seg -> Messages.create(seg.content(), seg.type()))
+                    .toList();
         }
         return List.of(Messages.customSystem(castNonNull(summary)));
     }

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -1238,7 +1238,8 @@ public class BrokkAcpAgent {
 
                     // Send agent response as AgentMessageChunk
                     var mopMarkdown = task.mopMarkdown();
-                    var responseText = mopMarkdown != null ? mopMarkdown : task.summary();
+                    var rawText = mopMarkdown != null ? mopMarkdown : task.summary();
+                    var responseText = rawText == null ? null : Messages.stripLegacyFraming(rawText);
                     if (responseText != null && !responseText.isBlank()) {
                         sender.sendSessionUpdate(
                                 sessionId,

--- a/app/src/main/java/ai/brokk/gui/mop/webview/MOPBridge.java
+++ b/app/src/main/java/ai/brokk/gui/mop/webview/MOPBridge.java
@@ -12,6 +12,7 @@ import ai.brokk.gui.mop.FilePathLookupService;
 import ai.brokk.gui.mop.SymbolLookupService;
 import ai.brokk.project.MainProject;
 import ai.brokk.util.Environment;
+import ai.brokk.util.Messages;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -232,7 +233,11 @@ public final class MOPBridge {
 
         if (taskFragment != null) {
             var text = taskFragment.text().join();
-            messages.add(new BrokkEvent.HistoryTask.Message(text, ChatMessageType.USER, false, true));
+            // Persisted task markdown may still contain legacy <message type=X>...</message> framing;
+            // parse it into per-segment bubbles so framing tags never reach the webview.
+            for (var segment : Messages.parseLegacyFraming(text)) {
+                messages.add(new BrokkEvent.HistoryTask.Message(segment.content(), segment.type(), false, true));
+            }
         }
 
         // Build event: compressed flag is true when summary is present (AI uses summary)

--- a/app/src/main/java/ai/brokk/util/Messages.java
+++ b/app/src/main/java/ai/brokk/util/Messages.java
@@ -9,11 +9,13 @@ import ai.brokk.context.ContextFragment;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.*;
 import dev.langchain4j.model.openai.OpenAiTokenCountEstimator;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -271,5 +273,99 @@ public class Messages {
                 .map(Messages::getReprForDisplay)
                 .filter(s -> !s.isBlank())
                 .collect(Collectors.joining("\n\n"));
+    }
+
+    /**
+     * One slice of pre-rendered task markdown after legacy framing has been stripped.
+     * Produced by {@link #parseLegacyFraming(String)}.
+     */
+    public record FramedSegment(ChatMessageType type, String content) {}
+
+    private static final Pattern LEGACY_OPEN_TAG = Pattern.compile("^\\s*<message type=(\\w+)>\\s*$");
+
+    private static final Pattern LEGACY_CLOSE_TAG = Pattern.compile("^\\s*</message>\\s*$");
+
+    private static final Pattern LEGACY_SECTION_LABEL = Pattern.compile("(?m)^(?:Reasoning|Text|Tool calls):\\s*$");
+
+    /**
+     * Parses task markdown that may contain legacy {@code <message type=X>...</message>} framing
+     * (produced by {@link #format(List)}) into a list of structured segments.
+     *
+     * <p>If no framing is detected the whole markdown is returned as a single CUSTOM segment so that
+     * post-fix data flows through unchanged. This is meant for display-side replay where structured
+     * messages are no longer available on the fragment but the persisted markdown still carries them.
+     *
+     * <p>Uses a line-based stack scanner so it correctly handles empty bodies and arbitrarily nested
+     * framing (e.g. {@code <message type=custom>} wrapping a full {@code <message type=user>...</message>}).
+     * When framing is nested only the inner segment is emitted, since the outer wrap carries no
+     * meaningful content of its own.
+     */
+    public static List<FramedSegment> parseLegacyFraming(String markdown) {
+        if (markdown.isEmpty()) {
+            return List.of();
+        }
+        if (!markdown.contains("<message type=")) {
+            return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
+        }
+        var typeStack = new ArrayDeque<ChatMessageType>();
+        var contentStack = new ArrayDeque<StringBuilder>();
+        var result = new ArrayList<FramedSegment>();
+        for (var line : markdown.split("\n", -1)) {
+            var openMatcher = LEGACY_OPEN_TAG.matcher(line);
+            if (openMatcher.matches()) {
+                ChatMessageType type;
+                try {
+                    type = ChatMessageType.valueOf(openMatcher.group(1).toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException ex) {
+                    type = ChatMessageType.CUSTOM;
+                }
+                typeStack.push(type);
+                contentStack.push(new StringBuilder());
+                continue;
+            }
+            if (LEGACY_CLOSE_TAG.matcher(line).matches()) {
+                if (typeStack.isEmpty()) {
+                    continue;
+                }
+                var type = typeStack.pop();
+                var cleaned = cleanFramedContent(contentStack.pop().toString());
+                if (!cleaned.isEmpty()) {
+                    result.add(new FramedSegment(type, cleaned));
+                }
+                continue;
+            }
+            if (!contentStack.isEmpty()) {
+                contentStack.peek().append(line).append('\n');
+            }
+        }
+        if (result.isEmpty()) {
+            return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
+        }
+        return result;
+    }
+
+    private static String cleanFramedContent(String content) {
+        if (content.isEmpty()) {
+            return "";
+        }
+        var minIndent = content.lines()
+                .filter(line -> !line.isBlank())
+                .mapToInt(line -> {
+                    int n = 0;
+                    while (n < line.length() && line.charAt(n) == ' ') n++;
+                    return n;
+                })
+                .min()
+                .orElse(0);
+        var deindented = content.lines()
+                .map(line -> line.length() >= minIndent ? line.substring(minIndent) : line)
+                .collect(Collectors.joining("\n"));
+        var withoutLabels = LEGACY_SECTION_LABEL.matcher(deindented).replaceAll("");
+        return withoutLabels.replaceAll("\\n{3,}", "\n\n").strip();
+    }
+
+    /** Strips legacy framing while preserving readable content; used where per-segment structure isn't needed. */
+    public static String stripLegacyFraming(String markdown) {
+        return parseLegacyFraming(markdown).stream().map(FramedSegment::content).collect(Collectors.joining("\n\n"));
     }
 }

--- a/app/src/test/java/ai/brokk/util/MessagesLegacyFramingTest.java
+++ b/app/src/test/java/ai/brokk/util/MessagesLegacyFramingTest.java
@@ -1,0 +1,145 @@
+package ai.brokk.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MessagesLegacyFramingTest {
+
+    @Test
+    void emptyInputReturnsEmptyList() {
+        assertEquals(List.of(), Messages.parseLegacyFraming(""));
+    }
+
+    @Test
+    void cleanMarkdownPassesThroughAsCustomSegment() {
+        var clean = "Some clean **markdown** with no framing.";
+        var segments = Messages.parseLegacyFraming(clean);
+        assertEquals(1, segments.size());
+        assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
+        assertEquals(clean, segments.get(0).content());
+    }
+
+    @Test
+    void parsesUserAndAiBlocksProducedByMessagesFormat() {
+        List<ChatMessage> messages = List.of(new UserMessage("hello"), new AiMessage("hi there"));
+        var framed = Messages.format(messages);
+
+        var segments = Messages.parseLegacyFraming(framed);
+
+        assertEquals(2, segments.size());
+        assertEquals(ChatMessageType.USER, segments.get(0).type());
+        assertEquals("hello", segments.get(0).content());
+        assertEquals(ChatMessageType.AI, segments.get(1).type());
+        assertEquals("hi there", segments.get(1).content());
+    }
+
+    @Test
+    void stripsAiSectionLabelsFromReasoningAndToolCalls() {
+        var ai = new AiMessage("", "thinking out loud"); // text empty, reasoning set
+        var framed = Messages.format(List.of(ai));
+        var segments = Messages.parseLegacyFraming(framed);
+        assertEquals(1, segments.size());
+        assertEquals(ChatMessageType.AI, segments.get(0).type());
+        // After stripping the "Reasoning:" label and de-indenting, only the reasoning body remains.
+        assertEquals("thinking out loud", segments.get(0).content());
+    }
+
+    @Test
+    void unknownTypeFallsBackToCustom() {
+        var framed =
+                """
+                <message type=mystery>
+                  payload
+                </message>
+                """;
+        var segments = Messages.parseLegacyFraming(framed);
+        assertEquals(1, segments.size());
+        assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
+        assertEquals("payload", segments.get(0).content());
+    }
+
+    @Test
+    void stripLegacyFramingJoinsSegments() {
+        List<ChatMessage> messages = List.of(new UserMessage("hello"), new AiMessage("hi there"));
+        var framed = Messages.format(messages);
+        assertEquals("hello\n\nhi there", Messages.stripLegacyFraming(framed));
+    }
+
+    @Test
+    void stripLegacyFramingPreservesCleanMarkdown() {
+        var clean = "Already clean";
+        assertEquals(clean, Messages.stripLegacyFraming(clean));
+    }
+
+    @Test
+    void flattensNestedFramingFromCustomWrappingUser() {
+        // Old persisted entries sometimes double-wrap: a CustomMessage carrying a markdown blob that
+        // itself contains <message type=user>...</message>. Verify we flatten to the inner segment.
+        var nested =
+                """
+                <message type=custom>
+                  <message type=user>
+                    can you list all the acp related issues?
+                  </message>
+                </message>
+                """;
+        var segments = Messages.parseLegacyFraming(nested);
+        assertEquals(1, segments.size());
+        assertEquals(ChatMessageType.USER, segments.get(0).type());
+        assertEquals("can you list all the acp related issues?", segments.get(0).content());
+    }
+
+    @Test
+    void emptyCustomBlockDoesNotSwallowFollowingBlock() {
+        // Real persisted data started with an empty custom wrapper followed by an AI block. A naive
+        // regex matched the outer custom open against the AI block's close, collapsing both into
+        // one segment whose content kept the inner framing. Verify each block is recognized separately.
+        var input =
+                """
+                <message type=custom>
+
+                </message>
+
+                <message type=ai>
+                  Reasoning:
+                  thought
+                </message>
+                """;
+        var segments = Messages.parseLegacyFraming(input);
+        assertEquals(1, segments.size());
+        assertEquals(ChatMessageType.AI, segments.get(0).type());
+        assertEquals("thought", segments.get(0).content());
+    }
+
+    @Test
+    void deindentDetectsCommonIndentForArbitraryDepth() {
+        // Inner content at 4-space indent (depth-2 nesting) must lose all 4 leading spaces.
+        var input =
+                """
+                <message type=custom>
+                  <message type=user>
+                    deeply indented user text
+                  </message>
+                </message>
+                """;
+        var segments = Messages.parseLegacyFraming(input);
+        assertEquals(1, segments.size());
+        assertEquals(ChatMessageType.USER, segments.get(0).type());
+        assertEquals("deeply indented user text", segments.get(0).content());
+    }
+
+    @Test
+    void parseReturnsCustomFallbackWhenFramingTokenPresentButMalformed() {
+        var malformed = "<message type=user> not a real block";
+        var segments = Messages.parseLegacyFraming(malformed);
+        assertEquals(1, segments.size());
+        assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
+        assertEquals(malformed, segments.get(0).content());
+    }
+}


### PR DESCRIPTION
## Summary

Sessions persisted before #3443 still carry `<message type=X>...</message>` framing baked into `mopMarkdown`, so the GUI replays them as literal `<message type=...>` text inside a single oversized USER bubble. This PR fixes that at the display boundary by parsing legacy framing back into structured per-segment messages, without touching persistence.

## What changed

- `Messages.parseLegacyFraming(String)` — new line-based stack scanner returning `List<FramedSegment(type, content)>`. Robust against:
  - Empty bodies (`<message type=custom>\n\n</message>` no longer "swallows" the next block)
  - Arbitrary nesting (`<message type=custom>` wrapping a complete `<message type=user>...</message>`, which the legacy persistence pipeline can produce)
  - Indent detection (minimum-indent algorithm so depth-2 nesting still de-indents fully)
  - `Reasoning:` / `Text:` / `Tool calls:` section labels left over from `Messages.getRepr`
- `Messages.stripLegacyFraming(String)` — convenience wrapper joining segments for callers that need plain text.
- `TaskEntry.mopMessages()` — replaces the single `customSystem(mopMarkdown)` wrap with one typed `ChatMessage` per parsed segment. Covers the **main task** display path (`MarkdownOutputPanel.setMainThenHistoryAsync` → `main.mopMessages()`).
- `MOPBridge.sendHistoryTask` — replaces the single USER bubble dump with one structured `HistoryTask.Message` per parsed segment. Covers the **history replay** path.
- `BrokkAcpAgent.scheduleConversationReplay` — applies `stripLegacyFraming` to `mopMarkdown` before emitting `AgentMessageChunk`, so the ACP transcript no longer leaks framing tags.

## Why a parser instead of a persistence change

The framing leak is structural — it dates back to #3324, which converted `TaskEntry` from `TaskFragment(messages, instructions)` to pre-rendered `mopMarkdown`. A proper fix stores structured messages alongside the markdown blob and prefers them on read; that's a deeper refactor tracked in #3462.

## Test plan

- [x] Eleven unit tests (`MessagesLegacyFramingTest`) covering empty/clean/framed/nested inputs, the empty-body regression, deep-nesting indent detection, and the section-label strip.
- [x] Manual GUI replay of a session persisted before #3443: previously rendered as `1 msg / 905 lines` with framing tags inline; now renders as `41 msgs / 700 lines` with per-message `You` / `Brokk` / `System` bubbles, callShellAgent and runShellCommand widgets intact.
- [x] `./gradlew tidy :app:test --tests "ai.brokk.util.MessagesLegacyFramingTest" --tests "ai.brokk.TaskEntryTest"` green.

## Out of scope

- Persistence migration / structured-message DTO — see #3462.

Generated with [Claude Code](https://claude.com/claude-code)
