### PR TITLE
brokk-code: bump BUNDLED_BIFROST_VERSION to 0.1.3 (fixes list_symbols mismatch)

### DIFF
--- a/brokk-code/brokk_code/rust_acp_install.py
+++ b/brokk-code/brokk_code/rust_acp_install.py
@@ -38,7 +38,7 @@ from brokk_code.settings import get_global_cache_dir
 
 logger = logging.getLogger(__name__)
 
-BUNDLED_BIFROST_VERSION = "0.1.2"
+BUNDLED_BIFROST_VERSION = "0.1.3"
 
 _BIFROST_RELEASE_URL = "https://github.com/BrokkAi/bifrost/releases/download"
 _BIFROST_DOWNLOAD_TIMEOUT_SECONDS = 300.0

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -17,7 +17,7 @@ claude --plugin-dir ./claude-plugin
 
 ## Prerequisites
 
-[uv](https://docs.astral.sh/uv/) must be installed. The plugin runs `uvx brokk bifrost`, which fetches the `brokk` package from PyPI and downloads the [bifrost](https://github.com/BrokkAi/bifrost) native MCP server (currently pinned to v0.1.2) on first use. Bifrost ships native binaries for arm64 macOS, x86_64/aarch64 Linux, and x86_64/aarch64 Windows; Intel macOS is not supported.
+[uv](https://docs.astral.sh/uv/) must be installed. The plugin runs `uvx brokk bifrost`, which fetches the `brokk` package from PyPI and downloads the [bifrost](https://github.com/BrokkAi/bifrost) native MCP server (currently pinned to v0.1.3) on first use. Bifrost ships native binaries for arm64 macOS, x86_64/aarch64 Linux, and x86_64/aarch64 Windows; Intel macOS is not supported.
 
 ## Skills
 


### PR DESCRIPTION
## Summary

Bumps `BUNDLED_BIFROST_VERSION` from `0.1.2` to `0.1.3` in
`brokk-code/brokk_code/rust_acp_install.py` to match the renamed
`list_symbols` bifrost API that the rust ACP code already calls.

## Why

[bifrost v0.1.3](https://github.com/BrokkAi/bifrost/releases/tag/v0.1.3)
(2026-04-30) renamed `skim_files` -> `list_symbols` (and retired
`summarize_symbols`). Commit
[`6fb319ac1`](https://github.com/BrokkAi/brokk/commit/6fb319ac1)
("Update Brokk for `list_symbols` rename") updated the rust ACP code
to call the new name, but the bundled-version pin was left at `0.1.2`.
End-state on master:

- `brokk-acp-rust` calls bifrost with `list_symbols` arguments.
- Production install path downloads bifrost v0.1.2 binaries.
- v0.1.2 doesn't expose `list_symbols`, so tool calls return errors.

The test `bifrost_client::tests::handshake_and_call_search_tools`
fails today on master for any contributor with bifrost on `PATH` --
the assertion that `list_symbols` is exposed only holds against v0.1.3+.

## Verification

```sh
# Manual download of each release binary, then BROKK_BIFROST_BINARY=...
$ # vs v0.1.3 release binary
$ cargo test bifrost_client::tests::handshake
test bifrost_client::tests::handshake_and_call_search_tools ... ok

$ # vs v0.1.2 release binary (reproduces the master failure)
$ cargo test bifrost_client::tests::handshake
test bifrost_client::tests::handshake_and_call_search_tools ... FAILED
panicked: missing tool list_symbols in [...]
```

`brokk-code/tests/test_bifrost_launcher.py` (15 tests) all still pass
-- their `"0.1.2"` string fixtures are exercising the matcher logic,
not Brokk's pinned version, so they're untouched.

## Note: bifrost upstream version self-report bug

The bifrost v0.1.3 release binary self-reports `bifrost 0.1.2` --
their `Cargo.toml` version was apparently not bumped before the v0.1.3
git tag. `_bifrost_version_matches` will therefore reject a $PATH
bifrost that says `0.1.2` (correct from Brokk's perspective: that
could be either a real-0.1.2 binary or a mis-versioned-0.1.3 binary --
no way to tell apart) and fall back to the download path, which is
keyed on the version directory and fetches the right v0.1.3 artifact.
Worth flagging upstream but it doesn't block this fix.

## Test plan

- [x] `cd brokk-code && uv run pytest tests/test_bifrost_launcher.py` (15/15)
- [x] `cd brokk-acp-rust && BROKK_BIFROST_BINARY=<v0.1.3-binary> cargo test bifrost_client` (passes)
- [x] `cd brokk-acp-rust && BROKK_BIFROST_BINARY=<v0.1.2-binary> cargo test bifrost_client` (fails, reproduces the original symptom)
