### PR TITLE
fix(acp): massively increase timeouts; bound fs/terminal ops to 5 min

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
@@ -36,14 +36,26 @@ final class AcpRequestContext implements AcpPromptContext {
     private static final Set<String> NON_CACHEABLE_TOOL_NAMES = Set.of("shell", "unknown");
 
     /**
-     * Per-permission round-trip timeout. The SDK already imposes a 5-minute global request timeout,
-     * but on timeout that propagates as an uncaught exception rather than something the user sees
-     * — observed in real sessions where a click on "Allow once" never reached the agent (IDE-side
-     * or pipe issue) and brokk silently waited 5 minutes before crashing the prompt. With this
-     * tighter timeout, the prompt is denied and the user gets a chat message explaining what
-     * happened, while leaving plenty of think-time for an attentive user to click.
+     * Per-permission round-trip timeout. The SDK's global request timeout (configured in {@link
+     * BrokkAcpRuntime} at {@code PERMISSION_TIMEOUT + 5 min}) propagates as an uncaught exception
+     * on expiry rather than something the user sees — observed in real sessions where a click on
+     * "Allow once" never reached the agent (IDE-side or pipe issue) and brokk silently crashed the
+     * prompt. With this tighter timeout, the prompt is denied and the user gets a chat message
+     * explaining what happened, while leaving generous think-time for an attentive user to click.
+     *
+     * <p>Package-private so {@link AcpServerMain}'s watchdog can quote it symbolically in
+     * diagnostic log messages.
      */
-    private static final Duration PERMISSION_TIMEOUT = Duration.ofMinutes(2);
+    static final Duration PERMISSION_TIMEOUT = Duration.ofMinutes(30);
+
+    /**
+     * Round-trip timeout for non-permission ACP requests (file I/O, terminal ops). Bounds how long
+     * a {@link reactor.core.scheduler.Schedulers#boundedElastic()} thread can be pinned by a stuck
+     * IDE round-trip; without this cap, the SDK's session timeout in {@link BrokkAcpRuntime} is the
+     * only ceiling, which is too generous for ops like {@code fs/read_text_file} that should
+     * normally complete in milliseconds.
+     */
+    private static final Duration IO_TIMEOUT = Duration.ofMinutes(5);
 
     /**
      * Number of agent→client {@code session/request_permission} calls currently awaiting a
@@ -82,6 +94,7 @@ final class AcpRequestContext implements AcpPromptContext {
     public AcpSchema.ReadTextFileResponse readTextFile(AcpSchema.ReadTextFileRequest request) {
         return requireNonNull(session.sendRequest(
                         AcpSchema.METHOD_FS_READ_TEXT_FILE, request, new TypeRef<AcpSchema.ReadTextFileResponse>() {})
+                .timeout(IO_TIMEOUT)
                 .block());
     }
 
@@ -89,6 +102,7 @@ final class AcpRequestContext implements AcpPromptContext {
     public AcpSchema.WriteTextFileResponse writeTextFile(AcpSchema.WriteTextFileRequest request) {
         return requireNonNull(session.sendRequest(
                         AcpSchema.METHOD_FS_WRITE_TEXT_FILE, request, new TypeRef<AcpSchema.WriteTextFileResponse>() {})
+                .timeout(IO_TIMEOUT)
                 .block());
     }
 
@@ -138,6 +152,7 @@ final class AcpRequestContext implements AcpPromptContext {
     public AcpSchema.CreateTerminalResponse createTerminal(AcpSchema.CreateTerminalRequest request) {
         return requireNonNull(session.sendRequest(
                         AcpSchema.METHOD_TERMINAL_CREATE, request, new TypeRef<AcpSchema.CreateTerminalResponse>() {})
+                .timeout(IO_TIMEOUT)
                 .block());
     }
 
@@ -145,6 +160,7 @@ final class AcpRequestContext implements AcpPromptContext {
     public AcpSchema.TerminalOutputResponse getTerminalOutput(AcpSchema.TerminalOutputRequest request) {
         return requireNonNull(session.sendRequest(
                         AcpSchema.METHOD_TERMINAL_OUTPUT, request, new TypeRef<AcpSchema.TerminalOutputResponse>() {})
+                .timeout(IO_TIMEOUT)
                 .block());
     }
 
@@ -152,6 +168,7 @@ final class AcpRequestContext implements AcpPromptContext {
     public AcpSchema.ReleaseTerminalResponse releaseTerminal(AcpSchema.ReleaseTerminalRequest request) {
         return requireNonNull(session.sendRequest(
                         AcpSchema.METHOD_TERMINAL_RELEASE, request, new TypeRef<AcpSchema.ReleaseTerminalResponse>() {})
+                .timeout(IO_TIMEOUT)
                 .block());
     }
 
@@ -161,6 +178,7 @@ final class AcpRequestContext implements AcpPromptContext {
                         AcpSchema.METHOD_TERMINAL_WAIT_FOR_EXIT,
                         request,
                         new TypeRef<AcpSchema.WaitForTerminalExitResponse>() {})
+                .timeout(IO_TIMEOUT)
                 .block());
     }
 
@@ -170,6 +188,7 @@ final class AcpRequestContext implements AcpPromptContext {
                         AcpSchema.METHOD_TERMINAL_KILL,
                         request,
                         new TypeRef<AcpSchema.KillTerminalCommandResponse>() {})
+                .timeout(IO_TIMEOUT)
                 .block());
     }
 

--- a/app/src/main/java/ai/brokk/acp/AcpServerMain.java
+++ b/app/src/main/java/ai/brokk/acp/AcpServerMain.java
@@ -186,13 +186,15 @@ public final class AcpServerMain {
 
     /**
      * If we've been awaiting a {@code session/request_permission} response and stdin has been
-     * silent at least this long, log a warning. {@link AcpRequestContext}'s own
-     * {@link AcpRequestContext#PERMISSION_TIMEOUT 2-minute} per-call timeout will eventually fire
-     * and surface a denial to the user — this watchdog provides earlier diagnostic breadcrumbs in
-     * {@code ~/.brokk/debug.log} so the failure mode (IDE never delivered the verdict) is easy to
-     * spot in incident logs.
+     * silent at least this long, log a warning. {@link AcpRequestContext#PERMISSION_TIMEOUT}'s
+     * per-call timeout will eventually fire and surface a denial to the user — this watchdog
+     * provides earlier diagnostic breadcrumbs in {@code ~/.brokk/debug.log} so the failure mode
+     * (IDE never delivered the verdict) is easy to spot in incident logs. Sized smaller than
+     * {@code PERMISSION_TIMEOUT} so a stuck IDE dialog produces at least one log breadcrumb before
+     * the per-call timeout itself fires, but large enough that legitimate human think-time
+     * doesn't spam the log every {@link #WATCHDOG_PERIOD}.
      */
-    private static final Duration INBOUND_STALL_THRESHOLD = Duration.ofSeconds(30);
+    private static final Duration INBOUND_STALL_THRESHOLD = Duration.ofMinutes(2);
 
     /**
      * Schedules a daemon task that warns when stdin has been quiet for {@link
@@ -220,7 +222,7 @@ public final class AcpServerMain {
                                         + "the verdict; brokk will time out the request after {}.",
                                 quietMillis / 1000,
                                 outstanding,
-                                Duration.ofMinutes(2));
+                                AcpRequestContext.PERMISSION_TIMEOUT);
                     }
                 },
                 WATCHDOG_PERIOD.toSeconds(),

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpRuntime.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpRuntime.java
@@ -37,7 +37,11 @@ final class BrokkAcpRuntime implements AutoCloseable {
     BrokkAcpRuntime(AcpAgentTransport transport, BrokkAcpAgent agent) {
         this.transport = transport;
         this.agent = agent;
-        this.session = new AcpAgentSession(Duration.ofMinutes(5), transport, requestHandlers(), notificationHandlers());
+        // Must exceed AcpRequestContext.PERMISSION_TIMEOUT so the graceful per-permission timeout
+        // fires before this SDK-level global timeout (otherwise the user sees an uncaught crash
+        // instead of the "Permission request timed out" chat message).
+        this.session =
+                new AcpAgentSession(Duration.ofMinutes(35), transport, requestHandlers(), notificationHandlers());
         agent.setSessionUpdateSender(
                 (sessionId, update) -> AcpRequestContext.sendSessionUpdate(session, sessionId, update));
         agent.start();


### PR DESCRIPTION
## Summary

Address user-reported issue: ACP permission timeout (2 min) and session timeout (5 min) were way too short — sessions died when the user was briefly distracted.

- Bump `PERMISSION_TIMEOUT` 2 min → 30 min so users get generous think-time before clicking Allow/Reject.
- Bump `AcpAgentSession` SDK timeout 5 min → 35 min so the per-permission Reactor `.timeout()` always fires before the SDK global request timeout (which would otherwise propagate as an uncaught crash).
- Bump `INBOUND_STALL_THRESHOLD` watchdog 30 s → 2 min so legitimate human think-time doesn't spam `~/.brokk/debug.log`.
- Add `IO_TIMEOUT` (5 min) and wrap the 7 non-permission `.block()` callers (`readTextFile`, `writeTextFile`, `terminal/*`) so a stuck IDE round-trip can't pin a `Schedulers.boundedElastic()` thread for the whole 35 min SDK ceiling. Restores the pre-bump 5 min cap for these ops.
- Replace one hardcoded `Duration.ofMinutes(2)` log literal with `AcpRequestContext.PERMISSION_TIMEOUT` for symbolic consistency; promote the constant to package-private for the new reference.

## Why

The session timeout had to move with `PERMISSION_TIMEOUT` because the SDK timeout sits *over* the per-permission Reactor timeout — it must remain `>` to preserve the graceful-denial chat-message path. Bumping the session timeout to 35 min, however, also extended the ceiling for `fs/*` and `terminal/*` ops, which a code review surfaced as a `boundedElastic` pool-saturation risk under parallel prompts. The `IO_TIMEOUT` wrap restores the pre-bump 5-min cap for those non-permission ops without touching the permission flow.

## Reviewer notes

- No new test added. The existing `BrokkAcpAgentTest.permissionTimeoutSurfacesAsDenialAndUserMessage` overrides the session timeout to 200 ms and is independent of the production constants — still exercises the graceful-denial path.
- The new `IO_TIMEOUT` will throw `TimeoutException` (propagating as `RuntimeException` through `.block()`) if a non-permission op hangs >5 min. That matches the pre-diff SDK-timeout behavior exactly — no regression on the failure path.
- Verified locally with `./gradlew :app:check` (full suite: spotless, errorprone, NullAway, all tests) — passes in ~2 min 14 s.
- Known follow-ups left unaddressed (LOW/MEDIUM, surfaced in review): the `session_timeout = PERMISSION_TIMEOUT + 5 min` invariant is still enforced only by code comment (could be derived in code); no metric exposes `OUTSTANDING_PERMISSION_REQUESTS` outside the watchdog log.

## Test plan

- [ ] CI runs `./gradlew :app:check` clean.
- [ ] Manual smoke (Zed or IntelliJ): trigger a tool requiring permission, walk away ~3 min, return and click Allow — prompt should complete (would have failed under the old 2-min limit).
- [ ] Optional: simulate a stuck `terminal/wait_for_exit` via an IDE that doesn't deliver the response — should fail at 5 min via `IO_TIMEOUT`, not 35 min via the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
