### PR TITLE
brokk-acp-rust: collapse tool kind/display_name into a single metadata table (#3396)

### DIFF
--- a/brokk-acp-rust/src/bifrost_client.rs
+++ b/brokk-acp-rust/src/bifrost_client.rs
@@ -355,6 +355,21 @@ mod tests {
             );
         }
 
+        // Anti-drift: every tool bifrost advertises must have a row in
+        // `tools::TOOLS`. Without one, `tool_kind` falls back to
+        // `Other` (refused in `readOnly`, prompts unnecessarily in
+        // `default`) and `display_name` falls back to "Executing
+        // tool" in the UI. If this assertion fires, bifrost likely
+        // added or renamed a tool -- update `TOOLS` in
+        // `tools/mod.rs` to match.
+        for tool_name in &names {
+            assert!(
+                crate::tools::is_known_tool(tool_name),
+                "bifrost advertises '{tool_name}' but it is not in the TOOLS metadata table; \
+                 add a ToolMeta row in tools/mod.rs (current bifrost surface: {names:?})"
+            );
+        }
+
         // Round-trip two distinct tool calls so we exercise back-to-back use
         // of the JSON-RPC reader/writer mutex (id correlation, sequential
         // dispatch, response-shape branching) -- not just one-shot dispatch.

--- a/brokk-acp-rust/src/tools/mod.rs
+++ b/brokk-acp-rust/src/tools/mod.rs
@@ -22,6 +22,113 @@ pub enum ToolStatus {
     InternalError,
 }
 
+/// Single source of truth for per-tool metadata (`ToolKind` for the
+/// permission gate, `display_name` for the UI fallback). Adding a new
+/// tool means adding one row here; the dispatcher in `execute` derives
+/// builtin routing from the inline `match`, and bifrost-loaded tools we
+/// don't recognize fall through to `ToolKind::Other` / "Executing tool".
+struct ToolMeta {
+    name: &'static str,
+    kind: ToolKind,
+    display_name: &'static str,
+}
+
+const TOOLS: &[ToolMeta] = &[
+    // --- Built-in tools (executed inline in `ToolRegistry::execute`) -------
+    ToolMeta {
+        name: "think",
+        kind: ToolKind::Think,
+        display_name: "Thinking",
+    },
+    ToolMeta {
+        name: "readFile",
+        kind: ToolKind::Read,
+        display_name: "Reading file",
+    },
+    ToolMeta {
+        name: "writeFile",
+        kind: ToolKind::Edit,
+        display_name: "Writing file",
+    },
+    ToolMeta {
+        name: "listDirectory",
+        kind: ToolKind::Read,
+        display_name: "Listing directory",
+    },
+    ToolMeta {
+        name: "searchFileContents",
+        kind: ToolKind::Search,
+        display_name: "Searching file contents",
+    },
+    ToolMeta {
+        name: "runShellCommand",
+        kind: ToolKind::Execute,
+        display_name: "Running shell command",
+    },
+    // --- Bifrost-loaded tools (dispatched via `execute_bifrost`) -----------
+    // Listed here so the permission gate can classify them; their actual
+    // execution is delegated to the bifrost subprocess.
+    ToolMeta {
+        name: "get_file_summaries",
+        kind: ToolKind::Read,
+        display_name: "Getting file summaries",
+    },
+    ToolMeta {
+        name: "search_symbols",
+        kind: ToolKind::Search,
+        display_name: "Searching for symbols",
+    },
+    ToolMeta {
+        name: "get_symbol_locations",
+        kind: ToolKind::Search,
+        display_name: "Finding symbol locations",
+    },
+    ToolMeta {
+        name: "get_symbol_summaries",
+        kind: ToolKind::Search,
+        display_name: "Getting symbol summaries",
+    },
+    ToolMeta {
+        name: "get_symbol_sources",
+        kind: ToolKind::Search,
+        display_name: "Fetching symbol source",
+    },
+    ToolMeta {
+        name: "list_symbols",
+        kind: ToolKind::Search,
+        display_name: "Listing symbols",
+    },
+    ToolMeta {
+        name: "most_relevant_files",
+        kind: ToolKind::Search,
+        display_name: "Finding related files",
+    },
+    // `refresh` mutates analyzer state, so it stays `Other` rather than
+    // `Read`: prompted in `default`, refused in `readOnly`.
+    ToolMeta {
+        name: "refresh",
+        kind: ToolKind::Other,
+        display_name: "Refreshing analyzer index",
+    },
+];
+
+fn tool_meta(name: &str) -> Option<&'static ToolMeta> {
+    TOOLS.iter().find(|t| t.name == name)
+}
+
+/// Built-in tool names handled by the inline `match` in
+/// `ToolRegistry::execute`. Used by tests to keep the metadata table
+/// in sync with the actual builtin dispatch.
+#[cfg(test)]
+const BUILTIN_TOOL_NAMES: &[&str] = &[
+    "think",
+    "readFile",
+    "writeFile",
+    "listDirectory",
+    "searchFileContents",
+    "runShellCommand",
+];
+
 /// Unified tool registry: filesystem tools + shell + think + (optionally) bifrost.
 pub struct ToolRegistry {
     cwd: PathBuf,
@@ -232,18 +339,13 @@ impl ToolRegistry {
                     .unwrap_or(60);
                 shell::run_shell_command(&self.cwd, command, timeout, policy).await
             }
-            "search_symbols"
-            | "get_symbol_locations"
-            | "get_symbol_summaries"
-            | "get_symbol_sources"
-            | "get_file_summaries"
-            | "list_symbols"
-            | "most_relevant_files"
-            | "refresh" => self.execute_bifrost(name, args).await,
-            _ => ToolResult {
-                status: ToolStatus::RequestError,
-                output: format!("Unknown tool: {name}"),
-            },
+            // Any name not handled above is delegated to the bifrost
+            // subprocess. This avoids a hardcoded list of bifrost tool
+            // names drifting out of sync with what bifrost actually
+            // exposes (`tool_definitions` already iterates bifrost tools
+            // dynamically via `client.tools()`). If bifrost is not
+            // running, `execute_bifrost` returns a clear error.
+            _ => self.execute_bifrost(name, args).await,
         }
     }
 
@@ -277,29 +379,15 @@ impl ToolRegistry {
     }
 
     /// ACP `ToolKind` for a tool, used by the permission gate to classify calls.
-    /// Built-in tools have hardcoded kinds; Bifrost-loaded tools fall through
-    /// to `Other` until Bifrost exposes kind metadata in its descriptors.
-    ///
-    /// Must stay in lockstep with `execute` and `headline` above. `refresh`
-    /// is intentionally `Other` rather than `Read` -- it mutates analyzer
-    /// state, so we want the user prompted in `default` and refused in
-    /// `readOnly`.
+    /// Looked up from the `TOOLS` table; tools we don't recognize fall
+    /// through to `Other`. Bifrost-loaded tools added without an entry in
+    /// `TOOLS` will hit this fallback (and a debug log).
     pub fn tool_kind(tool_name: &str) -> ToolKind {
-        match tool_name {
-            "think" => ToolKind::Think,
-            "readFile" | "listDirectory" | "get_file_summaries" => ToolKind::Read,
-            "searchFileContents"
-            | "search_symbols"
-            | "get_symbol_locations"
-            | "get_symbol_summaries"
-            | "get_symbol_sources"
-            | "list_symbols"
-            | "most_relevant_files" => ToolKind::Search,
-            "writeFile" => ToolKind::Edit,
-            "runShellCommand" => ToolKind::Execute,
-            other => {
+        match tool_meta(tool_name) {
+            Some(t) => t.kind,
+            None => {
                 tracing::debug!(
-                    tool_name = other,
+                    tool_name,
                     "tool_kind: unrecognized tool, classifying as Other"
                 );
                 ToolKind::Other
@@ -311,23 +399,9 @@ impl ToolRegistry {
     /// title can't be derived from the call's input args (notably for
     /// Bifrost-loaded tools we don't introspect by name in `announce`).
     pub fn display_name(tool_name: &str) -> &'static str {
-        match tool_name {
-            "think" => "Thinking",
-            "readFile" => "Reading file",
-            "writeFile" => "Writing file",
-            "listDirectory" => "Listing directory",
-            "searchFileContents" => "Searching file contents",
-            "runShellCommand" => "Running shell command",
-            "search_symbols" => "Searching for symbols",
-            "get_symbol_locations" => "Finding symbol locations",
-            "get_symbol_summaries" => "Getting symbol summaries",
-            "get_symbol_sources" => "Fetching symbol source",
-            "get_file_summaries" => "Getting file summaries",
-            "list_symbols" => "Listing symbols",
-            "most_relevant_files" => "Finding related files",
-            "refresh" => "Refreshing analyzer index",
-            _ => "Executing tool",
-        }
+        tool_meta(tool_name)
+            .map(|t| t.display_name)
+            .unwrap_or("Executing tool")
     }
 }
 
@@ -528,5 +602,44 @@ mod tests {
         assert!(resolved.ends_with("subdir/new.txt"));
 
         std::fs::remove_dir_all(&cwd).ok();
+    }
+
+    /// Anti-drift: every built-in tool name must (1) have a `ToolMeta` row in
+    /// the `TOOLS` table (otherwise the permission gate falls through to
+    /// `Other` and the UI to a generic label), and (2) be advertised by
+    /// `tool_definitions()` (otherwise the LLM never sees it). If you add a
+    /// new built-in dispatch arm in `execute`, also add the name to
+    /// `BUILTIN_TOOL_NAMES`, the `TOOLS` table, and `tool_definitions()`.
+    #[tokio::test]
+    async fn builtin_tools_have_metadata_and_are_advertised() {
+        let registry = ToolRegistry {
+            cwd: PathBuf::from("/tmp"),
+            bifrost: None,
+        };
+        let advertised: Vec<String> = registry
+            .tool_definitions()
+            .into_iter()
+            .map(|d| d.function.name)
+            .collect();
+
+        for name in BUILTIN_TOOL_NAMES {
+            assert!(
+                TOOLS.iter().any(|t| t.name == *name),
+                "built-in tool '{name}' is missing from the TOOLS metadata table"
+            );
+            assert!(
+                advertised.iter().any(|a| a == name),
+                "built-in tool '{name}' is missing from tool_definitions(); LLM will not see it"
+            );
+        }
+
+        // The inverse: with bifrost disabled, advertised tools should be a
+        // subset of the metadata table (no UI fallback for built-ins).
+        for advertised_name in &advertised {
+            assert!(
+                TOOLS.iter().any(|t| t.name == advertised_name.as_str()),
+                "tool_definitions() advertises '{advertised_name}' but it is missing from the TOOLS metadata table"
+            );
+        }
     }
 }

--- a/brokk-acp-rust/src/tools/mod.rs
+++ b/brokk-acp-rust/src/tools/mod.rs
@@ -67,11 +67,18 @@ const TOOLS: &[ToolMeta] = &[
     },
     // --- Bifrost-loaded tools (dispatched via `execute_bifrost`) -----------
     // Listed here so the permission gate can classify them; their actual
-    // execution is delegated to the bifrost subprocess.
+    // execution is delegated to the bifrost subprocess. The cross-check
+    // in `bifrost_client::tests::handshake_and_call_search_tools` keeps
+    // this list in sync with what the running bifrost subprocess exposes.
     ToolMeta {
-        name: "get_file_summaries",
+        name: "get_summaries",
         kind: ToolKind::Read,
-        display_name: "Getting file summaries",
+        display_name: "Getting code summaries",
+    },
+    ToolMeta {
+        name: "get_active_workspace",
+        kind: ToolKind::Read,
+        display_name: "Getting active workspace",
     },
     ToolMeta {
         name: "search_symbols",
@@ -103,8 +110,14 @@ const TOOLS: &[ToolMeta] = &[
         kind: ToolKind::Search,
         display_name: "Finding related files",
     },
-    // `refresh` mutates analyzer state, so it stays `Other` rather than
-    // `Read`: prompted in `default`, refused in `readOnly`.
+    // `activate_workspace` and `refresh` mutate analyzer state, so they
+    // stay `Other` rather than `Read`: prompted in `default`, refused in
+    // `readOnly`.
+    ToolMeta {
+        name: "activate_workspace",
+        kind: ToolKind::Other,
+        display_name: "Activating workspace",
+    },
     ToolMeta {
         name: "refresh",
         kind: ToolKind::Other,
@@ -114,6 +127,16 @@ const TOOLS: &[ToolMeta] = &[
 
 fn tool_meta(name: &str) -> Option<&'static ToolMeta> {
     TOOLS.iter().find(|t| t.name == name)
+}
+
+/// `true` iff `name` has a row in the `TOOLS` metadata table. Used by
+/// the bifrost handshake test to flag drift when bifrost adds or
+/// renames a tool without a matching `TOOLS` entry (which would
+/// otherwise silently fall back to `ToolKind::Other` / "Executing
+/// tool" in the permission gate and UI).
+#[cfg(test)]
+pub(crate) fn is_known_tool(name: &str) -> bool {
+    tool_meta(name).is_some()
 }
 
 /// Built-in tool names handled by the inline `match` in


### PR DESCRIPTION
## Summary

Closes #3396.

Replaces the three parallel `match name { ... }` statements
(`ToolRegistry::execute`, `tool_kind`, `display_name`) with one
`TOOLS` metadata table. Each row is `(name, kind, display_name)`;
adding a new tool is now a single-row change instead of three
coordinated edits.

Also drops the hardcoded list of bifrost tool names from the inline
arm in `execute`. `tool_definitions()` already iterates bifrost tools
dynamically via `client.tools()`, so any name not handled by a
built-in arm is now delegated to `execute_bifrost`. This closes a
latent gap where a bifrost-added tool that wasn't in the hardcoded
list would be advertised to the LLM (via `tool_definitions()`) but
then rejected at execution time with `Unknown tool: ...`.

The deliberate `refresh -> ToolKind::Other` divergence is preserved
in the table with a comment, since it mutates analyzer state and must
be prompted in `default` / refused in `readOnly`.

## What does the test catch?

`builtin_tools_have_metadata_and_are_advertised` (in `tools::tests`):

- For every name in `BUILTIN_TOOL_NAMES` (the inline match arms in
  `execute`), assert it has a `ToolMeta` row in `TOOLS`. Without this,
  `tool_kind` falls through to `Other` and the UI to "Executing tool".
- For every name in `BUILTIN_TOOL_NAMES`, assert it appears in
  `tool_definitions()`. Without this, the LLM never sees the tool.
- Inverse: with bifrost disabled, every advertised tool must have a
  `TOOLS` row.

Adding a new tool without updating the table now fails this test.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test tools::tests::` (6/6 pass, including the new one)
- [x] Full `cargo test` -- 46/47 pass; the one failure
  (`bifrost_client::tests::handshake_and_call_search_tools`)
  reproduces on `master` (`list_symbols` no longer in bifrost's tool
  list) and is unrelated to this change. That failing test is itself
  evidence of the same drift class this PR addresses, but on the
  bifrost-side rather than the client-side.
