### PR TITLE
test: stabilize SftServerTest macOS flake by avoiding tree-sitter load

### DIFF
--- a/app/src/test/java/ai/brokk/tools/SftServerTest.java
+++ b/app/src/test/java/ai/brokk/tools/SftServerTest.java
@@ -296,18 +296,18 @@ class SftServerTest {
         initGitRepo(repoA);
         initGitRepo(repoB);
 
-        var aFile = repoA.resolve("src/A.java");
+        var aFile = repoA.resolve("src/A.txt");
         Files.createDirectories(aFile.getParent());
-        Files.writeString(aFile, "class A { void before() {} }\n");
+        Files.writeString(aFile, "repo-a content before\n");
         commitAll(repoA, "a before");
-        Files.writeString(aFile, "class A { void after() {} }\n");
+        Files.writeString(aFile, "repo-a content after\n");
         commitAll(repoA, "a after");
 
-        var bFile = repoB.resolve("src/B.java");
+        var bFile = repoB.resolve("src/B.txt");
         Files.createDirectories(bFile.getParent());
-        Files.writeString(bFile, "class B { void before() {} }\n");
+        Files.writeString(bFile, "repo-b content before\n");
         var from = commitAll(repoB, "b before");
-        Files.writeString(bFile, "class B { void after() {} }\n");
+        Files.writeString(bFile, "repo-b content after\n");
         var to = commitAll(repoB, "b after");
 
         try (var server = new SftServer(0)) {
@@ -324,9 +324,9 @@ class SftServerTest {
             var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 
             assertEquals(200, response.statusCode());
-            assertTrue(response.body().contains("src/B.java"));
+            assertTrue(response.body().contains("src/B.txt"));
             assertTrue(response.body().contains("after"));
-            assertFalse(response.body().contains("src/A.java"));
+            assertFalse(response.body().contains("src/A.txt"));
         }
     }
 


### PR DESCRIPTION
## Summary

`SftServerTest.httpFormatPatch_usesRepoPathFromRequest` has been failing intermittently on macOS CI (most recent: run [25158778366](https://github.com/BrokkAi/brokk/actions/runs/25158778366)) with `Failed to delete temp directory ... junit-XXXXX`. The test creates `repo-b/src/B.java`; `MainProject.getAnalyzerLanguages()` auto-detects Java from the extension, so a real tree-sitter Java analyzer loads and writes `repo-b/.brokk/code_intelligence/java.bin.lz4` asynchronously. On macOS, those writes outlive `ContextManager.close()`'s 5s await and race JUnit's `@TempDir` cleanup.

Renaming the two fixtures to `.txt` makes `getAnalyzerLanguages()` return `Languages.NONE`, so `AnalyzerWrapper` uses `DisabledAnalyzer` — no tree-sitter writes, no race.

## Why this is safe

`format_patch` is extension-agnostic: it uses `GitRepoData.getFileDiffs` (pure JGit blob diffs), `SearchReplaceBlockFormatter.fromFileDiffs`, and `normalizePatchBlock`. None of them branch on `.java` vs `.txt`. The test's stated intent — verify `/format_patch` routes by the request's `repo_path` (B's content present, A's content absent) — is preserved by distinct text payloads in repo-a and repo-b.

Java-specific coverage is already provided by sibling tests (`formatPatch_formatsLocalizedSearchReplaceBlocks`, `formatPatch_filtersByIncludedFilenames`) which call `format_patch` directly without going through HTTP, so they don't exhibit the same timing race.

## Precedent

Same pattern applied in commit 62f1d0df2 ("Fix flaky macOS tests") for `AnalyzerWrapperPersistenceTest`. Underlying bug — `ContextManager.close()` / `AnalyzerWrapper.close()` returning before async tree-sitter writes finish — remains as preexisting tech debt; not addressed in this PR per scope decision.

## Test plan

- [x] `./gradlew :app:check` — BUILD SUCCESSFUL (full suite: spotless + errorprone + NullAway + tests)
- [x] `./gradlew :app:test --tests "ai.brokk.tools.SftServerTest.httpFormatPatch_usesRepoPathFromRequest" -i` — passes; logs confirm no `TreeSitterAnalyzer` / `TreeSitterStateIO` activity for repo-a/repo-b
- [x] `./gradlew :app:test --tests "ai.brokk.tools.SftServerTest"` — all 6 tests in class pass (no regression)
- [ ] Watch macOS leg of CI for 2-3 runs post-merge to confirm flake is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
