### PR TITLE
ACP: render showStatusBanner as title-only card

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
+++ b/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
@@ -6,7 +6,6 @@ import ai.brokk.agents.BlitzForge;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.cli.MemoryConsole;
 import ai.brokk.tools.ApprovalResult;
-import ai.brokk.tools.ExplanationRenderer;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.util.Json;
 import com.agentclientprotocol.sdk.spec.AcpSchema;
@@ -207,8 +206,7 @@ public class AcpConsoleIO extends MemoryConsole {
      */
     @Override
     public void showStatusBanner(String headline, Map<String, Object> details) {
-        var body = "```yaml\n" + ExplanationRenderer.toYaml(details) + "```";
-        emitSyntheticToolCall(new HeaderAndBody(headline, body), AcpSchema.ToolKind.THINK);
+        emitCompactStatus(headline, AcpSchema.ToolKind.THINK);
     }
 
     @Override

--- a/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
+++ b/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
@@ -385,7 +385,7 @@ class AcpConsoleIOTest {
     }
 
     @Test
-    void showStatusBannerEmitsSyntheticToolCall() {
+    void showStatusBannerEmitsTitleOnlyCard() {
         var ctx = new RecordingPromptContext();
         var io = new AcpConsoleIO(ctx);
 
@@ -401,9 +401,7 @@ class AcpConsoleIOTest {
                 .orElseThrow();
         assertEquals("Adding context to workspace", call.title());
         assertEquals(AcpSchema.ToolKind.THINK, call.kind());
-        var block = (AcpSchema.ToolCallContentBlock) call.content().getFirst();
-        var text = ((AcpSchema.TextContent) block.content()).text();
-        assertTrue(text.contains("fragmentCount"), "yaml body should be carried into content");
+        assertTrue(call.content().isEmpty(), "title-only card carries no body");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `AcpConsoleIO.showStatusBanner` now emits a title-only `tool_call` (via the existing `emitCompactStatus` helper) instead of wrapping the headline together with a YAML body of `fragmentCount` + `fragments`.
- The synthetic card produced by `LutzAgent.emitContextAddedExplanation` ("Adding context to workspace") therefore renders as a single compact line in ACP clients (e.g. Zed), matching the shape of peers like "Workspace ready".

## Why

The YAML body duplicated information the ACP client already shows in its workspace panel (the fragments themselves are about to land there as context). Side-by-side with title-only cards from `TERMINAL_ANSWER_TOOLS`, the verbose card stood out as visual noise rather than useful signal. Following the project memory rule "ACP cleanliness is rendering, not filtering", this fix narrows the rendered content block instead of suppressing or rerouting the tool call.

## Scope

- Only the ACP override is touched. The default `IConsoleIO.showStatusBanner` still routes through `ExplanationRenderer` + `llmOutput`, so GUI / Chrome / CLI consoles keep their existing YAML rendering — no regression for callers that rely on the detail.
- Unused import `ai.brokk.tools.ExplanationRenderer` removed from `AcpConsoleIO`.
- The existing test `showStatusBannerEmitsSyntheticToolCall` is renamed to `showStatusBannerEmitsTitleOnlyCard` and now asserts the content list is empty, locking in the new contract.

## Test plan

- [x] `./gradlew :app:check` (spotless + errorprone + NullAway + tests) — green locally.
- [ ] Smoke check in Zed: confirm "Adding context to workspace" renders as a one-line card alongside "Workspace ready".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
