### PR TITLE
LutzAgent: skip Workspace setup before shell/git delegations

### DIFF
--- a/app/src/main/java/ai/brokk/agents/LutzAgent.java
+++ b/app/src/main/java/ai/brokk/agents/LutzAgent.java
@@ -1364,7 +1364,7 @@ public class LutzAgent {
         }
 
         @Tool(
-                "Delegate a shell command task to the Shell Agent. Use this when the user needs to run commands like package installation, environment setup, build tools, or any CLI operation. The Shell Agent has full shell access and the user will approve each command interactively. Provide a clear description of what needs to be done.")
+                "Delegate a shell command task to the Shell Agent. Use this when the user needs to run commands like git operations (push, pull, commit, status, log, worktrees), package installation (npm/pip/cargo/etc.), environment setup, build tools (gradle, make), or any CLI operation. The Shell Agent has full shell access and the user will approve each command interactively. Provide a clear description of what needs to be done. Prefer this tool directly over callSearchAgent for any pure shell request; there is no Workspace context to gather for shell operations.")
         @Destructive
         @SuppressWarnings("UnusedMethod")
         public String callShellAgent(

--- a/app/src/main/java/ai/brokk/prompts/SearchPrompts.java
+++ b/app/src/main/java/ai/brokk/prompts/SearchPrompts.java
@@ -63,7 +63,7 @@ public class SearchPrompts {
                 "one of: answer, shell delegation, task list, or Code Agent invocation",
                 """
                 - Prefer answer(String) when no code changes are needed and the Workspace already justifies the answer (or the question is codebase-independent).
-                - When the request is a shell/CLI operation (installing tools, managing git worktrees, running scripts, environment setup, or any other "run this command" task), call callShellAgent(String task) to delegate to the Shell Agent, then summarize the result with answer(String). Delegating to the Shell Agent is NOT writing code; it is operating the user's system on their behalf, with their per-command approval. Do NOT respond with instructions for the user to run the command themselves, and do NOT propose adding a new tool to this codebase to perform the operation.
+                - When the request is a shell/CLI operation (running git commands such as `git push`, `git pull`, `git commit`, `git status`, `git log`; managing git worktrees; installing tools; running scripts; environment setup; build/test invocations; or any other "run this command" task), call callShellAgent(String task) to delegate to the Shell Agent, then summarize the result with answer(String). Delegating to the Shell Agent is NOT writing code; it is operating the user's system on their behalf, with their per-command approval. For pure shell/CLI requests, do NOT call callSearchAgent or add files to the Workspace first; the Workspace is irrelevant to shell operations. Do NOT respond with instructions for the user to run the command themselves, and do NOT propose adding a new tool to this codebase to perform the operation.
                 - Prefer callCodeAgent(String instructions, boolean deferBuild) if the requested change is small.
                 - Otherwise, decompose the problem with createOrReplaceTaskList(String explanation, List<TaskListEntry> tasks); do not attempt to write code yet.
                 """,
@@ -425,8 +425,11 @@ public class SearchPrompts {
                 {{~/if}}
 
                 {{#unless specialTooling~}}
-                Invariant: Before any final action, make reasonable efforts to first add the minimum sufficient, decision-relevant context
-                to the Workspace. If you cannot find relevant context, say so instead of guessing.
+                Invariant: Before any final action that depends on code knowledge (callCodeAgent, createOrReplaceTaskList, describeIssue,
+                or an answer that requires citing code), make reasonable efforts to first add the minimum sufficient, decision-relevant
+                context to the Workspace. If you cannot find relevant context, say so instead of guessing.
+                This invariant does NOT apply to callShellAgent: shell/CLI tasks operate on the user's system, not on the codebase, so
+                no Workspace context is needed first. Call callShellAgent directly when the request is a shell operation.
 
                 Workspace context guidance:
                   - If you know where to find what you're looking for, just add it, you don't need to keep searching "just in case".


### PR DESCRIPTION
## Summary

When asked to run a pure shell command such as `git push`, `LutzAgent`
often spent many turns calling `callSearchAgent` and adding fragments to
the Workspace before eventually delegating to `ShellAgent`. This PR fixes
that by addressing the three prompt signals that were pushing the model
toward search.

## Why this happened

Three concurrent signals in the LUTZ system prompt all biased toward
`callSearchAgent` rather than `callShellAgent` for shell tasks:

1. **Routing rule examples were incomplete.** The LUTZ routing rule in
   `SearchPrompts.LUTZ` listed `installing tools` and `managing git
   worktrees` as shell operations, but never mentioned `git push`,
   `git pull`, `git commit`, `git status`, or `git log`. LLMs lean
   heavily on the concrete examples in tool descriptions, so a bare
   `git push` was not strongly classified as a shell task.

2. **Universal "gather context first" invariant.** The directive-template
   invariant said *"Before any final action, make reasonable efforts to
   first add the minimum sufficient, decision-relevant context to the
   Workspace."* That applied to **every** terminal action, including
   `callShellAgent` — even though there is no Workspace context relevant
   to running a shell command. The invariant kept pushing the model to
   search before delegating, and the search yielded nothing useful, so
   LutzAgent looped trying to satisfy the invariant.

3. **`callShellAgent` `@Tool` description was code-centric.** The
   description listed `package installation, environment setup, build
   tools` but no git operations, weakening its match against
   git-flavored requests relative to the rich `callSearchAgent`
   description.

## What changed

- **`SearchPrompts.LUTZ` routing rule** now cites `git push`, `git pull`,
  `git commit`, `git status`, `git log` explicitly, and instructs the
  model **not** to call `callSearchAgent` or add files to the Workspace
  first for pure shell requests.
- **Directive-template invariant** is now scoped to code-dependent
  terminals (`callCodeAgent`, `createOrReplaceTaskList`, `describeIssue`,
  code-citing `answer`s) and explicitly exempts `callShellAgent`.
- **`callShellAgent` `@Tool` description** in `LutzAgent.java` leads
  with git operations as the first example, lists `npm/pip/cargo`,
  `gradle/make`, and instructs the model to prefer this tool directly
  over `callSearchAgent` for any pure shell request.

This is a prompt-only change — no code paths, control flow, or tool
registrations were modified.

## What a reviewer should know

- The fix targets three levers in concert (tool description, routing
  rule, global invariant). Patching only one of the three would likely
  leave a residual rate of misrouting; all three were aligned in the
  wrong direction simultaneously.
- We considered a fourth, more invasive option: a Java-side regex
  short-circuit in `LutzAgent.execute()` that would route obvious shell
  requests directly to `ShellAgent` without an LLM turn. We deferred
  that pending observation: if this prompt-only change is sufficient,
  there is no need to introduce a parallel routing path with its own
  maintenance debt.
- Verified locally with `./gradlew :app:spotlessCheck` and
  `./gradlew :app:compileJava`. End-to-end behavior should be validated
  by running `git push` / `git status` / `npm install` /
  `./gradlew :app:check` against a small planner model and confirming
  LutzAgent goes to `callShellAgent` on the first turn.

## Test plan

- [ ] Run Brokk with a shell prompt like `git push` against the planner
      model used in production and confirm `callShellAgent` is invoked
      on the first LUTZ turn (no `callSearchAgent` calls, no Workspace
      additions).
- [ ] Repeat with `git status`, `npm install`, `./gradlew :app:check`.
- [ ] Sanity-check a code-bearing prompt (e.g. "find where X is
      defined") still routes to `callSearchAgent` / Workspace tools as
      expected — the invariant should still apply to code-dependent
      terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
