### PR TITLE
ACP: auto-approve known-safe shell commands without prompting

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
+++ b/app/src/main/java/ai/brokk/acp/AcpConsoleIO.java
@@ -290,7 +290,11 @@ public class AcpConsoleIO extends MemoryConsole {
                 var cacheKey = arg.isEmpty() ? toolName : toolName + ":" + arg;
                 var prompt =
                         arg.isEmpty() ? "Allow shell tool: " + toolName + "?" : "Allow " + toolName + ": " + arg + "?";
-                var decision = context.askPermissionDetailed(prompt, toolName, cacheKey, true);
+                // Pass the raw command for runShellCommand so SafeCommand can auto-approve known
+                // safe read-only commands. For other shell-like tools (e.g. callShellAgent) the
+                // "command" is a high-level task description, so safety can't be checked statically.
+                var rawCommand = "runShellCommand".equals(toolName) && !arg.isEmpty() ? arg : null;
+                var decision = context.askPermissionDetailed(prompt, toolName, cacheKey, true, rawCommand);
                 result = switch (decision) {
                     case ALLOW -> ApprovalResult.APPROVED;
                     case ALLOW_NO_SANDBOX -> ApprovalResult.APPROVED_NO_SANDBOX;

--- a/app/src/main/java/ai/brokk/acp/AcpPromptContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpPromptContext.java
@@ -1,6 +1,7 @@
 package ai.brokk.acp;
 
 import com.agentclientprotocol.sdk.agent.SyncPromptContext;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Brokk-internal extension of {@link SyncPromptContext} that adds tool-aware permission prompts so
@@ -46,9 +47,12 @@ interface AcpPromptContext extends SyncPromptContext {
      * @param cacheKey key used for the session sticky cache; for shell tools this should encode the
      *     specific command/task so a session-level approval doesn't blanket-allow other invocations
      * @param offerSandboxBypass whether to offer the {@code allow_no_sandbox*} options
+     * @param rawCommand for shell-execution tools, the raw command string the model wants to run.
+     *     Enables {@link SafeCommand}'s known-safe auto-approval for read-only commands like
+     *     {@code ls}, {@code cat}, or {@code git status}. {@code null} for non-shell tools.
      */
     PermissionDecision askPermissionDetailed(
-            String action, String toolName, String cacheKey, boolean offerSandboxBypass);
+            String action, String toolName, String cacheKey, boolean offerSandboxBypass, @Nullable String rawCommand);
 
     @Override
     default boolean askPermission(String action) {

--- a/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
@@ -220,12 +220,12 @@ final class AcpRequestContext implements AcpPromptContext {
 
     @Override
     public boolean askPermission(String action, String toolName) {
-        return askPermissionDetailed(action, toolName, toolName, false).isApproved();
+        return askPermissionDetailed(action, toolName, toolName, false, null).isApproved();
     }
 
     @Override
     public PermissionDecision askPermissionDetailed(
-            String action, String toolName, String cacheKey, boolean offerSandboxBypass) {
+            String action, String toolName, String cacheKey, boolean offerSandboxBypass, @Nullable String rawCommand) {
         boolean cacheable = !NON_CACHEABLE_TOOL_NAMES.contains(toolName);
         var cache = cacheable ? agent : null;
 
@@ -240,7 +240,7 @@ final class AcpRequestContext implements AcpPromptContext {
             var kind = PermissionGate.classify(toolName);
             boolean alwaysAllowed = sticky.filter(v -> v != BrokkAcpAgent.PermissionVerdict.DENY)
                     .isPresent();
-            switch (PermissionGate.decide(mode, kind, toolName, alwaysAllowed)) {
+            switch (PermissionGate.decide(mode, kind, toolName, alwaysAllowed, rawCommand)) {
                 case ALLOW -> {
                     return sticky.filter(v -> v == BrokkAcpAgent.PermissionVerdict.ALLOW_NO_SANDBOX)
                                     .isPresent()

--- a/app/src/main/java/ai/brokk/acp/PermissionGate.java
+++ b/app/src/main/java/ai/brokk/acp/PermissionGate.java
@@ -1,6 +1,7 @@
 package ai.brokk.acp;
 
 import com.agentclientprotocol.sdk.spec.AcpSchema;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Pure permission-gate logic. Given a session's {@link PermissionMode} and the kind/name of the
@@ -36,13 +37,26 @@ final class PermissionGate {
         return "shell".equals(toolName);
     }
 
+    /** Tools that pass a raw shell command string we can safety-check via {@link SafeCommand}. */
+    private static boolean isShellExecutionTool(String toolName) {
+        return "runShellCommand".equals(toolName) || "shell".equals(toolName);
+    }
+
     /**
      * Returns the gate's outcome for the given mode/kind/tool/cache-state combination.
      *
      * @param isAlwaysAllowed {@code true} iff the user has previously chosen "Always allow" for
      *     this tool in this session (i.e. the sticky cache holds an ALLOW verdict).
+     * @param rawCommand for shell-execution tools, the raw command string the model wants to run;
+     *     used to short-circuit the prompt for known-safe read-only commands. {@code null} for
+     *     non-shell tools or when the command is not available at gate time.
      */
-    static Outcome decide(PermissionMode mode, AcpSchema.ToolKind kind, String toolName, boolean isAlwaysAllowed) {
+    static Outcome decide(
+            PermissionMode mode,
+            AcpSchema.ToolKind kind,
+            String toolName,
+            boolean isAlwaysAllowed,
+            @Nullable String rawCommand) {
         // BYPASS_PERMISSIONS: trust everything. Explicit user opt-out of the gate.
         if (mode == PermissionMode.BYPASS_PERMISSIONS) {
             return Outcome.ALLOW;
@@ -62,6 +76,13 @@ final class PermissionGate {
 
         // ACCEPT_EDITS auto-allows EDIT but still gates EXECUTE/OTHER.
         if (mode == PermissionMode.ACCEPT_EDITS && kind == AcpSchema.ToolKind.EDIT) {
+            return Outcome.ALLOW;
+        }
+
+        // Safe-command auto-allow: read-only shell commands (ls, cat, git status, ...) skip the
+        // prompt entirely. Mirrors Codex's is_safe_command.rs. Placed after the READ_ONLY reject so
+        // strict mode still blocks every shell call.
+        if (rawCommand != null && isShellExecutionTool(toolName) && SafeCommand.isKnownSafe(rawCommand)) {
             return Outcome.ALLOW;
         }
 

--- a/app/src/main/java/ai/brokk/acp/SafeCommand.java
+++ b/app/src/main/java/ai/brokk/acp/SafeCommand.java
@@ -1,0 +1,428 @@
+package ai.brokk.acp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Pure check for "is this shell command safe enough to auto-approve without a user prompt?".
+ * Mirrors {@code codex-rs/shell-command/src/command_safety/is_safe_command.rs} (OpenAI Codex CLI),
+ * adapted to Brokk's API where the shell command is a single raw string passed to {@code /bin/sh -c}.
+ *
+ * <p>The contract is intentionally conservative: any input that cannot be unambiguously decomposed
+ * into a list of known-safe subcommands returns {@code false}. Anything containing shell
+ * metacharacters we do not explicitly handle (parentheses, braces, redirection, command
+ * substitution, environment-variable expansion, escapes) is rejected.
+ */
+public final class SafeCommand {
+
+    private SafeCommand() {}
+
+    private static final int MAX_BASH_LC_RECURSION_DEPTH = 1;
+
+    private static final Set<String> SIMPLE_SAFE_NAMES = Set.of(
+            "cat", "cd", "cut", "echo", "expr", "false", "grep", "head", "id", "ls", "nl", "paste", "pwd", "rev", "seq",
+            "stat", "tail", "tr", "true", "uname", "uniq", "wc", "which", "whoami");
+
+    private static final Set<String> SHELL_INTERPRETERS = Set.of("bash", "sh", "zsh");
+
+    private static final Set<String> SHELL_LC_FLAGS = Set.of("-lc", "-c");
+
+    private static final Set<String> UNSAFE_FIND_OPTIONS =
+            Set.of("-exec", "-execdir", "-ok", "-okdir", "-delete", "-fls", "-fprint", "-fprint0", "-fprintf");
+
+    private static final Set<String> UNSAFE_RG_OPTIONS_WITH_ARGS = Set.of("--pre", "--hostname-bin");
+
+    private static final Set<String> UNSAFE_RG_OPTIONS_WITHOUT_ARGS = Set.of("--search-zip", "-z");
+
+    private static final Set<String> SAFE_GIT_SUBCOMMANDS = Set.of("status", "log", "diff", "show", "branch");
+
+    private static final Set<String> UNSAFE_GIT_SUBCOMMAND_FLAGS_EXACT =
+            Set.of("--output", "--ext-diff", "--textconv", "--exec", "--paginate");
+
+    private static final Set<String> UNSAFE_GIT_GLOBAL_FLAGS_EXACT =
+            Set.of("-c", "--config-env", "--git-dir", "--work-tree", "--exec-path", "--namespace", "--super-prefix");
+
+    private static final Set<String> UNSAFE_GIT_GLOBAL_FLAG_PREFIXES = Set.of(
+            "-c", "--config-env=", "--git-dir=", "--work-tree=", "--exec-path=", "--namespace=", "--super-prefix=");
+
+    private static final Set<String> SAFE_GIT_BRANCH_FLAGS =
+            Set.of("--list", "-l", "--show-current", "-a", "--all", "-r", "--remotes", "-v", "-vv", "--verbose");
+
+    /** Returns {@code true} if the raw shell command is known-safe and may be auto-approved. */
+    public static boolean isKnownSafe(String rawCommand) {
+        if (rawCommand.isEmpty()) {
+            return false;
+        }
+        return isKnownSafeScript(rawCommand, 0);
+    }
+
+    private static boolean isKnownSafeScript(String script, int depth) {
+        var segments = splitOnTopLevelOperators(script);
+        if (segments.isEmpty()) {
+            return false;
+        }
+        int nonEmpty = 0;
+        for (var raw : segments.get()) {
+            var trimmed = raw.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            nonEmpty++;
+            var argv = tokenize(trimmed);
+            if (argv.isEmpty() || argv.get().isEmpty()) {
+                return false;
+            }
+            if (!isKnownSafeArgv(argv.get(), depth)) {
+                return false;
+            }
+        }
+        return nonEmpty > 0;
+    }
+
+    private static boolean isKnownSafeArgv(List<String> argv, int depth) {
+        if (argv.size() == 3
+                && SHELL_INTERPRETERS.contains(argv.get(0))
+                && SHELL_LC_FLAGS.contains(argv.get(1))
+                && depth < MAX_BASH_LC_RECURSION_DEPTH) {
+            return isKnownSafeScript(argv.get(2), depth + 1);
+        }
+        return isSafeToCallWithExec(argv);
+    }
+
+    private static boolean isSafeToCallWithExec(List<String> argv) {
+        var name = executableLookupKey(argv.get(0));
+        if (SIMPLE_SAFE_NAMES.contains(name)) {
+            return true;
+        }
+        return switch (name) {
+            case "base64" -> isSafeBase64(argv);
+            case "find" -> isSafeFind(argv);
+            case "rg" -> isSafeRipgrep(argv);
+            case "git" -> isSafeGit(argv);
+            case "sed" -> isSafeSed(argv);
+            default -> false;
+        };
+    }
+
+    private static String executableLookupKey(String executable) {
+        int slash = Math.max(executable.lastIndexOf('/'), executable.lastIndexOf('\\'));
+        return slash >= 0 ? executable.substring(slash + 1) : executable;
+    }
+
+    private static boolean isSafeBase64(List<String> argv) {
+        for (int i = 1; i < argv.size(); i++) {
+            var arg = argv.get(i);
+            if (arg.equals("-o")
+                    || arg.equals("--output")
+                    || arg.startsWith("--output=")
+                    || (arg.startsWith("-o") && !arg.equals("-o"))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isSafeFind(List<String> argv) {
+        return argv.stream().skip(1).noneMatch(UNSAFE_FIND_OPTIONS::contains);
+    }
+
+    private static boolean isSafeRipgrep(List<String> argv) {
+        for (int i = 1; i < argv.size(); i++) {
+            var arg = argv.get(i);
+            if (UNSAFE_RG_OPTIONS_WITHOUT_ARGS.contains(arg)) {
+                return false;
+            }
+            for (var opt : UNSAFE_RG_OPTIONS_WITH_ARGS) {
+                if (arg.equals(opt) || arg.startsWith(opt + "=")) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean isSafeGit(List<String> argv) {
+        if (gitHasUnsafeGlobalOption(argv)) {
+            return false;
+        }
+        int subIdx = findGitSubcommandIndex(argv);
+        if (subIdx < 0 || subIdx >= argv.size()) {
+            return false;
+        }
+        var subcommand = argv.get(subIdx);
+        if (!SAFE_GIT_SUBCOMMANDS.contains(subcommand)) {
+            return false;
+        }
+        var subArgs = argv.subList(subIdx + 1, argv.size());
+        if (!gitSubcommandArgsAreReadOnly(subArgs)) {
+            return false;
+        }
+        if (subcommand.equals("branch") && !gitBranchIsReadOnly(subArgs)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean gitHasUnsafeGlobalOption(List<String> argv) {
+        for (int i = 1; i < argv.size(); i++) {
+            if (gitGlobalOptionRequiresPrompt(argv.get(i))) {
+                return true;
+            }
+            if (!argv.get(i).startsWith("-")) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static boolean gitGlobalOptionRequiresPrompt(String arg) {
+        if (UNSAFE_GIT_GLOBAL_FLAGS_EXACT.contains(arg)) {
+            return true;
+        }
+        for (var prefix : UNSAFE_GIT_GLOBAL_FLAG_PREFIXES) {
+            if (arg.startsWith(prefix)
+                    && !arg.equals(prefix.endsWith("=") ? prefix.substring(0, prefix.length() - 1) : prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int findGitSubcommandIndex(List<String> argv) {
+        int i = 1;
+        while (i < argv.size()) {
+            var arg = argv.get(i);
+            if (!arg.startsWith("-")) {
+                return i;
+            }
+            // Known safe global option: -C <path>
+            if (arg.equals("-C") || arg.equals("--no-pager")) {
+                if (arg.equals("-C")) {
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+            return -1;
+        }
+        return -1;
+    }
+
+    private static boolean gitSubcommandArgsAreReadOnly(List<String> args) {
+        for (var arg : args) {
+            if (UNSAFE_GIT_SUBCOMMAND_FLAGS_EXACT.contains(arg)
+                    || arg.startsWith("--output=")
+                    || arg.startsWith("--exec=")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean gitBranchIsReadOnly(List<String> branchArgs) {
+        if (branchArgs.isEmpty()) {
+            return true;
+        }
+        boolean sawReadOnlyFlag = false;
+        for (var arg : branchArgs) {
+            if (SAFE_GIT_BRANCH_FLAGS.contains(arg) || arg.startsWith("--format=")) {
+                sawReadOnlyFlag = true;
+            } else {
+                return false;
+            }
+        }
+        return sawReadOnlyFlag;
+    }
+
+    private static boolean isSafeSed(List<String> argv) {
+        if (argv.size() > 4 || argv.size() < 3) {
+            return false;
+        }
+        if (!"-n".equals(argv.get(1))) {
+            return false;
+        }
+        return isValidSedNArg(argv.get(2));
+    }
+
+    private static boolean isValidSedNArg(String arg) {
+        if (!arg.endsWith("p")) {
+            return false;
+        }
+        var core = arg.substring(0, arg.length() - 1);
+        var parts = core.split(",", -1);
+        if (parts.length < 1 || parts.length > 2) {
+            return false;
+        }
+        for (var part : parts) {
+            if (part.isEmpty()) {
+                return false;
+            }
+            for (int i = 0; i < part.length(); i++) {
+                if (!Character.isDigit(part.charAt(i))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Splits a shell command on top-level boolean and pipe operators ({@code &&}, {@code ||},
+     * {@code ;}, {@code |}) while preserving single- and double-quoted regions verbatim. Returns
+     * {@link Optional#empty()} if the command contains shell constructs not in our allow-list
+     * (subshells, redirection, command substitution, escapes, background {@code &}).
+     */
+    private static Optional<List<String>> splitOnTopLevelOperators(String command) {
+        var result = new ArrayList<String>();
+        int len = command.length();
+        int start = 0;
+        int i = 0;
+        while (i < len) {
+            char c = command.charAt(i);
+            if (c == '\'') {
+                int close = command.indexOf('\'', i + 1);
+                if (close < 0) {
+                    return Optional.empty();
+                }
+                i = close + 1;
+                continue;
+            }
+            if (c == '"') {
+                int j = i + 1;
+                while (j < len && command.charAt(j) != '"') {
+                    char cc = command.charAt(j);
+                    if (cc == '\\' || cc == '$' || cc == '`') {
+                        return Optional.empty();
+                    }
+                    j++;
+                }
+                if (j >= len) {
+                    return Optional.empty();
+                }
+                i = j + 1;
+                continue;
+            }
+            if (c == '$' || c == '`' || c == '(' || c == ')' || c == '{' || c == '}' || c == '<' || c == '>'
+                    || c == '\n' || c == '\r' || c == '\\') {
+                return Optional.empty();
+            }
+            if (c == '&') {
+                if (i + 1 < len && command.charAt(i + 1) == '&') {
+                    result.add(command.substring(start, i));
+                    i += 2;
+                    start = i;
+                    continue;
+                }
+                return Optional.empty();
+            }
+            if (c == '|') {
+                if (i + 1 < len && command.charAt(i + 1) == '|') {
+                    result.add(command.substring(start, i));
+                    i += 2;
+                } else {
+                    result.add(command.substring(start, i));
+                    i += 1;
+                }
+                start = i;
+                continue;
+            }
+            if (c == ';') {
+                result.add(command.substring(start, i));
+                i += 1;
+                start = i;
+                continue;
+            }
+            i++;
+        }
+        result.add(command.substring(start));
+        return Optional.of(result);
+    }
+
+    /**
+     * Tokenizes a single command segment (no top-level operators) into argv. Each token is either
+     * a bareword, a single-quoted literal, or a double-quoted literal. Mixed-quoting tokens
+     * (e.g. {@code abc'def'ghi}) are rejected. Any escape, expansion, or redirection metacharacter
+     * yields {@link Optional#empty()}.
+     */
+    private static Optional<List<String>> tokenize(String segment) {
+        var result = new ArrayList<String>();
+        int len = segment.length();
+        int i = 0;
+        while (i < len) {
+            char c = segment.charAt(i);
+            if (c == ' ' || c == '\t') {
+                i++;
+                continue;
+            }
+            if (c == '\n' || c == '\r') {
+                return Optional.empty();
+            }
+            if (c == '\'') {
+                int close = segment.indexOf('\'', i + 1);
+                if (close < 0) {
+                    return Optional.empty();
+                }
+                if (close + 1 < len && !isTokenBoundary(segment.charAt(close + 1))) {
+                    return Optional.empty();
+                }
+                result.add(segment.substring(i + 1, close));
+                i = close + 1;
+                continue;
+            }
+            if (c == '"') {
+                int j = i + 1;
+                while (j < len && segment.charAt(j) != '"') {
+                    char cc = segment.charAt(j);
+                    if (cc == '\\' || cc == '$' || cc == '`') {
+                        return Optional.empty();
+                    }
+                    j++;
+                }
+                if (j >= len) {
+                    return Optional.empty();
+                }
+                if (j + 1 < len && !isTokenBoundary(segment.charAt(j + 1))) {
+                    return Optional.empty();
+                }
+                result.add(segment.substring(i + 1, j));
+                i = j + 1;
+                continue;
+            }
+            int wordStart = i;
+            while (i < len) {
+                char cc = segment.charAt(i);
+                if (cc == ' ' || cc == '\t') {
+                    break;
+                }
+                if (cc == '\''
+                        || cc == '"'
+                        || cc == '$'
+                        || cc == '`'
+                        || cc == '('
+                        || cc == ')'
+                        || cc == '{'
+                        || cc == '}'
+                        || cc == '<'
+                        || cc == '>'
+                        || cc == '|'
+                        || cc == '&'
+                        || cc == ';'
+                        || cc == '\\'
+                        || cc == '\n'
+                        || cc == '\r') {
+                    return Optional.empty();
+                }
+                i++;
+            }
+            result.add(segment.substring(wordStart, i));
+        }
+        return Optional.of(result);
+    }
+
+    private static boolean isTokenBoundary(char c) {
+        return c == ' ' || c == '\t';
+    }
+}

--- a/app/src/main/java/ai/brokk/gui/Chrome.java
+++ b/app/src/main/java/ai/brokk/gui/Chrome.java
@@ -9,6 +9,7 @@ import ai.brokk.IAppContextManager;
 import ai.brokk.IConsoleIO;
 import ai.brokk.LlmOutputMeta;
 import ai.brokk.TaskEntry;
+import ai.brokk.acp.SafeCommand;
 import ai.brokk.agents.BlitzForge;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.context.Context;
@@ -2249,6 +2250,15 @@ public class Chrome
     public ApprovalResult beforeToolCall(ToolExecutionRequest request, boolean destructive) {
         if (!destructive) {
             return ApprovalResult.APPROVED;
+        }
+        // Phase 1 safe-command short-circuit: skip the banner for known-safe read-only shell
+        // commands (ls, cat, git status, ...). Mirrors the ACP path's PermissionGate logic so
+        // GUI and ACP behave identically. The sandbox still applies to the executed command.
+        if ("runShellCommand".equals(request.name())) {
+            var command = extractJsonField(request.arguments(), "command");
+            if (command != null && SafeCommand.isKnownSafe(command)) {
+                return ApprovalResult.APPROVED;
+            }
         }
         var approval = computeApprovalContext(request);
         var cached = sessionApprovedTools.get(approval.sessionKey());

--- a/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
+++ b/app/src/test/java/ai/brokk/acp/AcpConsoleIOTest.java
@@ -586,7 +586,11 @@ class AcpConsoleIOTest {
 
         @Override
         public PermissionDecision askPermissionDetailed(
-                String action, String toolName, String cacheKey, boolean offerSandboxBypass) {
+                String action,
+                String toolName,
+                String cacheKey,
+                boolean offerSandboxBypass,
+                @Nullable String rawCommand) {
             return PermissionDecision.ALLOW;
         }
 

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -905,30 +905,33 @@ class BrokkAcpAgentTest {
     void gateBypassAllowsEverything() {
         assertEquals(
                 PermissionGate.Outcome.ALLOW,
-                PermissionGate.decide(PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EDIT, "editFile", false));
+                PermissionGate.decide(
+                        PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EDIT, "editFile", false, null));
         assertEquals(
                 PermissionGate.Outcome.ALLOW,
-                PermissionGate.decide(PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EXECUTE, "shell", false));
+                PermissionGate.decide(
+                        PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.EXECUTE, "shell", false, null));
         assertEquals(
                 PermissionGate.Outcome.ALLOW,
-                PermissionGate.decide(PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.OTHER, "weird", false));
+                PermissionGate.decide(
+                        PermissionMode.BYPASS_PERMISSIONS, AcpSchema.ToolKind.OTHER, "weird", false, null));
     }
 
     @Test
     void gateReadOnlyRejectsEditExecuteAndOther() {
         assertEquals(
                 PermissionGate.Outcome.REJECT,
-                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EDIT, "editFile", false));
+                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EDIT, "editFile", false, null));
         assertEquals(
                 PermissionGate.Outcome.REJECT,
-                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EXECUTE, "shell", false));
+                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EXECUTE, "shell", false, null));
         assertEquals(
                 PermissionGate.Outcome.REJECT,
-                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.OTHER, "weird", false));
+                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.OTHER, "weird", false, null));
         // Always-allow does not lift the read-only brake.
         assertEquals(
                 PermissionGate.Outcome.REJECT,
-                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EDIT, "editFile", true));
+                PermissionGate.decide(PermissionMode.READ_ONLY, AcpSchema.ToolKind.EDIT, "editFile", true, null));
     }
 
     @Test
@@ -940,7 +943,7 @@ class BrokkAcpAgentTest {
                 AcpSchema.ToolKind.FETCH)) {
             assertEquals(
                     PermissionGate.Outcome.ALLOW,
-                    PermissionGate.decide(PermissionMode.READ_ONLY, k, "anything", false),
+                    PermissionGate.decide(PermissionMode.READ_ONLY, k, "anything", false, null),
                     "READ_ONLY must allow " + k);
         }
     }
@@ -949,26 +952,26 @@ class BrokkAcpAgentTest {
     void gateAcceptEditsAllowsEditButPromptsExecute() {
         assertEquals(
                 PermissionGate.Outcome.ALLOW,
-                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.EDIT, "editFile", false));
+                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.EDIT, "editFile", false, null));
         assertEquals(
                 PermissionGate.Outcome.PROMPT,
-                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.EXECUTE, "shell", false));
+                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.EXECUTE, "shell", false, null));
         assertEquals(
                 PermissionGate.Outcome.PROMPT,
-                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.OTHER, "weird", false));
+                PermissionGate.decide(PermissionMode.ACCEPT_EDITS, AcpSchema.ToolKind.OTHER, "weird", false, null));
     }
 
     @Test
     void gateDefaultPromptsExceptForReadOnlyKinds() {
         assertEquals(
                 PermissionGate.Outcome.ALLOW,
-                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.READ, "readFile", false));
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.READ, "readFile", false, null));
         assertEquals(
                 PermissionGate.Outcome.PROMPT,
-                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EDIT, "editFile", false));
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EDIT, "editFile", false, null));
         assertEquals(
                 PermissionGate.Outcome.PROMPT,
-                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EXECUTE, "shell", false));
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EXECUTE, "shell", false, null));
     }
 
     @Test
@@ -976,11 +979,11 @@ class BrokkAcpAgentTest {
         // Always-allow short-circuits the prompt for cacheable tools…
         assertEquals(
                 PermissionGate.Outcome.ALLOW,
-                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EDIT, "editFile", true));
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EDIT, "editFile", true, null));
         // …but never for shell, where one approval would blanket-allow every future shell command.
         assertEquals(
                 PermissionGate.Outcome.PROMPT,
-                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EXECUTE, "shell", true));
+                PermissionGate.decide(PermissionMode.DEFAULT, AcpSchema.ToolKind.EXECUTE, "shell", true, null));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/acp/SafeCommandTest.java
+++ b/app/src/test/java/ai/brokk/acp/SafeCommandTest.java
@@ -1,0 +1,218 @@
+package ai.brokk.acp;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SafeCommandTest {
+
+    @Test
+    void simpleSafeNamesAreApproved() {
+        assertTrue(SafeCommand.isKnownSafe("ls"));
+        assertTrue(SafeCommand.isKnownSafe("cat"));
+        assertTrue(SafeCommand.isKnownSafe("pwd"));
+        assertTrue(SafeCommand.isKnownSafe("whoami"));
+        assertTrue(SafeCommand.isKnownSafe("ls -la"));
+        assertTrue(SafeCommand.isKnownSafe("cat README.md"));
+        assertTrue(SafeCommand.isKnownSafe("grep -R foo src"));
+        assertTrue(SafeCommand.isKnownSafe("head -n 10 file.txt"));
+    }
+
+    @Test
+    void absolutePathExecutablesAreApproved() {
+        assertTrue(SafeCommand.isKnownSafe("/usr/bin/ls"));
+        assertTrue(SafeCommand.isKnownSafe("/bin/cat /etc/hosts"));
+    }
+
+    @Test
+    void unknownExecutablesAreRejected() {
+        assertFalse(SafeCommand.isKnownSafe("foo"));
+        assertFalse(SafeCommand.isKnownSafe("rm foo"));
+        assertFalse(SafeCommand.isKnownSafe("mvn test"));
+        assertFalse(SafeCommand.isKnownSafe("npm install"));
+        assertFalse(SafeCommand.isKnownSafe("cargo check"));
+    }
+
+    @Test
+    void emptyAndWhitespaceAreRejected() {
+        assertFalse(SafeCommand.isKnownSafe(""));
+        assertFalse(SafeCommand.isKnownSafe("   "));
+    }
+
+    @Test
+    void shellMetacharsRejected() {
+        assertFalse(SafeCommand.isKnownSafe("ls $(whoami)"));
+        assertFalse(SafeCommand.isKnownSafe("ls `whoami`"));
+        assertFalse(SafeCommand.isKnownSafe("ls > out.txt"));
+        assertFalse(SafeCommand.isKnownSafe("ls < input"));
+        assertFalse(SafeCommand.isKnownSafe("(ls)"));
+        assertFalse(SafeCommand.isKnownSafe("{ ls; }"));
+        assertFalse(SafeCommand.isKnownSafe("ls &"));
+        assertFalse(SafeCommand.isKnownSafe("ls\\ foo"));
+    }
+
+    @Test
+    void doubleQuotesWithEscapesRejected() {
+        assertFalse(SafeCommand.isKnownSafe("echo \"hello\\nworld\""));
+        assertFalse(SafeCommand.isKnownSafe("echo \"$(whoami)\""));
+        assertFalse(SafeCommand.isKnownSafe("echo \"`whoami`\""));
+    }
+
+    @Test
+    void singleQuotedTokensAreAllowed() {
+        assertTrue(SafeCommand.isKnownSafe("echo 'hello world'"));
+        assertTrue(SafeCommand.isKnownSafe("grep -R 'pattern' src"));
+    }
+
+    @Test
+    void doubleQuotedSimpleTokensAreAllowed() {
+        assertTrue(SafeCommand.isKnownSafe("echo \"hello world\""));
+        assertTrue(SafeCommand.isKnownSafe("grep -R \"Cargo.toml\" src"));
+    }
+
+    @Test
+    void operatorChainsOfSafeCommandsAreApproved() {
+        assertTrue(SafeCommand.isKnownSafe("ls && pwd"));
+        assertTrue(SafeCommand.isKnownSafe("ls || true"));
+        assertTrue(SafeCommand.isKnownSafe("echo hi ; ls"));
+        assertTrue(SafeCommand.isKnownSafe("ls | wc -l"));
+        assertTrue(SafeCommand.isKnownSafe("ls && pwd && whoami"));
+    }
+
+    @Test
+    void operatorChainWithUnsafeSubcommandRejected() {
+        assertFalse(SafeCommand.isKnownSafe("ls && rm -rf /"));
+        assertFalse(SafeCommand.isKnownSafe("ls || rm foo"));
+        assertFalse(SafeCommand.isKnownSafe("ls ; mvn test"));
+    }
+
+    @Test
+    void bashLcWrapperIsApproved() {
+        assertTrue(SafeCommand.isKnownSafe("bash -lc \"ls\""));
+        assertTrue(SafeCommand.isKnownSafe("bash -lc \"ls && pwd\""));
+        assertTrue(SafeCommand.isKnownSafe("sh -c \"git status\""));
+    }
+
+    @Test
+    void bashLcWrapperWithUnsafeContentRejected() {
+        assertFalse(SafeCommand.isKnownSafe("bash -lc \"rm -rf /\""));
+        assertFalse(SafeCommand.isKnownSafe("bash -lc \"ls && rm foo\""));
+    }
+
+    @Test
+    void nestedBashLcRejected() {
+        assertFalse(SafeCommand.isKnownSafe("bash -lc \"bash -lc 'ls'\""));
+    }
+
+    @Test
+    void findWithoutUnsafeFlagsIsApproved() {
+        assertTrue(SafeCommand.isKnownSafe("find . -name foo.txt"));
+        assertTrue(SafeCommand.isKnownSafe("find src -type f"));
+    }
+
+    @Test
+    void findWithUnsafeFlagsRejected() {
+        assertFalse(SafeCommand.isKnownSafe("find . -delete"));
+        assertFalse(SafeCommand.isKnownSafe("find . -exec rm '{}' ;"));
+        assertFalse(SafeCommand.isKnownSafe("find . -execdir true ;"));
+        assertFalse(SafeCommand.isKnownSafe("find . -fls /tmp/log"));
+    }
+
+    @Test
+    void ripgrepWithSafeFlagsIsApproved() {
+        assertTrue(SafeCommand.isKnownSafe("rg -n pattern"));
+        assertTrue(SafeCommand.isKnownSafe("rg --files-with-matches pattern src"));
+    }
+
+    @Test
+    void ripgrepWithUnsafeFlagsRejected() {
+        assertFalse(SafeCommand.isKnownSafe("rg --pre pwned files"));
+        assertFalse(SafeCommand.isKnownSafe("rg --pre=pwned files"));
+        assertFalse(SafeCommand.isKnownSafe("rg --hostname-bin pwned files"));
+        assertFalse(SafeCommand.isKnownSafe("rg --search-zip files"));
+        assertFalse(SafeCommand.isKnownSafe("rg -z files"));
+    }
+
+    @Test
+    void gitReadOnlySubcommandsApproved() {
+        assertTrue(SafeCommand.isKnownSafe("git status"));
+        assertTrue(SafeCommand.isKnownSafe("git log"));
+        assertTrue(SafeCommand.isKnownSafe("git diff"));
+        assertTrue(SafeCommand.isKnownSafe("git show HEAD"));
+        assertTrue(SafeCommand.isKnownSafe("git branch"));
+        assertTrue(SafeCommand.isKnownSafe("git branch --show-current"));
+        assertTrue(SafeCommand.isKnownSafe("git -C . status"));
+    }
+
+    @Test
+    void gitMutatingSubcommandsRejected() {
+        assertFalse(SafeCommand.isKnownSafe("git push"));
+        assertFalse(SafeCommand.isKnownSafe("git pull"));
+        assertFalse(SafeCommand.isKnownSafe("git fetch"));
+        assertFalse(SafeCommand.isKnownSafe("git checkout main"));
+        assertFalse(SafeCommand.isKnownSafe("git commit -m foo"));
+        assertFalse(SafeCommand.isKnownSafe("git branch -d feature"));
+        assertFalse(SafeCommand.isKnownSafe("git branch newbranch"));
+    }
+
+    @Test
+    void gitGlobalConfigOverridesRejected() {
+        assertFalse(SafeCommand.isKnownSafe("git -c core.pager=cat log"));
+        assertFalse(SafeCommand.isKnownSafe("git --git-dir=.evil log"));
+        assertFalse(SafeCommand.isKnownSafe("git --work-tree=. status"));
+        assertFalse(SafeCommand.isKnownSafe("git --exec-path=.evil show"));
+    }
+
+    @Test
+    void gitOutputFlagsRejected() {
+        assertFalse(SafeCommand.isKnownSafe("git log --output=/tmp/log"));
+        assertFalse(SafeCommand.isKnownSafe("git diff --ext-diff"));
+        assertFalse(SafeCommand.isKnownSafe("git show --textconv HEAD"));
+    }
+
+    @Test
+    void sedNumericPrintIsApproved() {
+        assertTrue(SafeCommand.isKnownSafe("sed -n 1,5p file.txt"));
+        assertTrue(SafeCommand.isKnownSafe("sed -n 10p file.txt"));
+    }
+
+    @Test
+    void sedNonReadOnlyRejected() {
+        assertFalse(SafeCommand.isKnownSafe("sed -i s/foo/bar/ file.txt"));
+        assertFalse(SafeCommand.isKnownSafe("sed -n xp file.txt"));
+        assertFalse(SafeCommand.isKnownSafe("sed s/foo/bar/ file.txt"));
+    }
+
+    @Test
+    void base64OutputOptionsRejected() {
+        assertFalse(SafeCommand.isKnownSafe("base64 -o out.bin"));
+        assertFalse(SafeCommand.isKnownSafe("base64 --output out.bin"));
+        assertFalse(SafeCommand.isKnownSafe("base64 --output=out.bin"));
+        assertFalse(SafeCommand.isKnownSafe("base64 -ofile.bin"));
+    }
+
+    @Test
+    void base64WithoutOutputApproved() {
+        assertTrue(SafeCommand.isKnownSafe("base64"));
+        assertTrue(SafeCommand.isKnownSafe("base64 -d input.txt"));
+    }
+
+    @Test
+    void unbalancedQuotesRejected() {
+        assertFalse(SafeCommand.isKnownSafe("echo 'unterminated"));
+        assertFalse(SafeCommand.isKnownSafe("echo \"unterminated"));
+    }
+
+    @Test
+    void mixedQuotingTokensRejected() {
+        assertFalse(SafeCommand.isKnownSafe("echo abc'def'"));
+        assertFalse(SafeCommand.isKnownSafe("echo 'abc'def"));
+    }
+
+    @Test
+    void quotedExecutableNameRejected() {
+        assertFalse(SafeCommand.isKnownSafe("'git status'"));
+        assertFalse(SafeCommand.isKnownSafe("\"ls -la\""));
+    }
+}


### PR DESCRIPTION
## Summary

Auto-approve known-safe read-only shell commands so users stop having to click "Allow" on every `ls`, `cat`, `git status`, etc.

This is **Phase 1 of 3** ports of Codex's permission system into Brokk. See [the full plan](https://github.com/BrokkAi/brokk/blob/claude/eager-williams-eaa3c7/.claude/plans/d-accord-tu-peux-faire-vast-rivest.md) (also attached below). Phases 2 (cross-session persistence) and 3 (sandbox-aware gating) will land as follow-up PRs to keep review surface manageable.

## What changed

A new `SafeCommand.isKnownSafe(String rawCommand)` helper mirrors OpenAI Codex CLI's [`is_safe_command.rs`](https://github.com/openai/codex/blob/main/codex-rs/shell-command/src/command_safety/is_safe_command.rs). The shell tool's raw command string is now threaded from `AcpConsoleIO.beforeToolCall` through `AcpRequestContext.askPermissionDetailed` into `PermissionGate.decide`. When the model invokes `runShellCommand` with a command on the safe-list, the gate returns `ALLOW` directly — no per-call prompt.

The Swing GUI (`Chrome.beforeToolCall`) gets a parallel short-circuit so banner behavior matches.

### Auto-approved (no prompt)

- Plain read-only utilities: `ls`, `cat`, `cd`, `cut`, `echo`, `expr`, `false`, `grep`, `head`, `id`, `nl`, `paste`, `pwd`, `rev`, `seq`, `stat`, `tail`, `tr`, `true`, `uname`, `uniq`, `wc`, `which`, `whoami`
- `find` without `-exec`, `-execdir`, `-ok`, `-okdir`, `-delete`, `-fls`, `-fprint*`
- `rg` without `--pre`, `--hostname-bin`, `--search-zip`, `-z`
- `git status`, `git log`, `git diff`, `git show`, `git branch` (read-only flags only); rejects when `-c`, `--git-dir`, `--work-tree`, `--exec-path`, `--namespace`, `--super-prefix`, `--config-env` are present
- `sed -n {N|M,N}p`
- `base64` without `-o` / `--output`
- `bash -lc "X && Y"` / `sh -c "..."` compositions of the above (depth 1)
- Operator chains using `&&`, `||`, `;`, `|`

### Still prompts (unchanged)

- `rm`, `mv`, `mvn`, `npm`, `cargo`, `git push`, `git pull`, `git checkout`, `git commit`, `find -delete`, `rg --pre`, etc.
- Anything containing `$`, backtick, `<`, `>`, `(`, `)`, `{`, `}`, escapes, or unbalanced quotes
- `callShellAgent` (its `task` arg is a high-level description, not an executable command — safety can't be verified statically)

### Tokenizer

A small purpose-built tokenizer in `SafeCommand` handles single quotes, double quotes (no escapes/expansion inside, conservative), bareword tokens, and rejects anything else. Mixed-quote tokens like `abc'def'ghi` are rejected — this is more restrictive than Codex but easier to reason about and removes the risk of subtle escape edge cases.

## PermissionMode interaction

| Mode | Behavior |
|------|----------|
| `BYPASS_PERMISSIONS` | Pre-empts before safe-list check (no change) |
| `READ_ONLY` | Still rejects all shell calls, including `ls`. The safe-list branch is placed **after** the `READ_ONLY` reject |
| `ACCEPT_EDITS` / `DEFAULT` | Safe-list applies normally |

A previously rejected command (`reject_always` in the sticky cache) is **not** overridden by the safe-list — the cache check runs in `askPermissionDetailed` after `decide` returns `PROMPT`, so a stuck reject stays stuck. Edge case but worth noting.

## Test plan

- [x] `./gradlew :app:check` — full suite (spotless + errorprone + NullAway + tests) passes
- [x] 28 new unit tests in `SafeCommandTest` covering each whitelist entry, each rejection rule, `bash -lc` composition, metacharacter rejection, mixed quoting, sed-N parsing, base64 output flags
- [x] All existing `BrokkAcpAgentTest` gate tests still pass with the new 5-arg `decide()` signature
- [ ] Manual: launch ACP from Zed/IntelliJ, ask the agent to run `ls`, `cat README.md`, `git status` — confirm no prompts. Then `rm foo` — confirm prompt fires.

## Out of scope (follow-ups)

- **Rust ACP server mirror**: `brokk-acp-rust/src/tool_loop.rs` (`pure_gate_decision`) needs the same change. Tracked separately.
- **Phase 2**: Cross-session persistence of "Always allow" decisions to `<projectRoot>/.brokk/permission_rules.json`.
- **Phase 3**: Sandbox-aware gating — when `WORKSPACE_WRITE` is active, auto-allow non-dangerous commands beyond the safe-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
