### PR TITLE
docs+build: add local-dev tasks and guide for Zed/JetBrains ACP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -959,7 +959,9 @@ tasks.shadowJar {
     enabled = project.hasProperty("enableShadowJar") ||
               System.getenv("CI") == "true" ||
               gradle.startParameter.taskNames.any {
-                  it.contains("shadowJar") || it.contains("deployMcpShadowJar")
+                  it.contains("shadowJar") ||
+                          it.contains("deployMcpShadowJar") ||
+                          it.contains("buildAcpServerJarFor")
               }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,6 +143,90 @@ tasks.register("deployMcpShadowJar") {
     }
 }
 
+// Resolves an executable on PATH so the JetBrains/Zed-spawned subprocess (which doesn't inherit
+// the user's shell PATH on macOS) gets an absolute command. Cross-platform: tries .exe/.cmd/.bat
+// extensions on Windows.
+fun findExecutableOnPath(name: String): String? {
+    val pathEnv = System.getenv("PATH") ?: return null
+    val isWindows = org.gradle.internal.os.OperatingSystem.current().isWindows
+    val sep = if (isWindows) ";" else ":"
+    val exts = if (isWindows) listOf("", ".exe", ".cmd", ".bat") else listOf("")
+    for (dir in pathEnv.split(sep)) {
+        if (dir.isBlank()) continue
+        for (ext in exts) {
+            val candidate = File(dir, name + ext)
+            if (candidate.canExecute()) return candidate.absolutePath
+        }
+    }
+    return null
+}
+
+// Writes the given JSON model to the config file, replacing any existing
+// agent_servers["Brokk Code (Local Jar)"] entry while leaving every other key intact.
+@Suppress("UNCHECKED_CAST")
+fun writeLocalJarAcpEntry(configFile: File, jar: File, uvxPath: String, includeZedTypeField: Boolean) {
+    val parsed: MutableMap<String, Any> = if (configFile.exists() && configFile.length() > 0L) {
+        JsonSlurper().parseText(configFile.readText()) as? MutableMap<String, Any>
+            ?: throw GradleException("Existing config at ${configFile.absolutePath} is not a JSON object.")
+    } else {
+        mutableMapOf()
+    }
+    val agentServers = (parsed["agent_servers"] as? MutableMap<String, Any>) ?: mutableMapOf<String, Any>().also {
+        parsed["agent_servers"] = it
+    }
+    val entry = linkedMapOf<String, Any>()
+    if (includeZedTypeField) entry["type"] = "custom"
+    entry["command"] = uvxPath
+    entry["args"] = listOf("brokk", "acp", "--jar", jar.absolutePath)
+    entry["env"] = emptyMap<String, String>()
+    agentServers["Brokk Code (Local Jar)"] = entry
+
+    configFile.parentFile.mkdirs()
+    configFile.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(parsed)) + "\n")
+}
+
+tasks.register("buildAcpServerJarForJetbrains") {
+    description = "Builds :app:shadowJar and rewrites the 'Brokk Code (Local Jar)' entry in ~/.jetbrains/acp.json to point at the just-built jar."
+    group = "distribution"
+
+    dependsOn(":app:shadowJar")
+
+    doLast {
+        val jar = rootDir.resolve("app/build/libs/brokk-${project.version}.jar")
+        if (!jar.exists()) {
+            throw GradleException("Expected shadow jar not found: ${jar.absolutePath}")
+        }
+        val uvxPath = findExecutableOnPath("uvx")
+            ?: throw GradleException("uvx not found on PATH. Install via 'pipx install brokk' or 'pip install --user brokk' and retry.")
+
+        val configFile = (findProperty("acpJetbrainsConfig") as String?)?.let(::File)
+            ?: File(System.getProperty("user.home"), ".jetbrains/acp.json")
+        writeLocalJarAcpEntry(configFile, jar, uvxPath, includeZedTypeField = false)
+        println("Updated 'Brokk Code (Local Jar)' in ${configFile.absolutePath} -> ${jar.absolutePath}")
+    }
+}
+
+tasks.register("buildAcpServerJarForZed") {
+    description = "Builds :app:shadowJar and rewrites the 'Brokk Code (Local Jar)' entry in ~/.config/zed/settings.json to point at the just-built jar."
+    group = "distribution"
+
+    dependsOn(":app:shadowJar")
+
+    doLast {
+        val jar = rootDir.resolve("app/build/libs/brokk-${project.version}.jar")
+        if (!jar.exists()) {
+            throw GradleException("Expected shadow jar not found: ${jar.absolutePath}")
+        }
+        val uvxPath = findExecutableOnPath("uvx")
+            ?: throw GradleException("uvx not found on PATH. Install via 'pipx install brokk' or 'pip install --user brokk' and retry.")
+
+        val configFile = (findProperty("acpZedConfig") as String?)?.let(::File)
+            ?: File(System.getProperty("user.home"), ".config/zed/settings.json")
+        writeLocalJarAcpEntry(configFile, jar, uvxPath, includeZedTypeField = true)
+        println("Updated 'Brokk Code (Local Jar)' in ${configFile.absolutePath} -> ${jar.absolutePath}")
+    }
+}
+
 tasks.register("deployCoreMcpShadowJar") {
     description = "Builds :brokk-core:shadowJar and copies it to a stable MCP jar path."
     group = "distribution"

--- a/docs/acp-jetbrains-local-dev.md
+++ b/docs/acp-jetbrains-local-dev.md
@@ -1,0 +1,121 @@
+# Running a local Brokk ACP server in JetBrains IDEs
+
+This guide explains how to build the Brokk Java ACP server from source and wire
+it into a JetBrains IDE (IntelliJ IDEA, PyCharm, etc.) for local development
+work — for example, when you want the IDE's Brokk Code panel to use your
+in-progress branch instead of the published release.
+
+The general design of the ACP server is described in
+[acp-native-java-server.md](acp-native-java-server.md); this document covers
+only the JetBrains wiring.
+
+## Prerequisites
+
+- A working JetBrains IDE with the Brokk Code plugin installed.
+- The Brokk PyPI release available on `PATH` (the `uvx brokk acp` wrapper). Most
+  developers already have it from `uvx brokk` for the headless CLI.
+- A local checkout of `BrokkAi/brokk` and the standard build environment
+  (Java 21, Gradle wrapper).
+
+You do **not** need a Python environment beyond what `uvx` already manages.
+
+## Step 1: Build the shadow jar
+
+The shadow jar is gated behind an explicit task name — running `./gradlew build`
+or `./gradlew :app:check` will not produce it. Run the task directly:
+
+```bash
+./gradlew :app:shadowJar
+```
+
+The output lands at `app/build/libs/brokk-${git-describe}.jar`, where
+`${git-describe}` is the result of `git describe` against the nearest version
+tag (for example `0.23.5.beta8-2-g3c724bef9`). The version embeds the commit
+SHA, so each rebuild on a different commit produces a distinctly named jar.
+
+The first build is slow (~2 min on a warm machine); incremental rebuilds when
+only application code changed are fast (~20 s) because Gradle caches the
+component jars.
+
+## Step 2: Wire the jar into `~/.jetbrains/acp.json`
+
+The JetBrains plugin reads agent server definitions from
+`~/.jetbrains/acp.json`. The schema is a top-level object with a single
+`agent_servers` map keyed by display name. Each entry specifies a `command`,
+optional `args`, and optional `env`.
+
+To run your local jar, add (or update) a `Brokk Code (Local Jar)` entry that
+delegates to the `uvx brokk acp` wrapper with `--jar` pointing at the absolute
+path of the shadow jar you just built:
+
+```json
+{
+  "default_mcp_settings": {},
+  "agent_servers": {
+    "Brokk Code (Local Jar)": {
+      "command": "/opt/homebrew/bin/uvx",
+      "args": [
+        "brokk",
+        "acp",
+        "--jar",
+        "/absolute/path/to/brokk/app/build/libs/brokk-0.23.5.betaN-K-gSHA.jar"
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+Replace `/absolute/path/to/brokk` with your checkout path and the version
+fragment with the actual filename produced by Step 1. `command` is whatever
+absolute path your `uvx` lives at — `which uvx` will tell you (`/opt/homebrew/bin/uvx`
+on Apple Silicon Homebrew, `/usr/local/bin/uvx` on Intel Homebrew, etc.).
+
+You can keep multiple entries in `agent_servers` simultaneously; the plugin
+shows them all in the agent server picker.
+
+## Step 3: Select the local jar in the IDE
+
+1. Restart the Brokk Code panel (or the IDE) so the plugin re-reads `acp.json`.
+2. In the Brokk Code panel's agent server selector, choose `Brokk Code (Local Jar)`.
+3. Start a new session. The first prompt should connect to your local jar — you
+   can confirm by tailing `~/.brokk/debug.log` and looking for the `acp_server`
+   entries.
+
+## Why route through `uvx brokk acp --jar` instead of `java -jar` directly
+
+The `uvx brokk acp` wrapper handles three things on your behalf that a raw
+`java -jar` invocation does not:
+
+1. **Stdio hygiene** — the wrapper redirects logging away from stdout, which is
+   reserved for JSON-RPC traffic. Any stray stdout output corrupts the protocol
+   stream and crashes the client (see
+   [acp-native-java-server.md § Logging must avoid stdout](acp-native-java-server.md)).
+2. **Brokk key plumbing** — the wrapper passes your stored Brokk API key to the
+   subprocess via the appropriate flags, without you having to thread it
+   through `acp.json` `env` blocks (which would land plaintext in a config file).
+3. **Proxy/vendor flag forwarding** — the wrapper accepts the same
+   `--proxy-setting` and `--vendor` flags as the published release and translates
+   them into `AcpServerMain` arguments, so the local jar inherits the same
+   defaults as the production binary.
+
+It is technically possible to bypass the wrapper with a `java -jar
+<path-to-jar> --workspace-dir … --brokk-api-key …` invocation, but you would
+have to replicate all three concerns above by hand, and any mistake is silent
+(the IDE just hangs on the first response).
+
+## Rebuilding after code changes
+
+After a `git pull` or local commit, re-run `./gradlew :app:shadowJar`. The new
+jar will land at a new path because the git-describe fragment changes. Either:
+
+- Update the `--jar` path in `~/.jetbrains/acp.json` to the new filename, or
+- Symlink (or copy) the new jar to a stable name and reference that in
+  `acp.json` so you do not have to edit it on every rebuild. For example:
+  ```bash
+  ln -sf "$(ls -t app/build/libs/brokk-*.jar | head -1)" \
+      app/build/libs/brokk-local.jar
+  ```
+
+The plugin only reads `acp.json` on (re)load, so after editing the file you
+must restart the Brokk Code panel.

--- a/docs/acp-jetbrains-local-dev.md
+++ b/docs/acp-jetbrains-local-dev.md
@@ -1,121 +1,131 @@
-# Running a local Brokk ACP server in JetBrains IDEs
+# Running a local Brokk ACP server in Zed and JetBrains IDEs
 
-This guide explains how to build the Brokk Java ACP server from source and wire
-it into a JetBrains IDE (IntelliJ IDEA, PyCharm, etc.) for local development
-work — for example, when you want the IDE's Brokk Code panel to use your
-in-progress branch instead of the published release.
+This guide explains how to build the Brokk Java ACP server from your local
+checkout and wire it into Zed or a JetBrains IDE (IntelliJ IDEA, PyCharm, etc.)
+for local development work — for example, when you want the editor's Brokk
+Code panel to use your in-progress branch instead of the published release.
 
 The general design of the ACP server is described in
 [acp-native-java-server.md](acp-native-java-server.md); this document covers
-only the JetBrains wiring.
+only the editor wiring.
 
 ## Prerequisites
 
-- A working JetBrains IDE with the Brokk Code plugin installed.
-- The Brokk PyPI release available on `PATH` (the `uvx brokk acp` wrapper). Most
-  developers already have it from `uvx brokk` for the headless CLI.
+- Zed and/or a JetBrains IDE with the Brokk Code agent installed.
+- The Brokk PyPI release available on `PATH` (the `uvx brokk acp` wrapper).
+  Most developers already have it from `uvx brokk` for the headless CLI; if
+  not, install with `pipx install brokk` or `pip install --user brokk`.
 - A local checkout of `BrokkAi/brokk` and the standard build environment
   (Java 21, Gradle wrapper).
 
-You do **not** need a Python environment beyond what `uvx` already manages.
+## One-command setup
 
-## Step 1: Build the shadow jar
-
-The shadow jar is gated behind an explicit task name — running `./gradlew build`
-or `./gradlew :app:check` will not produce it. Run the task directly:
+There are two Gradle tasks that build the shadow jar **and** rewrite a
+`Brokk Code (Local Jar)` entry in your editor's config to point at the just-
+built jar. Run the one you want:
 
 ```bash
-./gradlew :app:shadowJar
+# Wire the jar into Zed (~/.config/zed/settings.json)
+./gradlew :buildAcpServerJarForZed
+
+# Wire the jar into JetBrains (~/.jetbrains/acp.json)
+./gradlew :buildAcpServerJarForJetbrains
 ```
 
-The output lands at `app/build/libs/brokk-${git-describe}.jar`, where
-`${git-describe}` is the result of `git describe` against the nearest version
-tag (for example `0.23.5.beta8-2-g3c724bef9`). The version embeds the commit
-SHA, so each rebuild on a different commit produces a distinctly named jar.
+Each task:
 
-The first build is slow (~2 min on a warm machine); incremental rebuilds when
-only application code changed are fast (~20 s) because Gradle caches the
-component jars.
+1. Runs `:app:shadowJar` to produce `app/build/libs/brokk-${git-describe}.jar`.
+2. Resolves the absolute path of `uvx` on your `PATH` (so the editor's spawned
+   subprocess does not depend on inherited shell `PATH`, which GUI apps on
+   macOS do not get).
+3. Rewrites a single `Brokk Code (Local Jar)` entry under `agent_servers` in
+   the editor's config, replacing any prior entry with the same name and
+   leaving every other entry intact.
 
-## Step 2: Wire the jar into `~/.jetbrains/acp.json`
+Re-run the task after `git pull` or any code change. The new jar lands at a
+new filename (the version embeds the `git describe` output) and the entry
+gets updated to match — no manual edit, no symlink.
 
-The JetBrains plugin reads agent server definitions from
-`~/.jetbrains/acp.json`. The schema is a top-level object with a single
-`agent_servers` map keyed by display name. Each entry specifies a `command`,
-optional `args`, and optional `env`.
+## Selecting the local jar in your editor
 
-To run your local jar, add (or update) a `Brokk Code (Local Jar)` entry that
-delegates to the `uvx brokk acp` wrapper with `--jar` pointing at the absolute
-path of the shadow jar you just built:
+After running one of the tasks, the editor's `Brokk Code (Local Jar)` agent
+server entry is current. To activate it:
 
-```json
-{
-  "default_mcp_settings": {},
-  "agent_servers": {
-    "Brokk Code (Local Jar)": {
-      "command": "/opt/homebrew/bin/uvx",
-      "args": [
-        "brokk",
-        "acp",
-        "--jar",
-        "/absolute/path/to/brokk/app/build/libs/brokk-0.23.5.betaN-K-gSHA.jar"
-      ],
-      "env": {}
-    }
-  }
-}
+- **Zed**: open the agent server picker in the Brokk Code panel and pick
+  `Brokk Code (Local Jar)`. Restart the panel if it does not appear yet.
+- **JetBrains**: restart the Brokk Code panel (or the IDE) so the plugin
+  re-reads `~/.jetbrains/acp.json`, then pick `Brokk Code (Local Jar)` in the
+  agent server selector.
+
+You can confirm the local jar is in use by tailing `~/.brokk/debug.log` and
+looking for entries from the new build.
+
+## Custom config locations
+
+Both tasks honor a Gradle property that points at an alternative config file,
+which is useful for testing or for non-default editor installations:
+
+```bash
+./gradlew :buildAcpServerJarForJetbrains -PacpJetbrainsConfig=/some/other/acp.json
+./gradlew :buildAcpServerJarForZed       -PacpZedConfig=/some/other/settings.json
 ```
 
-Replace `/absolute/path/to/brokk` with your checkout path and the version
-fragment with the actual filename produced by Step 1. `command` is whatever
-absolute path your `uvx` lives at — `which uvx` will tell you (`/opt/homebrew/bin/uvx`
-on Apple Silicon Homebrew, `/usr/local/bin/uvx` on Intel Homebrew, etc.).
+## Why route through `uvx brokk acp --jar`
 
-You can keep multiple entries in `agent_servers` simultaneously; the plugin
-shows them all in the agent server picker.
-
-## Step 3: Select the local jar in the IDE
-
-1. Restart the Brokk Code panel (or the IDE) so the plugin re-reads `acp.json`.
-2. In the Brokk Code panel's agent server selector, choose `Brokk Code (Local Jar)`.
-3. Start a new session. The first prompt should connect to your local jar — you
-   can confirm by tailing `~/.brokk/debug.log` and looking for the `acp_server`
-   entries.
-
-## Why route through `uvx brokk acp --jar` instead of `java -jar` directly
-
-The `uvx brokk acp` wrapper handles three things on your behalf that a raw
-`java -jar` invocation does not:
+The tasks point the editor at `uvx brokk acp --jar <path>` rather than
+`java -jar <path>`. The wrapper handles three things that a raw `java -jar`
+invocation does not:
 
 1. **Stdio hygiene** — the wrapper redirects logging away from stdout, which is
    reserved for JSON-RPC traffic. Any stray stdout output corrupts the protocol
    stream and crashes the client (see
    [acp-native-java-server.md § Logging must avoid stdout](acp-native-java-server.md)).
 2. **Brokk key plumbing** — the wrapper passes your stored Brokk API key to the
-   subprocess via the appropriate flags, without you having to thread it
-   through `acp.json` `env` blocks (which would land plaintext in a config file).
+   subprocess via the appropriate flags, without threading it through the
+   editor config's `env` block (which would land plaintext in a config file).
 3. **Proxy/vendor flag forwarding** — the wrapper accepts the same
-   `--proxy-setting` and `--vendor` flags as the published release and translates
-   them into `AcpServerMain` arguments, so the local jar inherits the same
-   defaults as the production binary.
+   `--proxy-setting` and `--vendor` flags as the published release and
+   translates them into `AcpServerMain` arguments, so the local jar inherits
+   the same defaults as the production binary.
 
-It is technically possible to bypass the wrapper with a `java -jar
-<path-to-jar> --workspace-dir … --brokk-api-key …` invocation, but you would
-have to replicate all three concerns above by hand, and any mistake is silent
-(the IDE just hangs on the first response).
+A raw `java -jar` invocation can be made to work, but you would have to
+replicate all three concerns by hand and any mistake is silent (the editor
+just hangs on the first response).
 
-## Rebuilding after code changes
+## Schema reference
 
-After a `git pull` or local commit, re-run `./gradlew :app:shadowJar`. The new
-jar will land at a new path because the git-describe fragment changes. Either:
+If you want to inspect or hand-edit the entries the tasks write, this is the
+shape they produce.
 
-- Update the `--jar` path in `~/.jetbrains/acp.json` to the new filename, or
-- Symlink (or copy) the new jar to a stable name and reference that in
-  `acp.json` so you do not have to edit it on every rebuild. For example:
-  ```bash
-  ln -sf "$(ls -t app/build/libs/brokk-*.jar | head -1)" \
-      app/build/libs/brokk-local.jar
-  ```
+JetBrains (`~/.jetbrains/acp.json`):
 
-The plugin only reads `acp.json` on (re)load, so after editing the file you
-must restart the Brokk Code panel.
+```json
+{
+  "default_mcp_settings": {},
+  "agent_servers": {
+    "Brokk Code (Local Jar)": {
+      "command": "/absolute/path/to/uvx",
+      "args": ["brokk", "acp", "--jar", "/absolute/path/to/brokk-<version>.jar"],
+      "env": {}
+    }
+  }
+}
+```
+
+Zed (`~/.config/zed/settings.json`, under the same `agent_servers` key the
+existing built-in entries use):
+
+```json
+{
+  "agent_servers": {
+    "Brokk Code (Local Jar)": {
+      "type": "custom",
+      "command": "/absolute/path/to/uvx",
+      "args": ["brokk", "acp", "--jar", "/absolute/path/to/brokk-<version>.jar"],
+      "env": {}
+    }
+  }
+}
+```
+
+The Zed entry needs `"type": "custom"`; JetBrains does not use that field.


### PR DESCRIPTION
## Summary

Adds two Gradle tasks plus a developer guide for running a locally-built Brokk ACP server in Zed or a JetBrains IDE. The tasks build the shadow jar **and** rewrite a `Brokk Code (Local Jar)` entry in the editor's config to point at the just-built jar — no manual editing, no symlink, idempotent on every code change.

## Why

Running a local Brokk ACP server in Zed/JetBrains was undocumented and required manual edits to `~/.config/zed/settings.json` or `~/.jetbrains/acp.json` after every rebuild (the shadow jar filename embeds `git describe`, so it changes on every commit). Two issues compound: most contributors don't know the JSON schema, and the file path has to change every time the SHA does.

Tasks own the loop end-to-end. The doc explains the editor wiring and falls back to a hand-edit reference for anyone who wants it.

## What changed

### `build.gradle.kts` (root)

- New task `:buildAcpServerJarForJetbrains` — `dependsOn(":app:shadowJar")`, then writes/replaces a `Brokk Code (Local Jar)` entry in `~/.jetbrains/acp.json` (default; overridable via `-PacpJetbrainsConfig=<path>`).
- New task `:buildAcpServerJarForZed` — same shape, writes to `~/.config/zed/settings.json` (overridable via `-PacpZedConfig=<path>`) and includes Zed's required `"type": "custom"` field.
- Both tasks resolve `uvx` to its absolute path so the editor-spawned subprocess does not depend on inherited shell `PATH` (GUI apps on macOS do not get it). They preserve every other entry in the file and replace only `Brokk Code (Local Jar)`.
- A small `findExecutableOnPath()` helper plus a `writeLocalJarAcpEntry()` helper shared by both tasks; ~80 lines total.

### `app/build.gradle.kts`

- Extends the `tasks.shadowJar { enabled = ... }` gating predicate to recognize task names containing `buildAcpServerJarFor`, so the new tasks actually trigger the shadow build (the existing predicate already gates `shadowJar` and `deployMcpShadowJar`).

### `docs/acp-jetbrains-local-dev.md`

- Covers Zed and JetBrains, replacing the earlier symlink-based draft.
- Documents the two new tasks as the primary path; keeps the JSON schemas as a reference for hand-editing.
- Keeps the existing rationale for routing through `uvx brokk acp --jar` rather than `java -jar` directly (stdio hygiene, Brokk key plumbing, proxy flag forwarding).

## Test plan

- [x] `./gradlew :buildAcpServerJarForJetbrains -PacpJetbrainsConfig=/tmp/test-jetbrains-acp.json` against an empty file: writes a clean valid JSON with the `Brokk Code (Local Jar)` entry and the absolute jar path.
- [x] Same task against a config containing other entries (e.g. `Brokk Code`, `Brokk Code (Rust)`) and a stale `Brokk Code (Local Jar)`: only the `Brokk Code (Local Jar)` entry is rewritten, all others preserved exactly.
- [x] `./gradlew :buildAcpServerJarForZed -PacpZedConfig=/tmp/test-zed-settings.json` against a Zed-shaped fixture (`agent_servers.claude-acp.type = "registry"` etc.): the new entry includes `"type": "custom"`, registry entries are preserved.
- [x] `./gradlew :app:check` passes with the gating change in `app/build.gradle.kts`.
- [ ] Manual: a teammate runs `./gradlew :buildAcpServerJarForZed` on a fresh checkout, picks `Brokk Code (Local Jar)` in Zed, and the panel actually launches the local jar.

## Notes

Supersedes [#3506](https://github.com/BrokkAi/brokk/pull/3506) (an earlier `:shadowJarLatest` symlink approach that the team preferred to scrap in favor of the explicit named tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
