### PR TITLE
ACP: fix Run command title pollution and lost output on failure

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
+++ b/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
@@ -316,7 +316,7 @@ public class AcpConsoleIO extends MemoryConsole {
     @Override
     public ApprovalResult beforeShellCommand(String command) {
         var toolCallId = UUID.randomUUID().toString();
-        var title = "Shell: " + truncate(command, 60);
+        var title = ellipsize("Shell: " + command, 80);
         pendingToolKinds.put(toolCallId, AcpSchema.ToolKind.EXECUTE);
         pendingToolTitles.put(toolCallId, title);
 
@@ -505,7 +505,7 @@ public class AcpConsoleIO extends MemoryConsole {
     public void commandStart(String stage, String command) {
         // Model build/test commands as tool_call with EXECUTE kind
         var toolCallId = UUID.randomUUID().toString();
-        var title = stage + ": " + truncate(command, 60);
+        var title = ellipsize(stage + ": " + command, 80);
         activeCommandToolCallId = toolCallId;
         pendingToolTitles.put(toolCallId, title);
 
@@ -540,8 +540,10 @@ public class AcpConsoleIO extends MemoryConsole {
         }
 
         var status = success ? AcpSchema.ToolCallStatus.COMPLETED : AcpSchema.ToolCallStatus.FAILED;
-        var resultText = success ? output : (exception != null && !exception.isBlank() ? exception : output);
-        var title = pendingToolTitles.getOrDefault(toolCallId, stage + ": " + truncate(command, 60));
+        // On failure, callers (e.g. ProjectBuildRunner) already concatenate the exception
+        // message into `output`, so prefer it; fall back to `exception` only when output is blank.
+        var resultText = !output.isBlank() ? output : (exception != null && !exception.isBlank() ? exception : output);
+        var title = pendingToolTitles.getOrDefault(toolCallId, ellipsize(stage + ": " + command, 80));
         pendingToolTitles.remove(toolCallId);
 
         List<AcpSchema.ToolCallContent> content = renderToolContent(AcpSchema.ToolKind.EXECUTE, resultText);
@@ -661,9 +663,9 @@ public class AcpConsoleIO extends MemoryConsole {
                     "addMethodsToWorkspace",
                     "addUrlContentsToWorkspace" -> "Add to workspace";
             case "dropWorkspaceFragments" -> "Drop workspace fragments";
-            case "searchAgent" -> "Search agent: " + truncate(textArg(args, "query", "request"), 60);
-            case "callCodeAgent" -> "Code agent: " + truncate(textArg(args, "instructions", "task"), 60);
-            case "callShellAgent" -> "Shell agent: " + truncate(textArg(args, "task", "command"), 60);
+            case "searchAgent" -> ellipsize("Search agent: " + textArg(args, "query", "request"), 80);
+            case "callCodeAgent" -> ellipsize("Code agent: " + textArg(args, "instructions", "task"), 80);
+            case "callShellAgent" -> ellipsize("Shell agent: " + textArg(args, "task", "command"), 80);
             case "callMcpTool" -> "MCP: " + textArg(args, "toolName", "tool");
             case "answer" -> "Final answer";
             case "workspaceComplete" -> "Workspace ready";
@@ -904,6 +906,20 @@ public class AcpConsoleIO extends MemoryConsole {
             return text;
         }
         return text.substring(0, maxBytes) + "\n... [truncated " + (text.length() - maxBytes) + " chars]";
+    }
+
+    /**
+     * Single-line ellipsizer for tool-call titles. Returns a string of length at most {@code max}
+     * with no embedded newline. The body-style {@link #truncate} would inject a "\n... [truncated
+     * N chars]" marker, which a client would render as a multi-line title — never what we want.
+     */
+    private static String ellipsize(String text, int max) {
+        assert max >= 4 : "ellipsize requires room for at least one char plus '...'";
+        var oneLine = text.indexOf('\n') < 0 ? text : text.replace('\n', ' ');
+        if (oneLine.length() <= max) {
+            return oneLine;
+        }
+        return oneLine.substring(0, max - 3) + "...";
     }
 
     // ---- Tool kind classification ----

--- a/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
+++ b/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
@@ -420,6 +420,77 @@ class AcpConsoleIOTest {
         assertTrue(ctx.updates.isEmpty(), "Final-answer text must stay as chat, not be wrapped");
     }
 
+    @Test
+    void commandStartTitleStaysSingleLineForLongCommand() {
+        var ctx = new RecordingPromptContext();
+        var io = new AcpConsoleIO(ctx);
+
+        var longCommand =
+                "cd brokk-code;uv run pytest -q brokk-code/tests/test_bifrost_launcher.py brokk-code/tests/test_cli_modes.py";
+        io.commandStart("Verification", longCommand);
+
+        var call = ctx.updates.stream()
+                .filter(AcpSchema.ToolCall.class::isInstance)
+                .map(AcpSchema.ToolCall.class::cast)
+                .findFirst()
+                .orElseThrow();
+        var title = call.title();
+        assertFalse(title.contains("\n"), "title must be single-line, got: " + title);
+        assertFalse(
+                title.contains("[truncated"), "title must not contain a body-style truncation marker, got: " + title);
+        assertTrue(title.length() <= 80, "title must be capped at 80 chars, got " + title.length() + ": " + title);
+        assertTrue(title.startsWith("Verification: "), "title should keep the stage prefix, got: " + title);
+        assertTrue(title.endsWith("..."), "title should end with an ellipsis when truncated, got: " + title);
+    }
+
+    @Test
+    void commandResultPreservesStreamedOutputWhenCommandFails() {
+        var ctx = new RecordingPromptContext();
+        var io = new AcpConsoleIO(ctx);
+
+        var command = "uv run pytest -q";
+        io.commandStart("Verification", command);
+
+        // ProjectBuildRunner builds `fullOutput = stdout + "\n" + e.getMessage() + "\n" + e.getOutput()`
+        // and passes it as `output`. The exception arg is just `e.getMessage()`. The richer output
+        // must win.
+        var streamedOutput = "FAILED tests/test_x.py::test_a - AssertionError: expected 1 got 2";
+        var processError = "process 'uv run pytest -q' signaled error code 4";
+        var fullOutput = streamedOutput + "\n" + processError;
+        io.commandResult("Verification", command, false, fullOutput, processError);
+
+        var failed = ctx.updates.stream()
+                .filter(AcpSchema.ToolCallUpdateNotification.class::isInstance)
+                .map(AcpSchema.ToolCallUpdateNotification.class::cast)
+                .filter(u -> u.status() == AcpSchema.ToolCallStatus.FAILED)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected a FAILED tool_call_update"));
+        var block = (AcpSchema.ToolCallContentBlock) failed.content().getFirst();
+        var text = ((AcpSchema.TextContent) block.content()).text();
+        assertTrue(
+                text.contains(streamedOutput), "rendered body must preserve the streamed stdout/stderr, got: " + text);
+    }
+
+    @Test
+    void commandResultFallsBackToExceptionWhenOutputIsBlank() {
+        var ctx = new RecordingPromptContext();
+        var io = new AcpConsoleIO(ctx);
+
+        var command = "false";
+        io.commandStart("Verification", command);
+        io.commandResult("Verification", command, false, "", "process 'false' signaled error code 1");
+
+        var failed = ctx.updates.stream()
+                .filter(AcpSchema.ToolCallUpdateNotification.class::isInstance)
+                .map(AcpSchema.ToolCallUpdateNotification.class::cast)
+                .filter(u -> u.status() == AcpSchema.ToolCallStatus.FAILED)
+                .findFirst()
+                .orElseThrow();
+        var block = (AcpSchema.ToolCallContentBlock) failed.content().getFirst();
+        var text = ((AcpSchema.TextContent) block.content()).text();
+        assertTrue(text.contains("error code 1"), "exception text must surface when output is blank, got: " + text);
+    }
+
     private static final class RecordingPromptContext implements AcpPromptContext {
         final List<AcpSchema.SessionUpdate> updates = new ArrayList<>();
         final List<String> messages = new ArrayList<>();


### PR DESCRIPTION
## Summary

Fixes #3477.

In ACP clients, `Run command` cards from `ProjectBuildRunner` rendered with a polluted multi-line title and lost the actual stdout/stderr of failed commands. Two distinct bugs in `AcpConsoleIO.java` combined to produce the symptom.

## Bug 1 — title built with body-style `truncate()`

`commandStart`, `commandResult`, `beforeShellCommand`, and the `searchAgent` / `callCodeAgent` / `callShellAgent` title cases all built titles via `truncate(text, 60)`. That helper appends `"\n... [truncated N chars]"` — a body-style multi-line marker — meaning a long command produced a two-line title like:

```
Verification: cd brokk-code;uv run pytest -q brokk-code/tests/test_bifrost
... [truncated 47 chars]
```

Replace with a new `ellipsize(text, max)` helper that returns a single-line, `…`-ASCII-style truncated string (`first N-3 chars + "..."`) and use it at all six title-building sites. Cap raised from 60 (command-only) to 80 (full title), which is roughly the same usable budget once you account for the stage prefix.

## Bug 2 — `output` discarded in favor of `exception` on failure

At the failure branch:

```java
var resultText = success ? output : (exception != null && !exception.isBlank() ? exception : output);
```

`ProjectBuildRunner` already concatenates `streamedStdout + e.getMessage() + e.getOutput()` into the `output` arg, then passes just `e.getMessage()` as `exception`. The ternary picked the strictly poorer one, so users saw only `process '...' signaled error code N` and lost the actual test failure output. Inverted the ternary so `output` wins when non-blank; `exception` is now only the fallback when output is empty.

## Tests

Three new tests in `AcpConsoleIOTest`:

- `commandStartTitleStaysSingleLineForLongCommand` — asserts the title is single-line, ≤ 80 chars, contains no body-style truncation marker, and ends with `...` when truncated.
- `commandResultPreservesStreamedOutputWhenCommandFails` — asserts the rendered body of a failed command preserves the streamed stdout/stderr passed via `output`, not just the wrapper exception.
- `commandResultFallsBackToExceptionWhenOutputIsBlank` — guards the fallback path so we don't render an empty card when only the exception is available.

## Test plan

- [x] `./gradlew :app:test --tests "ai.brokk.acp.AcpConsoleIOTest"` — 23 tests pass
- [x] `./gradlew :app:check` — full suite (spotless + errorprone + NullAway + tests) green
- [ ] Manual verification in Zed: trigger a failing pytest verification and confirm the rendered card has a single-line title and shows the actual test failure output rather than just the process error code.
