### PR TITLE
ACP: render status badge as bold label in transcript

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
+++ b/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.ChatMessageType;
 import java.awt.Component;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
@@ -211,7 +213,25 @@ public class AcpConsoleIO extends MemoryConsole {
 
     @Override
     public void showStatusLine(String message) {
-        emitCompactStatus(message, AcpSchema.ToolKind.THINK);
+        // Emit via agent_message_chunk so the status renders as inline transcript text.
+        // Replace the shields.io image-markdown that StatusBadge embeds with a bold label,
+        // since Zed's ACP renderer parses markdown text but does not load remote images.
+        var rewritten = rewriteStatusBadge(message);
+        var formatted = "\n" + rewritten + "\n";
+        super.llmOutput(formatted, ChatMessageType.CUSTOM, LlmOutputMeta.newMessage());
+        context.sendMessage(formatted);
+    }
+
+    private static final Pattern STATUS_BADGE = Pattern.compile(
+            "^!\\[Status\\]\\(https://img\\.shields\\.io/badge/Status-(.+?)-(?:brightgreen|yellow|orange|red)\\?style=flat\\)\\s*");
+
+    private static String rewriteStatusBadge(String message) {
+        var matcher = STATUS_BADGE.matcher(message);
+        if (!matcher.find()) {
+            return message;
+        }
+        var label = URLDecoder.decode(matcher.group(1), StandardCharsets.UTF_8);
+        return "**[" + label + "]** " + message.substring(matcher.end());
     }
 
     /**


### PR DESCRIPTION
## Summary

`showStatusLine` previously emitted a synthetic ACP `tool_call` whose `title` carried the `StatusBadge` markdown image (e.g. `![Status](https://img.shields.io/badge/Status-build%20error-red?style=flat) Code Agent finished - ...`). ACP clients render `tool_call.title` as plain text, so the markdown surfaced literally in Zed.

This PR routes the status through `agent_message_chunk` (inline transcript content, where Zed does parse markdown) and rewrites the shields.io image-markdown to a bold `**[label]**` prefix decoded from the badge URL. Zed renders bold/text but does not load remote images in `agent_message_chunks`, so the image fallback is necessary there.

Before (Zed):

    ![Status](https://img.shields.io/badge/Status-build%20error-red?style=flat) Code Agent finished - Build failed 3 consecutive times; aborting.

After (Zed):

    **[build error]** Code Agent finished - Build failed 3 consecutive times; aborting.

The Swing renderer is unaffected: `StatusBadge` still emits the same image markdown, and the in-app HTML renderer continues to display the colored badge image.

## Implementation notes

- Anchor the rewrite regex to the start of the message and constrain the color group to the four colors `StatusBadge` emits (`brightgreen`, `yellow`, `orange`, `red`), with a non-greedy label capture so labels containing hyphens (`read-only violation`) decode correctly via `URLDecoder`.
- Messages without a leading badge (e.g. the plain `io.showStatusLine(message)` call at `CodeAgent.java:746`) pass through unchanged.
- `super.llmOutput(...)` is still called so `MemoryConsole` keeps the rewritten line in the in-memory transcript, matching the default `IConsoleIO.showStatusLine` behavior.

## Test plan

- [ ] In Zed, open an ACP session against this branch and trigger a Code Agent build failure; verify the transcript shows `**[build error]** Code Agent finished - ...` with `[build error]` rendered in bold and no raw `![Status](...)` markdown visible.
- [ ] Repeat with a Search Agent interrupt (Ctrl+C) and verify the `[interrupted]` label.
- [ ] Confirm the Swing UI still renders the colored shields.io badge image for the same agent completions.
