### PR TITLE
feat: support path syntax in /config ACP command

### DIFF
--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -36,6 +36,9 @@ import com.agentclientprotocol.sdk.spec.AcpSchema;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -77,6 +80,15 @@ public class BrokkAcpAgent {
     private static final int MODEL_DISCOVERY_INITIAL_ATTEMPTS = 3;
     private static final int MODEL_DISCOVERY_RECOVERY_ATTEMPTS = 2;
     private static final long MODEL_DISCOVERY_INITIAL_BACKOFF_MS = 200;
+    private static final Set<String> KNOWN_CONFIG_SECTIONS = Set.of(
+            "buildDetails",
+            "projectSettings",
+            "shellConfig",
+            "issueProvider",
+            "dataRetentionPolicy",
+            "analyzerLanguages",
+            "global");
+
     private static final String ACP_SETTINGS_PATH_PROPERTY = "brokk.acp.settings.path";
     private static final Path DEFAULT_ACP_SETTINGS_PATH =
             Path.of(System.getProperty("user.home"), ".brokk", "acp_settings.json");
@@ -1687,21 +1699,40 @@ public class BrokkAcpAgent {
             return;
         }
 
-        try {
-            var update = OBJECT_MAPPER.readTree(trimmedPayload);
+        if (trimmedPayload.startsWith("{") || trimmedPayload.startsWith("[")) {
+            JsonNode update;
+            try {
+                update = OBJECT_MAPPER.readTree(trimmedPayload);
+            } catch (JsonProcessingException e) {
+                promptContext.sendMessage(
+                        "Error: invalid JSON payload for /config. Example: /config {\"global\":{\"theme\":\"dark\"}}\n\n"
+                                + e.getOriginalMessage());
+                return;
+            }
             if (!update.isObject()) {
                 promptContext.sendMessage(
                         "Error: /config update payload must be a JSON object. Example: /config {\"projectSettings\":{\"commitMessageFormat\":\"feat: {{description}}\"}}");
                 return;
             }
+            applyAndReport(sessionId, bundle, update, promptContext);
+            return;
+        }
 
+        var parts = trimmedPayload.split("\\s+", 2);
+        var path = parts[0];
+        if (parts.length == 1) {
+            handleConfigPathShow(sessionId, bundle, path, promptContext);
+        } else {
+            handleConfigPathSet(sessionId, bundle, path, parts[1].trim(), promptContext);
+        }
+    }
+
+    private void applyAndReport(
+            String sessionId, WorkspaceBundle bundle, JsonNode update, AcpPromptContext promptContext) {
+        try {
             applyConfigUpdate(sessionId, bundle, update);
             promptContext.sendMessage(
                     "Updated configuration successfully.\n\n" + renderConfigSnapshot(sessionId, bundle));
-        } catch (JsonProcessingException e) {
-            promptContext.sendMessage(
-                    "Error: invalid JSON payload for /config. Example: /config {\"global\":{\"theme\":\"dark\"}}\n\n"
-                            + e.getOriginalMessage());
         } catch (IllegalArgumentException e) {
             promptContext.sendMessage("Error updating configuration: " + e.getMessage());
         } catch (Exception e) {
@@ -1710,14 +1741,79 @@ public class BrokkAcpAgent {
         }
     }
 
+    private void handleConfigPathShow(
+            String sessionId, WorkspaceBundle bundle, String path, AcpPromptContext promptContext) {
+        var segments = splitConfigPath(path);
+        if (segments.isEmpty()) {
+            promptContext.sendMessage("Error: invalid configuration path: " + path);
+            return;
+        }
+        Object cursor = buildConfigSnapshot(sessionId, bundle);
+        for (var segment : segments) {
+            if (cursor instanceof Map<?, ?> map && map.containsKey(segment)) {
+                cursor = map.get(segment);
+            } else {
+                promptContext.sendMessage("Error: configuration path not found: " + path);
+                return;
+            }
+        }
+        try {
+            var rendered = OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(cursor);
+            promptContext.sendMessage("Configuration at `%s`:\n```json\n%s\n```".formatted(path, rendered));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to render configuration path " + path, e);
+        }
+    }
+
+    private void handleConfigPathSet(
+            String sessionId, WorkspaceBundle bundle, String path, String rawValue, AcpPromptContext promptContext) {
+        var segments = splitConfigPath(path);
+        if (segments.isEmpty()) {
+            promptContext.sendMessage("Error: invalid configuration path: " + path);
+            return;
+        }
+        if (!KNOWN_CONFIG_SECTIONS.contains(segments.getFirst())) {
+            promptContext.sendMessage("Error: unknown configuration section: " + segments.getFirst()
+                    + ". Known sections: " + String.join(", ", KNOWN_CONFIG_SECTIONS));
+            return;
+        }
+        JsonNode leaf;
+        try {
+            leaf = OBJECT_MAPPER.readTree(rawValue);
+        } catch (JsonProcessingException ignore) {
+            leaf = TextNode.valueOf(rawValue);
+        }
+        var factory = JsonNodeFactory.instance;
+        var root = factory.objectNode();
+        ObjectNode cursor = root;
+        for (int i = 0; i < segments.size() - 1; i++) {
+            var next = factory.objectNode();
+            cursor.set(segments.get(i), next);
+            cursor = next;
+        }
+        cursor.set(segments.getLast(), leaf);
+        applyAndReport(sessionId, bundle, root, promptContext);
+    }
+
+    private static List<String> splitConfigPath(String path) {
+        var segments = List.of(path.split("\\."));
+        if (segments.stream().anyMatch(String::isEmpty)) {
+            return List.of();
+        }
+        return segments;
+    }
+
     private String renderConfigSnapshot(String sessionId, WorkspaceBundle bundle) {
         var snapshot = buildConfigSnapshot(sessionId, bundle);
         try {
             return """
                     Current editable Brokk configuration.
 
-                    Update it by sending:
-                    /config {"projectSettings": {...}, "global": {...}}
+                    Usage:
+                    - `/config <path> <value>` to set a value, e.g. `/config global.theme dark`
+                    - `/config <path> <json>` to set a JSON literal, e.g. `/config buildDetails.exclusionPatterns ["target","build"]`
+                    - `/config <path>` to show just that section/value, e.g. `/config global`
+                    - `/config {"section": {...}}` to apply a batch JSON update
 
                     Editable sections:
                     - buildDetails
@@ -2374,7 +2470,11 @@ public class BrokkAcpAgent {
             try {
                 var commands = List.of(
                         new AcpSchema.AvailableCommand("context", "Show current context snapshot", null),
-                        new AcpSchema.AvailableCommand("config", "Show or update editable Brokk configuration", null));
+                        new AcpSchema.AvailableCommand(
+                                "config",
+                                "Show or update editable Brokk configuration",
+                                new AcpSchema.AvailableCommandInput(
+                                        "[<path> [value] | {section:{...}}] e.g. global.theme dark")));
                 sender.sendSessionUpdate(
                         sessionId, new AcpSchema.AvailableCommandsUpdate("available_commands_update", commands));
             } catch (Exception e) {

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -609,6 +609,105 @@ class BrokkAcpAgentTest {
     }
 
     @Test
+    void promptConfigPathSetUpdatesScalar() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        try (var fixture = new PermissionFixture()) {
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/config global.theme dark"),
+                    fixture.contextFor(created.sessionId()));
+
+            assertEquals("dark", MainProject.getTheme());
+            assertTrue(joinedPromptMessages(fixture.transport).contains("Updated configuration successfully."));
+        }
+    }
+
+    @Test
+    void promptConfigPathSetParsesJsonLiteral() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        try (var fixture = new PermissionFixture()) {
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/config projectSettings.runCommandTimeoutSeconds 30"),
+                    fixture.contextFor(created.sessionId()));
+
+            assertEquals(30L, contextManager.getProject().getRunCommandTimeoutSeconds());
+            assertTrue(joinedPromptMessages(fixture.transport).contains("Updated configuration successfully."));
+        }
+    }
+
+    @Test
+    void promptConfigPathSetUpdatesTopLevelScalar() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        try (var fixture = new PermissionFixture()) {
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/config dataRetentionPolicy MINIMAL"),
+                    fixture.contextFor(created.sessionId()));
+
+            assertEquals(
+                    MainProject.DataRetentionPolicy.MINIMAL,
+                    contextManager.getProject().getDataRetentionPolicy());
+        }
+    }
+
+    @Test
+    void promptConfigPathShowReturnsSingleSection() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        try (var fixture = new PermissionFixture()) {
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/config dataRetentionPolicy"),
+                    fixture.contextFor(created.sessionId()));
+
+            var messages = joinedPromptMessages(fixture.transport);
+            assertTrue(messages.contains("Configuration at `dataRetentionPolicy`:"));
+        }
+    }
+
+    @Test
+    void promptConfigPathShowReportsUnknownPath() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        try (var fixture = new PermissionFixture()) {
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/config global.nonExistentKey"),
+                    fixture.contextFor(created.sessionId()));
+
+            assertTrue(joinedPromptMessages(fixture.transport)
+                    .contains("Error: configuration path not found: global.nonExistentKey"));
+        }
+    }
+
+    @Test
+    void promptConfigPathSetReportsInvalidValue() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        try (var fixture = new PermissionFixture()) {
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/config dataRetentionPolicy INVALID"),
+                    fixture.contextFor(created.sessionId()));
+
+            assertTrue(joinedPromptMessages(fixture.transport)
+                    .contains("Error updating configuration: Invalid dataRetentionPolicy: INVALID"));
+        }
+    }
+
+    @Test
+    void promptConfigPathSetReportsUnknownSection() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        try (var fixture = new PermissionFixture()) {
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/config bogusSection somevalue"),
+                    fixture.contextFor(created.sessionId()));
+
+            assertTrue(joinedPromptMessages(fixture.transport)
+                    .contains("Error: unknown configuration section: bogusSection"));
+        }
+    }
+
+    @Test
     void initializeAdvertisesMcpCapabilities() {
         var response = agent.initialize();
         var mcp = response.agentCapabilities().mcpCapabilities();


### PR DESCRIPTION
## Summary

The `/config` ACP session command (introduced in #3491) currently only accepts an empty payload (snapshot) or a full JSON object (batch update). To set a single value, users had to read the entire snapshot, copy the surrounding object structure, and resend nested JSON in chat — for each change.

This PR adds a dotted-path syntax that is the natural way to set or read a single value, while keeping the existing JSON form for batch edits.

## Behavior

| Input | Effect |
|---|---|
| `/config` | Snapshot + usage help (unchanged) |
| `/config global.theme dark` | Set scalar via path |
| `/config projectSettings.runCommandTimeoutSeconds 30` | JSON literal value (number, bool, array, null) |
| `/config buildDetails.exclusionPatterns ["target","build"]` | Same — array literal |
| `/config global.theme` | Show single value |
| `/config global` | Show single section |
| `/config {"global":{"theme":"light"}}` | Batch JSON (unchanged) |

Detection rule in `handleConfigCommand`:
- Empty payload -> snapshot
- Starts with `{` or `[` -> existing JSON path
- Otherwise -> first whitespace splits into `<path>` and optional `<value>`

For value parsing, the raw value is first run through `OBJECT_MAPPER.readTree` so JSON literals (`true`, `42`, `["a","b"]`) are typed correctly; on parse failure, the value is wrapped as a `TextNode` (so `dark` and `"dark"` both work).

For path-set, the dotted path is materialized into a nested `ObjectNode` and handed to the existing `applyConfigUpdate` — no changes to any of the section-applier methods. A `KNOWN_CONFIG_SECTIONS` guard rejects unknown top-level segments with a clean error.

## Errors

Each new failure mode returns a clear message via `sendMessage` instead of throwing:
- `Error: invalid configuration path: ...` — empty segment in dotted path
- `Error: unknown configuration section: bogusSection. Known sections: ...`
- `Error: configuration path not found: global.nonExistentKey`
- `Error updating configuration: ...` — bubbles up `IllegalArgumentException` from existing appliers (e.g. `Invalid dataRetentionPolicy: INVALID`)

Plus the ACP `AvailableCommand.input` is now populated with a hint (`[<path> [value] | {section:{...}}] e.g. global.theme dark`) so clients can surface usage info; previously it was `null`.

## Tests

7 new tests in `BrokkAcpAgentTest`, mirroring the existing `promptConfig*` style:
- `promptConfigPathSetUpdatesScalar` — `global.theme dark`
- `promptConfigPathSetParsesJsonLiteral` — `runCommandTimeoutSeconds 30` parsed as long
- `promptConfigPathSetUpdatesTopLevelScalar` — `dataRetentionPolicy MINIMAL`
- `promptConfigPathShowReturnsSingleSection` — show-mode renders only the requested subtree
- `promptConfigPathShowReportsUnknownPath` — clean not-found error
- `promptConfigPathSetReportsInvalidValue` — `dataRetentionPolicy INVALID` reuses existing applier validation
- `promptConfigPathSetReportsUnknownSection` — `bogusSection somevalue` rejected

Existing `/config` JSON-form tests are untouched to lock in backward compatibility.

## Verification

- `./gradlew :app:check` — full suite (spotless + ErrorProne + NullAway + 3172 tests)

## Test plan

- [ ] In Zed/IntelliJ ACP, run `/config` and confirm new help text appears
- [ ] Run `/config global.theme dark`, then `/config` again to confirm the change took
- [ ] Run `/config projectSettings.commitMessageFormat "feat: {{description}}"` and verify quoted strings round-trip
- [ ] Run `/config {"global":{"theme":"light"}}` to confirm batch JSON still works (regression)
- [ ] Run `/config global` to see only that section, and `/config global.theme` to see only that scalar
