### PR TITLE
ACP: add /codex-login slash command for OpenAI OAuth sign-in

### DIFF
--- a/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
+++ b/app/src/main/java/ai/brokk/acp/AcpRequestContext.java
@@ -204,7 +204,12 @@ final class AcpRequestContext implements AcpPromptContext {
 
     @Override
     public void sendMessage(String text) {
-        sendUpdate(sessionId, new AcpSchema.AgentMessageChunk("agent_message_chunk", new AcpSchema.TextContent(text)));
+        sendUpdate(sessionId, agentMessageChunk(text));
+    }
+
+    /** Shared constructor for the agent_message_chunk session update; reused by async senders. */
+    static AcpSchema.AgentMessageChunk agentMessageChunk(String text) {
+        return new AcpSchema.AgentMessageChunk("agent_message_chunk", new AcpSchema.TextContent(text));
     }
 
     @Override

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -7,6 +7,7 @@ import ai.brokk.IAppContextManager;
 import ai.brokk.IssueProvider;
 import ai.brokk.Service;
 import ai.brokk.SessionManager.SessionInfo;
+import ai.brokk.SettingsChangeListener;
 import ai.brokk.agents.BuildAgent.BuildDetails;
 import ai.brokk.agents.BuildAgent.ModuleBuildEntry;
 import ai.brokk.analyzer.Language;
@@ -15,6 +16,7 @@ import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.concurrent.AtomicWrites;
 import ai.brokk.concurrent.LoggingFuture;
 import ai.brokk.context.Context;
+import ai.brokk.exception.GlobalExceptionHandler;
 import ai.brokk.executor.jobs.JobRunner;
 import ai.brokk.executor.jobs.JobSpec;
 import ai.brokk.executor.jobs.JobStore;
@@ -25,6 +27,7 @@ import ai.brokk.mcpclient.HttpMcpServer;
 import ai.brokk.mcpclient.McpServer;
 import ai.brokk.mcpclient.McpUtils;
 import ai.brokk.mcpclient.StdioMcpServer;
+import ai.brokk.openai.OpenAiOAuthService;
 import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
 import ai.brokk.project.ModelProperties;
@@ -56,6 +59,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -189,6 +196,24 @@ public class BrokkAcpAgent {
     interface SessionUpdateSender {
         void sendSessionUpdate(String sessionId, AcpSchema.SessionUpdate update);
     }
+
+    /**
+     * In-flight Codex OAuth attempt. {@link OpenAiOAuthService} only supports one OAuth flow per
+     * JVM (static lock, single bound port 1455), so this is held as a single
+     * {@link AtomicReference} rather than per-session. Cleared when the OAuth callback fires, the
+     * timeout expires, or the owning session is closed.
+     */
+    private record LoginPending(String sessionId, SettingsChangeListener listener, ScheduledFuture<?> timeout) {}
+
+    private final AtomicReference<LoginPending> pendingLogin = new AtomicReference<>();
+
+    private static final ScheduledExecutorService LOGIN_TIMEOUT_EXEC = Executors.newSingleThreadScheduledExecutor(r -> {
+        var t = new Thread(r, "acp-codex-login-timeout");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private static final long LOGIN_TIMEOUT_MINUTES = 5;
 
     /**
      * Production constructor. Bundles are created lazily by {@code factory} on the first session
@@ -325,6 +350,11 @@ public class BrokkAcpAgent {
         pendingPlanBySession.clear();
         sessionsOnFallbackCatalog.clear();
         bundleBySession.clear();
+        var pending = pendingLogin.getAndSet(null);
+        if (pending != null) {
+            pending.timeout().cancel(false);
+            MainProject.removeSettingsChangeListener(pending.listener());
+        }
     }
 
     /**
@@ -566,7 +596,20 @@ public class BrokkAcpAgent {
         lastTaskListBySession.remove(sessionId);
         pendingPlanBySession.remove(sessionId);
         bundleBySession.remove(sessionId);
+        cancelPendingLoginIfOwnedBy(sessionId);
         return new AcpProtocol.CloseSessionResponse(null);
+    }
+
+    /**
+     * If a Codex login attempt is in flight and owned by {@code sessionId}, unregister its listener
+     * and cancel its timeout. The OAuth callback server itself is left alone — if a callback still
+     * arrives later it will flip the global flag harmlessly with no listener to notify.
+     */
+    private void cancelPendingLoginIfOwnedBy(String sessionId) {
+        var pending = pendingLogin.get();
+        if (pending != null && pending.sessionId().equals(sessionId)) {
+            cancelPending(pending);
+        }
     }
 
     public AcpProtocol.ForkSessionResponse forkSession(AcpProtocol.ForkSessionRequest request) {
@@ -1661,10 +1704,7 @@ public class BrokkAcpAgent {
                     var rawText = mopMarkdown != null ? mopMarkdown : task.summary();
                     var responseText = rawText == null ? null : Messages.stripLegacyFraming(rawText);
                     if (responseText != null && !responseText.isBlank()) {
-                        sender.sendSessionUpdate(
-                                sessionId,
-                                new AcpSchema.AgentMessageChunk(
-                                        "agent_message_chunk", new AcpSchema.TextContent(responseText)));
+                        sender.sendSessionUpdate(sessionId, AcpRequestContext.agentMessageChunk(responseText));
                     }
                 }
                 logger.info("Conversation replay complete for session {} ({} entries)", sessionId, taskHistory.size());
@@ -1799,6 +1839,10 @@ public class BrokkAcpAgent {
             }
             case "/sandbox" -> {
                 handleSandboxCommand(sessionId, parts.length > 1 ? parts[1] : "", promptContext);
+                yield true;
+            }
+            case "/codex-login" -> {
+                handleCodexLoginCommand(sessionId, parts.length > 1 ? parts[1] : "", promptContext);
                 yield true;
             }
             default -> false;
@@ -1947,6 +1991,218 @@ public class BrokkAcpAgent {
             default ->
                 promptContext.sendMessage("Error: unknown /sandbox argument '" + arg.trim()
                         + "'. Usage: `/sandbox on|off` (or `/sandbox` to show status).");
+        }
+    }
+
+    /**
+     * Handles {@code /codex-login} with optional subcommand.
+     *
+     * <p>Reuses {@link OpenAiOAuthService#startAuthorization(java.awt.Component)} — the same flow
+     * used by the GUI sign-in. The browser opens locally on the user's machine; the OAuth callback
+     * lands on {@code http://localhost:1455/auth/callback}, forwards to the Brokk backend, and
+     * flips {@link MainProject#setOpenAiCodexOauthConnected(boolean)}. We register a one-shot
+     * {@link SettingsChangeListener} so the agent can push an async confirmation message to the
+     * session once the user completes the browser flow, with a 5-minute timeout as the failsafe.
+     */
+    private void handleCodexLoginCommand(String sessionId, String arg, AcpPromptContext promptContext) {
+        var trimmed = arg.trim().toLowerCase(Locale.ROOT);
+        switch (trimmed) {
+            case "" -> startCodexLogin(sessionId, promptContext);
+            case "status" -> showCodexLoginStatus(promptContext);
+            case "disconnect" -> disconnectCodex(sessionId, promptContext);
+            case "open" -> reopenCodexLoginBrowser(promptContext);
+            default ->
+                promptContext.sendMessage("Error: unknown /codex-login argument '" + arg.trim()
+                        + "'. Usage: `/codex-login [status|disconnect|open]`.");
+        }
+    }
+
+    private void startCodexLogin(String sessionId, AcpPromptContext promptContext) {
+        if (MainProject.isOpenAiCodexOauthConnected()) {
+            promptContext.sendMessage(
+                    "Already signed in to Codex. Use `/codex-login disconnect` to sign out, or `/codex-login status` to check.");
+            return;
+        }
+        if (MainProject.getBrokkKey().isBlank()) {
+            promptContext.sendMessage(
+                    "Brokk key is not set. Set it in the Brokk GUI (Settings) or via the `BROKK_KEY` environment variable, then retry `/codex-login`.");
+            return;
+        }
+
+        SettingsChangeListener listener = new SettingsChangeListener() {
+            @Override
+            public void openAiOauthConnectionChanged() {
+                if (!MainProject.isOpenAiCodexOauthConnected()) {
+                    return;
+                }
+                var current = pendingLogin.get();
+                if (current == null || !current.sessionId().equals(sessionId)) {
+                    return;
+                }
+                if (!pendingLogin.compareAndSet(current, null)) {
+                    return;
+                }
+                try {
+                    current.timeout().cancel(false);
+                } finally {
+                    MainProject.removeSettingsChangeListener(this);
+                }
+                pushSessionMessage(sessionId, "Codex sign-in successful.");
+                logger.info("ACP /codex-login completed for session {}", sessionId);
+                // Mirror SettingsGlobalPanel.maybeRunCodexAutoSetup so ACP and GUI converge after
+                // sign-in: install Codex favorites, then reload Service so getAvailableModels
+                // sees the new OAuth-only catalog. Run off the OAuth callback thread.
+                LoggingFuture.runVirtual(() -> {
+                    MainProject.saveFavoriteModels(ModelProperties.CODEX_OAUTH_FAVORITES);
+                    var bundle = bundleBySession.get(sessionId);
+                    if (bundle != null) {
+                        bundle.cm().reloadService();
+                    }
+                });
+            }
+        };
+
+        // Raw ScheduledExecutorService swallows runnable exceptions; wrap so unexpected throws
+        // surface through the project-wide handler instead of disabling future scheduled tasks.
+        ScheduledFuture<?> timeout = LOGIN_TIMEOUT_EXEC.schedule(
+                () -> {
+                    try {
+                        var current = pendingLogin.get();
+                        if (current == null || !current.sessionId().equals(sessionId)) {
+                            return;
+                        }
+                        if (!pendingLogin.compareAndSet(current, null)) {
+                            return;
+                        }
+                        MainProject.removeSettingsChangeListener(current.listener());
+                        OpenAiOAuthService.cancelAuthorization();
+                        pushSessionMessage(
+                                sessionId,
+                                "Codex sign-in timed out after " + LOGIN_TIMEOUT_MINUTES
+                                        + " minutes. Run `/codex-login` again to retry.");
+                        logger.info("ACP /codex-login timed out for session {}", sessionId);
+                    } catch (Throwable t) {
+                        GlobalExceptionHandler.handle(t, st -> {});
+                    }
+                },
+                LOGIN_TIMEOUT_MINUTES,
+                TimeUnit.MINUTES);
+
+        var pending = new LoginPending(sessionId, listener, timeout);
+        if (!pendingLogin.compareAndSet(null, pending)) {
+            timeout.cancel(false);
+            var current = pendingLogin.get();
+            var owner = current == null ? "another" : current.sessionId();
+            promptContext.sendMessage("Another session (" + owner
+                    + ") is already signing in to Codex. Try again in a moment, or run `/codex-login status`.");
+            return;
+        }
+
+        MainProject.addSettingsChangeListener(listener);
+
+        try {
+            OpenAiOAuthService.startAuthorization(null);
+        } catch (IllegalStateException e) {
+            // OpenAiOAuthService re-throws this in headless mode when the callback server cannot
+            // bind port 1455 (typically: another process or a stale Brokk GUI is using it).
+            cancelPending(pending);
+            logger.warn("ACP /codex-login failed to start OAuth server", e);
+            promptContext.sendMessage(
+                    "Failed to start the Codex OAuth callback server on port 1455. Another process may be using it. Close any other Brokk instance and retry.");
+            return;
+        } catch (RuntimeException e) {
+            cancelPending(pending);
+            logger.warn("ACP /codex-login failed", e);
+            promptContext.sendMessage("Failed to start Codex sign-in: " + e.getMessage());
+            return;
+        }
+
+        var url = OpenAiOAuthService.getPendingAuthorizationUrl();
+        var base =
+                """
+                Opened your browser to sign in to Codex.
+
+                Complete the OAuth flow in the browser; this chat will receive a confirmation when done. Times out in %d minutes."""
+                        .formatted(LOGIN_TIMEOUT_MINUTES);
+        var msg = url == null ? base : base + "\n\nIf nothing opened, paste this URL:\n\n" + url;
+        promptContext.sendMessage(msg);
+        logger.info("ACP /codex-login started for session {}", sessionId);
+    }
+
+    private void showCodexLoginStatus(AcpPromptContext promptContext) {
+        var connected = MainProject.isOpenAiCodexOauthConnected();
+        var pending = pendingLogin.get();
+        var status = "Codex OAuth: " + (connected ? "**connected**" : "**not connected**") + ".";
+        var msg = pending == null
+                ? status
+                : status + "\n\nA sign-in attempt is in flight (session " + pending.sessionId() + ").";
+        promptContext.sendMessage(msg);
+    }
+
+    private void disconnectCodex(String sessionId, AcpPromptContext promptContext) {
+        if (!MainProject.isOpenAiCodexOauthConnected()) {
+            promptContext.sendMessage("Codex is not connected; nothing to disconnect.");
+            return;
+        }
+        promptContext.sendMessage("Disconnecting Codex...");
+        // Service.disconnectCodexOauth() is a synchronous HTTP DELETE; off-load it so the slash
+        // response returns immediately and the prompt thread is not blocked on the backend.
+        LoggingFuture.runVirtual(() -> {
+            var error = Service.disconnectCodexOauth();
+            if (error == null) {
+                MainProject.setOpenAiCodexOauthConnected(false);
+                // Drop any in-flight login on this JVM so its listener cannot fire a phantom
+                // "successful" message on a future unrelated reconnection.
+                var pending = pendingLogin.get();
+                if (pending != null) {
+                    cancelPending(pending);
+                }
+                pushSessionMessage(sessionId, "Codex sign-in disconnected.");
+                logger.info("ACP /codex-login disconnect succeeded");
+            } else {
+                pushSessionMessage(sessionId, "Failed to disconnect Codex: " + error);
+                logger.warn("ACP /codex-login disconnect failed: {}", error);
+            }
+        });
+    }
+
+    private void reopenCodexLoginBrowser(AcpPromptContext promptContext) {
+        // Only honor /codex-login open while an attempt is actually in flight. Without this guard
+        // we would re-open a stale URL whose pending state was already torn down by cancelPending,
+        // which would race the still-bound server.
+        if (pendingLogin.get() == null) {
+            promptContext.sendMessage("No pending Codex sign-in. Run `/codex-login` first.");
+            return;
+        }
+        var url = OpenAiOAuthService.getPendingAuthorizationUrl();
+        if (url == null) {
+            promptContext.sendMessage("No pending Codex sign-in. Run `/codex-login` first.");
+            return;
+        }
+        Environment.openInBrowser(url, null);
+        promptContext.sendMessage("Re-opened browser. If nothing opened, paste this URL:\n\n" + url);
+    }
+
+    private void cancelPending(LoginPending pending) {
+        if (!pendingLogin.compareAndSet(pending, null)) {
+            return;
+        }
+        pending.timeout().cancel(false);
+        MainProject.removeSettingsChangeListener(pending.listener());
+        // Tear down the local callback server so port 1455 and the PKCE verifier do not linger.
+        OpenAiOAuthService.cancelAuthorization();
+    }
+
+    private void pushSessionMessage(String sessionId, String text) {
+        var sender = sessionUpdateSender;
+        if (sender == null) {
+            logger.debug("No sessionUpdateSender available; dropping message for session {}", sessionId);
+            return;
+        }
+        try {
+            sender.sendSessionUpdate(sessionId, AcpRequestContext.agentMessageChunk(text));
+        } catch (Exception e) {
+            logger.warn("Failed to push session message to {}", sessionId, e);
         }
     }
 
@@ -2699,7 +2955,11 @@ public class BrokkAcpAgent {
                         new AcpSchema.AvailableCommand(
                                 "sandbox",
                                 "Show or toggle the kernel sandbox for shell commands",
-                                new AcpSchema.AvailableCommandInput("on|off")));
+                                new AcpSchema.AvailableCommandInput("on|off")),
+                        new AcpSchema.AvailableCommand(
+                                "codex-login",
+                                "Sign in to Codex (OpenAI OAuth) or disconnect",
+                                new AcpSchema.AvailableCommandInput("[status|disconnect|open]")));
                 sender.sendSessionUpdate(
                         sessionId, new AcpSchema.AvailableCommandsUpdate("available_commands_update", commands));
             } catch (Exception e) {

--- a/app/src/main/java/ai/brokk/openai/OpenAiOAuthService.java
+++ b/app/src/main/java/ai/brokk/openai/OpenAiOAuthService.java
@@ -224,6 +224,18 @@ public class OpenAiOAuthService {
         }
     }
 
+    /**
+     * Stops the OAuth callback server (if any) and clears pending state. Safe to call when no flow
+     * is in progress; in that case it is a no-op. Used by callers that need to abandon a pending
+     * authorization without waiting for the user (e.g. ACP {@code /codex-login} timeout / cancel)
+     * so the local port and PKCE state do not linger across attempts.
+     */
+    public static void cancelAuthorization() {
+        synchronized (lock) {
+            stopActiveServerInternal();
+        }
+    }
+
     private static void handleCallback(HttpExchange exchange) {
         String query = exchange.getRequestURI().getQuery();
         Map<String, String> params = parseQueryParams(query);

--- a/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
+++ b/app/src/test/java/ai/brokk/acp/BrokkAcpAgentTest.java
@@ -13,6 +13,7 @@ import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.executor.jobs.JobRunner;
 import ai.brokk.executor.jobs.JobStore;
 import ai.brokk.io.ProjectFiles;
+import ai.brokk.openai.OpenAiOAuthService;
 import ai.brokk.project.MainProject;
 import ai.brokk.project.ModelProperties;
 import ai.brokk.testutil.TestService;
@@ -705,6 +706,108 @@ class BrokkAcpAgentTest {
 
             assertTrue(joinedPromptMessages(fixture.transport)
                     .contains("Error: unknown configuration section: bogusSection"));
+        }
+    }
+
+    @Test
+    void promptCodexLoginUnknownArgPrintsUsage() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+
+        try (var fixture = new PermissionFixture()) {
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/codex-login bogus"), fixture.contextFor(created.sessionId()));
+
+            assertTrue(joinedPromptMessages(fixture.transport).contains("unknown /codex-login argument 'bogus'"));
+        }
+    }
+
+    @Test
+    void promptCodexLoginStatusReportsConnectedAndNotConnected() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        boolean previous = MainProject.isOpenAiCodexOauthConnected();
+        try (var fixture = new PermissionFixture()) {
+            MainProject.setOpenAiCodexOauthConnected(true);
+            agent.prompt(
+                    promptRequest(created.sessionId(), "/codex-login status"), fixture.contextFor(created.sessionId()));
+            assertTrue(joinedPromptMessages(fixture.transport).contains("**connected**"));
+
+            try (var fixture2 = new PermissionFixture()) {
+                MainProject.setOpenAiCodexOauthConnected(false);
+                agent.prompt(
+                        promptRequest(created.sessionId(), "/codex-login status"),
+                        fixture2.contextFor(created.sessionId()));
+                assertTrue(joinedPromptMessages(fixture2.transport).contains("**not connected**"));
+            }
+        } finally {
+            MainProject.setOpenAiCodexOauthConnected(previous);
+        }
+    }
+
+    @Test
+    void promptCodexLoginStartRefusesWhenAlreadyConnected() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        boolean previous = MainProject.isOpenAiCodexOauthConnected();
+        try (var fixture = new PermissionFixture()) {
+            MainProject.setOpenAiCodexOauthConnected(true);
+            agent.prompt(promptRequest(created.sessionId(), "/codex-login"), fixture.contextFor(created.sessionId()));
+            assertTrue(joinedPromptMessages(fixture.transport).contains("Already signed in to Codex"));
+        } finally {
+            MainProject.setOpenAiCodexOauthConnected(previous);
+        }
+    }
+
+    @Test
+    void promptCodexLoginStartRefusesWhenBrokkKeyBlank() {
+        var created = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+        boolean previousConnected = MainProject.isOpenAiCodexOauthConnected();
+        String previousKey = MainProject.getBrokkKey();
+        try (var fixture = new PermissionFixture()) {
+            MainProject.setOpenAiCodexOauthConnected(false);
+            MainProject.setHeadlessBrokkApiKeyOverride("");
+            agent.prompt(promptRequest(created.sessionId(), "/codex-login"), fixture.contextFor(created.sessionId()));
+            assertTrue(joinedPromptMessages(fixture.transport).contains("Brokk key is not set"));
+        } finally {
+            MainProject.setOpenAiCodexOauthConnected(previousConnected);
+            MainProject.setHeadlessBrokkApiKeyOverride(previousKey.isBlank() ? null : previousKey);
+        }
+    }
+
+    @Test
+    void promptCodexLoginCloseSessionAllowsRetryFromAnotherSession() throws InterruptedException {
+        boolean previousConnected = MainProject.isOpenAiCodexOauthConnected();
+        Runnable previousHook = OpenAiOAuthService.testAuthorizationHook;
+        try {
+            MainProject.setOpenAiCodexOauthConnected(false);
+            MainProject.setHeadlessBrokkApiKeyOverride("test-brokk-key");
+            // Hook bypasses the real port-1455 callback server while still letting our agent's
+            // CAS/listener bookkeeping run.
+            OpenAiOAuthService.testAuthorizationHook = () -> {};
+
+            var first = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+            try (var fixture = new PermissionFixture()) {
+                agent.prompt(promptRequest(first.sessionId(), "/codex-login"), fixture.contextFor(first.sessionId()));
+                assertTrue(joinedPromptMessages(fixture.transport).contains("Opened your browser to sign in to Codex"));
+            }
+
+            agent.closeSession(new AcpProtocol.CloseSessionRequest(first.sessionId(), null));
+
+            // After the owning session closed, a new session must be able to start its own login
+            // without hitting the "Another session is already signing in" guard.
+            var second = agent.newSession(new AcpSchema.NewSessionRequest(projectRoot.toString(), List.of()));
+            try (var fixture = new PermissionFixture()) {
+                agent.prompt(promptRequest(second.sessionId(), "/codex-login"), fixture.contextFor(second.sessionId()));
+                var messages = joinedPromptMessages(fixture.transport);
+                assertFalse(messages.contains("Another session"), messages);
+                assertTrue(messages.contains("Opened your browser to sign in to Codex"), messages);
+            }
+        } finally {
+            // clearAllSessions drops any pendingLogin and unregisters its MainProject listener so a
+            // later test that flips the OAuth flag does not fire the leaked listener and trigger
+            // saveFavoriteModels(CODEX_OAUTH_FAVORITES) globally.
+            agent.clearAllSessions();
+            OpenAiOAuthService.testAuthorizationHook = previousHook;
+            MainProject.setOpenAiCodexOauthConnected(previousConnected);
+            MainProject.setHeadlessBrokkApiKeyOverride(null);
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a `/codex-login` slash command to Brokk's Java ACP server so users running Brokk through Zed/IntelliJ can sign into Codex (OpenAI OAuth) the same way the Brokk GUI does — there was no path to it before.

The command reuses the existing `OpenAiOAuthService.startAuthorization` flow (PKCE, browser open, callback on `http://localhost:1455/auth/callback`). Subcommands: `status`, `disconnect`, `open`. After successful sign-in the agent installs `CODEX_OAUTH_FAVORITES` and reloads the service, mirroring `SettingsGlobalPanel.maybeRunCodexAutoSetup` so ACP reaches feature parity with the GUI.

## What changed

- New `BrokkAcpAgent.handleCodexLoginCommand` plus support methods `startCodexLogin`, `showCodexLoginStatus`, `disconnectCodex`, `reopenCodexLoginBrowser`.
- One-shot `SettingsChangeListener` registered against `MainProject` plus a 5-minute `ScheduledFuture` failsafe; both are torn down via the new `cancelPending` helper. Cleanup is also wired into `closeSession` and `clearAllSessions`.
- `OpenAiOAuthService.cancelAuthorization()` (new public API) so the local callback server and PKCE state are released when an attempt is cancelled or times out — keeps port 1455 from lingering across attempts.
- `disconnectCodex` runs the HTTP DELETE off the prompt thread via `LoggingFuture.runVirtual`, posting the result through the out-of-prompt sender. Disconnect also drops any in-flight pending login on the same JVM.
- A small `AcpRequestContext.agentMessageChunk(String)` helper consolidates the `AgentMessageChunk("agent_message_chunk", new TextContent(...))` literal across `AcpRequestContext.sendMessage`, the new async `pushSessionMessage`, and `scheduleConversationReplay`.
- `/codex-login` is advertised through `scheduleAvailableCommandsUpdate` so ACP clients see it in their slash-command palette.

## Concurrency

`OpenAiOAuthService` already enforces a single in-flight OAuth attempt per JVM (static lock + bound port). The agent reflects that with one `AtomicReference<LoginPending>`; a second `/codex-login` while one is in flight is rejected with an explicit message rather than silently clobbering the first attempt.

The timeout lambda is wrapped in `try/catch (Throwable)` routed through `GlobalExceptionHandler`. `ScheduledExecutorService` swallows runnable exceptions; `LoggingExecutorService` does not implement `ScheduledExecutorService`, so the inline guard is the closest analog to the project's executor-wrapping guideline.

## Tests

5 new tests in `BrokkAcpAgentTest`, all using the existing `PermissionFixture` and `OpenAiOAuthService.testAuthorizationHook` so nothing actually binds port 1455 or hits the network:

- `promptCodexLoginUnknownArgPrintsUsage`
- `promptCodexLoginStatusReportsConnectedAndNotConnected`
- `promptCodexLoginStartRefusesWhenAlreadyConnected`
- `promptCodexLoginStartRefusesWhenBrokkKeyBlank`
- `promptCodexLoginCloseSessionAllowsRetryFromAnotherSession` (verifies that after the owning session closes, the listener and pending state are cleared so a fresh session can retry without hitting the in-flight guard)

The last test calls `agent.clearAllSessions()` in its `finally` block to drop the listener it registered against `MainProject` (a static field) so subsequent tests that flip the OAuth flag do not re-fire it.

## Test plan

- [x] `./gradlew :app:check` passes locally (Spotless + ErrorProne + NullAway + JUnit).
- [ ] Manual smoke from a Zed ACP session: `/codex-login` opens the browser; completing the flow posts the async confirmation and `/codex-login status` reports connected.
- [ ] Manual: `/codex-login` while already connected returns the "Already signed in" hint, and `/codex-login disconnect` succeeds.
- [ ] Manual: bind port 1455 separately (e.g. `python3 -m http.server 1455`) and run `/codex-login` to confirm the friendly port-busy message.
- [ ] Manual: from two ACP sessions in the same JVM, run `/codex-login` concurrently and confirm the second session is rejected with the in-flight message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
