### PR TITLE
feat: add session code model selector to ACP agent

### DIFF
--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -100,6 +100,7 @@ public class BrokkAcpAgent {
     // Per-session state
     private final Map<String, String> modeBySession = new ConcurrentHashMap<>();
     private final Map<String, String> modelBySession = new ConcurrentHashMap<>();
+    private final Map<String, String> codeModelBySession = new ConcurrentHashMap<>();
     private final Set<String> sessionsOnFallbackCatalog = ConcurrentHashMap.newKeySet();
     private final Map<String, String> reasoningBySession = new ConcurrentHashMap<>();
     private final Map<String, String> activeJobBySession = new ConcurrentHashMap<>();
@@ -255,6 +256,7 @@ public class BrokkAcpAgent {
     public void clearAllSessions() {
         modeBySession.clear();
         modelBySession.clear();
+        codeModelBySession.clear();
         reasoningBySession.clear();
         activeJobBySession.clear();
         stickyPermissionsBySession.clear();
@@ -383,6 +385,7 @@ public class BrokkAcpAgent {
 
         modeBySession.put(sessionId, "LUTZ");
         reasoningBySession.put(sessionId, defaultReasoningLevel);
+        codeModelBySession.put(sessionId, resolveInitialCodeModelSelection(sessionId));
         permissionModeBySession.put(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
@@ -412,6 +415,11 @@ public class BrokkAcpAgent {
 
         modeBySession.putIfAbsent(sessionId, "LUTZ");
         reasoningBySession.putIfAbsent(sessionId, defaultReasoningLevel);
+        codeModelBySession.compute(
+                sessionId,
+                (ignored, existing) -> existing == null
+                        ? resolveInitialCodeModelSelection(sessionId)
+                        : sanitizeCodeModelSelection(sessionId, existing));
         permissionModeBySession.putIfAbsent(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
@@ -436,6 +444,11 @@ public class BrokkAcpAgent {
 
         modeBySession.putIfAbsent(sessionId, "LUTZ");
         reasoningBySession.putIfAbsent(sessionId, defaultReasoningLevel);
+        codeModelBySession.compute(
+                sessionId,
+                (ignored, existing) -> existing == null
+                        ? resolveInitialCodeModelSelection(sessionId)
+                        : sanitizeCodeModelSelection(sessionId, existing));
         permissionModeBySession.putIfAbsent(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
@@ -491,6 +504,7 @@ public class BrokkAcpAgent {
         }
         modeBySession.remove(sessionId);
         modelBySession.remove(sessionId);
+        codeModelBySession.remove(sessionId);
         reasoningBySession.remove(sessionId);
         stickyPermissionsBySession.remove(sessionId);
         sessionsOnFallbackCatalog.remove(sessionId);
@@ -526,6 +540,12 @@ public class BrokkAcpAgent {
             if (model != null) {
                 modelBySession.put(forkSessionId, model);
             }
+            codeModelBySession.put(
+                    forkSessionId,
+                    sanitizeCodeModelSelection(
+                            forkSessionId,
+                            codeModelBySession.getOrDefault(
+                                    request.sessionId(), resolveInitialCodeModelSelection(forkSessionId))));
             reasoningBySession.put(
                     forkSessionId, reasoningBySession.getOrDefault(request.sessionId(), defaultReasoningLevel));
             permissionModeBySession.put(
@@ -614,9 +634,7 @@ public class BrokkAcpAgent {
         var tags = new HashMap<String, String>();
         tags.put("mode", mode);
 
-        // Fall back to planner model if default code model is not available
-        var availableModels = bundle.cm().getService().getAvailableModels();
-        var codeModel = availableModels.containsKey(DEFAULT_CODE_MODEL) ? DEFAULT_CODE_MODEL : model;
+        var codeModel = resolveCurrentCodeModelSelection(sessionId);
 
         var spec = new JobSpec(
                 text, // taskInput
@@ -713,29 +731,32 @@ public class BrokkAcpAgent {
                 setMode(new AcpSchema.SetSessionModeRequest(sessionId, value));
             }
             case "model_selection" -> setModel(new AcpSchema.SetSessionModelRequest(sessionId, value));
+            case "code_model_selection" ->
+                codeModelBySession.put(sessionId, sanitizeCodeModelSelection(sessionId, value));
             default ->
                 throw new IllegalArgumentException("Unknown configId '" + configId
-                        + "'. Supported: permission_mode, behavior_mode, model_selection");
+                        + "'. Supported: permission_mode, behavior_mode, model_selection, code_model_selection");
         }
         return new AcpProtocol.SetSessionConfigOptionResponse(buildConfigOptions(sessionId), null);
     }
 
     /**
-     * Builds the dropdown advertisement for one session. Behavior, permission, and a flat
-     * model+reasoning dropdown are emitted via {@code configOptions} — IntelliJ hides the legacy
+     * Builds the dropdown advertisement for one session. Behavior, permission, planner-model, and
+     * code-model selectors are emitted via {@code configOptions} — IntelliJ hides the legacy
      * {@code modes} / {@code models} channels once anything appears here, so every selector must
      * come through this channel or it vanishes from the UI.
      *
-     * <p>Model and reasoning are presented as a single flat list of {@code name/variant} entries
-     * because IntelliJ doesn't render the spec'd {@code thought_level} category yet. When it does,
-     * we should split this into two adjacent dropdowns to match the legacy two-picker UX.
+     * <p>The planner-model selector remains a flat {@code name/variant} list because IntelliJ
+     * doesn't render the spec'd {@code thought_level} category yet. When it does, we should split
+     * planner model and reasoning into adjacent dropdowns to match the legacy two-picker UX.
      */
     private List<AcpProtocol.SessionConfigOption> buildConfigOptions(String sessionId) {
         var currentBehavior = modeBySession.getOrDefault(sessionId, "LUTZ");
         return List.of(
                 behaviorConfigOption(currentBehavior),
                 permissionConfigOption(permissionModeFor(sessionId)),
-                modelConfigOption(sessionId));
+                modelConfigOption(sessionId),
+                codeModelConfigOption(sessionId));
     }
 
     private AcpProtocol.SessionConfigOption modelConfigOption(String sessionId) {
@@ -772,6 +793,57 @@ public class BrokkAcpAgent {
                 "model",
                 currentValue,
                 List.copyOf(options));
+    }
+
+    private AcpProtocol.SessionConfigOption codeModelConfigOption(String sessionId) {
+        var availableModels = bundleForSession(sessionId).cm().getService().getAvailableModels();
+        var options = availableModels.keySet().stream()
+                .sorted()
+                .map(name -> new AcpProtocol.SessionConfigSelectOption(name, name, null))
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (options.isEmpty()) {
+            options.add(new AcpProtocol.SessionConfigSelectOption("default", "Default Code Model", null));
+        }
+
+        var currentValue = resolveCurrentCodeModelSelection(sessionId);
+        if (currentValue.isBlank()) {
+            currentValue = options.getFirst().value();
+        }
+
+        return AcpProtocol.SessionConfigOption.select(
+                "code_model_selection",
+                "Code Model",
+                "Selects the code model for this session.",
+                "model",
+                currentValue,
+                List.copyOf(options));
+    }
+
+    private String resolveInitialCodeModelSelection(String sessionId) {
+        return sanitizeCodeModelSelection(sessionId, modelBySession.getOrDefault(sessionId, defaultModelId));
+    }
+
+    private String resolveCurrentCodeModelSelection(String sessionId) {
+        var resolved = sanitizeCodeModelSelection(sessionId, codeModelBySession.getOrDefault(sessionId, ""));
+        codeModelBySession.put(sessionId, resolved);
+        return resolved;
+    }
+
+    private String sanitizeCodeModelSelection(String sessionId, String requestedModel) {
+        var availableModels = bundleForSession(sessionId).cm().getService().getAvailableModels();
+        var stripped = requestedModel.strip();
+        if (!stripped.isEmpty() && availableModels.containsKey(stripped)) {
+            return stripped;
+        }
+        if (availableModels.containsKey(DEFAULT_CODE_MODEL)) {
+            return DEFAULT_CODE_MODEL;
+        }
+        var plannerModel =
+                modelBySession.getOrDefault(sessionId, defaultModelId).strip();
+        if (!plannerModel.isEmpty() && availableModels.containsKey(plannerModel)) {
+            return plannerModel;
+        }
+        return availableModels.keySet().stream().sorted().findFirst().orElse("default");
     }
 
     private static AcpProtocol.SessionConfigOption behaviorConfigOption(String currentValue) {

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -882,11 +882,11 @@ class BrokkAcpAgentTest {
         var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
 
         assertNotNull(created.configOptions());
-        // All three selectors must come through configOptions. IntelliJ hides legacy `modes` and
+        // All selectors must come through configOptions. IntelliJ hides legacy `modes` and
         // `models` channels once configOptions is non-empty, so dropping any of these would make
         // the corresponding toolbar element vanish.
         assertEquals(
-                List.of("behavior_mode", "permission_mode", "model_selection"),
+                List.of("behavior_mode", "permission_mode", "model_selection", "code_model_selection"),
                 created.configOptions().stream()
                         .map(AcpProtocol.SessionConfigOption::id)
                         .toList());
@@ -954,6 +954,23 @@ class BrokkAcpAgentTest {
     }
 
     @Test
+    void newSessionAdvertisesCodeModelDropdownWithModelCategory() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var codeModel = created.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("model", codeModel.category());
+        assertEquals("select", codeModel.type());
+        assertNotNull(codeModel.currentValue());
+        assertFalse(codeModel.currentValue().isBlank());
+        assertFalse(codeModel.options().isEmpty());
+        assertTrue(codeModel.options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .anyMatch(codeModel.currentValue()::equals));
+    }
+
+    @Test
     void setSessionConfigOptionRejectsUnknownBehaviorMode() {
         var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
         org.junit.jupiter.api.Assertions.assertThrows(
@@ -975,6 +992,81 @@ class BrokkAcpAgentTest {
                 .findFirst()
                 .orElseThrow();
         assertEquals("acceptEdits", permission.currentValue());
+    }
+
+    @Test
+    void setSessionConfigOptionStoresCodeModel() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var initial = created.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        var selectedValue = initial.options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .filter(v -> !v.equals(initial.currentValue()))
+                .findFirst()
+                .orElse(initial.currentValue());
+
+        var resp = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "code_model_selection", selectedValue, null));
+
+        var updated = resp.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(selectedValue, updated.currentValue());
+        assertTrue(updated.options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .anyMatch(selectedValue::equals));
+    }
+
+    @Test
+    void loadSessionRetainsConfiguredCodeModel() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var initial = created.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        var selectedValue = initial.options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .filter(v -> !v.equals(initial.currentValue()))
+                .findFirst()
+                .orElse(initial.currentValue());
+
+        agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "code_model_selection", selectedValue, null));
+
+        var loaded = agent.loadSession(
+                new AcpSchema.LoadSessionRequest(created.sessionId(), projectRoot.toString(), List.of(), null));
+
+        var updated = loaded.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(selectedValue, updated.currentValue());
+        assertTrue(updated.options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .anyMatch(selectedValue::equals));
+    }
+
+    @Test
+    void resumeSessionSanitizesStaleCodeModelSelection() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "code_model_selection", "not-a-real-model", null));
+
+        var resumed = agent.resumeSession(
+                new AcpProtocol.ResumeSessionRequest(created.sessionId(), projectRoot.toString(), null, null));
+
+        var updated = resumed.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+        assertFalse(updated.currentValue().isBlank());
+        assertTrue(updated.options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .anyMatch(updated.currentValue()::equals));
     }
 
     @Test
@@ -1007,20 +1099,29 @@ class BrokkAcpAgentTest {
                     Map.of("cwd", projectRoot.toString(), "mcpServers", List.of()));
             var sessionId = ((AcpProtocol.NewSessionResponseExt) newSession.result()).sessionId();
 
+            var advertised = ((AcpProtocol.NewSessionResponseExt) newSession.result())
+                    .configOptions().stream()
+                            .filter(o -> "code_model_selection".equals(o.id()))
+                            .findFirst()
+                            .orElseThrow();
+            var selectedValue = advertised.options().stream()
+                    .map(AcpProtocol.SessionConfigSelectOption::value)
+                    .findFirst()
+                    .orElseThrow();
+
             var setConfig = transport.exchange(
                     AcpProtocol.METHOD_SESSION_SET_CONFIG_OPTION,
                     "setcfg",
-                    Map.of("sessionId", sessionId, "configId", "permission_mode", "value", "readOnly"));
+                    Map.of("sessionId", sessionId, "configId", "code_model_selection", "value", selectedValue));
             assertNull(setConfig.error());
             var result = assertInstanceOf(AcpProtocol.SetSessionConfigOptionResponse.class, setConfig.result());
             assertEquals(
-                    "readOnly",
+                    selectedValue,
                     result.configOptions().stream()
-                            .filter(o -> "permission_mode".equals(o.id()))
+                            .filter(o -> "code_model_selection".equals(o.id()))
                             .findFirst()
                             .orElseThrow()
                             .currentValue());
-            assertEquals(PermissionMode.READ_ONLY, agent.permissionModeFor(sessionId));
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a per-session `code_model_selection` dropdown to the ACP agent so users can pick the code model independently of the planner model.
- Persists the selection across `loadSession` / `resumeSession` / `forkSession` and sanitizes stale or unknown values back to a sensible default (preferred default code model, planner model, or first available).
- Replaces the inline planner-fallback logic in `runJob` with `resolveCurrentCodeModelSelection`, so job dispatch honors the session's chosen code model.

## Test plan
- [x] `BrokkAcpAgentTest` — new coverage for advertisement, set/load/resume persistence, stale-value sanitization, and the JSON-RPC round-trip.
- [ ] Manual smoke in IntelliJ: confirm the new "Code Model" dropdown appears alongside behavior / permission / planner-model selectors and that picking a value sticks across session reload.
