### PR TITLE
ACP/Codex: substitute role configs at read time when restrict flag is active

### DIFF
--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -2470,34 +2470,20 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
     private void maybeRunCodexAutoSetup() {
         if (MainProject.isOpenAiCodexOauthConnected()) {
-            logger.info("Running first-time Codex auto-setup...");
-
-            MainProject.setOtherModelsVendorPreference("OpenAI - Codex");
-            Map<ModelProperties.ModelType, Service.ModelConfig> vendorModels =
-                    ModelProperties.getVendorModels("OpenAI - Codex");
-            var mainProject = chrome.getProject().getMainProject();
-            if (vendorModels != null) {
-                for (var entry : vendorModels.entrySet()) {
-                    mainProject.setModelConfig(entry.getKey(), entry.getValue());
-                }
-            }
+            logger.info("Codex OAuth connected; installing Codex favorites preset.");
 
             MainProject.saveFavoriteModels(ModelProperties.CODEX_OAUTH_FAVORITES);
             logger.info("Replaced favorites list with Codex OAuth models");
 
-            mainProject.setModelConfig(ModelProperties.ModelType.CODE, ModelProperties.CODEX_OAUTH_CODE_CONFIG);
-            mainProject.setModelConfig(
-                    ModelProperties.ModelType.ARCHITECT, ModelProperties.CODEX_OAUTH_ARCHITECT_CONFIG);
-
             chrome.getContextManager().reloadService();
 
-            // Show popup and navigate to Model Roles tab
             SwingUtilities.invokeLater(() -> {
                 String message =
                         """
-                        "OpenAI - Codex" vendor has been configured automatically.
-                        GPT-5.2 (Architect) and Codex (Coder) models were set.
-                        This can be changed at any time in Settings.
+                        Codex OAuth is connected. While the OAuth-only restriction is enabled
+                        (Settings > Global), all model roles route to Codex models automatically
+                        without overwriting your saved preferences. The favorites list has been
+                        updated with Codex presets.
                         """
                                 .stripIndent();
 

--- a/app/src/main/java/ai/brokk/project/ModelProperties.java
+++ b/app/src/main/java/ai/brokk/project/ModelProperties.java
@@ -1,5 +1,7 @@
 package ai.brokk.project;
 
+import static java.util.Objects.requireNonNull;
+
 import ai.brokk.AbstractService.ModelConfig;
 import ai.brokk.AbstractService.ReasoningLevel;
 import ai.brokk.Service;
@@ -260,11 +262,10 @@ public final class ModelProperties {
             case CODE -> CODEX_OAUTH_CODE_CONFIG;
             case ARCHITECT -> CODEX_OAUTH_ARCHITECT_CONFIG;
             default -> {
-                var codexMap = getVendorModelMap().get("OpenAI - Codex");
-                assert codexMap != null : "OpenAI - Codex vendor map missing";
-                var cfg = codexMap.get(modelType);
-                assert cfg != null : "OpenAI - Codex vendor map missing entry for " + modelType;
-                yield cfg;
+                var codexMap =
+                        requireNonNull(getVendorModelMap().get("OpenAI - Codex"), "OpenAI - Codex vendor map missing");
+                yield requireNonNull(
+                        codexMap.get(modelType), "OpenAI - Codex vendor map missing entry for " + modelType);
             }
         };
     }

--- a/app/src/main/java/ai/brokk/project/ModelProperties.java
+++ b/app/src/main/java/ai/brokk/project/ModelProperties.java
@@ -230,6 +230,10 @@ public final class ModelProperties {
      * Ensures ProcessingTier is non-null (backward compatibility against older JSON).
      */
     static ModelConfig getModelConfig(Properties props, ModelType modelType) {
+        // Codex OAuth + restrict flag substitutes role configs at read time; persisted values stay intact.
+        if (MainProject.isOpenAiCodexOauthConnected() && MainProject.isRestrictToOauthModelsWhenConnected()) {
+            return codexOauthConfigFor(modelType);
+        }
         String jsonString = props.getProperty(modelType.propertyKey);
         if (jsonString != null && !jsonString.isBlank()) {
             try {
@@ -249,6 +253,20 @@ public final class ModelProperties {
             }
         }
         return modelType.defaultConfig();
+    }
+
+    private static ModelConfig codexOauthConfigFor(ModelType modelType) {
+        return switch (modelType) {
+            case CODE -> CODEX_OAUTH_CODE_CONFIG;
+            case ARCHITECT -> CODEX_OAUTH_ARCHITECT_CONFIG;
+            default -> {
+                var codexMap = getVendorModelMap().get("OpenAI - Codex");
+                assert codexMap != null : "OpenAI - Codex vendor map missing";
+                var cfg = codexMap.get(modelType);
+                assert cfg != null : "OpenAI - Codex vendor map missing entry for " + modelType;
+                yield cfg;
+            }
+        };
     }
 
     /**

--- a/app/src/test/java/ai/brokk/project/CodexAutoSetupTest.java
+++ b/app/src/test/java/ai/brokk/project/CodexAutoSetupTest.java
@@ -116,7 +116,8 @@ class CodexAutoSetupTest {
         MainProject.setOpenAiCodexOauthConnected(false);
         assertEquals("claude-sonnet-4-6", project.getModelConfig(ModelType.CODE).name());
         assertEquals(
-                "gemini-3-flash-preview", project.getModelConfig(ModelType.SUMMARIZE).name());
+                "gemini-3-flash-preview",
+                project.getModelConfig(ModelType.SUMMARIZE).name());
 
         MainProject.setOpenAiCodexOauthConnected(true);
         MainProject.setRestrictToOauthModelsWhenConnected(true);

--- a/app/src/test/java/ai/brokk/project/CodexAutoSetupTest.java
+++ b/app/src/test/java/ai/brokk/project/CodexAutoSetupTest.java
@@ -1,5 +1,6 @@
 package ai.brokk.project;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,5 +97,51 @@ class CodexAutoSetupTest {
         // Check persistence of model config
         ModelConfig loadedConfig = mainProject.getModelConfig(ModelType.CODE);
         assertEquals("gpt-5.1-codex-max-oauth", loadedConfig.name(), "Model config should persist");
+    }
+
+    @Test
+    void testCodexFlagSubstitutesModelConfigAtReadTime(@TempDir Path tempDir) {
+        System.setProperty("brokk.test.mode", "true");
+        System.setProperty("brokk.test.sandbox.root", tempDir.toString());
+        MainProject.resetGlobalConfigCachesForTests();
+
+        Path projectRoot = tempDir.resolve("dummy-project");
+        projectRoot.toFile().mkdirs();
+        MainProject project = new MainProject(projectRoot);
+
+        // Persist non-Codex preferences for a directly-selected role and a vendor-driven one.
+        project.setModelConfig(ModelType.CODE, new ModelConfig("claude-sonnet-4-6"));
+        project.setModelConfig(ModelType.SUMMARIZE, new ModelConfig("gemini-3-flash-preview"));
+
+        MainProject.setOpenAiCodexOauthConnected(false);
+        assertEquals("claude-sonnet-4-6", project.getModelConfig(ModelType.CODE).name());
+        assertEquals(
+                "gemini-3-flash-preview", project.getModelConfig(ModelType.SUMMARIZE).name());
+
+        MainProject.setOpenAiCodexOauthConnected(true);
+        MainProject.setRestrictToOauthModelsWhenConnected(true);
+        assertEquals(
+                ModelProperties.CODEX_OAUTH_CODE_CONFIG.name(),
+                project.getModelConfig(ModelType.CODE).name(),
+                "CODE should substitute to Codex OAuth config when restrict flag is active");
+        var codexVendorMap = requireNonNull(ModelProperties.getVendorModels("OpenAI - Codex"));
+        assertEquals(
+                requireNonNull(codexVendorMap.get(ModelType.SUMMARIZE)).name(),
+                project.getModelConfig(ModelType.SUMMARIZE).name(),
+                "SUMMARIZE should substitute via Codex vendor map when restrict flag is active");
+
+        MainProject.setRestrictToOauthModelsWhenConnected(false);
+        assertEquals(
+                "claude-sonnet-4-6",
+                project.getModelConfig(ModelType.CODE).name(),
+                "Persisted CODE returns when restrict flag is disabled");
+        assertEquals(
+                "gemini-3-flash-preview",
+                project.getModelConfig(ModelType.SUMMARIZE).name(),
+                "Persisted SUMMARIZE returns when restrict flag is disabled");
+
+        // Persistence sanity: substitution never wrote anything to disk.
+        MainProject.resetGlobalConfigCachesForTests();
+        assertEquals("claude-sonnet-4-6", project.getModelConfig(ModelType.CODE).name());
     }
 }


### PR DESCRIPTION
## Summary
- `ModelProperties.getModelConfig` now substitutes Codex OAuth role configs at read time when `isOpenAiCodexOauthConnected() && isRestrictToOauthModelsWhenConnected()`, so the ACP server picks the right models without needing the GUI's auto-setup mutation to have run for that project.
- `maybeRunCodexAutoSetup` no longer mutates per-project role configs or vendor preference; it only installs the Codex favorites preset and shows an updated popup. Disconnecting OAuth (or unchecking the restriction) immediately reveals the user's prior persisted preferences instead of leaving Codex configs orphaned.
- Adds `CodexAutoSetupTest.testCodexFlagSubstitutesModelConfigAtReadTime` covering all three states (disconnected, restrict on, restrict off) for both a directly-selected role (CODE) and a vendor-driven role (SUMMARIZE), and asserts nothing is written to disk.

## Why
`AcpServerMain.createWorkspaceBundle` materializes a fresh `MainProject` per session cwd. The GUI's `maybeRunCodexAutoSetup` runs only when the user authenticates Codex OAuth from the Settings dialog and writes role configs into the *currently open* project's properties — so any other project (including those opened first via ACP) saw stale `sonnet4_6` for ARCHITECT or `codex5_3` for CODE while `getAvailableModels()` was filtering non-OAuth models out. The persisted role pointed at a model that wasn't even available, producing the "code model changes" symptom in ACP sessions.

This mirrors the existing pattern in `brokk-code` (`brokkApiKey`, `githubToken`, `llmProxySetting`): a single global property in `brokk.properties` is the source of truth, and code re-evaluates it on every read. The `restrictToOauthModelsWhenConnected` flag (default `true`) is now the only switch — flipping it via the existing GUI checkbox or, later, a `/config` slash command on the Python side, is sufficient.

## Notes for reviewer
- The original plan also considered substituting inside `getVendorModels`, but that method sits on the *write* path (CLI `applyVendorPreference` and the Settings panel persist role configs through it). Substituting there would create an inconsistent on-disk state where `OtherModelsVendorPreference="Anthropic"` could coexist with Codex role configs persisted to disk. The single substitution point in `getModelConfig` covers all read paths cleanly.
- `CODEX_OAUTH_CODE_CONFIG` and `CODEX_OAUTH_ARCHITECT_CONFIG` are reused for CODE/ARCHITECT; for the rest the existing `getVendorModelMap().get("OpenAI - Codex")` map provides the canonical Codex equivalents (and `getVendorModelMap()` already asserts every non-CODE/ARCHITECT `ModelType` has an entry there).
- The popup text in `maybeRunCodexAutoSetup` no longer claims that GPT-5.4 / Codex were "set" — it now describes the dynamic-substitution semantics.
- Follow-up (separate PR): a `/config codex-restrict {on|off}` command on the Python side that calls `write_brokk_properties({"restrictToOauthModelsWhenConnected": ...})`. With the read-time substitution in place, that's the entire wiring needed.

## Test plan
- [x] `./gradlew :app:test --tests "ai.brokk.project.CodexAutoSetupTest" --tests "ai.brokk.ServiceCodexGatingTest"` — all 4 tests pass
- [x] `./gradlew :app:test --tests "ai.brokk.project.*"` plus `OpenAiAuthRouterTest` — green, no regressions
- [ ] Manual: connect Codex OAuth in GUI, open ACP session against a project that never had auto-setup run; ACP should resolve `gpt-5.3-codex-oauth` for CODE and `gpt-5.4-oauth` for ARCHITECT
- [ ] Manual: disconnect Codex OAuth; previous role preferences (e.g., Sonnet for ARCHITECT) reappear without manual reset
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
