### PR TITLE
ACP: add sandbox-bypass option for shell tool approvals

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
+++ b/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
@@ -282,15 +282,53 @@ public class AcpConsoleIO extends MemoryConsole {
         context.sendUpdate(sessionId, toolCall);
 
         if (destructive) {
-            boolean approved = context.askPermission("Allow destructive tool: " + toolName + "?", toolName);
-            if (!approved) {
+            // Tools that ultimately run shell commands (directly or via a sub-agent) get the
+            // sandbox-bypass options and a per-invocation cache key so a session approval doesn't
+            // blanket-allow other tasks. Other destructive tools use the legacy boolean prompt.
+            ApprovalResult result;
+            String shellArgField = SHELL_TOOLS_TO_ARG_FIELD.get(toolName);
+            if (shellArgField != null) {
+                var arg = extractStringArg(request.arguments(), shellArgField);
+                var cacheKey = arg.isEmpty() ? toolName : toolName + ":" + arg;
+                var prompt =
+                        arg.isEmpty() ? "Allow shell tool: " + toolName + "?" : "Allow " + toolName + ": " + arg + "?";
+                var decision = context.askPermissionDetailed(prompt, toolName, cacheKey, true);
+                result = switch (decision) {
+                    case ALLOW -> ApprovalResult.APPROVED;
+                    case ALLOW_NO_SANDBOX -> ApprovalResult.APPROVED_NO_SANDBOX;
+                    case DENY -> ApprovalResult.DENIED;
+                };
+            } else {
+                boolean approved = context.askPermission("Allow destructive tool: " + toolName + "?", toolName);
+                result = approved ? ApprovalResult.APPROVED : ApprovalResult.DENIED;
+            }
+            if (!result.isApproved()) {
                 pendingToolKinds.remove(toolCallId);
                 pendingToolTitles.remove(toolCallId);
                 emitDeniedToolCallUpdate(toolCallId, title, kind);
             }
-            return approved ? ApprovalResult.APPROVED : ApprovalResult.DENIED;
+            return result;
         }
         return ApprovalResult.APPROVED;
+    }
+
+    /**
+     * Tools whose approval prompts should expose the sandbox-bypass options. The map value is the
+     * JSON argument name to extract for the per-invocation cache key — e.g. for {@code
+     * runShellCommand("ls -la")} the cache key becomes {@code "runShellCommand:ls -la"}, so a
+     * session-level approval doesn't blanket-allow other commands.
+     */
+    private static final Map<String, String> SHELL_TOOLS_TO_ARG_FIELD =
+            Map.of("runShellCommand", "command", "callShellAgent", "task");
+
+    /** Best-effort extraction of a string argument from a tool-call's JSON payload; "" on miss. */
+    private static String extractStringArg(@Nullable String argumentsJson, String field) {
+        var node = parseArgs(argumentsJson);
+        if (node == null) {
+            return "";
+        }
+        var value = node.get(field);
+        return value != null && value.isTextual() ? value.asText() : "";
     }
 
     /**

--- a/app/src/main/java/ai/brokk/acp/AcpPromptContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpPromptContext.java
@@ -9,6 +9,20 @@ import com.agentclientprotocol.sdk.agent.SyncPromptContext;
  */
 interface AcpPromptContext extends SyncPromptContext {
 
+    /** Outcome of a tool-permission prompt that may include a sandbox-bypass option. */
+    enum PermissionDecision {
+        /** Allow execution under the default sandbox policy. */
+        ALLOW,
+        /** Allow execution and bypass sandbox restrictions for this run. */
+        ALLOW_NO_SANDBOX,
+        /** Deny execution. */
+        DENY;
+
+        boolean isApproved() {
+            return this != DENY;
+        }
+    }
+
     /**
      * Asks the client for permission to execute the given action for {@code toolName}.
      *
@@ -18,6 +32,23 @@ interface AcpPromptContext extends SyncPromptContext {
      * outcome is remembered.
      */
     boolean askPermission(String action, String toolName);
+
+    /**
+     * Asks for permission with optional sandbox-bypass options. Equivalent to {@link
+     * #askPermission(String, String)} when {@code offerSandboxBypass} is false.
+     *
+     * <p>When {@code offerSandboxBypass} is true, the client is shown two extra buttons that map
+     * to {@link PermissionDecision#ALLOW_NO_SANDBOX}: a one-shot variant and an "always" variant
+     * remembered for the rest of the session under {@code cacheKey}.
+     *
+     * @param action the human-readable action for the tool-call card
+     * @param toolName the tool name (used to classify the kind of permission)
+     * @param cacheKey key used for the session sticky cache; for shell tools this should encode the
+     *     specific command/task so a session-level approval doesn't blanket-allow other invocations
+     * @param offerSandboxBypass whether to offer the {@code allow_no_sandbox*} options
+     */
+    PermissionDecision askPermissionDetailed(
+            String action, String toolName, String cacheKey, boolean offerSandboxBypass);
 
     @Override
     default boolean askPermission(String action) {

--- a/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
@@ -220,8 +220,17 @@ final class AcpRequestContext implements AcpPromptContext {
 
     @Override
     public boolean askPermission(String action, String toolName) {
+        return askPermissionDetailed(action, toolName, toolName, false).isApproved();
+    }
+
+    @Override
+    public PermissionDecision askPermissionDetailed(
+            String action, String toolName, String cacheKey, boolean offerSandboxBypass) {
         boolean cacheable = !NON_CACHEABLE_TOOL_NAMES.contains(toolName);
         var cache = cacheable ? agent : null;
+
+        Optional<BrokkAcpAgent.PermissionVerdict> sticky =
+                cache != null ? cache.stickyPermissionFor(sessionId, cacheKey) : Optional.empty();
 
         // Session-level PermissionMode is consulted BEFORE the sticky cache so READ_ONLY can deny
         // even tools the user previously approved, and BYPASS_PERMISSIONS can short-circuit before
@@ -229,17 +238,18 @@ final class AcpRequestContext implements AcpPromptContext {
         if (agent != null) {
             var mode = agent.permissionModeFor(sessionId);
             var kind = PermissionGate.classify(toolName);
-            boolean alwaysAllowed = cache != null
-                    && cache.stickyPermissionFor(sessionId, toolName)
-                            .filter(v -> v == BrokkAcpAgent.PermissionVerdict.ALLOW)
-                            .isPresent();
+            boolean alwaysAllowed = sticky.filter(v -> v != BrokkAcpAgent.PermissionVerdict.DENY)
+                    .isPresent();
             switch (PermissionGate.decide(mode, kind, toolName, alwaysAllowed)) {
                 case ALLOW -> {
-                    return true;
+                    return sticky.filter(v -> v == BrokkAcpAgent.PermissionVerdict.ALLOW_NO_SANDBOX)
+                                    .isPresent()
+                            ? PermissionDecision.ALLOW_NO_SANDBOX
+                            : PermissionDecision.ALLOW;
                 }
                 case REJECT -> {
                     sendMessage("\n**" + toolName + " denied:** " + PermissionGate.READ_ONLY_REJECTION + "\n");
-                    return false;
+                    return PermissionDecision.DENY;
                 }
                 case PROMPT -> {
                     // Fall through to the legacy sticky-cache + prompt path. We still need the
@@ -249,12 +259,14 @@ final class AcpRequestContext implements AcpPromptContext {
             }
         }
 
-        if (cache != null) {
-            var sticky = cache.stickyPermissionFor(sessionId, toolName);
-            if (sticky.isPresent()) {
-                return sticky.get() == BrokkAcpAgent.PermissionVerdict.ALLOW;
-            }
+        if (sticky.isPresent()) {
+            return switch (sticky.get()) {
+                case ALLOW -> PermissionDecision.ALLOW;
+                case ALLOW_NO_SANDBOX -> PermissionDecision.ALLOW_NO_SANDBOX;
+                case DENY -> PermissionDecision.DENY;
+            };
         }
+
         var toolCall = new AcpSchema.ToolCallUpdate(
                 UUID.randomUUID().toString(),
                 action,
@@ -264,36 +276,61 @@ final class AcpRequestContext implements AcpPromptContext {
                 null,
                 null,
                 null);
-        // Non-cacheable prompts (shell, confirm dialogs) only get once-options to make the
-        // per-invocation nature explicit. Cacheable prompts get the full four-option set.
-        List<AcpSchema.PermissionOption> options = cacheable
-                ? List.of(
-                        new AcpSchema.PermissionOption(
-                                "allow_once", "Allow once", AcpSchema.PermissionOptionKind.ALLOW_ONCE),
-                        new AcpSchema.PermissionOption(
-                                "allow_always", "Always allow", AcpSchema.PermissionOptionKind.ALLOW_ALWAYS),
-                        new AcpSchema.PermissionOption(
-                                "reject_once", "Reject once", AcpSchema.PermissionOptionKind.REJECT_ONCE),
-                        new AcpSchema.PermissionOption(
-                                "reject_always", "Always reject", AcpSchema.PermissionOptionKind.REJECT_ALWAYS))
-                : List.of(
-                        new AcpSchema.PermissionOption(
-                                "allow_once", "Allow", AcpSchema.PermissionOptionKind.ALLOW_ONCE),
-                        new AcpSchema.PermissionOption(
-                                "reject_once", "Reject", AcpSchema.PermissionOptionKind.REJECT_ONCE));
+        var options = buildPermissionOptions(cacheable, offerSandboxBypass);
         var response = requestPermission(new AcpSchema.RequestPermissionRequest(sessionId, toolCall, options));
         if (!(response.outcome() instanceof AcpSchema.PermissionSelected selected)) {
-            return false;
+            return PermissionDecision.DENY;
         }
         var optionId = selected.optionId();
         if (cache != null) {
-            if ("allow_always".equals(optionId)) {
-                cache.rememberPermission(sessionId, toolName, BrokkAcpAgent.PermissionVerdict.ALLOW);
-            } else if ("reject_always".equals(optionId)) {
-                cache.rememberPermission(sessionId, toolName, BrokkAcpAgent.PermissionVerdict.DENY);
+            switch (optionId) {
+                case "allow_always" ->
+                    cache.rememberPermission(sessionId, cacheKey, BrokkAcpAgent.PermissionVerdict.ALLOW);
+                case "allow_no_sandbox_always" ->
+                    cache.rememberPermission(sessionId, cacheKey, BrokkAcpAgent.PermissionVerdict.ALLOW_NO_SANDBOX);
+                case "reject_always" ->
+                    cache.rememberPermission(sessionId, cacheKey, BrokkAcpAgent.PermissionVerdict.DENY);
+                default -> {}
             }
         }
-        return "allow_once".equals(optionId) || "allow_always".equals(optionId);
+        return switch (optionId) {
+            case "allow_once", "allow_always" -> PermissionDecision.ALLOW;
+            case "allow_no_sandbox_once", "allow_no_sandbox_always" -> PermissionDecision.ALLOW_NO_SANDBOX;
+            default -> PermissionDecision.DENY;
+        };
+    }
+
+    /**
+     * Build the permission-option set for an ACP {@code session/request_permission}. Order is
+     * load-bearing: ACP clients render options in array order, and the first option is shown as
+     * the default — so safer choices come first.
+     */
+    private static List<AcpSchema.PermissionOption> buildPermissionOptions(
+            boolean cacheable, boolean offerSandboxBypass) {
+        var options = new ArrayList<AcpSchema.PermissionOption>();
+        options.add(new AcpSchema.PermissionOption(
+                "allow_once", cacheable ? "Allow once" : "Allow", AcpSchema.PermissionOptionKind.ALLOW_ONCE));
+        if (cacheable) {
+            options.add(new AcpSchema.PermissionOption(
+                    "allow_always", "Always allow", AcpSchema.PermissionOptionKind.ALLOW_ALWAYS));
+        }
+        if (offerSandboxBypass) {
+            options.add(new AcpSchema.PermissionOption(
+                    "allow_no_sandbox_once", "Allow without sandbox", AcpSchema.PermissionOptionKind.ALLOW_ONCE));
+            if (cacheable) {
+                options.add(new AcpSchema.PermissionOption(
+                        "allow_no_sandbox_always",
+                        "Always allow without sandbox",
+                        AcpSchema.PermissionOptionKind.ALLOW_ALWAYS));
+            }
+        }
+        options.add(new AcpSchema.PermissionOption(
+                "reject_once", cacheable ? "Reject once" : "Reject", AcpSchema.PermissionOptionKind.REJECT_ONCE));
+        if (cacheable) {
+            options.add(new AcpSchema.PermissionOption(
+                    "reject_always", "Always reject", AcpSchema.PermissionOptionKind.REJECT_ALWAYS));
+        }
+        return options;
     }
 
     @Override

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -125,6 +125,7 @@ public class BrokkAcpAgent {
 
     public enum PermissionVerdict {
         ALLOW,
+        ALLOW_NO_SANDBOX,
         DENY
     }
 

--- a/app/src/main/java/ai/brokk/gui/Chrome.java
+++ b/app/src/main/java/ai/brokk/gui/Chrome.java
@@ -124,7 +124,7 @@ public class Chrome
 
     private final RightPanel rightPanel;
     private final ToolsPane toolsPane;
-    private final Set<String> sessionApprovedTools = ConcurrentHashMap.newKeySet();
+    private final Map<String, Boolean> sessionApprovedTools = new ConcurrentHashMap<>();
     private final JSplitPane leftVerticalSplitPane; // Left: tabs (top) + file history (bottom)
     private final JTabbedPane fileHistoryPane; // Bottom area for file history
     private int originalLeftVerticalDividerSize;
@@ -2251,8 +2251,9 @@ public class Chrome
             return ApprovalResult.APPROVED;
         }
         var approval = computeApprovalContext(request);
-        if (sessionApprovedTools.contains(approval.sessionKey())) {
-            return ApprovalResult.APPROVED;
+        var cached = sessionApprovedTools.get(approval.sessionKey());
+        if (cached != null) {
+            return cached ? ApprovalResult.APPROVED_NO_SANDBOX : ApprovalResult.APPROVED;
         }
         var hop = rightPanel.getHistoryOutputPanel();
         CompletableFuture<HistoryOutputPanel.ApprovalChoice> future;
@@ -2281,11 +2282,13 @@ public class Chrome
         try {
             var choice = future.get();
             if (choice == HistoryOutputPanel.ApprovalChoice.ALLOW_SESSION) {
-                sessionApprovedTools.add(approval.sessionKey());
+                sessionApprovedTools.put(approval.sessionKey(), false);
+            } else if (choice == HistoryOutputPanel.ApprovalChoice.ALLOW_NO_SANDBOX_SESSION) {
+                sessionApprovedTools.put(approval.sessionKey(), true);
             }
             return switch (choice) {
                 case DENY -> ApprovalResult.DENIED;
-                case ALLOW_NO_SANDBOX -> ApprovalResult.APPROVED_NO_SANDBOX;
+                case ALLOW_NO_SANDBOX, ALLOW_NO_SANDBOX_SESSION -> ApprovalResult.APPROVED_NO_SANDBOX;
                 default -> ApprovalResult.APPROVED;
             };
         } catch (ExecutionException e) {
@@ -2318,6 +2321,15 @@ public class Chrome
                         command != null ? command : request.arguments(),
                         "Allow Command for Session",
                         "runShellCommand:" + (command != null ? command : ""),
+                        true);
+            }
+            case "callShellAgent" -> {
+                var task = extractJsonField(request.arguments(), "task");
+                yield new ApprovalContext(
+                        "Agent wants to run a shell agent",
+                        task != null ? task : request.arguments(),
+                        "Allow Shell Agent for Session",
+                        "callShellAgent:" + (task != null ? task : ""),
                         true);
             }
             default ->

--- a/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
+++ b/app/src/main/java/ai/brokk/gui/HistoryOutputPanel.java
@@ -109,6 +109,7 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
         ALLOW,
         ALLOW_SESSION,
         ALLOW_NO_SANDBOX,
+        ALLOW_NO_SANDBOX_SESSION,
         DENY
     }
 
@@ -561,6 +562,10 @@ public class HistoryOutputPanel extends JPanel implements ThemeAware {
             var noSandboxButton = new MaterialButton("Allow Without Sandbox");
             noSandboxButton.addActionListener(e -> resolveApproval(ApprovalChoice.ALLOW_NO_SANDBOX));
             buttonPanel.add(noSandboxButton);
+
+            var noSandboxSessionButton = new MaterialButton("Always Allow Without Sandbox");
+            noSandboxSessionButton.addActionListener(e -> resolveApproval(ApprovalChoice.ALLOW_NO_SANDBOX_SESSION));
+            buttonPanel.add(noSandboxSessionButton);
         }
         buttonPanel.add(denyButton);
 

--- a/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
+++ b/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
@@ -516,6 +516,12 @@ class AcpConsoleIOTest {
         }
 
         @Override
+        public PermissionDecision askPermissionDetailed(
+                String action, String toolName, String cacheKey, boolean offerSandboxBypass) {
+            return PermissionDecision.ALLOW;
+        }
+
+        @Override
         public @Nullable String askChoice(String question, String... options) {
             return options.length > 0 ? options[0] : null;
         }


### PR DESCRIPTION
## Summary

Adds a sandbox-bypass option to the ACP permission flow for shell-running tools (`runShellCommand`, `callShellAgent`), letting the user approve a shell tool while opting out of the sandbox for that invocation — or for the rest of the session.

- New `PermissionDecision` enum (`ALLOW`, `ALLOW_NO_SANDBOX`, `DENY`) and a parallel `askPermissionDetailed` entry point that surfaces "Allow without sandbox" / "Always allow without sandbox" buttons when the tool is shell-shaped.
- Shell tools now use a per-invocation cache key (`toolName:argument`) so a session-level approval doesn't blanket-allow other shell commands. Other destructive tools keep the legacy boolean prompt.
- `BrokkAcpAgent.PermissionVerdict` gains `ALLOW_NO_SANDBOX`, and `Chrome` switches its session approval cache from `Set<String>` to `Map<String, Boolean>` so the no-sandbox decision survives within a session.
- `HistoryOutputPanel` adds an `ALLOW_NO_SANDBOX_SESSION` choice and the matching "Always Allow Without Sandbox" button.

## Test plan

- [ ] Drive an ACP client (Zed) through `runShellCommand` and confirm the four bypass options appear in the expected order, with safer options first.
- [x] Approve once with "Allow without sandbox" and verify the next invocation re-prompts.
- [x] Approve with "Always allow without sandbox" and verify subsequent invocations of the *same* command short-circuit, while a *different* command re-prompts.
- [x] Repeat with `callShellAgent` and confirm task-text becomes part of the cache key.
- [ ] In desktop Brokk (not via an ACP client), trigger a `runShellCommand`. Confirm the Swing approval dialog shows the new "Always Allow Without Sandbox" button. Click it, run the same command again, and verify it executes without re-prompting and without the sandbox. Run a different shell command and verify it re-prompts (cache key includes the argument).
