### PR TITLE
Use code model capabilities to build ACP model-selection menu

### DIFF
--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -101,6 +101,7 @@ public class BrokkAcpAgent {
     private final Map<String, String> modeBySession = new ConcurrentHashMap<>();
     private final Map<String, String> modelBySession = new ConcurrentHashMap<>();
     private final Map<String, String> codeModelBySession = new ConcurrentHashMap<>();
+    private final Map<String, String> codeReasoningBySession = new ConcurrentHashMap<>();
     private final Set<String> sessionsOnFallbackCatalog = ConcurrentHashMap.newKeySet();
     private final Map<String, String> reasoningBySession = new ConcurrentHashMap<>();
     private final Map<String, String> activeJobBySession = new ConcurrentHashMap<>();
@@ -385,7 +386,7 @@ public class BrokkAcpAgent {
 
         modeBySession.put(sessionId, "LUTZ");
         reasoningBySession.put(sessionId, defaultReasoningLevel);
-        codeModelBySession.put(sessionId, resolveInitialCodeModelSelection(sessionId));
+        normalizeCodeModelSelection(sessionId, modelBySession.getOrDefault(sessionId, defaultModelId), null, true);
         permissionModeBySession.put(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
@@ -415,11 +416,7 @@ public class BrokkAcpAgent {
 
         modeBySession.putIfAbsent(sessionId, "LUTZ");
         reasoningBySession.putIfAbsent(sessionId, defaultReasoningLevel);
-        codeModelBySession.compute(
-                sessionId,
-                (ignored, existing) -> existing == null
-                        ? resolveInitialCodeModelSelection(sessionId)
-                        : sanitizeCodeModelSelection(sessionId, existing));
+        normalizeCodeModelSelection(sessionId, preferredCodeBaseModel(sessionId), null, true);
         permissionModeBySession.putIfAbsent(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
@@ -444,11 +441,7 @@ public class BrokkAcpAgent {
 
         modeBySession.putIfAbsent(sessionId, "LUTZ");
         reasoningBySession.putIfAbsent(sessionId, defaultReasoningLevel);
-        codeModelBySession.compute(
-                sessionId,
-                (ignored, existing) -> existing == null
-                        ? resolveInitialCodeModelSelection(sessionId)
-                        : sanitizeCodeModelSelection(sessionId, existing));
+        normalizeCodeModelSelection(sessionId, preferredCodeBaseModel(sessionId), null, true);
         permissionModeBySession.putIfAbsent(sessionId, PermissionMode.DEFAULT);
         applySessionMcpServers(sessionId, request.mcpServers());
 
@@ -505,6 +498,7 @@ public class BrokkAcpAgent {
         modeBySession.remove(sessionId);
         modelBySession.remove(sessionId);
         codeModelBySession.remove(sessionId);
+        codeReasoningBySession.remove(sessionId);
         reasoningBySession.remove(sessionId);
         stickyPermissionsBySession.remove(sessionId);
         sessionsOnFallbackCatalog.remove(sessionId);
@@ -540,12 +534,13 @@ public class BrokkAcpAgent {
             if (model != null) {
                 modelBySession.put(forkSessionId, model);
             }
-            codeModelBySession.put(
-                    forkSessionId,
-                    sanitizeCodeModelSelection(
-                            forkSessionId,
-                            codeModelBySession.getOrDefault(
-                                    request.sessionId(), resolveInitialCodeModelSelection(forkSessionId))));
+            var parentCodeModel = codeModelBySession.getOrDefault(request.sessionId(), "");
+            if (parentCodeModel.isEmpty()) {
+                parentCodeModel = modelBySession.getOrDefault(forkSessionId, defaultModelId);
+            }
+            var parentCodeReasoning =
+                    codeReasoningBySession.getOrDefault(request.sessionId(), DEFAULT_REASONING_LEVEL_CODE);
+            normalizeCodeModelSelection(forkSessionId, parentCodeModel, parentCodeReasoning, true);
             reasoningBySession.put(
                     forkSessionId, reasoningBySession.getOrDefault(request.sessionId(), defaultReasoningLevel));
             permissionModeBySession.put(
@@ -634,7 +629,9 @@ public class BrokkAcpAgent {
         var tags = new HashMap<String, String>();
         tags.put("mode", mode);
 
-        var codeModel = resolveCurrentCodeModelSelection(sessionId);
+        var codeSelection = normalizeCodeModelSelection(sessionId, preferredCodeBaseModel(sessionId), null, true);
+        var codeModel = codeSelection.baseModel();
+        var codeReasoning = codeSelection.reasoning();
 
         var spec = new JobSpec(
                 text, // taskInput
@@ -648,7 +645,7 @@ public class BrokkAcpAgent {
                 null, // sourceBranch
                 null, // targetBranch
                 reasoning, // reasoningLevel
-                DEFAULT_REASONING_LEVEL_CODE, // reasoningLevelCode
+                codeReasoning, // reasoningLevelCode
                 null, // temperature
                 null, // temperatureCode
                 false, // skipVerification
@@ -731,8 +728,10 @@ public class BrokkAcpAgent {
                 setMode(new AcpSchema.SetSessionModeRequest(sessionId, value));
             }
             case "model_selection" -> setModel(new AcpSchema.SetSessionModelRequest(sessionId, value));
-            case "code_model_selection" ->
-                codeModelBySession.put(sessionId, sanitizeCodeModelSelection(sessionId, value));
+            case "code_model_selection" -> {
+                var parsed = parseModelSelection(value);
+                normalizeCodeModelSelection(sessionId, parsed.baseModel(), parsed.reasoning(), true);
+            }
             default ->
                 throw new IllegalArgumentException("Unknown configId '" + configId
                         + "'. Supported: permission_mode, behavior_mode, model_selection, code_model_selection");
@@ -785,16 +784,16 @@ public class BrokkAcpAgent {
     }
 
     private AcpProtocol.SessionConfigOption codeModelConfigOption(String sessionId) {
-        var availableModels = bundleForSession(sessionId).cm().getService().getAvailableModels();
-        var options = availableModels.keySet().stream()
-                .sorted()
-                .map(name -> new AcpProtocol.SessionConfigSelectOption(name, name, null))
-                .collect(Collectors.toCollection(ArrayList::new));
+        var service = bundleForSession(sessionId).cm().getService();
+        var availableModels = service.getAvailableModels();
+
+        var options = buildModelSelectOptions(sessionId, availableModels);
         if (options.isEmpty()) {
-            options.add(new AcpProtocol.SessionConfigSelectOption("default", "Default Code Model", null));
+            options = List.of(new AcpProtocol.SessionConfigSelectOption("default", "Default Code Model", null));
         }
 
-        var currentValue = resolveCurrentCodeModelSelection(sessionId);
+        var selection = normalizeCodeModelSelection(sessionId, preferredCodeBaseModel(sessionId), null, false);
+        var currentValue = formatModelIdWithVariant(selection.baseModel(), selection.reasoning());
         if (currentValue.isBlank()) {
             currentValue = options.getFirst().value();
         }
@@ -802,24 +801,65 @@ public class BrokkAcpAgent {
         return AcpProtocol.SessionConfigOption.select(
                 "code_model_selection",
                 "Code Model",
-                "Selects the code model for this session.",
+                "Selects the code model and reasoning effort for this session.",
                 "model",
                 currentValue,
-                List.copyOf(options));
+                options);
     }
 
-    private String resolveInitialCodeModelSelection(String sessionId) {
-        return sanitizeCodeModelSelection(sessionId, modelBySession.getOrDefault(sessionId, defaultModelId));
+    /**
+     * Resolves the code-model state for {@code sessionId}: validates {@code requestedBaseModel}
+     * against the live catalog (falling back to {@code DEFAULT_CODE_MODEL}, then the planner
+     * model, then the first sorted entry), then sanitizes the requested or persisted reasoning
+     * level against the chosen model's capabilities. Mirrors {@link #normalizeModelSelection}
+     * for the code-model side.
+     */
+    private NormalizedModelSelection normalizeCodeModelSelection(
+            String sessionId,
+            String requestedBaseModel,
+            @Nullable String requestedReasoning,
+            boolean persistResolvedState) {
+        var service = bundleForSession(sessionId).cm().getService();
+        var availableModels = service.getAvailableModels();
+        var baseModel = resolveCodeBaseModel(sessionId, availableModels, requestedBaseModel);
+        var sourceReasoning = requestedReasoning != null
+                ? requestedReasoning
+                : codeReasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL_CODE);
+        var reasoning = sanitizeReasoningLevelForModel(baseModel, sourceReasoning, service);
+        if (persistResolvedState) {
+            codeModelBySession.put(sessionId, baseModel);
+            codeReasoningBySession.put(sessionId, reasoning);
+        } else {
+            codeModelBySession.putIfAbsent(sessionId, baseModel);
+            codeReasoningBySession.putIfAbsent(sessionId, reasoning);
+            var existingModel = codeModelBySession.get(sessionId);
+            var existingReasoning = codeReasoningBySession.get(sessionId);
+            assert existingModel != null;
+            assert existingReasoning != null;
+            if (!existingModel.equals(baseModel)) {
+                codeModelBySession.put(sessionId, baseModel);
+            }
+            if (!existingReasoning.equals(reasoning)) {
+                codeReasoningBySession.put(sessionId, reasoning);
+            }
+        }
+        return new NormalizedModelSelection(baseModel, reasoning);
     }
 
-    private String resolveCurrentCodeModelSelection(String sessionId) {
-        var resolved = sanitizeCodeModelSelection(sessionId, codeModelBySession.getOrDefault(sessionId, ""));
-        codeModelBySession.put(sessionId, resolved);
-        return resolved;
+    /**
+     * Returns the existing per-session code-model selection if any, otherwise the planner model.
+     * Used to seed {@link #normalizeCodeModelSelection} when a session resumes/loads — the
+     * normalize step then validates this preference against the live catalog.
+     */
+    private String preferredCodeBaseModel(String sessionId) {
+        var preferred = codeModelBySession.getOrDefault(sessionId, "");
+        if (preferred.isEmpty()) {
+            preferred = modelBySession.getOrDefault(sessionId, defaultModelId);
+        }
+        return preferred;
     }
 
-    private String sanitizeCodeModelSelection(String sessionId, String requestedModel) {
-        var availableModels = bundleForSession(sessionId).cm().getService().getAvailableModels();
+    private String resolveCodeBaseModel(String sessionId, Map<String, String> availableModels, String requestedModel) {
         var stripped = requestedModel.strip();
         if (!stripped.isEmpty() && availableModels.containsKey(stripped)) {
             return stripped;
@@ -883,14 +923,17 @@ public class BrokkAcpAgent {
                 ? parsed.reasoning()
                 : reasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL);
         var normalized = normalizeModelSelection(sessionId, availableModels, service, requestedBaseModel, true);
-        var normalizedReasoning =
-                sanitizeReasoningLevelForModel(normalized.baseModel(), requestedReasoning, service);
+        var normalizedReasoning = sanitizeReasoningLevelForModel(normalized.baseModel(), requestedReasoning, service);
 
         modelBySession.put(sessionId, normalized.baseModel());
         reasoningBySession.put(sessionId, normalizedReasoning);
 
-        logger.info("ACP set model parsed: base={} reasoning={} normalizedBase={} normalizedReasoning={}",
-                parsed.baseModel(), parsed.reasoning(), normalized.baseModel(), normalizedReasoning);
+        logger.info(
+                "ACP set model parsed: base={} reasoning={} normalizedBase={} normalizedReasoning={}",
+                parsed.baseModel(),
+                parsed.reasoning(),
+                normalized.baseModel(),
+                normalizedReasoning);
 
         // Persist updated defaults
         saveAcpDefaults(normalized.baseModel(), normalizedReasoning);
@@ -1238,8 +1281,8 @@ public class BrokkAcpAgent {
                 .sorted()
                 .<AcpProtocol.SessionConfigSelectOption>mapMulti((name, downstream) -> {
                     downstream.accept(new AcpProtocol.SessionConfigSelectOption(name, name, null));
-                    modelVariantsFor(sessionId, name).forEach(level -> downstream.accept(
-                            new AcpProtocol.SessionConfigSelectOption(
+                    modelVariantsFor(sessionId, name)
+                            .forEach(level -> downstream.accept(new AcpProtocol.SessionConfigSelectOption(
                                     name + "/" + level, name + " (" + level + ")", null)));
                 })
                 .toList();
@@ -1250,8 +1293,9 @@ public class BrokkAcpAgent {
                 .sorted()
                 .<AcpSchema.ModelInfo>mapMulti((name, downstream) -> {
                     downstream.accept(new AcpSchema.ModelInfo(name, name, null));
-                    modelVariantsFor(sessionId, name).forEach(level ->
-                            downstream.accept(new AcpSchema.ModelInfo(name + "/" + level, name + " (" + level + ")", null)));
+                    modelVariantsFor(sessionId, name)
+                            .forEach(level -> downstream.accept(
+                                    new AcpSchema.ModelInfo(name + "/" + level, name + " (" + level + ")", null)));
                 })
                 .toList();
     }

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -763,25 +763,14 @@ public class BrokkAcpAgent {
         var service = bundleForSession(sessionId).cm().getService();
         var availableModels = service.getAvailableModels();
 
-        var options = new ArrayList<AcpProtocol.SessionConfigSelectOption>();
-        availableModels.keySet().stream().sorted().forEach(name -> {
-            options.add(new AcpProtocol.SessionConfigSelectOption(name, name, null));
-            for (var level : List.of("low", "medium", "high", "disable")) {
-                options.add(
-                        new AcpProtocol.SessionConfigSelectOption(name + "/" + level, name + " (" + level + ")", null));
-            }
-        });
+        var options = buildModelSelectOptions(sessionId, availableModels);
         if (options.isEmpty()) {
-            options.add(new AcpProtocol.SessionConfigSelectOption("default", "Default Model", null));
+            options = List.of(new AcpProtocol.SessionConfigSelectOption("default", "Default Model", null));
         }
 
-        var baseModel = modelBySession.getOrDefault(sessionId, defaultModelId);
-        var modelNames = availableModels.keySet();
-        if (!baseModel.isEmpty() && !modelNames.contains(baseModel) && !modelNames.isEmpty()) {
-            baseModel = modelNames.stream().sorted().findFirst().orElse(baseModel);
-        }
-        var reasoning = reasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL);
-        var currentValue = formatModelIdWithVariant(baseModel, reasoning);
+        var selection = normalizeModelSelection(
+                sessionId, availableModels, service, modelBySession.getOrDefault(sessionId, defaultModelId), false);
+        var currentValue = formatModelIdWithVariant(selection.baseModel(), selection.reasoning());
         if (currentValue.isBlank()) {
             currentValue = options.getFirst().value();
         }
@@ -792,7 +781,7 @@ public class BrokkAcpAgent {
                 "Selects the LLM and reasoning effort for this session.",
                 "model",
                 currentValue,
-                List.copyOf(options));
+                options);
     }
 
     private AcpProtocol.SessionConfigOption codeModelConfigOption(String sessionId) {
@@ -885,15 +874,26 @@ public class BrokkAcpAgent {
 
         // Parse "model/variant" format: split on last "/" and check if last segment is a reasoning level
         var parsed = parseModelSelection(modelId);
-        modelBySession.put(sessionId, parsed.baseModel);
-        if (parsed.reasoning != null) {
-            reasoningBySession.put(sessionId, parsed.reasoning);
-        }
+        var service = bundleForSession(sessionId).cm().getService();
+        var availableModels = sessionsOnFallbackCatalog.contains(sessionId)
+                ? service.getAvailableModels()
+                : discoverModelsWithRetry(service, MODEL_DISCOVERY_RECOVERY_ATTEMPTS);
+        var requestedBaseModel = parsed.baseModel();
+        var requestedReasoning = parsed.reasoning() != null
+                ? parsed.reasoning()
+                : reasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL);
+        var normalized = normalizeModelSelection(sessionId, availableModels, service, requestedBaseModel, true);
+        var normalizedReasoning =
+                sanitizeReasoningLevelForModel(normalized.baseModel(), requestedReasoning, service);
 
-        logger.info("ACP set model parsed: base={} reasoning={}", parsed.baseModel, parsed.reasoning);
+        modelBySession.put(sessionId, normalized.baseModel());
+        reasoningBySession.put(sessionId, normalizedReasoning);
+
+        logger.info("ACP set model parsed: base={} reasoning={} normalizedBase={} normalizedReasoning={}",
+                parsed.baseModel(), parsed.reasoning(), normalized.baseModel(), normalizedReasoning);
 
         // Persist updated defaults
-        saveAcpDefaults(parsed.baseModel, reasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL));
+        saveAcpDefaults(normalized.baseModel(), normalizedReasoning);
 
         refreshCatalogIfFallback(sessionId);
 
@@ -1091,29 +1091,12 @@ public class BrokkAcpAgent {
         // do not overwrite user-configured defaults.
         revalidatePersistedDefaults(sessionId, availableModels, service);
 
-        // Build model list with reasoning variants (model/low, model/medium, model/high, etc.)
-        var models = new ArrayList<AcpSchema.ModelInfo>();
-        availableModels.keySet().stream().sorted().forEach(name -> {
-            models.add(new AcpSchema.ModelInfo(name, name, null));
-            for (var level : List.of("low", "medium", "high", "disable")) {
-                models.add(new AcpSchema.ModelInfo(name + "/" + level, name + " (" + level + ")", null));
-            }
-        });
+        var models = buildModelStateOptions(sessionId, availableModels);
+        var selection = normalizeModelSelection(
+                sessionId, availableModels, service, modelBySession.getOrDefault(sessionId, defaultModelId), false);
+        var currentModelId = formatModelIdWithVariant(selection.baseModel(), selection.reasoning());
 
-        // Resolve current model, preferring persisted default for new sessions
-        var baseModel = modelBySession.getOrDefault(sessionId, defaultModelId);
-        // Validate against available models; fall back to first if not found
-        var modelNames = availableModels.keySet();
-        if (!baseModel.isEmpty() && !modelNames.contains(baseModel) && !modelNames.isEmpty()) {
-            baseModel = modelNames.stream().sorted().findFirst().orElse(baseModel);
-        }
-        modelBySession.putIfAbsent(sessionId, baseModel);
-
-        // Format current model ID with variant
-        var reasoning = reasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL);
-        var currentModelId = formatModelIdWithVariant(baseModel, reasoning);
-
-        return new AcpSchema.SessionModelState(currentModelId, List.copyOf(models));
+        return new AcpSchema.SessionModelState(currentModelId, models);
     }
 
     /**
@@ -1249,6 +1232,63 @@ public class BrokkAcpAgent {
         return List.copyOf(variants);
     }
 
+    private List<AcpProtocol.SessionConfigSelectOption> buildModelSelectOptions(
+            String sessionId, Map<String, String> availableModels) {
+        return availableModels.keySet().stream()
+                .sorted()
+                .<AcpProtocol.SessionConfigSelectOption>mapMulti((name, downstream) -> {
+                    downstream.accept(new AcpProtocol.SessionConfigSelectOption(name, name, null));
+                    modelVariantsFor(sessionId, name).forEach(level -> downstream.accept(
+                            new AcpProtocol.SessionConfigSelectOption(
+                                    name + "/" + level, name + " (" + level + ")", null)));
+                })
+                .toList();
+    }
+
+    private List<AcpSchema.ModelInfo> buildModelStateOptions(String sessionId, Map<String, String> availableModels) {
+        return availableModels.keySet().stream()
+                .sorted()
+                .<AcpSchema.ModelInfo>mapMulti((name, downstream) -> {
+                    downstream.accept(new AcpSchema.ModelInfo(name, name, null));
+                    modelVariantsFor(sessionId, name).forEach(level ->
+                            downstream.accept(new AcpSchema.ModelInfo(name + "/" + level, name + " (" + level + ")", null)));
+                })
+                .toList();
+    }
+
+    private NormalizedModelSelection normalizeModelSelection(
+            String sessionId,
+            Map<String, String> availableModels,
+            AbstractService service,
+            String preferredBaseModel,
+            boolean persistResolvedState) {
+        var modelNames = availableModels.keySet();
+        var baseModel = preferredBaseModel;
+        if (!baseModel.isEmpty() && !modelNames.contains(baseModel) && !modelNames.isEmpty()) {
+            baseModel = modelNames.stream().sorted().findFirst().orElse(baseModel);
+        }
+        var reasoning = sanitizeReasoningLevelForModel(
+                baseModel, reasoningBySession.getOrDefault(sessionId, DEFAULT_REASONING_LEVEL), service);
+        if (persistResolvedState) {
+            modelBySession.put(sessionId, baseModel);
+            reasoningBySession.put(sessionId, reasoning);
+        } else {
+            modelBySession.putIfAbsent(sessionId, baseModel);
+            reasoningBySession.putIfAbsent(sessionId, reasoning);
+            var existingModel = modelBySession.get(sessionId);
+            var existingReasoning = reasoningBySession.get(sessionId);
+            assert existingModel != null;
+            assert existingReasoning != null;
+            if (!existingModel.equals(baseModel)) {
+                modelBySession.put(sessionId, baseModel);
+            }
+            if (!existingReasoning.equals(reasoning)) {
+                reasoningBySession.put(sessionId, reasoning);
+            }
+        }
+        return new NormalizedModelSelection(baseModel, reasoning);
+    }
+
     private static String formatModelIdWithVariant(String baseModel, String reasoning) {
         if (reasoning.equals("default") || reasoning.isEmpty()) {
             return baseModel;
@@ -1259,6 +1299,8 @@ public class BrokkAcpAgent {
     // ---- Model selection parsing ----
 
     private record ParsedModelSelection(String baseModel, @Nullable String reasoning) {}
+
+    private record NormalizedModelSelection(String baseModel, String reasoning) {}
 
     private ParsedModelSelection parseModelSelection(String modelId) {
         if (modelId.isBlank()) {

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -40,6 +41,7 @@ import reactor.core.publisher.Mono;
 class BrokkAcpAgentTest {
     private ContextManager contextManager;
     private JobRunner jobRunner;
+    private TestService testService;
     private BrokkAcpAgent agent;
     private Path projectRoot;
 
@@ -47,7 +49,18 @@ class BrokkAcpAgentTest {
     void setUp(@TempDir Path tempDir) throws Exception {
         projectRoot = tempDir.toAbsolutePath().normalize();
         var project = MainProject.forTests(projectRoot);
-        contextManager = new ContextManager(project, TestService.provider(project));
+        testService = new TestService(project);
+        contextManager = new ContextManager(project, new ai.brokk.Service.Provider() {
+            @Override
+            public ai.brokk.AbstractService get() {
+                return testService;
+            }
+
+            @Override
+            public void reinit(ai.brokk.project.IProject p) {
+                testService = new TestService(p);
+            }
+        });
         var jobStore = new JobStore(projectRoot.resolve(".brokk-test-jobs"));
         jobRunner = new JobRunner(contextManager, jobStore);
         agent = new BrokkAcpAgent(contextManager, jobRunner, jobStore);
@@ -971,6 +984,94 @@ class BrokkAcpAgentTest {
     }
 
     @Test
+    void newSessionAdvertisesOnlyBaseEntryForModelWithoutEffortSupport() {
+        seedModelCapabilities(Map.of("plain-model", TestService.modelInfo(false, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        var optionValues = modelSelectionOption(created).options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .toList();
+        var modelValues =
+                created.models().availableModels().stream().map(AcpSchema.ModelInfo::modelId).toList();
+
+        assertEquals(List.of("plain-model"), optionValues);
+        assertEquals(List.of("plain-model"), modelValues);
+        assertEquals("plain-model", modelSelectionOption(created).currentValue());
+        assertEquals("plain-model", created.models().currentModelId());
+    }
+
+    @Test
+    void newSessionAdvertisesLowMediumHighForEffortModelWithoutDisable() {
+        seedModelCapabilities(Map.of("effort-model", TestService.modelInfo(true, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        var expected = List.of("effort-model", "effort-model/low", "effort-model/medium", "effort-model/high");
+        var optionValues = modelSelectionOption(created).options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .toList();
+        var modelValues =
+                created.models().availableModels().stream().map(AcpSchema.ModelInfo::modelId).toList();
+
+        assertEquals(expected, optionValues);
+        assertEquals(expected, modelValues);
+    }
+
+    @Test
+    void newSessionAdvertisesDisableOnlyWhenModelSupportsIt() {
+        seedModelCapabilities(Map.of("disable-model", TestService.modelInfo(true, true)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        var expected = List.of(
+                "disable-model",
+                "disable-model/low",
+                "disable-model/medium",
+                "disable-model/high",
+                "disable-model/disable");
+        var optionValues = modelSelectionOption(created).options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .toList();
+        var modelValues =
+                created.models().availableModels().stream().map(AcpSchema.ModelInfo::modelId).toList();
+
+        assertEquals(expected, optionValues);
+        assertEquals(expected, modelValues);
+    }
+
+    @Test
+    void configRefreshNormalizesUnsupportedReasoningLevelToValidCurrentSelection() {
+        seedModelCapabilities(Map.of("plain-model", TestService.modelInfo(false, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var response = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "model_selection", "plain-model/high", null));
+
+        assertEquals("plain-model", modelSelectionOption(response).currentValue());
+
+        var resumed = agent.resumeSession(
+                new AcpProtocol.ResumeSessionRequest(created.sessionId(), projectRoot.toString(), null, null));
+        assertEquals("plain-model", resumed.models().currentModelId());
+        assertEquals("plain-model", modelSelectionOption(resumed).currentValue());
+    }
+
+    @Test
+    void configRefreshNormalizesDisableWhenModelDoesNotSupportIt() {
+        seedModelCapabilities(Map.of("effort-model", TestService.modelInfo(true, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var response = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "model_selection", "effort-model/disable", null));
+
+        assertEquals("effort-model", modelSelectionOption(response).currentValue());
+
+        var loaded = agent.loadSession(new AcpSchema.LoadSessionRequest(created.sessionId(), projectRoot.toString(), null));
+        assertEquals("effort-model", loaded.models().currentModelId());
+        assertEquals("effort-model", modelSelectionOption(loaded).currentValue());
+    }
+
+    @Test
     void setSessionConfigOptionRejectsUnknownBehaviorMode() {
         var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
         org.junit.jupiter.api.Assertions.assertThrows(
@@ -1197,6 +1298,39 @@ class BrokkAcpAgentTest {
             assertTrue(ctx.askPermission("Allow shell?", "shell"));
             assertEquals(1, calls.get(), "ACCEPT_EDITS must still prompt for shell");
         }
+    }
+
+    private void seedModelCapabilities(Map<String, Map<String, Object>> modelInfoByName) {
+        testService.setAvailableModels(modelInfoByName);
+    }
+
+    private static AcpProtocol.SessionConfigOption modelSelectionOption(AcpProtocol.NewSessionResponseExt response) {
+        return response.configOptions().stream()
+                .filter(o -> "model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static AcpProtocol.SessionConfigOption modelSelectionOption(AcpProtocol.ResumeSessionResponse response) {
+        return response.configOptions().stream()
+                .filter(o -> "model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static AcpProtocol.SessionConfigOption modelSelectionOption(AcpProtocol.LoadSessionResponseExt response) {
+        return response.configOptions().stream()
+                .filter(o -> "model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static AcpProtocol.SessionConfigOption modelSelectionOption(
+            AcpProtocol.SetSessionConfigOptionResponse response) {
+        return response.configOptions().stream()
+                .filter(o -> "model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
     }
 
     static final class FakeTransport implements AcpAgentTransport {

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -992,8 +991,9 @@ class BrokkAcpAgentTest {
         var optionValues = modelSelectionOption(created).options().stream()
                 .map(AcpProtocol.SessionConfigSelectOption::value)
                 .toList();
-        var modelValues =
-                created.models().availableModels().stream().map(AcpSchema.ModelInfo::modelId).toList();
+        var modelValues = created.models().availableModels().stream()
+                .map(AcpSchema.ModelInfo::modelId)
+                .toList();
 
         assertEquals(List.of("plain-model"), optionValues);
         assertEquals(List.of("plain-model"), modelValues);
@@ -1011,8 +1011,9 @@ class BrokkAcpAgentTest {
         var optionValues = modelSelectionOption(created).options().stream()
                 .map(AcpProtocol.SessionConfigSelectOption::value)
                 .toList();
-        var modelValues =
-                created.models().availableModels().stream().map(AcpSchema.ModelInfo::modelId).toList();
+        var modelValues = created.models().availableModels().stream()
+                .map(AcpSchema.ModelInfo::modelId)
+                .toList();
 
         assertEquals(expected, optionValues);
         assertEquals(expected, modelValues);
@@ -1033,8 +1034,9 @@ class BrokkAcpAgentTest {
         var optionValues = modelSelectionOption(created).options().stream()
                 .map(AcpProtocol.SessionConfigSelectOption::value)
                 .toList();
-        var modelValues =
-                created.models().availableModels().stream().map(AcpSchema.ModelInfo::modelId).toList();
+        var modelValues = created.models().availableModels().stream()
+                .map(AcpSchema.ModelInfo::modelId)
+                .toList();
 
         assertEquals(expected, optionValues);
         assertEquals(expected, modelValues);
@@ -1066,9 +1068,108 @@ class BrokkAcpAgentTest {
 
         assertEquals("effort-model", modelSelectionOption(response).currentValue());
 
-        var loaded = agent.loadSession(new AcpSchema.LoadSessionRequest(created.sessionId(), projectRoot.toString(), null));
+        var loaded =
+                agent.loadSession(new AcpSchema.LoadSessionRequest(created.sessionId(), projectRoot.toString(), null));
         assertEquals("effort-model", loaded.models().currentModelId());
         assertEquals("effort-model", modelSelectionOption(loaded).currentValue());
+    }
+
+    // ---- Code-model selector capability coverage (mirrors model_selection above) -------
+
+    @Test
+    void newSessionAdvertisesOnlyCodeBaseEntryForModelWithoutEffortSupport() {
+        seedModelCapabilities(Map.of("plain-model", TestService.modelInfo(false, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        var optionValues = codeModelSelectionOption(created).options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .toList();
+        assertEquals(List.of("plain-model"), optionValues);
+        assertEquals("plain-model", codeModelSelectionOption(created).currentValue());
+    }
+
+    @Test
+    void newSessionAdvertisesCodeLowMediumHighForEffortModelWithoutDisable() {
+        seedModelCapabilities(Map.of("effort-model", TestService.modelInfo(true, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        var expected = List.of("effort-model", "effort-model/low", "effort-model/medium", "effort-model/high");
+        var optionValues = codeModelSelectionOption(created).options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .toList();
+        assertEquals(expected, optionValues);
+        // DEFAULT_REASONING_LEVEL_CODE = "disable" but the model does not support disable, so
+        // the level sanitizes to "default" and the current selection drops the variant suffix.
+        assertEquals("effort-model", codeModelSelectionOption(created).currentValue());
+    }
+
+    @Test
+    void newSessionAdvertisesCodeDisableOnlyWhenCodeModelSupportsIt() {
+        seedModelCapabilities(Map.of("disable-model", TestService.modelInfo(true, true)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        var expected = List.of(
+                "disable-model",
+                "disable-model/low",
+                "disable-model/medium",
+                "disable-model/high",
+                "disable-model/disable");
+        var optionValues = codeModelSelectionOption(created).options().stream()
+                .map(AcpProtocol.SessionConfigSelectOption::value)
+                .toList();
+        assertEquals(expected, optionValues);
+        // DEFAULT_REASONING_LEVEL_CODE = "disable" and the model supports it, so it survives.
+        assertEquals("disable-model/disable", codeModelSelectionOption(created).currentValue());
+    }
+
+    @Test
+    void setSessionConfigOptionParsesCodeModelVariantAndPersistsAcrossLoad() {
+        seedModelCapabilities(Map.of("effort-model", TestService.modelInfo(true, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var response = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "code_model_selection", "effort-model/high", null));
+
+        assertEquals("effort-model/high", codeModelSelectionOption(response).currentValue());
+
+        var loaded =
+                agent.loadSession(new AcpSchema.LoadSessionRequest(created.sessionId(), projectRoot.toString(), null));
+        assertEquals("effort-model/high", codeModelSelectionOption(loaded).currentValue());
+    }
+
+    @Test
+    void configRefreshNormalizesUnsupportedCodeReasoningLevelToValidCurrentSelection() {
+        seedModelCapabilities(Map.of("plain-model", TestService.modelInfo(false, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var response = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "code_model_selection", "plain-model/high", null));
+
+        // plain-model does not support reasoning_effort, so /high collapses back to the bare model.
+        assertEquals("plain-model", codeModelSelectionOption(response).currentValue());
+
+        var resumed = agent.resumeSession(
+                new AcpProtocol.ResumeSessionRequest(created.sessionId(), projectRoot.toString(), null, null));
+        assertEquals("plain-model", codeModelSelectionOption(resumed).currentValue());
+    }
+
+    @Test
+    void configRefreshNormalizesCodeDisableWhenCodeModelDoesNotSupportIt() {
+        seedModelCapabilities(Map.of("effort-model", TestService.modelInfo(true, false)));
+
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        var response = agent.setSessionConfigOption(new AcpProtocol.SetSessionConfigOptionRequest(
+                created.sessionId(), "code_model_selection", "effort-model/disable", null));
+
+        // effort-model supports effort but not disable; /disable normalizes back to base model.
+        assertEquals("effort-model", codeModelSelectionOption(response).currentValue());
+
+        var loaded =
+                agent.loadSession(new AcpSchema.LoadSessionRequest(created.sessionId(), projectRoot.toString(), null));
+        assertEquals("effort-model", codeModelSelectionOption(loaded).currentValue());
     }
 
     @Test
@@ -1329,6 +1430,38 @@ class BrokkAcpAgentTest {
             AcpProtocol.SetSessionConfigOptionResponse response) {
         return response.configOptions().stream()
                 .filter(o -> "model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static AcpProtocol.SessionConfigOption codeModelSelectionOption(
+            AcpProtocol.NewSessionResponseExt response) {
+        return response.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static AcpProtocol.SessionConfigOption codeModelSelectionOption(
+            AcpProtocol.ResumeSessionResponse response) {
+        return response.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static AcpProtocol.SessionConfigOption codeModelSelectionOption(
+            AcpProtocol.LoadSessionResponseExt response) {
+        return response.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static AcpProtocol.SessionConfigOption codeModelSelectionOption(
+            AcpProtocol.SetSessionConfigOptionResponse response) {
+        return response.configOptions().stream()
+                .filter(o -> "code_model_selection".equals(o.id()))
                 .findFirst()
                 .orElseThrow();
     }

--- a/app/src/test/java/ai/brokk/testutil/TestService.java
+++ b/app/src/test/java/ai/brokk/testutil/TestService.java
@@ -10,6 +10,7 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,6 +49,38 @@ public class TestService extends AbstractService {
 
     public void setModel(ModelType modelType, StreamingChatModel model) {
         modelOverrides.put(modelType, model);
+    }
+
+    public void setAvailableModels(Map<String, Map<String, Object>> modelInfoByName) {
+        this.modelInfoMap = modelInfoByName.entrySet().stream()
+                .collect(java.util.stream.Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey,
+                        entry -> Map.copyOf(entry.getValue())));
+        this.modelLocations = modelInfoByName.keySet().stream()
+                .collect(java.util.stream.Collectors.toUnmodifiableMap(name -> name, name -> name));
+    }
+
+    public static Map<String, Object> modelInfo(boolean supportsReasoningEffort, boolean supportsReasoningDisable) {
+        var supportedParams = supportsReasoningEffort
+                ? List.of("reasoning_effort", "temperature")
+                : List.of("temperature");
+        return Map.ofEntries(
+                Map.entry("supported_openai_params", supportedParams),
+                Map.entry("supports_reasoning_disable", supportsReasoningDisable),
+                Map.entry("model_location", "unused"),
+                Map.entry("mode", "chat"),
+                Map.entry("max_input_tokens", 8192),
+                Map.entry("max_output_tokens", 2048),
+                Map.entry("supports_tool_choice", true),
+                Map.entry("supports_response_schema", false),
+                Map.entry("supports_vision", false),
+                Map.entry("supports_reasoning", supportsReasoningEffort),
+                Map.entry("is_codex", false),
+                Map.entry("free_tier_eligible", true),
+                Map.entry("is_private", true),
+                Map.entry("input_cost_per_token", 0.0),
+                Map.entry("output_cost_per_token", 0.0),
+                Map.entry("cache_read_input_token_cost", 0.0));
     }
 
     @Override

--- a/app/src/test/java/ai/brokk/testutil/TestService.java
+++ b/app/src/test/java/ai/brokk/testutil/TestService.java
@@ -54,16 +54,14 @@ public class TestService extends AbstractService {
     public void setAvailableModels(Map<String, Map<String, Object>> modelInfoByName) {
         this.modelInfoMap = modelInfoByName.entrySet().stream()
                 .collect(java.util.stream.Collectors.toUnmodifiableMap(
-                        Map.Entry::getKey,
-                        entry -> Map.copyOf(entry.getValue())));
+                        Map.Entry::getKey, entry -> Map.copyOf(entry.getValue())));
         this.modelLocations = modelInfoByName.keySet().stream()
                 .collect(java.util.stream.Collectors.toUnmodifiableMap(name -> name, name -> name));
     }
 
     public static Map<String, Object> modelInfo(boolean supportsReasoningEffort, boolean supportsReasoningDisable) {
-        var supportedParams = supportsReasoningEffort
-                ? List.of("reasoning_effort", "temperature")
-                : List.of("temperature");
+        var supportedParams =
+                supportsReasoningEffort ? List.of("reasoning_effort", "temperature") : List.of("temperature");
         return Map.ofEntries(
                 Map.entry("supported_openai_params", supportedParams),
                 Map.entry("supports_reasoning_disable", supportsReasoningDisable),


### PR DESCRIPTION
## Summary
- Use the code model's capabilities to drive the ACP model-selection menu so reasoning variants only appear for models that support them
- Centralize model/reasoning normalization through `normalizeModelSelection` + `sanitizeReasoningLevelForModel`, replacing duplicated logic in `newSession`/`resumeSession`/`loadSession`/`setSessionConfigOption`
- Add `BrokkAcpAgentTest` coverage for capability-driven menu options and unsupported-effort normalization, plus `TestService.setAvailableModels` to seed model info in tests

## Test plan
- [ ] `./gradlew :app:check`
