### PR TITLE
LutzAgent: route context-engine status through showStatusBanner

### DIFF
--- a/app/src/main/java/ai/brokk/agents/LutzAgent.java
+++ b/app/src/main/java/ai/brokk/agents/LutzAgent.java
@@ -714,10 +714,7 @@ public class LutzAgent {
         Set<ProjectFile> filesBeforeScan = workspaceFiles(context);
 
         var contextAgent = new ContextAgent(cm, scanModel, goal, this.io);
-        io.llmOutput(
-                "\n**Brokk Context Engine** analyzing repository context…\n",
-                ChatMessageType.AI,
-                LlmOutputMeta.newMessage());
+        io.showStatusBanner("Brokk Context Engine analyzing repository context", Map.of());
 
         var recommendation = contextAgent.getRecommendations(context);
 
@@ -736,10 +733,7 @@ public class LutzAgent {
             } else {
                 context = context.addFragments(recommendation.fragments());
                 emitContextAddedExplanation(recommendation.fragments());
-                io.llmOutput(
-                        "\n\n**Brokk Context Engine** complete — contextual insights added to Workspace.\n",
-                        ChatMessageType.AI,
-                        LlmOutputMeta.DEFAULT);
+                io.showStatusBanner("Brokk Context Engine complete - contextual insights added to Workspace", Map.of());
             }
         } else {
             io.llmOutput("\n\nNo additional context insights found\n", ChatMessageType.AI, LlmOutputMeta.DEFAULT);


### PR DESCRIPTION
## Summary

- Route the two `Brokk Context Engine` narration lines in `LutzAgent.scanContext()` through `io.showStatusBanner(...)` instead of `io.llmOutput(...)`.
- After upstream #3480, `AcpConsoleIO.showStatusBanner` always emits a compact title-only `tool_call`, so all three context-engine signals (analyzing / fragments-added / complete) now render as uniform title-only cards in Zed instead of prose-sandwich-card.
- No new API, no `IConsoleIO` change, no pattern-matching shim in `AcpConsoleIO`.

## Why

In ACP/Zed, the previous code emitted `**Brokk Context Engine** ...` as `agent_message_chunk` markdown text. The sibling `emitContextAddedExplanation` already used `showStatusBanner`, which the ACP override renders as a tool_call card. That mismatch showed up as bold prose surrounding a single styled card in the transcript. Routing the surrounding lines through the same `showStatusBanner` API makes the three signals visually consistent.

## Behavioural notes

- **ACP (Zed):** all three lines render as compact title-only `THINK` cards with checkmarks. Verified locally with a fresh shadowJar pointed at via `~/.jetbrains/acp.json`.
- **GUI / CLI consoles:** fall back to the `IConsoleIO` default, which renders the headline via `ExplanationRenderer.renderExplanation(headline, Map.of())`. Output is a backtick-quoted headline followed by an empty YAML fence — a minor cosmetic regression compared to the previous bold markdown; acceptable for status emissions and consistent with how other `showStatusBanner` callers render in those consoles.
- **Raw transcript / history:** still records the headline strings via `super.llmOutput` inside `showStatusBanner`'s structured path, so memory/replay see the same status events.

## Test plan

- [x] `./gradlew :app:shadowJar` succeeds locally.
- [x] `./gradlew :app:check` (spotless + errorprone + NullAway + tests) — to be run by CI.
- [x] Manual smoke test in Zed via `Brokk Code (Java dev)` agent: three context-engine signals appear as compact aligned cards.
- [ ] Manual smoke test in Brokk GUI: confirm the headline-only banner is acceptable in the conversation panel.
