### PR TITLE
ACP: warn outdated IntelliJ AI Assistant clients

### DIFF
--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -135,6 +135,10 @@ public class BrokkAcpAgent {
     // Set by BrokkAcpRuntime to enable session updates outside of prompt context
     private volatile @Nullable SessionUpdateSender sessionUpdateSender;
 
+    // Set by BrokkAcpRuntime at initialize when the client is below MIN_CLIENT_VERSIONS. When
+    // non-null, prompt() short-circuits with this message instead of invoking the LLM.
+    private volatile @Nullable String compatibilityWarning;
+
     @FunctionalInterface
     interface SessionUpdateSender {
         void sendSessionUpdate(String sessionId, AcpSchema.SessionUpdate update);
@@ -175,6 +179,10 @@ public class BrokkAcpAgent {
 
     public void setSessionUpdateSender(SessionUpdateSender sessionUpdateSender) {
         this.sessionUpdateSender = sessionUpdateSender;
+    }
+
+    public void setCompatibilityWarning(@Nullable String warning) {
+        this.compatibilityWarning = warning;
     }
 
     /**
@@ -572,6 +580,16 @@ public class BrokkAcpAgent {
             return AcpSchema.PromptResponse.endTurn();
         }
         var bundle = bundleOpt.get();
+
+        // If the connecting client is too old, short-circuit before invoking any LLM: the user's
+        // prompt will not be honored, but they'll see why. We have to do this in prompt() rather
+        // than newSession() because JetBrains AI Assistant silently drops agent_message_chunk
+        // events that arrive outside of an active turn.
+        var warning = compatibilityWarning;
+        if (warning != null) {
+            promptContext.sendMessage("**[Brokk]** " + warning);
+            return AcpSchema.PromptResponse.endTurn();
+        }
 
         // Handle slash commands
         var firstWord = text.strip().split("\\s+", 2)[0].toLowerCase(Locale.ROOT);

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpRuntime.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpRuntime.java
@@ -6,15 +6,28 @@ import com.agentclientprotocol.sdk.spec.AcpAgentTransport;
 import com.agentclientprotocol.sdk.spec.AcpSchema;
 import io.modelcontextprotocol.json.TypeRef;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 /** Explicit ACP method router for Brokk's native Java ACP server. */
 final class BrokkAcpRuntime implements AutoCloseable {
+    private static final Logger logger = LogManager.getLogger(BrokkAcpRuntime.class);
+
+    /**
+     * Minimum version per known-buggy client, keyed on the exact {@code clientInfo.name} sent in
+     * {@code initialize}. Below the threshold, the agent runs in degraded mode: every prompt is
+     * short-circuited with a warning instead of invoking the LLM. Clients not in this map run at
+     * full feature regardless of version.
+     */
+    private static final Map<String, String> MIN_CLIENT_VERSIONS = Map.of("JetBrains.IntelliJ IDEA", "2026.1.1");
+
     private final AcpAgentTransport transport;
     private final BrokkAcpAgent agent;
     private final AtomicReference<NegotiatedCapabilities> clientCapabilities = new AtomicReference<>();
@@ -38,6 +51,30 @@ final class BrokkAcpRuntime implements AutoCloseable {
         var handlers = new HashMap<String, AcpAgentSession.RequestHandler<?>>();
         handlers.put(AcpSchema.METHOD_INITIALIZE, params -> {
             var request = unmarshal(params, new TypeRef<AcpSchema.InitializeRequest>() {});
+            // Log the client identity. clientInfo carries (name, version, title); _meta sometimes
+            // carries host-specific extras (e.g. proxy config). Useful for diagnosing "the IDE
+            // version is too old" reports from users.
+            logger.info(
+                    "ACP initialize: protocolVersion={}, clientInfo={}, clientCapabilities={}, meta={}",
+                    request.protocolVersion(),
+                    request.clientInfo(),
+                    request.clientCapabilities(),
+                    request.meta());
+            // We can't reject initialize: JetBrains AI Assistant silently marks the agent broken
+            // without surfacing the JSON-RPC error to the user. Stash a warning instead; prompt()
+            // will surface it inside an active turn (the only place AI Assistant renders chunks).
+            var info = request.clientInfo();
+            if (info != null && info.version() != null) {
+                var min = MIN_CLIENT_VERSIONS.get(info.name());
+                if (min != null && isOlderThan(info.version(), min)) {
+                    agent.setCompatibilityWarning("Brokk requires " + info.name() + " >= " + min + " (got "
+                            + info.version() + "). Brokk cannot process prompts on this IDE version. Please update.");
+                } else {
+                    agent.setCompatibilityWarning(null);
+                }
+            } else {
+                agent.setCompatibilityWarning(null);
+            }
             clientCapabilities.set(NegotiatedCapabilities.fromClient(request.clientCapabilities()));
             return Mono.fromCallable(() -> agent.initialize());
         });
@@ -109,6 +146,35 @@ final class BrokkAcpRuntime implements AutoCloseable {
 
     private <T> T unmarshal(Object params, TypeRef<T> typeRef) {
         return transport.unmarshalFrom(params, typeRef);
+    }
+
+    /**
+     * Returns true if {@code observed} is strictly older than {@code required}. Versions are
+     * compared as dot-separated numeric components, with missing components treated as 0
+     * ({@code "2026.1"} is older than {@code "2026.1.1"}). Non-digit suffixes on a component are
+     * stripped, so {@code "2026.1-EAP"} compares equal to {@code "2026.1"}.
+     */
+    static boolean isOlderThan(String observed, String required) {
+        int[] o = parseVersion(observed);
+        int[] r = parseVersion(required);
+        int len = Math.max(o.length, r.length);
+        for (int i = 0; i < len; i++) {
+            int a = i < o.length ? o[i] : 0;
+            int b = i < r.length ? r[i] : 0;
+            if (a != b) {
+                return a < b;
+            }
+        }
+        return false;
+    }
+
+    private static int[] parseVersion(String v) {
+        return Arrays.stream(v.split("\\."))
+                .mapToInt(s -> {
+                    var digits = s.replaceAll("[^0-9].*", "");
+                    return digits.isEmpty() ? 0 : Integer.parseInt(digits);
+                })
+                .toArray();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Detect outdated JetBrains IntelliJ IDEA (`< 2026.1.1`) at ACP `initialize` via the `clientInfo` field.
- On the first prompt in any session, surface a warning chunk and `endTurn()` immediately — no LLM call, no tool loop.
- Zed and every non-IntelliJ ACP client are unaffected at every version (allow-list keyed on `clientInfo.name`).

## Why this shape

Three approaches were tried; only the third survived empirically.

- **Reject `initialize` with `INVALID_PARAMS`?** AI Assistant silently marks the agent "broken" and the JSON-RPC error message never reaches the chat. The user sees nothing.
- **Push an `agent_message_chunk` from `newSession`?** AI Assistant receives the chunk (confirmed in client-side `acp.log`) but doesn't render it. Chunks received outside of an active turn are dropped on the floor.
- **Push the warning from inside `prompt()`?** Works. The user sees the warning at the top of the response to their first message.

While there, this PR also adds an `info`-level log of `clientInfo` / `clientCapabilities` / `protocolVersion` at `initialize`. Useful for diagnosing future "my IDE doesn't work" reports without needing to ship custom builds for capture.

## What is _not_ in this PR
- No suppression of `modes` / `models` / `configOptions` in compat mode — that path was tried and reverted because emitting empty model lists tripped the LLM validator with `Model is required`. The textual warning is sufficient on its own.
- The compat path covers `prompt()` only. Slash commands and other operational entry points are not gated; they continue to work normally even on outdated IDE.

## Test plan
- [x] `:app:compileJava` and `:app:spotlessJavaCheck` clean.
- [x] `:app:test --tests "ai.brokk.acp.*"` — 14 tests pass.
- [x] `:app:check` (full suite: errorprone + NullAway + spotless + tests).
- [x] `isOlderThan` validated manually on 11 cases (equality, newer, older, EAP suffix, varying length).
- [x] Manual end-to-end: built shadow jar, wired through `~/.jetbrains/acp.json` via `uvx brokk acp --jar <jar>`, exercised in IntelliJ AI Assistant on a real `2026.1.1` build (no warning, normal flow) and with threshold artificially raised to `2027.0` (warning rendered at the top of the first prompt response, no LLM call observed in `~/.brokk/debug.log`).
