### PR TITLE
build: add :shadowJarLatest task for stable local-jar symlink

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,6 +143,33 @@ tasks.register("deployMcpShadowJar") {
     }
 }
 
+tasks.register("shadowJarLatest") {
+    description = "Builds :app:shadowJar and refreshes app/build/libs/brokk-local.jar to point at the just-built versioned jar."
+    group = "distribution"
+
+    dependsOn(":app:shadowJar")
+
+    doLast {
+        val versionedJar = rootDir.resolve("app/build/libs/brokk-${project.version}.jar")
+        if (!versionedJar.exists()) {
+            throw GradleException("Expected shadow jar not found: ${versionedJar.absolutePath}")
+        }
+
+        val linkPath = versionedJar.parentFile.resolve("brokk-local.jar").toPath()
+        java.nio.file.Files.deleteIfExists(linkPath)
+        try {
+            // Relative target so the link survives moving the build/libs directory.
+            java.nio.file.Files.createSymbolicLink(linkPath, java.nio.file.Paths.get(versionedJar.name))
+        } catch (e: java.nio.file.FileSystemException) {
+            // Symbolic links require Developer Mode or admin on Windows; fall back to a copy so
+            // ~/.jetbrains/acp.json --jar paths keep working.
+            versionedJar.copyTo(linkPath.toFile(), overwrite = true)
+            logger.lifecycle("createSymbolicLink failed (${e.message}); copied versioned jar to brokk-local.jar instead.")
+        }
+        println("brokk-local.jar -> ${versionedJar.name}")
+    }
+}
+
 tasks.register("deployCoreMcpShadowJar") {
     description = "Builds :brokk-core:shadowJar and copies it to a stable MCP jar path."
     group = "distribution"


### PR DESCRIPTION
## Summary

Adds a small `:shadowJarLatest` Gradle task that wraps `:app:shadowJar` and, after the build, points `app/build/libs/brokk-local.jar` at the just-built versioned jar via a relative symlink. Falls back to a copy on platforms where `createSymbolicLink` is not permitted (Windows without Developer Mode).

## Why

The shadow jar filename embeds `git describe` (e.g. `brokk-0.23.5.beta8-2-g3c724bef9.jar`), so every commit produces a new filename. Developers running a local Brokk ACP server in JetBrains via the `~/.jetbrains/acp.json --jar <path>` pattern (see #3505 for the doc) had to edit `acp.json` on every rebuild, or maintain the symlink by hand. With this task, a single `./gradlew :shadowJarLatest` keeps `brokk-local.jar` current and `acp.json` can reference that stable path forever.

The new task lives next to `deployMcpShadowJar` in the root `build.gradle.kts`, mirroring its structure (`dependsOn(":app:shadowJar")` + `doLast { ... }`).

## Test plan

- [x] `./gradlew :shadowJarLatest` produces `app/build/libs/brokk-local.jar` as a relative symlink to the latest versioned jar.
- [x] Re-running the task after a no-op rebuild leaves the symlink correct (idempotent — `Files.deleteIfExists` then `createSymbolicLink`).
- [ ] Manual on Windows without Developer Mode: confirm the copy fallback path (logs `createSymbolicLink failed (...); copied versioned jar to brokk-local.jar instead.`).

## Follow-up

Once this lands, [#3505](https://github.com/BrokkAi/brokk/pull/3505) (the JetBrains local-dev doc) should be updated to recommend `:shadowJarLatest` over the manual `ln -sf` snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
