### PR TITLE
brokk-acp-rust: add cargo xtask for editor wiring (Zed/JetBrains)

### DIFF
--- a/brokk-acp-rust/.cargo/config.toml
+++ b/brokk-acp-rust/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --release --"

--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -1908,6 +1908,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -2869,6 +2870,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde_json",
+]
 
 [[package]]
 name = "xz2"

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -1,3 +1,10 @@
+[workspace]
+members = ["xtask"]
+# Keep `cargo build` / `cargo test` from the workspace root focused on the
+# root crate. The xtask sub-crate is dev-only and is invoked through the
+# `cargo xtask` alias (see .cargo/config.toml), which builds it on demand.
+default-members = ["."]
+
 [package]
 name = "brokk-acp-rust"
 version = "0.1.0"

--- a/brokk-acp-rust/README.md
+++ b/brokk-acp-rust/README.md
@@ -36,17 +36,52 @@ The server binary is named `brokk-acp`. It can be configured via CLI flags or en
 
 ## Running Locally
 
-To build and run the server from the repository root:
+### Quickest path: build + wire into your editor in one step
+
+The crate ships with two `cargo xtask` subcommands that build the release
+binary **and** rewrite a `Brokk Code (Rust Local)` entry under `agent_servers`
+in your editor's config. Run from `brokk-acp-rust/`:
+
+```bash
+# Wire into Zed   (~/.config/zed/settings.json)
+cargo xtask build-acp-for-zed
+
+# Wire into JetBrains   (~/.jetbrains/acp.json)
+cargo xtask build-acp-for-jetbrains
+```
+
+Each task runs `cargo build --release --bin brokk-acp`, then writes a
+single agent-server entry pointing at `target/release/brokk-acp`. Other
+entries in the file are preserved verbatim. Re-run any time the binary
+changes — the entry is rewritten in place. After running, restart the
+editor's Brokk panel and pick `Brokk Code (Rust Local)` in the agent
+server selector.
+
+Both subcommands accept:
+- `--config <path>` — override the editor config path (mostly for tests).
+- `--bifrost-binary <name|path>` — value passed via `--bifrost-binary`
+  in the entry's args. Defaults to the literal `bifrost` (assumed to be
+  on the editor's `PATH`); pass an absolute path if Bifrost lives
+  somewhere `PATH` does not reach.
+
+### Manual / advanced
+
+If you prefer to wire things up by hand (or just want to run the binary
+standalone):
 
 ```bash
 # Build the release binary
-cargo build --release -p brokk-acp-rust
+cargo build --release --bin brokk-acp
 
-# Run with a local Ollama instance
+# Run against a local Ollama instance
 ./target/release/brokk-acp --default-model llama3.1
 ```
 
-To use it with an ACP-compatible client like Zed, add the binary path to your `settings.json` under the agent configuration.
+Then add the binary path to your editor's agent server config:
+- Zed: `~/.config/zed/settings.json` under `agent_servers`, with
+  `"type": "custom"` and `"command"` set to the absolute path.
+- JetBrains: `~/.jetbrains/acp.json` under `agent_servers`, same shape
+  minus the `type` field.
 
 ## Tool Calling and Permissions
 

--- a/brokk-acp-rust/xtask/Cargo.toml
+++ b/brokk-acp-rust/xtask/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2024"
+publish = false
+license = "LGPL-3.0"
+description = "Workspace developer helpers for brokk-acp-rust (build + editor wiring)."
+
+[[bin]]
+name = "xtask"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }

--- a/brokk-acp-rust/xtask/src/main.rs
+++ b/brokk-acp-rust/xtask/src/main.rs
@@ -1,0 +1,152 @@
+//! Workspace developer helpers. Run via the `cargo xtask` alias defined in
+//! `../.cargo/config.toml`. Mirrors the `:buildAcpServerJarFor{Jetbrains,Zed}` Gradle tasks
+//! in the Java side of the brokk repo: build the Rust ACP binary in release mode and
+//! rewrite a `Brokk Code (Rust Local)` entry under `agent_servers` in the editor's config.
+
+use anyhow::{Context, Result, ensure};
+use clap::{Parser, Subcommand};
+use serde_json::{Map, Value, json};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Parser)]
+#[command(
+    name = "xtask",
+    about = "Brokk-acp-rust developer helpers (build + editor wiring)."
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Build the Rust ACP binary in release mode and wire it into ~/.config/zed/settings.json.
+    BuildAcpForZed(BuildArgs),
+    /// Build the Rust ACP binary in release mode and wire it into ~/.jetbrains/acp.json.
+    BuildAcpForJetbrains(BuildArgs),
+}
+
+#[derive(Parser)]
+struct BuildArgs {
+    /// Override the editor config path. Defaults to the editor's standard location under $HOME.
+    #[arg(long)]
+    config: Option<PathBuf>,
+    /// Path or PATH name of the bifrost analyzer binary to pass via --bifrost-binary in the
+    /// editor entry's args. The `brokk-acp` binary needs this to find its analyzer backend.
+    #[arg(long, default_value = "bifrost")]
+    bifrost_binary: String,
+}
+
+#[derive(Copy, Clone)]
+enum EditorKind {
+    Zed,
+    Jetbrains,
+}
+
+const ENTRY_NAME: &str = "Brokk Code (Rust Local)";
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let (kind, args) = match cli.command {
+        Commands::BuildAcpForZed(a) => (EditorKind::Zed, a),
+        Commands::BuildAcpForJetbrains(a) => (EditorKind::Jetbrains, a),
+    };
+    run(kind, args)
+}
+
+fn workspace_root() -> &'static Path {
+    // CARGO_MANIFEST_DIR is `<workspace>/xtask`; its parent is the workspace root.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask manifest dir must have a parent")
+}
+
+fn run(kind: EditorKind, args: BuildArgs) -> Result<()> {
+    let root = workspace_root();
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let status = Command::new(&cargo)
+        .args(["build", "--release", "--bin", "brokk-acp"])
+        .current_dir(root)
+        .status()
+        .context("failed to invoke cargo build")?;
+    ensure!(
+        status.success(),
+        "cargo build --release --bin brokk-acp failed (status: {status})"
+    );
+
+    let binary = root.join("target/release/brokk-acp");
+    ensure!(
+        binary.exists(),
+        "expected binary not found at {}",
+        binary.display()
+    );
+
+    let config_path = args.config.clone().unwrap_or_else(|| match kind {
+        EditorKind::Zed => home_dir().join(".config/zed/settings.json"),
+        EditorKind::Jetbrains => home_dir().join(".jetbrains/acp.json"),
+    });
+
+    write_entry(&config_path, kind, &binary, &args.bifrost_binary)?;
+    println!(
+        "Updated '{ENTRY_NAME}' in {} -> {}",
+        config_path.display(),
+        binary.display()
+    );
+    Ok(())
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .expect("HOME env var must be set")
+}
+
+fn write_entry(
+    config_path: &Path,
+    kind: EditorKind,
+    binary: &Path,
+    bifrost_binary: &str,
+) -> Result<()> {
+    let mut root: Value = if config_path.exists() && std::fs::metadata(config_path)?.len() > 0 {
+        let txt = std::fs::read_to_string(config_path)
+            .with_context(|| format!("reading {}", config_path.display()))?;
+        serde_json::from_str(&txt)
+            .with_context(|| format!("parsing JSON in {}", config_path.display()))?
+    } else {
+        json!({})
+    };
+    let root_obj = root.as_object_mut().with_context(|| {
+        format!(
+            "config root in {} is not a JSON object",
+            config_path.display()
+        )
+    })?;
+    let agent_servers = root_obj
+        .entry("agent_servers")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .context("agent_servers is not a JSON object")?;
+
+    let mut entry = Map::new();
+    if matches!(kind, EditorKind::Zed) {
+        // Zed requires `type: "custom"` on user-defined agent server entries; JetBrains ignores it.
+        entry.insert("type".into(), json!("custom"));
+    }
+    entry.insert(
+        "command".into(),
+        json!(binary.to_str().context("binary path is not valid UTF-8")?),
+    );
+    entry.insert("args".into(), json!(["--bifrost-binary", bifrost_binary]));
+    entry.insert("env".into(), json!({}));
+    agent_servers.insert(ENTRY_NAME.into(), Value::Object(entry));
+
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dir {}", parent.display()))?;
+    }
+    let pretty = serde_json::to_string_pretty(&root)? + "\n";
+    std::fs::write(config_path, pretty)
+        .with_context(|| format!("writing {}", config_path.display()))?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Mirrors the `:buildAcpServerJarFor{Jetbrains,Zed}` Gradle tasks (#3505) on the Rust side. Two `cargo xtask` subcommands build the `brokk-acp` release binary **and** rewrite a `Brokk Code (Rust Local)` entry under `agent_servers` in the editor's config, in one step.

```bash
cd brokk-acp-rust

cargo xtask build-acp-for-zed         # writes ~/.config/zed/settings.json
cargo xtask build-acp-for-jetbrains   # writes ~/.jetbrains/acp.json
```

After running, restart the editor's Brokk panel and pick `Brokk Code (Rust Local)` from the agent server selector — same loop as the Java tasks, no manual edits, idempotent on every code change.

## What changed (single commit, 5 files, +187 LOC)

### `brokk-acp-rust/Cargo.toml`

- Adds `[workspace] members = ["xtask"]` and `default-members = ["."]`. The latter keeps `cargo build` / `cargo test` from the workspace root focused on the `brokk-acp-rust` crate, so existing CI runs (and contributor muscle memory) are unaffected — `xtask` only builds when explicitly requested via the alias.

### `brokk-acp-rust/.cargo/config.toml` (new)

- Defines the `xtask` cargo alias: `run --package xtask --release --`. Standard xtask pattern.

### `brokk-acp-rust/xtask/Cargo.toml` (new)

- Tiny dev crate, `publish = false`. Three deps: `anyhow`, `clap` (derive), `serde_json` with `preserve_order` so existing `agent_servers` entries keep their original order on rewrite.

### `brokk-acp-rust/xtask/src/main.rs` (new)

- ~150 lines. clap-derive CLI with two subcommands. Each:
  1. Runs `cargo build --release --bin brokk-acp` from the workspace root.
  2. Loads the editor's config JSON (or starts from `{}` if missing).
  3. Inserts/replaces the `Brokk Code (Rust Local)` entry under `agent_servers` with `command` set to the absolute path of `target/release/brokk-acp` and `args` set to `["--bifrost-binary", "<name>"]`.
  4. Writes the file back, pretty-printed, preserving every other key.

- Both subcommands accept:
  - `--config <path>` — override the editor config file (used by tests).
  - `--bifrost-binary <name|path>` — defaults to the literal `bifrost` (assumes it is on PATH, matching the user's existing `Brokk Code (Rust)` entry shape). Pass an absolute path here if you also build bifrost locally.

- The Zed entry sets `"type": "custom"`; the JetBrains entry omits it. That's the only schema difference between the two editors at this layer.

## Why workspace + xtask vs alternatives

User picked `cargo xtask` over a shell-script equivalent or a second-binary-in-the-same-crate. xtask is the established Rust pattern for one-off developer tooling and keeps the dev-only deps separate from the release crate's dependency graph.

The migration is minimal: `default-members = ["."]` preserves the existing `cargo build` semantics for everyone who isn't using xtask.

## Test plan

- [x] `cargo xtask --help` lists both subcommands with descriptions.
- [x] `cargo xtask build-acp-for-zed --config /tmp/test-zed-rust.json` against an empty `{}`: writes a valid JSON with the entry and `type: "custom"`, points `command` at the worktree's `target/release/brokk-acp`.
- [x] `cargo xtask build-acp-for-jetbrains --config /tmp/test-jetbrains-rust.json` against a fixture with another `agent_servers["Brokk Code"]` entry and a stale `Brokk Code (Rust Local)`: replaces only the `Brokk Code (Rust Local)` entry, preserves `Brokk Code` exactly, no `type` field.
- [x] `cargo fmt --all -- --check` passes.
- [x] `cargo clippy --package xtask --release -- -D warnings` passes.
- [ ] Manual: a teammate runs `cargo xtask build-acp-for-zed` on a fresh checkout, picks `Brokk Code (Rust Local)` in Zed, and the panel actually launches the local binary.

## Follow-up

Once this lands, [#3505](https://github.com/BrokkAi/brokk/pull/3505) (the local-dev guide for the Java jar tasks) can be extended to mention the Rust path too — the editor wiring story is now symmetric across both implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
