### PR TITLE
Disable Seatbelt sandbox for build verification on macOS

### DIFF
--- a/app/src/main/java/ai/brokk/util/BuildVerifier.java
+++ b/app/src/main/java/ai/brokk/util/BuildVerifier.java
@@ -130,10 +130,15 @@ public final class BuildVerifier {
         Deque<String> lines = new ArrayDeque<>(MAX_OUTPUT_LINES);
 
         try {
+            // Build verification runs the user-configured verificationCommand, not an LLM-chosen
+            // command. Sandboxing it via Seatbelt on macOS reliably breaks JVM/Gradle builds (no
+            // working network-interface enumeration for FileLockContentionHandler, no /tmp, no
+            // ~/.gradle/caches writes). The threat model that motivates SandboxPolicy.WORKSPACE_WRITE
+            // for ShellTools.runShellCommand does not apply here, so this path runs unsandboxed.
             Environment.instance.runShellCommand(
                     trimmed,
                     root,
-                    SandboxPolicy.WORKSPACE_WRITE,
+                    SandboxPolicy.NONE,
                     line -> {
                         synchronized (lines) {
                             appendBounded(lines, line);

--- a/app/src/main/java/ai/brokk/util/ProjectBuildRunner.java
+++ b/app/src/main/java/ai/brokk/util/ProjectBuildRunner.java
@@ -215,10 +215,14 @@ public class ProjectBuildRunner {
         io.commandStart("Verification", verificationCommand);
         var output = io.supportsCommandResult() ? new StringBuilder() : null;
         try {
+            // verificationCommand is user-configured project setup, not an LLM-chosen command,
+            // so the sandbox protections ShellTools.runShellCommand applies to LLM-driven shell
+            // calls are not appropriate here. See BuildVerifier.verifyStreaming for the longer
+            // rationale.
             Environment.instance.runShellCommand(
                     verificationCommand,
                     project.getRoot(),
-                    SandboxPolicy.WORKSPACE_WRITE,
+                    SandboxPolicy.NONE,
                     line -> {
                         if (output != null) output.append(line).append("\n");
                         io.commandOutput(line);
@@ -273,10 +277,12 @@ public class ProjectBuildRunner {
         var output = io.supportsCommandResult() ? new StringBuilder() : null;
         try {
             BuildDetails details = override != null ? override : project.awaitBuildDetails();
+            // Post-task command is user-configured (same threat model as the verification path
+            // above); see BuildVerifier.verifyStreaming for why this is not sandboxed.
             Environment.instance.runShellCommand(
                     command,
                     project.getRoot(),
-                    SandboxPolicy.WORKSPACE_WRITE,
+                    SandboxPolicy.NONE,
                     line -> {
                         if (output != null) output.append(line).append("\n");
                         io.commandOutput(line);


### PR DESCRIPTION
## Summary

The user-configured `verificationCommand` (run by `ProjectBuildRunner` and `BuildVerifier`) was previously sandboxed via `SandboxPolicy.WORKSPACE_WRITE`. On macOS the equivalent Seatbelt policy in `Environment.buildSeatbeltCommand` is incomplete — it only adds `(allow file-write* (subpath "<projectRoot>"))` to the base policy. That breaks any non-trivial JVM/Gradle build because:

- Network is denied → Gradle dep resolution fails
- `/private/var/folders` (macOS `$TMPDIR`) is denied → javac/kotlinc scratch fails
- `~/.gradle/caches` is denied → file-lock and dep cache writes fail
- Whatever Seatbelt operation gates `getifaddrs(3)` is denied → Gradle's `FileLockContentionHandler` fails with "Could not determine a usable wildcard IP for this machine"

We tried adding `(allow network*)` + `system-socket` + `system-info` + `mach-lookup` + `mach-register` + `ipc-posix-shm*` + `iokit-open` + cache subpaths and still hit the wildcard-IP failure. Diagnosing the missing operation requires `log stream --predicate 'sender == "sandboxd"'` and likely a non-trivial policy rewrite.

This PR takes the pragmatic short-term route: switch the three build-verification call sites to `SandboxPolicy.NONE`. Threat-model justification: those call sites all run the user-configured `verificationCommand` (set in `SettingsProjectBuildPanel`), not an LLM-chosen command. `ShellTools.runShellCommand`, which *is* LLM-driven, remains sandboxed.

Issue #3474 tracks the long-term work to restore defense-in-depth on macOS.

## Changes

- `BuildVerifier.verifyStreaming`: `WORKSPACE_WRITE` → `NONE` with explanatory comment
- `ProjectBuildRunner.runBuildAndUpdateFragmentInternal`: same
- `ProjectBuildRunner.runExplicitBuildAndUpdateFragmentInternal`: same

The Linux path (bwrap) is unaffected by this change since `SandboxPolicy.NONE` is now used for builds on both platforms; users who relied on Linux build sandboxing should track #3474. ShellTools / LLM-driven shell commands still use `WORKSPACE_WRITE`.

## Test plan

- [x] `./gradlew :app:compileJava` (sanity)
- [x] `./gradlew :app:check` — full suite (spotless + errorprone + NullAway + tests) passes in 1m 50s
- [ ] Manual: run brokk's Java ACP server on macOS, drive a CodeAgent edit that triggers post-edit build verification; confirm the build now runs to completion instead of failing inside the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)
