### PR TITLE
brokk-acp-rust: add per-chunk idle timeout on LLM streaming response (#3453)

### DIFF
--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -32,3 +32,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 walkdir = "2"
+
+[dev-dependencies]
+# `test-util` enables `tokio::time::pause()` and `#[tokio::test(start_paused = true)]`,
+# used by the LLM stream idle-timeout test to avoid waiting wall-clock seconds.
+tokio = { version = "1", features = ["test-util"] }

--- a/brokk-acp-rust/src/llm_client.rs
+++ b/brokk-acp-rust/src/llm_client.rs
@@ -7,30 +7,21 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-/// Maximum gap between two streamed chunks from the LLM before we abort
-/// the request as "stalled". Distinct from the reqwest client's overall
-/// `.timeout()` (wall-clock) -- a server that drips one byte every 599s
-/// would defeat wall-clock but not this idle check. Chosen to stay above
-/// reasoning-model "thinking pauses" (which still emit periodic SSE
-/// pings) and well below the 600s client timeout.
+/// Maximum gap between two pieces of *meaningful* SSE progress before we
+/// abort the request. "Meaningful progress" is a parsed `data:` event
+/// that contributed content, tool-call deltas, or `[DONE]`. Comments
+/// (`:keepalive\n`), blank lines, and partial bytes that don't advance
+/// the parser do NOT reset this timer -- otherwise a server or proxy
+/// could keep us alive forever by drip-feeding pings.
+///
+/// Distinct from the reqwest client's overall `.timeout()` (wall-clock).
+/// Chosen to stay above realistic reasoning-model "thinking pauses"
+/// (which still emit periodic SSE pings) and well below the 600s
+/// client timeout.
 const IDLE_CHUNK_TIMEOUT: Duration = Duration::from_secs(90);
 
-/// Read the next item from a stream, aborting with a clear error if no
-/// item arrives within `idle`. `Ok(None)` means the stream ended cleanly;
-/// the per-item error type is preserved for the caller (network errors,
-/// SSE decode failures, etc. are surfaced verbatim).
-async fn next_with_idle_timeout<S>(stream: &mut S, idle: Duration) -> Result<Option<S::Item>>
-where
-    S: Stream + Unpin,
-{
-    match tokio::time::timeout(idle, stream.next()).await {
-        Ok(opt) => Ok(opt),
-        Err(_elapsed) => anyhow::bail!(
-            "LLM stream idle for {}s; aborting (server-side hang or stuck connection)",
-            idle.as_secs()
-        ),
-    }
-}
+/// Owning callback handed token deltas as the LLM streams them.
+type TokenSink = Box<dyn FnMut(&str) + Send>;
 
 // ---------------------------------------------------------------------------
 // Tool calling types (OpenAI-compatible)
@@ -359,7 +350,7 @@ impl OpenAiClient {
         model: String,
         messages: Vec<ChatMessage>,
         tools: Option<Vec<ToolDefinition>>,
-        mut on_token: Box<dyn FnMut(&str) + Send>,
+        on_token: TokenSink,
         cancel: CancellationToken,
     ) -> Result<LlmResponse> {
         let url = self.api_url("/chat/completions");
@@ -388,86 +379,127 @@ impl OpenAiClient {
             anyhow::bail!("chat completion failed (HTTP {status}): {body_text}");
         }
 
-        let mut full_text = String::new();
-        let mut tool_acc = ToolCallAccumulator::default();
-        let mut stream = resp.bytes_stream();
-        let mut raw_buf: Vec<u8> = Vec::new();
+        let stream = resp
+            .bytes_stream()
+            .map(|r| r.map(|b| b.to_vec()).map_err(anyhow::Error::from));
 
-        loop {
-            tokio::select! {
-                _ = cancel.cancelled() => {
-                    tracing::info!("streaming cancelled by client");
-                    break;
-                }
-                chunk_result = next_with_idle_timeout(&mut stream, IDLE_CHUNK_TIMEOUT) => {
-                    let Some(chunk) = chunk_result? else { break; };
-                    let chunk = chunk.context("stream read error")?;
-                    raw_buf.extend_from_slice(&chunk);
+        drive_sse_stream(stream, on_token, cancel, IDLE_CHUNK_TIMEOUT).await
+    }
+}
 
-                    while let Some(pos) = raw_buf.iter().position(|&b| b == b'\n') {
-                        let line_bytes = raw_buf.drain(..=pos).collect::<Vec<_>>();
-                        let line = String::from_utf8_lossy(&line_bytes).trim().to_string();
+/// Drive an SSE byte stream until the LLM emits `[DONE]`, the stream
+/// ends, or the cancellation token fires. Aborts with a clear error if
+/// no *meaningful progress* (parsed `data:` event contributing content
+/// or tool-call deltas, or `[DONE]`) is observed within `idle`. SSE
+/// keepalive comments (`:\n`), blank lines, and partial bytes that
+/// don't advance the parser do NOT reset the deadline, so a server or
+/// proxy that drip-feeds pings every <90s can no longer hold the
+/// request open indefinitely.
+async fn drive_sse_stream<S>(
+    mut stream: S,
+    mut on_token: TokenSink,
+    cancel: CancellationToken,
+    idle: Duration,
+) -> Result<LlmResponse>
+where
+    S: Stream<Item = Result<Vec<u8>>> + Unpin,
+{
+    let mut full_text = String::new();
+    let mut tool_acc = ToolCallAccumulator::default();
+    let mut raw_buf: Vec<u8> = Vec::new();
+    let mut deadline = tokio::time::Instant::now() + idle;
 
-                        if line.is_empty() || line.starts_with(':') {
-                            continue;
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                tracing::info!("streaming cancelled by client");
+                break;
+            }
+            chunk_or_timeout = tokio::time::timeout_at(deadline, stream.next()) => {
+                let chunk_opt = match chunk_or_timeout {
+                    Ok(opt) => opt,
+                    Err(_elapsed) => anyhow::bail!(
+                        "LLM stream made no meaningful progress for {}s; aborting (server-side hang or keepalive-only flood)",
+                        idle.as_secs()
+                    ),
+                };
+                let Some(chunk) = chunk_opt else { break; };
+                let chunk = chunk.context("stream read error")?;
+                raw_buf.extend_from_slice(&chunk);
+
+                let mut made_progress = false;
+
+                while let Some(pos) = raw_buf.iter().position(|&b| b == b'\n') {
+                    let line_bytes = raw_buf.drain(..=pos).collect::<Vec<_>>();
+                    let line = String::from_utf8_lossy(&line_bytes).trim().to_string();
+
+                    if line.is_empty() || line.starts_with(':') {
+                        continue;
+                    }
+
+                    let data = if let Some(stripped) = line.strip_prefix("data: ") {
+                        stripped.trim()
+                    } else {
+                        continue;
+                    };
+
+                    if data == "[DONE]" {
+                        if tool_acc.is_empty() {
+                            return Ok(LlmResponse::Text(full_text));
                         }
+                        return Ok(LlmResponse::ToolCalls {
+                            text: full_text,
+                            calls: tool_acc.into_tool_calls(),
+                        });
+                    }
 
-                        let data = if let Some(stripped) = line.strip_prefix("data: ") {
-                            stripped.trim()
-                        } else {
-                            continue;
-                        };
-
-                        if data == "[DONE]" {
-                            if tool_acc.is_empty() {
-                                return Ok(LlmResponse::Text(full_text));
-                            }
-                            return Ok(LlmResponse::ToolCalls {
-                                text: full_text,
-                                calls: tool_acc.into_tool_calls(),
-                            });
-                        }
-
-                        match serde_json::from_str::<ChatCompletionChunk>(data) {
-                            Ok(chunk) => {
-                                for choice in &chunk.choices {
-                                    // Accumulate text content
-                                    if let Some(content) = &choice.delta.content {
-                                        on_token(content);
-                                        full_text.push_str(content);
+                    match serde_json::from_str::<ChatCompletionChunk>(data) {
+                        Ok(chunk) => {
+                            for choice in &chunk.choices {
+                                // Accumulate text content
+                                if let Some(content) = &choice.delta.content {
+                                    made_progress = true;
+                                    on_token(content);
+                                    full_text.push_str(content);
+                                }
+                                // Accumulate tool call fragments
+                                if let Some(tc_chunks) = &choice.delta.tool_calls {
+                                    if !tc_chunks.is_empty() {
+                                        made_progress = true;
                                     }
-                                    // Accumulate tool call fragments
-                                    if let Some(tc_chunks) = &choice.delta.tool_calls {
-                                        for tc in tc_chunks {
-                                            tool_acc.push(tc);
-                                        }
+                                    for tc in tc_chunks {
+                                        tool_acc.push(tc);
                                     }
                                 }
                             }
-                            Err(e) => {
-                                tracing::debug!("skipping unparseable SSE chunk: {e}");
-                            }
+                        }
+                        Err(e) => {
+                            tracing::debug!("skipping unparseable SSE chunk: {e}");
                         }
                     }
                 }
+
+                if made_progress {
+                    deadline = tokio::time::Instant::now() + idle;
+                }
             }
         }
+    }
 
-        // If we exited the loop via cancellation, tool call fragments may be incomplete
-        // (arguments JSON truncated mid-stream). Return only the text we've already
-        // streamed to the caller to avoid dispatching malformed tool calls.
-        if cancel.is_cancelled() {
-            return Ok(LlmResponse::Text(full_text));
-        }
+    // If we exited the loop via cancellation, tool call fragments may be incomplete
+    // (arguments JSON truncated mid-stream). Return only the text we've already
+    // streamed to the caller to avoid dispatching malformed tool calls.
+    if cancel.is_cancelled() {
+        return Ok(LlmResponse::Text(full_text));
+    }
 
-        if tool_acc.is_empty() {
-            Ok(LlmResponse::Text(full_text))
-        } else {
-            Ok(LlmResponse::ToolCalls {
-                text: full_text,
-                calls: tool_acc.into_tool_calls(),
-            })
-        }
+    if tool_acc.is_empty() {
+        Ok(LlmResponse::Text(full_text))
+    } else {
+        Ok(LlmResponse::ToolCalls {
+            text: full_text,
+            calls: tool_acc.into_tool_calls(),
+        })
     }
 }
 
@@ -475,34 +507,101 @@ impl OpenAiClient {
 mod tests {
     use super::*;
     use futures::stream;
+    use std::sync::{Arc, Mutex};
 
-    /// A stream that never yields must trip the idle timeout. Uses tokio's
-    /// paused-time auto-advance (`start_paused = true`) so the test runs in
-    /// milliseconds of wall time rather than waiting `idle` seconds.
+    fn collect_tokens() -> (TokenSink, Arc<Mutex<Vec<String>>>) {
+        let collected = Arc::new(Mutex::new(Vec::<String>::new()));
+        let inner = collected.clone();
+        let cb: TokenSink = Box::new(move |t| {
+            inner.lock().unwrap().push(t.to_string());
+        });
+        (cb, collected)
+    }
+
+    /// A stream that emits only SSE keepalive comments (`:\n`) must trip
+    /// the deadline -- otherwise a server can hold the request open
+    /// forever by drip-feeding pings. Regression for the failure mode
+    /// flagged in PR #3510 review.
     #[tokio::test(start_paused = true)]
-    async fn next_with_idle_timeout_fires_on_pending_stream() {
-        let mut s = stream::pending::<u32>();
-        let result = next_with_idle_timeout(&mut s, Duration::from_secs(90)).await;
+    async fn drive_sse_stream_bails_on_keepalive_only_chunks() {
+        // One keepalive, then permanently pending. Auto-advance under
+        // `start_paused` will roll forward to the deadline since no task
+        // is ready -- the keepalive line does NOT count as progress.
+        let chunks: Vec<Result<Vec<u8>>> = vec![Ok(b":keepalive\n".to_vec())];
+        let s = stream::iter(chunks).chain(stream::pending());
 
-        let err = result.expect_err("idle stream should produce error");
+        let (on_token, _) = collect_tokens();
+        let cancel = CancellationToken::new();
+        let result = drive_sse_stream(s, on_token, cancel, Duration::from_secs(90)).await;
+
+        let err = result.expect_err("keepalive-only stream should bail");
         let msg = err.to_string();
         assert!(
-            msg.contains("idle") && msg.contains("90"),
-            "error should mention 'idle' and the timeout duration, got: {msg}"
+            msg.contains("no meaningful progress") && msg.contains("90"),
+            "error should mention 'no meaningful progress' and the timeout, got: {msg}"
         );
     }
 
-    /// A stream that yields immediately must pass through unchanged.
+    /// A stream that emits content data resets the deadline. Mixed with
+    /// many keepalives, the helper must still complete normally.
+    #[tokio::test(start_paused = true)]
+    async fn drive_sse_stream_resets_deadline_on_content_chunks() {
+        let chunks: Vec<Result<Vec<u8>>> = vec![
+            Ok(b":keepalive\n".to_vec()),
+            Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"hel\"}}]}\n".to_vec()),
+            Ok(b":keepalive\n".to_vec()),
+            Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n".to_vec()),
+            Ok(b"data: [DONE]\n".to_vec()),
+        ];
+        let s = stream::iter(chunks);
+
+        let (on_token, collected) = collect_tokens();
+        let cancel = CancellationToken::new();
+        let result = drive_sse_stream(s, on_token, cancel, Duration::from_secs(90)).await;
+
+        match result.expect("should complete") {
+            LlmResponse::Text(t) => assert_eq!(t, "hello"),
+            other => panic!("expected text response, got {other:?}"),
+        }
+        assert_eq!(*collected.lock().unwrap(), vec!["hel", "lo"]);
+    }
+
+    /// `[DONE]` ends the stream cleanly with whatever has been accumulated.
     #[tokio::test]
-    async fn next_with_idle_timeout_passes_through_immediate_yield() {
-        let mut s = stream::iter(vec![42u32, 43]);
-        let result = next_with_idle_timeout(&mut s, Duration::from_secs(60)).await;
-        assert_eq!(result.unwrap(), Some(42));
+    async fn drive_sse_stream_returns_text_on_done() {
+        let chunks: Vec<Result<Vec<u8>>> = vec![
+            Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n".to_vec()),
+            Ok(b"data: [DONE]\n".to_vec()),
+        ];
+        let s = stream::iter(chunks);
 
-        let result = next_with_idle_timeout(&mut s, Duration::from_secs(60)).await;
-        assert_eq!(result.unwrap(), Some(43));
+        let (on_token, collected) = collect_tokens();
+        let cancel = CancellationToken::new();
+        let result = drive_sse_stream(s, on_token, cancel, Duration::from_secs(90)).await;
 
-        let result = next_with_idle_timeout(&mut s, Duration::from_secs(60)).await;
-        assert_eq!(result.unwrap(), None);
+        match result.expect("should complete") {
+            LlmResponse::Text(t) => assert_eq!(t, "hi"),
+            other => panic!("expected text response, got {other:?}"),
+        }
+        assert_eq!(*collected.lock().unwrap(), vec!["hi"]);
+    }
+
+    /// A pre-cancelled token routes through the cancel arm of `select!`
+    /// and returns an empty `Text`, never `ToolCalls` (which would be
+    /// malformed if the stream cut mid-arguments). Sanity check that the
+    /// cancel arm exists and produces text.
+    #[tokio::test]
+    async fn drive_sse_stream_cancellation_returns_text() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let s = stream::pending::<Result<Vec<u8>>>();
+
+        let (on_token, _) = collect_tokens();
+        let result = drive_sse_stream(s, on_token, cancel, Duration::from_secs(90)).await;
+
+        match result.expect("should complete via cancel") {
+            LlmResponse::Text(t) => assert_eq!(t, ""),
+            other => panic!("expected text response, got {other:?}"),
+        }
     }
 }

--- a/brokk-acp-rust/src/llm_client.rs
+++ b/brokk-acp-rust/src/llm_client.rs
@@ -1,10 +1,36 @@
 use anyhow::{Context, Result};
+use futures::Stream;
 use futures::StreamExt;
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
+
+/// Maximum gap between two streamed chunks from the LLM before we abort
+/// the request as "stalled". Distinct from the reqwest client's overall
+/// `.timeout()` (wall-clock) -- a server that drips one byte every 599s
+/// would defeat wall-clock but not this idle check. Chosen to stay above
+/// reasoning-model "thinking pauses" (which still emit periodic SSE
+/// pings) and well below the 600s client timeout.
+const IDLE_CHUNK_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Read the next item from a stream, aborting with a clear error if no
+/// item arrives within `idle`. `Ok(None)` means the stream ended cleanly;
+/// the per-item error type is preserved for the caller (network errors,
+/// SSE decode failures, etc. are surfaced verbatim).
+async fn next_with_idle_timeout<S>(stream: &mut S, idle: Duration) -> Result<Option<S::Item>>
+where
+    S: Stream + Unpin,
+{
+    match tokio::time::timeout(idle, stream.next()).await {
+        Ok(opt) => Ok(opt),
+        Err(_elapsed) => anyhow::bail!(
+            "LLM stream idle for {}s; aborting (server-side hang or stuck connection)",
+            idle.as_secs()
+        ),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Tool calling types (OpenAI-compatible)
@@ -373,8 +399,8 @@ impl OpenAiClient {
                     tracing::info!("streaming cancelled by client");
                     break;
                 }
-                chunk = stream.next() => {
-                    let Some(chunk) = chunk else { break; };
+                chunk_result = next_with_idle_timeout(&mut stream, IDLE_CHUNK_TIMEOUT) => {
+                    let Some(chunk) = chunk_result? else { break; };
                     let chunk = chunk.context("stream read error")?;
                     raw_buf.extend_from_slice(&chunk);
 
@@ -442,5 +468,41 @@ impl OpenAiClient {
                 calls: tool_acc.into_tool_calls(),
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    /// A stream that never yields must trip the idle timeout. Uses tokio's
+    /// paused-time auto-advance (`start_paused = true`) so the test runs in
+    /// milliseconds of wall time rather than waiting `idle` seconds.
+    #[tokio::test(start_paused = true)]
+    async fn next_with_idle_timeout_fires_on_pending_stream() {
+        let mut s = stream::pending::<u32>();
+        let result = next_with_idle_timeout(&mut s, Duration::from_secs(90)).await;
+
+        let err = result.expect_err("idle stream should produce error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("idle") && msg.contains("90"),
+            "error should mention 'idle' and the timeout duration, got: {msg}"
+        );
+    }
+
+    /// A stream that yields immediately must pass through unchanged.
+    #[tokio::test]
+    async fn next_with_idle_timeout_passes_through_immediate_yield() {
+        let mut s = stream::iter(vec![42u32, 43]);
+        let result = next_with_idle_timeout(&mut s, Duration::from_secs(60)).await;
+        assert_eq!(result.unwrap(), Some(42));
+
+        let result = next_with_idle_timeout(&mut s, Duration::from_secs(60)).await;
+        assert_eq!(result.unwrap(), Some(43));
+
+        let result = next_with_idle_timeout(&mut s, Duration::from_secs(60)).await;
+        assert_eq!(result.unwrap(), None);
     }
 }

--- a/brokk-acp-rust/src/tool_loop.rs
+++ b/brokk-acp-rust/src/tool_loop.rs
@@ -189,11 +189,10 @@ pub(crate) async fn run(
         });
 
         // Wall-clock bound on this stream is enforced by the reqwest client's
-        // own `.timeout(...)` (see `OpenAiClient::new`); duplicating it here
-        // would fire at ~the same moment with no added value. The original
-        // concern in #3366 -- streams that drip occasional bytes -- is
-        // genuinely about per-chunk inactivity, which a wall-clock timeout
-        // doesn't catch. Tracked as a separate fix in #3453.
+        // own `.timeout(...)` (see `OpenAiClient::new`). Per-chunk idle
+        // inactivity (the case in #3366 / #3453: streams that drip
+        // occasional bytes and would defeat wall-clock) is enforced inside
+        // `OpenAiClient::stream_chat_impl` via `IDLE_CHUNK_TIMEOUT`.
         let response = llm
             .stream_chat(
                 model,


### PR DESCRIPTION
## Summary

Closes #3453.

`OpenAiClient::stream_chat_impl` now wraps each `stream.next()` await
with `tokio::time::timeout(IDLE_CHUNK_TIMEOUT, ...)`. The chunk-fetch
is factored into a small generic helper `next_with_idle_timeout<S:
Stream + Unpin>` so the timeout behavior can be unit-tested with any
stream item type.

`IDLE_CHUNK_TIMEOUT` is a module-level constant set to 90s. Chosen
to stay above realistic reasoning-model "thinking pauses" (which still
emit periodic SSE pings) and well below the 600s reqwest client
`.timeout()`. If review wants this configurable per `OpenAiClient`,
that is a one-field follow-up.

## Why

The reqwest client's `.timeout(600s)` is wall-clock against the entire
request, not per-chunk. A server (or a network path) that drips one
byte every 599s would never trip wall-clock, but the user's request
is effectively hung. Per-chunk idle inactivity catches the actual
failure mode -- "stream stalled mid-response."

Updates the explanatory comment at `tool_loop.rs:191-196` that
pointed to #3453 as a tracked follow-up (it now points at the new
constant inside `OpenAiClient`).

## Adds dev-dependency on `tokio[test-util]`

`tokio[full]` does not include `test-util`, which is what enables
`#[tokio::test(start_paused = true)]` and `tokio::time::pause()`.
The new dev-dependency entry adds it for tests only -- production
binary size is unaffected.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test llm_client::tests::` (2/2 pass)
- [x] Full `cargo test` -- 47/48 pass; the one failure
  (`bifrost_client::tests::handshake_and_call_search_tools`) reproduces
  on `master` and is unrelated to this change.

The two new tests:
- `next_with_idle_timeout_fires_on_pending_stream` -- uses
  `start_paused = true` + auto-advance to fire the 90s timer in
  milliseconds of wall time, then asserts the error message mentions
  "idle" and "90".
- `next_with_idle_timeout_passes_through_immediate_yield` -- checks
  that an iterator-backed stream yields its items normally without
  triggering the timeout.
