### PR TITLE
ACP: persist 'Always allow' decisions across sessions and IDE restarts

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
@@ -248,8 +248,13 @@ final class AcpRequestContext implements AcpPromptContext {
         boolean cacheable = !NON_CACHEABLE_TOOL_NAMES.contains(toolName);
         var cache = cacheable ? agent : null;
 
+        // Lookup order: in-RAM sticky cache (this session) → on-disk persistent rules (Phase 2).
+        // The in-RAM cache wins on hit so we don't re-read the rules file on every prompt.
         Optional<BrokkAcpAgent.PermissionVerdict> sticky =
                 cache != null ? cache.stickyPermissionFor(sessionId, cacheKey) : Optional.empty();
+        if (sticky.isEmpty() && cache != null) {
+            sticky = cache.persistentPermissionFor(sessionId, toolName, PermissionRules.argMatchOf(toolName, cacheKey));
+        }
 
         // Session-level PermissionMode is consulted BEFORE the sticky cache so READ_ONLY can deny
         // even tools the user previously approved, and BYPASS_PERMISSIONS can short-circuit before
@@ -302,14 +307,19 @@ final class AcpRequestContext implements AcpPromptContext {
         }
         var optionId = selected.optionId();
         if (cache != null) {
-            switch (optionId) {
-                case "allow_always" ->
-                    cache.rememberPermission(sessionId, cacheKey, BrokkAcpAgent.PermissionVerdict.ALLOW);
-                case "allow_no_sandbox_always" ->
-                    cache.rememberPermission(sessionId, cacheKey, BrokkAcpAgent.PermissionVerdict.ALLOW_NO_SANDBOX);
-                case "reject_always" ->
-                    cache.rememberPermission(sessionId, cacheKey, BrokkAcpAgent.PermissionVerdict.DENY);
-                default -> {}
+            BrokkAcpAgent.PermissionVerdict toRemember =
+                    switch (optionId) {
+                        case "allow_always" -> BrokkAcpAgent.PermissionVerdict.ALLOW;
+                        case "allow_no_sandbox_always" -> BrokkAcpAgent.PermissionVerdict.ALLOW_NO_SANDBOX;
+                        case "reject_always" -> BrokkAcpAgent.PermissionVerdict.DENY;
+                        default -> null;
+                    };
+            if (toRemember != null) {
+                cache.rememberPermission(sessionId, cacheKey, toRemember);
+                // Persist across sessions (Phase 2). Failure to write is logged inside the agent
+                // and does not break the in-RAM caching path.
+                cache.rememberPermissionPersistently(
+                        sessionId, toolName, PermissionRules.argMatchOf(toolName, cacheKey), toRemember);
             }
         }
         return switch (optionId) {

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -136,6 +137,14 @@ public class BrokkAcpAgent {
     private final Map<String, String> reasoningBySession = new ConcurrentHashMap<>();
     private final Map<String, String> activeJobBySession = new ConcurrentHashMap<>();
     private final Map<String, Map<String, PermissionVerdict>> stickyPermissionsBySession = new ConcurrentHashMap<>();
+
+    /**
+     * Cross-session persistent permission rules, keyed by project root. Loaded lazily on first
+     * access for a project; survives ACP session close (intentionally NOT cleared by
+     * {@link #clearAllSessions()}). Backing file is {@code <projectRoot>/.brokk/permission_rules.json}.
+     */
+    private final Map<Path, PermissionRules> rulesByProjectRoot = new ConcurrentHashMap<>();
+
     private final Map<String, PermissionMode> permissionModeBySession = new ConcurrentHashMap<>();
     private final Map<String, List<McpServer>> mcpServersBySession = new ConcurrentHashMap<>();
     private static final InheritableThreadLocal<List<McpServer>> SESSION_MCP_SCOPE = new InheritableThreadLocal<>();
@@ -1179,6 +1188,58 @@ public class BrokkAcpAgent {
         stickyPermissionsBySession
                 .computeIfAbsent(sessionId, ignored -> new ConcurrentHashMap<>())
                 .put(toolName, verdict);
+    }
+
+    /**
+     * Looks up a cross-session persisted permission verdict for {@code (toolName, argMatch)} in
+     * the rules file owned by this session's project. Returns empty when the session has no
+     * registered bundle, or when no rule matches. Mirrors {@link #stickyPermissionFor} but persists
+     * across restarts.
+     */
+    @Blocking
+    public Optional<PermissionVerdict> persistentPermissionFor(String sessionId, String toolName, String argMatch) {
+        var bundle = tryBundleForSession(sessionId);
+        if (bundle.isEmpty()) {
+            return Optional.empty();
+        }
+        return rulesFor(bundle.get().root()).lookup(toolName, argMatch);
+    }
+
+    /**
+     * Persists a permission verdict for {@code (toolName, argMatch)} to disk under the session's
+     * project root. Failure to write is logged and swallowed — the verdict still lives in the
+     * in-memory sticky cache for the rest of this session.
+     */
+    @Blocking
+    public void rememberPermissionPersistently(
+            String sessionId, String toolName, String argMatch, PermissionVerdict verdict) {
+        var bundle = tryBundleForSession(sessionId);
+        if (bundle.isEmpty()) {
+            logger.warn("rememberPermissionPersistently called for unknown session {}; skipping disk write", sessionId);
+            return;
+        }
+        var root = bundle.get().root();
+        var store = rulesFor(root);
+        store.put(toolName, argMatch, verdict);
+        try {
+            store.save(root);
+        } catch (IOException e) {
+            logger.warn(
+                    "Failed to persist permission rule ({}, {}, {}) under {}: {}",
+                    toolName,
+                    argMatch,
+                    verdict,
+                    root,
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * Returns the per-project rules store, lazily loading from disk on first access. Cached so
+     * subsequent lookups don't re-parse the file on every prompt.
+     */
+    private PermissionRules rulesFor(Path projectRoot) {
+        return rulesByProjectRoot.computeIfAbsent(projectRoot, PermissionRules::loadForProject);
     }
 
     public void cancel(AcpSchema.CancelNotification notification) {

--- a/app/src/main/java/ai/brokk/acp/PermissionRules.java
+++ b/app/src/main/java/ai/brokk/acp/PermissionRules.java
@@ -1,0 +1,184 @@
+package ai.brokk.acp;
+
+import ai.brokk.concurrent.AtomicWrites;
+import ai.brokk.util.Json;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Blocking;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * On-disk per-project store of "Always allow" / "Always reject" verdicts for ACP and GUI
+ * permission prompts. Persisted at {@code <projectRoot>/.brokk/permission_rules.json}, this lets a
+ * verdict survive ACP session restarts and IDE reboots — Phase 2 of the Codex-permission port (see
+ * {@code docs/permission_phases.md} or PR #3497 for context).
+ *
+ * <p>The match is exact-string on the {@code (toolName, argMatch)} tuple. {@code argMatch} mirrors
+ * the per-call cache-key suffix used today (e.g. for {@code runShellCommand} the raw command). A
+ * {@code DENY} rule wins over any {@code ALLOW}, including the Phase 1 hardcoded safe-list.
+ *
+ * <p>Thread-safe: all read/write operations are guarded by a {@link ReentrantLock}.
+ * {@link #save(Path)} performs a load+merge before writing so concurrent processes (e.g. two ACP
+ * sessions for the same project) cannot stomp each other's rules.
+ */
+public final class PermissionRules {
+
+    private static final Logger logger = LogManager.getLogger(PermissionRules.class);
+
+    /** Schema version for forward compatibility. Bumped on breaking changes only. */
+    static final int SCHEMA_VERSION = 1;
+
+    private static final String FILE_RELATIVE_PATH = ".brokk/permission_rules.json";
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    /** Mutable list of rules. Always accessed under {@link #lock}. */
+    private final List<Rule> rules;
+
+    private PermissionRules(List<Rule> rules) {
+        this.rules = new ArrayList<>(rules);
+    }
+
+    /** Single allow/deny rule. */
+    record Rule(String toolName, String argMatch, BrokkAcpAgent.PermissionVerdict verdict) {}
+
+    /**
+     * On-disk schema. Wraps the rule list with a version field so future migrations can detect
+     * old files and either upgrade or refuse them. {@code rules} is {@link Nullable} because
+     * Jackson supplies {@code null} when the JSON omits the key entirely; callers must default it
+     * via {@link Objects#requireNonNullElse}.
+     */
+    record PermissionRulesFile(
+            @JsonProperty("version") int version, @Nullable @JsonProperty("rules") List<Rule> rules) {
+        @JsonCreator
+        PermissionRulesFile {
+            // Compact constructor body intentionally empty — defaulting happens at use sites so
+            // the @Nullable contract is preserved on the accessor.
+        }
+    }
+
+    /**
+     * Loads the rules file at {@code <projectRoot>/.brokk/permission_rules.json}. Returns an empty
+     * instance on missing file, parse failure, or unsupported schema version — never throws,
+     * because permission persistence must not brick the ACP agent.
+     */
+    @Blocking
+    public static PermissionRules loadForProject(Path projectRoot) {
+        var file = projectRoot.resolve(FILE_RELATIVE_PATH);
+        if (!Files.exists(file)) {
+            return new PermissionRules(List.of());
+        }
+        try {
+            var json = Files.readString(file);
+            var parsed = Json.fromJson(json, PermissionRulesFile.class);
+            if (parsed.version() != SCHEMA_VERSION) {
+                logger.warn(
+                        "PermissionRules at {} has unsupported version {} (expected {}); ignoring file. "
+                                + "Edit it manually or delete it to start fresh.",
+                        file,
+                        parsed.version(),
+                        SCHEMA_VERSION);
+                return new PermissionRules(List.of());
+            }
+            return new PermissionRules(Objects.requireNonNullElse(parsed.rules(), List.of()));
+        } catch (Exception e) {
+            logger.warn(
+                    "Failed to parse PermissionRules at {}: {}. Treating as empty — file is preserved on disk so it can be repaired.",
+                    file,
+                    e.getMessage());
+            return new PermissionRules(List.of());
+        }
+    }
+
+    /** Returns the verdict for {@code (toolName, argMatch)}, or empty if no rule matches. */
+    public Optional<BrokkAcpAgent.PermissionVerdict> lookup(String toolName, String argMatch) {
+        lock.lock();
+        try {
+            return rules.stream()
+                    .filter(r -> r.toolName().equals(toolName) && r.argMatch().equals(argMatch))
+                    .map(Rule::verdict)
+                    .findFirst();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Inserts or replaces the rule for {@code (toolName, argMatch)}. Caller is responsible for
+     * calling {@link #save(Path)} to persist the change.
+     */
+    public void put(String toolName, String argMatch, BrokkAcpAgent.PermissionVerdict verdict) {
+        lock.lock();
+        try {
+            rules.removeIf(r -> r.toolName().equals(toolName) && r.argMatch().equals(argMatch));
+            rules.add(new Rule(toolName, argMatch, verdict));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Atomically writes the current rules to {@code <projectRoot>/.brokk/permission_rules.json}.
+     * Re-reads any concurrent on-disk changes first and merges them — last-writer-wins per
+     * {@code (toolName, argMatch)} key, but rules from other processes are preserved.
+     */
+    @Blocking
+    public void save(Path projectRoot) throws IOException {
+        var file = projectRoot.resolve(FILE_RELATIVE_PATH);
+        Files.createDirectories(file.getParent());
+        lock.lock();
+        try {
+            // Merge in any rules another process may have added since we loaded.
+            var onDisk = loadForProject(projectRoot);
+            for (var theirs : onDisk.snapshot()) {
+                boolean weHaveIt = rules.stream()
+                        .anyMatch(r -> r.toolName().equals(theirs.toolName())
+                                && r.argMatch().equals(theirs.argMatch()));
+                if (!weHaveIt) {
+                    rules.add(theirs);
+                }
+            }
+            var payload = new PermissionRulesFile(SCHEMA_VERSION, List.copyOf(rules));
+            var json = Json.getMapper().writerWithDefaultPrettyPrinter().writeValueAsString(payload);
+            AtomicWrites.save(file, json);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Snapshot of the current rules for read-only iteration. Test/internal use. */
+    List<Rule> snapshot() {
+        lock.lock();
+        try {
+            return List.copyOf(rules);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Splits a permission cache key into the {@code argMatch} component used by this store. Cache
+     * keys are shaped as {@code toolName} (no per-call differentiation) or {@code toolName + ":" +
+     * arg} (shell tools). Returns {@code ""} when there is no arg suffix.
+     */
+    public static String argMatchOf(String toolName, String cacheKey) {
+        if (cacheKey.equals(toolName)) {
+            return "";
+        }
+        var prefix = toolName + ":";
+        if (cacheKey.startsWith(prefix)) {
+            return cacheKey.substring(prefix.length());
+        }
+        return cacheKey;
+    }
+}

--- a/app/src/main/java/ai/brokk/gui/Chrome.java
+++ b/app/src/main/java/ai/brokk/gui/Chrome.java
@@ -9,6 +9,8 @@ import ai.brokk.IAppContextManager;
 import ai.brokk.IConsoleIO;
 import ai.brokk.LlmOutputMeta;
 import ai.brokk.TaskEntry;
+import ai.brokk.acp.BrokkAcpAgent;
+import ai.brokk.acp.PermissionRules;
 import ai.brokk.acp.SafeCommand;
 import ai.brokk.agents.BlitzForge;
 import ai.brokk.analyzer.ProjectFile;
@@ -126,6 +128,15 @@ public class Chrome
     private final RightPanel rightPanel;
     private final ToolsPane toolsPane;
     private final Map<String, Boolean> sessionApprovedTools = new ConcurrentHashMap<>();
+
+    /**
+     * Lazy-loaded cross-session permission rules for this project (Phase 2). Backed by
+     * {@code <projectRoot>/.brokk/permission_rules.json}. Initialized on first {@link
+     * #beforeToolCall} that needs it; cached for the lifetime of this Chrome.
+     */
+    @Nullable
+    private volatile PermissionRules permissionRulesCache;
+
     private final JSplitPane leftVerticalSplitPane; // Left: tabs (top) + file history (bottom)
     private final JTabbedPane fileHistoryPane; // Bottom area for file history
     private int originalLeftVerticalDividerSize;
@@ -2261,6 +2272,19 @@ public class Chrome
             }
         }
         var approval = computeApprovalContext(request);
+        // Phase 2 cross-session persistence: a previously stored "Always allow / always reject"
+        // verdict (in <projectRoot>/.brokk/permission_rules.json) wins over the in-RAM session
+        // cache, so a manual edit of the rules file or a verdict from a prior IDE run is honored
+        // immediately without firing the banner.
+        var persistentVerdict = permissionRules()
+                .lookup(request.name(), PermissionRules.argMatchOf(request.name(), approval.sessionKey()));
+        if (persistentVerdict.isPresent()) {
+            return switch (persistentVerdict.get()) {
+                case DENY -> ApprovalResult.DENIED;
+                case ALLOW_NO_SANDBOX -> ApprovalResult.APPROVED_NO_SANDBOX;
+                case ALLOW -> ApprovalResult.APPROVED;
+            };
+        }
         var cached = sessionApprovedTools.get(approval.sessionKey());
         if (cached != null) {
             return cached ? ApprovalResult.APPROVED_NO_SANDBOX : ApprovalResult.APPROVED;
@@ -2293,8 +2317,10 @@ public class Chrome
             var choice = future.get();
             if (choice == HistoryOutputPanel.ApprovalChoice.ALLOW_SESSION) {
                 sessionApprovedTools.put(approval.sessionKey(), false);
+                persistRule(request.name(), approval.sessionKey(), BrokkAcpAgent.PermissionVerdict.ALLOW);
             } else if (choice == HistoryOutputPanel.ApprovalChoice.ALLOW_NO_SANDBOX_SESSION) {
                 sessionApprovedTools.put(approval.sessionKey(), true);
+                persistRule(request.name(), approval.sessionKey(), BrokkAcpAgent.PermissionVerdict.ALLOW_NO_SANDBOX);
             }
             return switch (choice) {
                 case DENY -> ApprovalResult.DENIED;
@@ -2307,6 +2333,41 @@ public class Chrome
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return ApprovalResult.DENIED;
+        }
+    }
+
+    /**
+     * Lazy-loads the per-project {@link PermissionRules}. Loaded once on first call and cached in
+     * {@link #permissionRulesCache} for the lifetime of this Chrome — Brokk doesn't watch the
+     * rules file for external edits, so users editing it by hand must restart the IDE.
+     */
+    private PermissionRules permissionRules() {
+        var cached = permissionRulesCache;
+        if (cached != null) {
+            return cached;
+        }
+        synchronized (this) {
+            if (permissionRulesCache == null) {
+                permissionRulesCache =
+                        PermissionRules.loadForProject(getProject().getRoot());
+            }
+            return permissionRulesCache;
+        }
+    }
+
+    /**
+     * Persists a permission verdict to disk. Failures (read-only filesystem, permissions issues)
+     * are logged and swallowed; the in-RAM {@code sessionApprovedTools} cache still works for the
+     * remainder of this run.
+     */
+    private void persistRule(String toolName, String sessionKey, BrokkAcpAgent.PermissionVerdict verdict) {
+        try {
+            var argMatch = PermissionRules.argMatchOf(toolName, sessionKey);
+            var rules = permissionRules();
+            rules.put(toolName, argMatch, verdict);
+            rules.save(getProject().getRoot());
+        } catch (Exception e) {
+            logger.warn("Failed to persist permission rule for {}: {}", toolName, e.getMessage());
         }
     }
 

--- a/app/src/test/java/ai/brokk/acp/PermissionRulesTest.java
+++ b/app/src/test/java/ai/brokk/acp/PermissionRulesTest.java
@@ -1,0 +1,139 @@
+package ai.brokk.acp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PermissionRulesTest {
+
+    @Test
+    void emptyOnMissingFile(@TempDir Path projectRoot) {
+        var rules = PermissionRules.loadForProject(projectRoot);
+        assertTrue(rules.snapshot().isEmpty());
+        assertTrue(rules.lookup("runShellCommand", "ls").isEmpty());
+    }
+
+    @Test
+    void putAndLookup(@TempDir Path projectRoot) {
+        var rules = PermissionRules.loadForProject(projectRoot);
+        rules.put("runShellCommand", "mvn test", BrokkAcpAgent.PermissionVerdict.ALLOW);
+        rules.put("runShellCommand", "git push", BrokkAcpAgent.PermissionVerdict.DENY);
+
+        assertEquals(
+                java.util.Optional.of(BrokkAcpAgent.PermissionVerdict.ALLOW),
+                rules.lookup("runShellCommand", "mvn test"));
+        assertEquals(
+                java.util.Optional.of(BrokkAcpAgent.PermissionVerdict.DENY),
+                rules.lookup("runShellCommand", "git push"));
+        assertTrue(rules.lookup("runShellCommand", "unknown").isEmpty());
+    }
+
+    @Test
+    void putReplacesExistingRule(@TempDir Path projectRoot) {
+        var rules = PermissionRules.loadForProject(projectRoot);
+        rules.put("runShellCommand", "mvn test", BrokkAcpAgent.PermissionVerdict.ALLOW);
+        rules.put("runShellCommand", "mvn test", BrokkAcpAgent.PermissionVerdict.DENY);
+
+        assertEquals(1, rules.snapshot().size());
+        assertEquals(
+                java.util.Optional.of(BrokkAcpAgent.PermissionVerdict.DENY),
+                rules.lookup("runShellCommand", "mvn test"));
+    }
+
+    @Test
+    void saveAndReload(@TempDir Path projectRoot) throws IOException {
+        var first = PermissionRules.loadForProject(projectRoot);
+        first.put("runShellCommand", "mvn test", BrokkAcpAgent.PermissionVerdict.ALLOW);
+        first.put("callShellAgent", "deploy", BrokkAcpAgent.PermissionVerdict.DENY);
+        first.save(projectRoot);
+
+        assertTrue(Files.exists(projectRoot.resolve(".brokk/permission_rules.json")));
+
+        var reloaded = PermissionRules.loadForProject(projectRoot);
+        assertEquals(2, reloaded.snapshot().size());
+        assertEquals(
+                java.util.Optional.of(BrokkAcpAgent.PermissionVerdict.ALLOW),
+                reloaded.lookup("runShellCommand", "mvn test"));
+        assertEquals(
+                java.util.Optional.of(BrokkAcpAgent.PermissionVerdict.DENY),
+                reloaded.lookup("callShellAgent", "deploy"));
+    }
+
+    @Test
+    void corruptJsonReturnsEmptyAndPreservesFile(@TempDir Path projectRoot) throws IOException {
+        var brokk = projectRoot.resolve(".brokk");
+        Files.createDirectories(brokk);
+        var file = brokk.resolve("permission_rules.json");
+        Files.writeString(file, "{ this is not valid json");
+
+        var rules = PermissionRules.loadForProject(projectRoot);
+        assertTrue(rules.snapshot().isEmpty());
+        assertTrue(Files.exists(file), "corrupt file must be preserved for manual repair");
+    }
+
+    @Test
+    void unsupportedVersionReturnsEmpty(@TempDir Path projectRoot) throws IOException {
+        var brokk = projectRoot.resolve(".brokk");
+        Files.createDirectories(brokk);
+        var file = brokk.resolve("permission_rules.json");
+        Files.writeString(file, "{\"version\": 99, \"rules\": []}");
+
+        var rules = PermissionRules.loadForProject(projectRoot);
+        assertTrue(rules.snapshot().isEmpty());
+    }
+
+    @Test
+    void mergeOnSavePreservesConcurrentRules(@TempDir Path projectRoot) throws IOException {
+        // Process A loads, adds rule, persists.
+        var procA = PermissionRules.loadForProject(projectRoot);
+        procA.put("runShellCommand", "ls", BrokkAcpAgent.PermissionVerdict.ALLOW);
+        procA.save(projectRoot);
+
+        // Process B loads (sees A's rule), but a concurrent C writes a DIFFERENT rule before B saves.
+        var procB = PermissionRules.loadForProject(projectRoot);
+        procB.put("runShellCommand", "pwd", BrokkAcpAgent.PermissionVerdict.ALLOW);
+
+        var procC = PermissionRules.loadForProject(projectRoot);
+        procC.put("runShellCommand", "cat", BrokkAcpAgent.PermissionVerdict.ALLOW);
+        procC.save(projectRoot);
+
+        // B saves now — must merge C's "cat" rule, not stomp it.
+        procB.save(projectRoot);
+
+        var finalState = PermissionRules.loadForProject(projectRoot);
+        assertEquals(3, finalState.snapshot().size());
+        assertTrue(finalState.lookup("runShellCommand", "ls").isPresent());
+        assertTrue(finalState.lookup("runShellCommand", "pwd").isPresent());
+        assertTrue(finalState.lookup("runShellCommand", "cat").isPresent());
+    }
+
+    @Test
+    void differentToolNamesIsolated(@TempDir Path projectRoot) {
+        var rules = PermissionRules.loadForProject(projectRoot);
+        rules.put("runShellCommand", "deploy", BrokkAcpAgent.PermissionVerdict.ALLOW);
+        rules.put("callShellAgent", "deploy", BrokkAcpAgent.PermissionVerdict.DENY);
+
+        assertEquals(
+                java.util.Optional.of(BrokkAcpAgent.PermissionVerdict.ALLOW),
+                rules.lookup("runShellCommand", "deploy"));
+        assertEquals(
+                java.util.Optional.of(BrokkAcpAgent.PermissionVerdict.DENY), rules.lookup("callShellAgent", "deploy"));
+    }
+
+    @Test
+    void emptyArgMatchSupported(@TempDir Path projectRoot) throws IOException {
+        var rules = PermissionRules.loadForProject(projectRoot);
+        rules.put("editFile", "", BrokkAcpAgent.PermissionVerdict.ALLOW);
+        rules.save(projectRoot);
+
+        var reloaded = PermissionRules.loadForProject(projectRoot);
+        assertEquals(java.util.Optional.of(BrokkAcpAgent.PermissionVerdict.ALLOW), reloaded.lookup("editFile", ""));
+        assertFalse(reloaded.lookup("editFile", "something").isPresent());
+    }
+}


### PR DESCRIPTION
## Summary

Persist `Always allow` / `Always reject` permission verdicts to disk so users stop re-approving the same `mvn test`, `gradle build`, `python manage.py migrate`, etc. on every ACP reconnect or IDE restart.

This is **Phase 2 of 3** of the [Codex permission port](https://github.com/BrokkAi/brokk/blob/claude/phase-2-permission-rules/.claude/plans/d-accord-tu-peux-faire-vast-rivest.md). Phase 1 ([#3497](https://github.com/BrokkAi/brokk/pull/3497)) added the hardcoded safe-list (`ls`, `cat`, `git status`, …). Phase 3 will follow with sandbox-aware gating.

## What changed

### New: `PermissionRules` (per-project, on-disk)

`<projectRoot>/.brokk/permission_rules.json` stores `(toolName, argMatch, verdict)` tuples:

```json
{
  "version": 1,
  "rules": [
    { "toolName": "runShellCommand", "argMatch": "mvn test", "verdict": "ALLOW" },
    { "toolName": "runShellCommand", "argMatch": "git push", "verdict": "DENY" }
  ]
}
```

`PermissionRules` is package-`public` so the GUI (`Chrome`) and the ACP server (`BrokkAcpAgent`) share the same store. Atomic writes via `AtomicWrites.save()`. Corrupt or version-mismatched files are logged and treated as empty without overwriting the on-disk file (so users can repair them manually).

### ACP server flow (`AcpRequestContext.askPermissionDetailed`)

```
in-RAM sticky cache (this session) ─→ on-disk persistent rules (NEW) ─→ PermissionGate ─→ user prompt
```

When the user clicks `Always allow` / `Always reject` / `Always allow without sandbox`, the verdict is written to **both** the in-RAM `stickyPermissionsBySession` and the on-disk `permission_rules.json`.

### GUI flow (`Chrome.beforeToolCall`)

Same precedence:

```
Phase 1 safe-list ─→ persistent rules (NEW) ─→ in-RAM sessionApprovedTools ─→ approval banner
```

`Allow for Session` / `Allow without sandbox for Session` clicks now also persist to disk.

### `BrokkAcpAgent`

- New `Map<Path, PermissionRules> rulesByProjectRoot` — lazy-loaded per project root, cached for the lifetime of the agent.
- New methods `persistentPermissionFor(sessionId, toolName, argMatch)` and `rememberPermissionPersistently(sessionId, toolName, argMatch, verdict)`.
- `clearAllSessions()` deliberately does **not** clear `rulesByProjectRoot` — project-scoped rules outlive ACP sessions by design.

## Per-project rationale

Storing per-project rather than per-user because:
- Approving `mvn test` in project A shouldn't blanket-allow it in project B (different security postures).
- Brokk's existing pattern is project-scoped (`.brokk/project.properties`, sessions, code-intelligence cache).
- The user-global allowlist is Phase 1's hardcoded list, by design.

## Concurrency

`PermissionRules.save()` re-reads the file under lock and merges any rules added by other processes (think: two ACP sessions running against the same project) before writing. Later writers preserve earlier writers' rules.

## Test plan

- [x] `./gradlew :app:check` — full suite (spotless + errorprone + NullAway + tests) passes
- [x] 9 new unit tests in `PermissionRulesTest`: empty/missing file, save+reload, replace-existing, corrupt JSON, unsupported version, concurrent merge, isolated tool names, empty argMatch
- [ ] **Manual**: Approve `mvn test` with `Always allow` in Zed/IntelliJ ACP. Confirm `<project>/.brokk/permission_rules.json` contains the rule. Restart Brokk. Run `mvn test` again — should run without prompt.
- [ ] **Manual**: Same workflow in the Swing GUI (Brokk desktop app).
- [ ] **Manual**: Reject `git push` with `Always reject`. Restart. Confirm `git push` is still rejected without prompt.

## Out of scope (follow-ups)

- **Rust ACP server mirror** (`brokk-acp-rust/`): tracked as separate issue. Rust currently always re-prompts shell, so the port also needs to introduce the in-RAM sticky cache before persistence.
- **File-watcher for hand-edits**: editing `permission_rules.json` by hand requires IDE restart. Documented in the code as "restart Brokk to reload".
- **Phase 3**: sandbox-aware gating (Codex-style — when `WORKSPACE_WRITE` sandbox is active, auto-allow non-dangerous commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
