### PR TITLE
feat: add /sandbox ACP session command to toggle kernel sandbox

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
@@ -242,10 +242,11 @@ final class AcpRequestContext implements AcpPromptContext {
                     .isPresent();
             switch (PermissionGate.decide(mode, kind, toolName, alwaysAllowed)) {
                 case ALLOW -> {
-                    return sticky.filter(v -> v == BrokkAcpAgent.PermissionVerdict.ALLOW_NO_SANDBOX)
+                    var base = sticky.filter(v -> v == BrokkAcpAgent.PermissionVerdict.ALLOW_NO_SANDBOX)
                                     .isPresent()
                             ? PermissionDecision.ALLOW_NO_SANDBOX
                             : PermissionDecision.ALLOW;
+                    return applySandboxOverride(base, toolName);
                 }
                 case REJECT -> {
                     sendMessage("\n**" + toolName + " denied:** " + PermissionGate.READ_ONLY_REJECTION + "\n");
@@ -261,7 +262,7 @@ final class AcpRequestContext implements AcpPromptContext {
 
         if (sticky.isPresent()) {
             return switch (sticky.get()) {
-                case ALLOW -> PermissionDecision.ALLOW;
+                case ALLOW -> applySandboxOverride(PermissionDecision.ALLOW, toolName);
                 case ALLOW_NO_SANDBOX -> PermissionDecision.ALLOW_NO_SANDBOX;
                 case DENY -> PermissionDecision.DENY;
             };
@@ -294,10 +295,25 @@ final class AcpRequestContext implements AcpPromptContext {
             }
         }
         return switch (optionId) {
-            case "allow_once", "allow_always" -> PermissionDecision.ALLOW;
+            case "allow_once", "allow_always" -> applySandboxOverride(PermissionDecision.ALLOW, toolName);
             case "allow_no_sandbox_once", "allow_no_sandbox_always" -> PermissionDecision.ALLOW_NO_SANDBOX;
             default -> PermissionDecision.DENY;
         };
+    }
+
+    /**
+     * Upgrades an {@link PermissionDecision#ALLOW} to {@link PermissionDecision#ALLOW_NO_SANDBOX}
+     * when the session has opted out of the kernel sandbox via {@code /sandbox off}. Logs the
+     * upgrade so audit trails can correlate sandbox-off transitions with the actual tool calls
+     * that ran without filesystem isolation. Idempotent for {@code DENY} and already-no-sandbox
+     * decisions.
+     */
+    private PermissionDecision applySandboxOverride(PermissionDecision base, String toolName) {
+        if (base == PermissionDecision.ALLOW && agent != null && agent.isSandboxDisabledFor(sessionId)) {
+            logger.warn("ACP tool allowed without sandbox via /sandbox off (session={}, tool={})", sessionId, toolName);
+            return PermissionDecision.ALLOW_NO_SANDBOX;
+        }
+        return base;
     }
 
     /**

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -29,6 +29,7 @@ import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
 import ai.brokk.project.ModelProperties;
 import ai.brokk.tasks.TaskList;
+import ai.brokk.util.Environment;
 import ai.brokk.util.GlobalUiSettings;
 import ai.brokk.util.Messages;
 import ai.brokk.util.ShellConfig;
@@ -125,6 +126,7 @@ public class BrokkAcpAgent {
     private final Map<String, String> activeJobBySession = new ConcurrentHashMap<>();
     private final Map<String, Map<String, PermissionVerdict>> stickyPermissionsBySession = new ConcurrentHashMap<>();
     private final Map<String, PermissionMode> permissionModeBySession = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> sandboxDisabledBySession = new ConcurrentHashMap<>();
     private final Map<String, List<McpServer>> mcpServersBySession = new ConcurrentHashMap<>();
     private static final InheritableThreadLocal<List<McpServer>> SESSION_MCP_SCOPE = new InheritableThreadLocal<>();
     private final Map<String, TaskList.TaskListData> lastTaskListBySession = new ConcurrentHashMap<>();
@@ -289,6 +291,7 @@ public class BrokkAcpAgent {
         activeJobBySession.clear();
         stickyPermissionsBySession.clear();
         permissionModeBySession.clear();
+        sandboxDisabledBySession.clear();
         mcpServersBySession.clear();
         rejectedMcpServersBySession.clear();
         lastTaskListBySession.clear();
@@ -530,6 +533,7 @@ public class BrokkAcpAgent {
         stickyPermissionsBySession.remove(sessionId);
         sessionsOnFallbackCatalog.remove(sessionId);
         permissionModeBySession.remove(sessionId);
+        sandboxDisabledBySession.remove(sessionId);
         mcpServersBySession.remove(sessionId);
         rejectedMcpServersBySession.remove(sessionId);
         lastTaskListBySession.remove(sessionId);
@@ -565,6 +569,10 @@ public class BrokkAcpAgent {
                     forkSessionId, reasoningBySession.getOrDefault(request.sessionId(), defaultReasoningLevel));
             permissionModeBySession.put(
                     forkSessionId, permissionModeBySession.getOrDefault(request.sessionId(), PermissionMode.DEFAULT));
+            // sandboxDisabledBySession is intentionally NOT inherited: a fork resets to
+            // sandbox-enabled. Treating fork as a fresh session for the kernel-sandbox toggle is
+            // the safer default; users who want the parent's looser posture can re-issue
+            // `/sandbox off` in the fork.
             // Inherit MCP servers from parent unless the fork request supplies a fresh list.
             if (request.mcpServers() != null) {
                 applySessionMcpServers(forkSessionId, request.mcpServers());
@@ -727,6 +735,27 @@ public class BrokkAcpAgent {
     /** Returns the active permission mode for {@code sessionId}, defaulting to {@code DEFAULT}. */
     public PermissionMode permissionModeFor(String sessionId) {
         return permissionModeBySession.getOrDefault(sessionId, PermissionMode.DEFAULT);
+    }
+
+    /**
+     * Returns whether the kernel sandbox has been disabled for {@code sessionId} via the
+     * {@code /sandbox off} slash command. Defaults to {@code false} (sandbox enabled). Affects
+     * shell commands only; other tools do not consult {@link ai.brokk.util.SandboxPolicy}.
+     */
+    public boolean isSandboxDisabledFor(String sessionId) {
+        return sandboxDisabledBySession.getOrDefault(sessionId, false);
+    }
+
+    /**
+     * Sets the per-session sandbox-disabled flag. Used by the {@code /sandbox} slash command;
+     * not exposed via {@code session/set_config_option} on purpose (slash-only by design).
+     */
+    void setSandboxDisabledFor(String sessionId, boolean disabled) {
+        if (disabled) {
+            sandboxDisabledBySession.put(sessionId, true);
+        } else {
+            sandboxDisabledBySession.remove(sessionId);
+        }
     }
 
     /**
@@ -1627,6 +1656,10 @@ public class BrokkAcpAgent {
                 handleConfigCommand(sessionId, parts.length > 1 ? parts[1] : "", bundle, promptContext);
                 yield true;
             }
+            case "/sandbox" -> {
+                handleSandboxCommand(sessionId, parts.length > 1 ? parts[1] : "", promptContext);
+                yield true;
+            }
             default -> false;
         };
     }
@@ -1707,6 +1740,53 @@ public class BrokkAcpAgent {
         } catch (Exception e) {
             logger.error("Failed to handle /config for bundle {}", bundle.root(), e);
             promptContext.sendMessage("Error updating configuration: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Handles {@code /sandbox} with optional {@code on|off} arg. The toggle is per-session and
+     * in-memory only: a fresh session always starts with the sandbox enabled, and {@link
+     * #closeSession} / {@link #clearAllSessions} drop the flag with the rest of the per-session
+     * state. Disabling it makes shell commands run with {@link ai.brokk.util.SandboxPolicy#NONE}
+     * instead of {@link ai.brokk.util.SandboxPolicy#WORKSPACE_WRITE}, by upgrading the {@code
+     * ALLOW} verdicts produced in {@link AcpRequestContext#askPermissionDetailed} to {@code
+     * ALLOW_NO_SANDBOX}.
+     *
+     * <p>Asymmetry note: {@code /sandbox on} re-enables the sandbox for <em>future</em> approvals,
+     * but does not retroactively dégrade tools the user previously approved with "Always allow
+     * without sandbox" in this session — those sticky verdicts are honored as the user's explicit
+     * earlier choice. To force them re-prompt, start a new session.
+     */
+    private void handleSandboxCommand(String sessionId, String arg, AcpPromptContext promptContext) {
+        var trimmed = arg.trim().toLowerCase(Locale.ROOT);
+        var platformNote = Environment.isSandboxAvailable()
+                ? ""
+                : "\n\n_Note: kernel sandbox is not available on this platform (Windows, or Linux without Bubblewrap installed); this toggle has no effect on shell command isolation._";
+        switch (trimmed) {
+            case "" -> {
+                var state = isSandboxDisabledFor(sessionId) ? "**disabled**" : "**enabled**";
+                promptContext.sendMessage("Sandbox is currently " + state
+                        + " for this session. Affects shell commands only.\n\nUsage: `/sandbox on|off`"
+                        + platformNote);
+            }
+            case "on" -> {
+                setSandboxDisabledFor(sessionId, false);
+                logger.info("ACP /sandbox on session={}", sessionId);
+                promptContext.sendMessage(
+                        "Sandbox **enabled** for this session. Shell commands will run with filesystem isolation."
+                                + "\n\n_Note: tools you previously approved with \"Always allow without sandbox\" in this session keep that approval. Start a new session to force re-prompting._"
+                                + platformNote);
+            }
+            case "off" -> {
+                setSandboxDisabledFor(sessionId, true);
+                logger.info("ACP /sandbox off session={}", sessionId);
+                promptContext.sendMessage(
+                        "Sandbox **disabled** for this session. Shell commands will run without filesystem isolation until you re-enable with `/sandbox on` or start a new session."
+                                + platformNote);
+            }
+            default ->
+                promptContext.sendMessage("Error: unknown /sandbox argument '" + arg.trim()
+                        + "'. Usage: `/sandbox on|off` (or `/sandbox` to show status).");
         }
     }
 
@@ -2374,7 +2454,9 @@ public class BrokkAcpAgent {
             try {
                 var commands = List.of(
                         new AcpSchema.AvailableCommand("context", "Show current context snapshot", null),
-                        new AcpSchema.AvailableCommand("config", "Show or update editable Brokk configuration", null));
+                        new AcpSchema.AvailableCommand("config", "Show or update editable Brokk configuration", null),
+                        new AcpSchema.AvailableCommand(
+                                "sandbox", "Show or toggle the kernel sandbox for shell commands (on|off)", null));
                 sender.sendSessionUpdate(
                         sessionId, new AcpSchema.AvailableCommandsUpdate("available_commands_update", commands));
             } catch (Exception e) {

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -669,6 +669,35 @@ class BrokkAcpAgentTest {
     }
 
     @Test
+    void sandboxDisabledDefaultsToFalse() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        assertFalse(agent.isSandboxDisabledFor(created.sessionId()));
+    }
+
+    @Test
+    void setSandboxDisabledForFlipsTheFlag() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        agent.setSandboxDisabledFor(created.sessionId(), true);
+        assertTrue(agent.isSandboxDisabledFor(created.sessionId()));
+
+        agent.setSandboxDisabledFor(created.sessionId(), false);
+        assertFalse(agent.isSandboxDisabledFor(created.sessionId()));
+    }
+
+    @Test
+    void closeSessionClearsSandboxDisabled() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        agent.setSandboxDisabledFor(created.sessionId(), true);
+        assertTrue(agent.isSandboxDisabledFor(created.sessionId()));
+
+        agent.closeSession(new AcpProtocol.CloseSessionRequest(created.sessionId(), null));
+
+        assertFalse(agent.isSandboxDisabledFor(created.sessionId()));
+    }
+
+    @Test
     void extractResourceRelPathsHandlesFileUriResourceLink() {
         var fileUnderRoot = projectRoot.resolve("src/main/java/Foo.java");
         var blocks = List.<AcpSchema.ContentBlock>of(


### PR DESCRIPTION
## Summary

Adds `/sandbox on|off|status` as an ACP slash command that lets users opt out of the kernel sandbox (Apple Seatbelt / Bubblewrap) for the rest of an ACP session, instead of clicking "Allow Without Sandbox" on every shell-tool approval.

When the toggle is off, `AcpRequestContext.askPermissionDetailed` upgrades `PermissionDecision.ALLOW` verdicts to `ALLOW_NO_SANDBOX`. Downstream, `AcpConsoleIO` translates that to `ApprovalResult.APPROVED_NO_SANDBOX`, `ToolExecutionHelper` sets the thread-local `SANDBOX_OVERRIDE`, and `ShellTools.runShellCommand` picks `SandboxPolicy.NONE` instead of `WORKSPACE_WRITE`. The existing `permission_mode = bypassPermissions` does **not** disable the sandbox; this toggle is genuinely orthogonal.

State is per-ACP-session and in-memory:
- Lives in `BrokkAcpAgent.sandboxDisabledBySession` (mirror of `permissionModeBySession`).
- Cleared in `closeSession` and `clearAllSessions` alongside the other per-session maps.
- Intentionally **not** inherited on `forkSession` — a fork resets to sandbox-enabled, which is the safer default.

Each `ALLOW → ALLOW_NO_SANDBOX` upgrade is logged at `warn` so audit trails can correlate `/sandbox off` transitions with the actual tool calls that ran without filesystem isolation.

A platform note is appended to the `/sandbox` reply when `Environment.isSandboxAvailable()` is `false` (Windows, or Linux without Bubblewrap installed) so users on those platforms aren't misled into thinking the toggle changed something.

## Files changed

- `app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java` — new map, accessor, slash dispatch, `handleSandboxCommand`, advertise entry, lifecycle cleanup, fork comment.
- `app/src/main/java/ai/brokk/acp/AcpRequestContext.java` — `applySandboxOverride(PermissionDecision, String)` helper invoked at the three `ALLOW` return points in `askPermissionDetailed`, with audit log.
- `app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java` — three tests: default, set/is round-trip, cleanup-on-close.

## Review process

This PR went through a guided multi-agent review (security, dry, senior-dev, devops, architect). Six findings were applied in this commit:

- **HIGH**: cleanup of `sandboxDisabledBySession` in `closeSession`/`clearAllSessions` (was missing from initial implementation).
- **MEDIUM**: audit logging on each `applySandboxOverride` upgrade.
- **MEDIUM**: documented the asymmetry — `/sandbox on` does not retroactively dégrade tools the user already approved with "Always allow without sandbox" in this session.
- **MEDIUM**: cross-platform-aware status message via `Environment.isSandboxAvailable()`.
- **LOW**: explicit comment in `forkSession` documenting the no-inherit choice.
- **LOW**: unit tests covering toggle and post-close cleanup.

Follow-up: [#3493](https://github.com/BrokkAi/brokk/issues/3493) tracks extracting a shared slash-command registry once a 4th command lands.

## Test plan

- [x] `./gradlew :app:check` passes locally (spotless + ErrorProne + NullAway + tests, including the three new ones).
- [ ] Smoke test from a real ACP client (Zed or IntelliJ AI Assistant):
  - [ ] `/sandbox` reports "enabled" on a fresh session.
  - [ ] `/sandbox off` flips to "disabled" and shows the asymmetry note about sticky `allow_no_sandbox_always`.
  - [ ] After `/sandbox off`, asking the agent to run a shell command that would write outside the project root succeeds (sandbox is genuinely off).
  - [ ] `/sandbox on` flips back to "enabled" and the same shell command now fails as expected (sandbox is back on).
  - [ ] Closing and reopening the session resets to "enabled" (no leak across `closeSession`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
