### PR TITLE
fix: exclude Codex OAuth gpt-5.2-codex variants from restricted model lists

### DIFF
--- a/app/src/main/java/ai/brokk/AbstractService.java
+++ b/app/src/main/java/ai/brokk/AbstractService.java
@@ -409,8 +409,16 @@ public abstract class AbstractService implements ExceptionReporter.ReportingServ
                 .filter(name -> !UNAVAILABLE.equals(name))
                 .filter(name -> !ModelProperties.SYSTEM_ONLY_MODELS.contains(name))
                 .filter(name -> codexConnected || !isCodexModel(name))
-                .filter(name -> !restrictToOauth || (name.endsWith("-oauth") && !name.startsWith("gpt-5.1-")))
+                .filter(name -> !restrictToOauth || isAllowedOauthRestrictedModel(name))
                 .collect(Collectors.toMap(name -> name, name -> modelLocations.getOrDefault(name, name)));
+    }
+
+    private static boolean isAllowedOauthRestrictedModel(String name) {
+        return name.endsWith("-oauth") && !isExcludedOauthRestrictedModel(name);
+    }
+
+    private static boolean isExcludedOauthRestrictedModel(String name) {
+        return name.startsWith("gpt-5.1-") || name.startsWith("gpt-5.2-codex");
     }
 
     /**

--- a/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
+++ b/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
@@ -62,6 +62,11 @@ class ServiceCodexGatingTest {
         service.addModel("gpt-5.4-oauth", "oauth-loc", false);
         service.addModel("gpt-5.2-oauth", "oauth-5.2-loc", false);
         service.addModel("gpt-5.2-codex-fast-oauth", "oauth-5.2-codex-loc", false);
+        // Non-OAuth Codex API variant: gated by is_codex, not by the OAuth-prefix filter.
+        // Shares the gpt-5.2-codex prefix used to exclude OAuth variants but must remain
+        // governed solely by isCodexModel(); the OAuth restriction never applies to it
+        // because it lacks the -oauth suffix.
+        service.addModel("gpt-5.2-codex", "codex-5.2-loc", true);
 
         // 1. Not connected
         MainProject.setOpenAiCodexOauthConnected(false);
@@ -71,8 +76,10 @@ class ServiceCodexGatingTest {
         assertTrue(available.containsKey("gpt-5.4-oauth"));
         assertTrue(available.containsKey("gpt-5.2-oauth"));
         assertTrue(available.containsKey("gpt-5.2-codex-fast-oauth"));
+        assertFalse(available.containsKey("gpt-5.2-codex"));
         assertFalse(service.isCodexModel("Normal Model"));
         assertTrue(service.isCodexModel("Codex Model"));
+        assertTrue(service.isCodexModel("gpt-5.2-codex"));
 
         // 2. Connected with OAuth restriction disabled: all models visible
         MainProject.setOpenAiCodexOauthConnected(true);
@@ -83,8 +90,11 @@ class ServiceCodexGatingTest {
         assertTrue(available.containsKey("gpt-5.4-oauth"));
         assertTrue(available.containsKey("gpt-5.2-oauth"));
         assertTrue(available.containsKey("gpt-5.2-codex-fast-oauth"));
+        assertTrue(available.containsKey("gpt-5.2-codex"));
 
-        // 3. Connected with OAuth restriction enabled (default): only allowed -oauth-suffixed models visible
+        // 3. Connected with OAuth restriction enabled (default): only allowed -oauth-suffixed models visible.
+        // gpt-5.2-codex (no -oauth suffix) is hidden by the suffix check, independently of the
+        // gpt-5.2-codex- prefix exclusion that targets OAuth variants.
         MainProject.setRestrictToOauthModelsWhenConnected(true);
         available = service.getAvailableModels();
         assertFalse(available.containsKey("Normal Model"));
@@ -92,6 +102,7 @@ class ServiceCodexGatingTest {
         assertTrue(available.containsKey("gpt-5.4-oauth"));
         assertTrue(available.containsKey("gpt-5.2-oauth"));
         assertFalse(available.containsKey("gpt-5.2-codex-fast-oauth"));
+        assertFalse(available.containsKey("gpt-5.2-codex"));
     }
 
     /**

--- a/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
+++ b/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
@@ -62,6 +62,7 @@ class ServiceCodexGatingTest {
         service.addModel("gpt-5.4-oauth", "oauth-loc", false);
         service.addModel("gpt-5.2-oauth", "oauth-5.2-loc", false);
         service.addModel("gpt-5.2-codex-fast-oauth", "oauth-5.2-codex-loc", false);
+        service.addModel("gpt-5.1-mini-oauth", "oauth-5.1-mini-loc", false);
         // Non-OAuth Codex API variant: gated by is_codex, not by the OAuth-prefix filter.
         // Shares the gpt-5.2-codex prefix used to exclude OAuth variants but must remain
         // governed solely by isCodexModel(); the OAuth restriction never applies to it
@@ -76,6 +77,7 @@ class ServiceCodexGatingTest {
         assertTrue(available.containsKey("gpt-5.4-oauth"));
         assertTrue(available.containsKey("gpt-5.2-oauth"));
         assertTrue(available.containsKey("gpt-5.2-codex-fast-oauth"));
+        assertTrue(available.containsKey("gpt-5.1-mini-oauth"));
         assertFalse(available.containsKey("gpt-5.2-codex"));
         assertFalse(service.isCodexModel("Normal Model"));
         assertTrue(service.isCodexModel("Codex Model"));
@@ -90,6 +92,7 @@ class ServiceCodexGatingTest {
         assertTrue(available.containsKey("gpt-5.4-oauth"));
         assertTrue(available.containsKey("gpt-5.2-oauth"));
         assertTrue(available.containsKey("gpt-5.2-codex-fast-oauth"));
+        assertTrue(available.containsKey("gpt-5.1-mini-oauth"));
         assertTrue(available.containsKey("gpt-5.2-codex"));
 
         // 3. Connected with OAuth restriction enabled (default): only allowed -oauth-suffixed models visible.
@@ -102,6 +105,7 @@ class ServiceCodexGatingTest {
         assertTrue(available.containsKey("gpt-5.4-oauth"));
         assertTrue(available.containsKey("gpt-5.2-oauth"));
         assertFalse(available.containsKey("gpt-5.2-codex-fast-oauth"));
+        assertFalse(available.containsKey("gpt-5.1-mini-oauth"));
         assertFalse(available.containsKey("gpt-5.2-codex"));
     }
 

--- a/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
+++ b/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
@@ -60,6 +60,8 @@ class ServiceCodexGatingTest {
         service.addModel("Normal Model", "normal-loc", false);
         service.addModel("Codex Model", "codex-loc", true);
         service.addModel("gpt-5.4-oauth", "oauth-loc", false);
+        service.addModel("gpt-5.2-oauth", "oauth-5.2-loc", false);
+        service.addModel("gpt-5.2-codex-fast-oauth", "oauth-5.2-codex-loc", false);
 
         // 1. Not connected
         MainProject.setOpenAiCodexOauthConnected(false);
@@ -67,6 +69,8 @@ class ServiceCodexGatingTest {
         assertTrue(available.containsKey("Normal Model"));
         assertFalse(available.containsKey("Codex Model"));
         assertTrue(available.containsKey("gpt-5.4-oauth"));
+        assertTrue(available.containsKey("gpt-5.2-oauth"));
+        assertTrue(available.containsKey("gpt-5.2-codex-fast-oauth"));
         assertFalse(service.isCodexModel("Normal Model"));
         assertTrue(service.isCodexModel("Codex Model"));
 
@@ -77,13 +81,17 @@ class ServiceCodexGatingTest {
         assertTrue(available.containsKey("Normal Model"));
         assertTrue(available.containsKey("Codex Model"));
         assertTrue(available.containsKey("gpt-5.4-oauth"));
+        assertTrue(available.containsKey("gpt-5.2-oauth"));
+        assertTrue(available.containsKey("gpt-5.2-codex-fast-oauth"));
 
-        // 3. Connected with OAuth restriction enabled (default): only -oauth-suffixed models visible
+        // 3. Connected with OAuth restriction enabled (default): only allowed -oauth-suffixed models visible
         MainProject.setRestrictToOauthModelsWhenConnected(true);
         available = service.getAvailableModels();
         assertFalse(available.containsKey("Normal Model"));
         assertFalse(available.containsKey("Codex Model"));
         assertTrue(available.containsKey("gpt-5.4-oauth"));
+        assertTrue(available.containsKey("gpt-5.2-oauth"));
+        assertFalse(available.containsKey("gpt-5.2-codex-fast-oauth"));
     }
 
     /**


### PR DESCRIPTION
## Summary
- exclude `gpt-5.2-codex...` OAuth variants from restricted model lists
- preserve `gpt-5.2-oauth` behavior
- add regression coverage in `ServiceCodexGatingTest`

## Testing
- regression coverage in `ServiceCodexGatingTest`