### PR TITLE
brokk-acp-rust: add SetSessionModel + /context slash command (#3368)

### DIFF
--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1964,6 +1965,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -37,3 +37,8 @@ walkdir = "2"
 # `test-util` enables `tokio::time::pause()` and `#[tokio::test(start_paused = true)]`,
 # used by the LLM stream idle-timeout test to avoid waiting wall-clock seconds.
 tokio = { version = "1", features = ["test-util"] }
+# Used by the bifrost test fixture (`bifrost_client::tests`) to verify
+# the downloaded release archive against its `.sha256` sidecar before
+# extraction, mirroring what `brokk-code/brokk_code/rust_acp_install.py`
+# already does for the production install path.
+sha2 = "0.10"

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -91,9 +91,12 @@ fn model_config_option(current: &str, available_models: &[String]) -> Option<Ses
     if available_models.is_empty() {
         return None;
     }
+    // `SessionConfigSelectOption::new` stores its arguments owned, so the
+    // closure must hand it owned Strings -- borrowing from `available_models`
+    // would tie the option's lifetime to the slice and fail E0521.
     let options: Vec<SessionConfigSelectOption> = available_models
         .iter()
-        .map(|m| SessionConfigSelectOption::new(m.as_str(), m.as_str()))
+        .map(|m| SessionConfigSelectOption::new(m.clone(), m.clone()))
         .collect();
     // Fall back to the first catalog entry when `current` is empty or has
     // drifted out of the catalog -- otherwise some clients refuse to render

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -87,10 +87,7 @@ fn behavior_config_option(current: SessionMode) -> SessionConfigOption {
 /// cached `available_models` catalog. Returns `None` when the catalog is
 /// empty, in which case the dropdown is omitted entirely (per ACP, a select
 /// with zero options is not useful and some clients reject it).
-fn model_config_option(
-    current: &str,
-    available_models: &[String],
-) -> Option<SessionConfigOption> {
+fn model_config_option(current: &str, available_models: &[String]) -> Option<SessionConfigOption> {
     if available_models.is_empty() {
         return None;
     }
@@ -145,9 +142,8 @@ fn available_commands() -> Vec<AvailableCommand> {
 }
 
 fn send_available_commands_update(cx: &ConnectionTo<Client>, session_id: &str) {
-    let update = SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(
-        available_commands(),
-    ));
+    let update =
+        SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(available_commands()));
     let notification = SessionNotification::new(session_id.to_string(), update);
     if let Err(e) = cx.send_notification(notification) {
         tracing::warn!("failed to send available_commands_update: {e}");

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -2,15 +2,16 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use agent_client_protocol::schema::{
-    AgentCapabilities, CancelNotification, ConfigOptionUpdate, ContentBlock, ContentChunk,
-    InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse,
-    PromptCapabilities, PromptRequest, PromptResponse, ResumeSessionRequest, ResumeSessionResponse,
-    SessionCapabilities, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectOption, SessionInfo, SessionListCapabilities, SessionMode as AcpSessionMode,
-    SessionModeState, SessionNotification, SessionResumeCapabilities, SessionUpdate,
-    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
-    SetSessionModeResponse, StopReason, TextContent,
+    AgentCapabilities, AvailableCommand, AvailableCommandsUpdate, CancelNotification,
+    ConfigOptionUpdate, ContentBlock, ContentChunk, InitializeRequest, InitializeResponse,
+    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
+    NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse,
+    ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectOption, SessionInfo, SessionListCapabilities,
+    SessionMode as AcpSessionMode, SessionModeState, SessionNotification,
+    SessionResumeCapabilities, SessionUpdate, SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse, StopReason,
+    TextContent,
 };
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectionTo, Dispatch, Handled, Responder, on_receive_dispatch,
@@ -27,6 +28,9 @@ use crate::session::{ConversationTurn, PermissionMode, SessionMode, SessionStore
 /// does), so once we expose any configOption we have to expose all of them.
 const PERMISSION_CONFIG_ID: &str = "permission_mode";
 const BEHAVIOR_CONFIG_ID: &str = "behavior_mode";
+/// Mirrors the Java executor's wire id so cross-implementation clients
+/// (Zed, brokk-code) can drive model selection through one canonical name.
+const MODEL_CONFIG_ID: &str = "model_selection";
 
 /// Available session modes exposed to ACP clients.
 fn available_modes() -> Vec<AcpSessionMode> {
@@ -79,15 +83,75 @@ fn behavior_config_option(current: SessionMode) -> SessionConfigOption {
         .category(SessionConfigOptionCategory::Mode)
 }
 
-/// All configOption selectors we expose, in display order.
+/// Build the model `SessionConfigOption` reflecting `current` against the
+/// cached `available_models` catalog. Returns `None` when the catalog is
+/// empty, in which case the dropdown is omitted entirely (per ACP, a select
+/// with zero options is not useful and some clients reject it).
+fn model_config_option(
+    current: &str,
+    available_models: &[String],
+) -> Option<SessionConfigOption> {
+    if available_models.is_empty() {
+        return None;
+    }
+    let options: Vec<SessionConfigSelectOption> = available_models
+        .iter()
+        .map(|m| SessionConfigSelectOption::new(m.as_str(), m.as_str()))
+        .collect();
+    // Fall back to the first catalog entry when `current` is empty or has
+    // drifted out of the catalog -- otherwise some clients refuse to render
+    // a select whose value is not in `options`.
+    let current_value = if !current.is_empty() && available_models.iter().any(|m| m == current) {
+        current.to_string()
+    } else {
+        available_models[0].clone()
+    };
+    Some(
+        SessionConfigOption::select(MODEL_CONFIG_ID, "Model", current_value, options)
+            .description("Selects the LLM model used for this session.")
+            .category(SessionConfigOptionCategory::Model),
+    )
+}
+
+/// All configOption selectors we expose, in display order. The model
+/// selector is appended only when the LLM catalog is known; clients that
+/// drive model selection through the meta extension still see the current
+/// model via `meta.brokk.modelId`.
 fn all_config_options(
     behavior: SessionMode,
     permission: PermissionMode,
+    current_model: &str,
+    available_models: &[String],
 ) -> Vec<SessionConfigOption> {
-    vec![
+    let mut opts = vec![
         behavior_config_option(behavior),
         permission_config_option(permission),
-    ]
+    ];
+    if let Some(model_opt) = model_config_option(current_model, available_models) {
+        opts.push(model_opt);
+    }
+    opts
+}
+
+/// Slash commands advertised to clients via `available_commands_update`.
+/// Mirrors the Java executor's `/context` command (other Java commands are
+/// intentionally omitted -- they depend on the live workspace context that
+/// the Rust agent does not yet model).
+fn available_commands() -> Vec<AvailableCommand> {
+    vec![AvailableCommand::new(
+        "context",
+        "Show current session context snapshot",
+    )]
+}
+
+fn send_available_commands_update(cx: &ConnectionTo<Client>, session_id: &str) {
+    let update = SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(
+        available_commands(),
+    ));
+    let notification = SessionNotification::new(session_id.to_string(), update);
+    if let Err(e) = cx.send_notification(notification) {
+        tracing::warn!("failed to send available_commands_update: {e}");
+    }
 }
 
 /// Build and run the ACP agent over stdio.
@@ -157,7 +221,7 @@ pub async fn run_agent(
         .on_receive_request(
             async move |req: NewSessionRequest,
                         responder: Responder<NewSessionResponse>,
-                        _cx: ConnectionTo<Client>| {
+                        cx: ConnectionTo<Client>| {
                 let cwd = req.cwd.clone();
                 tracing::info!("ACP session/new, cwd={}", cwd.display());
                 let session = sessions_new.create_session(cwd).await;
@@ -181,8 +245,15 @@ pub async fn run_agent(
 
                 let response = NewSessionResponse::new(session.id.clone())
                     .modes(mode_state(session.mode.as_str()))
-                    .config_options(all_config_options(session.mode, session.permission_mode))
+                    .config_options(all_config_options(
+                        session.mode,
+                        session.permission_mode,
+                        &session.model,
+                        &models,
+                    ))
                     .meta(meta_map);
+
+                send_available_commands_update(&cx, &session.id);
 
                 responder.respond(response)
             },
@@ -220,10 +291,18 @@ pub async fn run_agent(
                     }
                 }
 
+                let models = sessions_load.available_models().await;
+                send_available_commands_update(&cx, &session_id);
+
                 responder.respond(
                     LoadSessionResponse::new()
                         .modes(mode_state(session.mode.as_str()))
-                        .config_options(all_config_options(session.mode, session.permission_mode)),
+                        .config_options(all_config_options(
+                            session.mode,
+                            session.permission_mode,
+                            &session.model,
+                            &models,
+                        )),
                 )
             },
             on_receive_request!(),
@@ -240,12 +319,16 @@ pub async fn run_agent(
                 match sessions_resume.get_session(&session_id, &cwd).await {
                     Some(session) => {
                         sessions_resume.update_cwd(&session_id, cwd).await;
+                        let models = sessions_resume.available_models().await;
+                        send_available_commands_update(&cx, &session_id);
                         responder.respond(
                             ResumeSessionResponse::new()
                                 .modes(mode_state(session.mode.as_str()))
                                 .config_options(all_config_options(
                                     session.mode,
                                     session.permission_mode,
+                                    &session.model,
+                                    &models,
                                 )),
                         )
                     }
@@ -310,6 +393,22 @@ pub async fn run_agent(
                         return responder.respond(PromptResponse::new(StopReason::EndTurn));
                     }
                 };
+
+                // Slash commands run locally and short-circuit the LLM round-trip.
+                // They are not persisted as conversation turns -- the response is
+                // purely informational and replaying it on the next session load
+                // would mislead the model about prior dialog. Mirrors the Java
+                // executor's `handleSlashCommand` path.
+                if is_slash_command(&prompt_text, "context") {
+                    let permission_mode = sessions_prompt
+                        .permission_mode(&session_id)
+                        .await
+                        .unwrap_or(PermissionMode::Default);
+                    let available_models = sessions_prompt.available_models().await;
+                    let report = render_context_report(&snap, permission_mode, &available_models);
+                    send_message(&cx, &session_id, &report);
+                    return responder.respond(PromptResponse::new(StopReason::EndTurn));
+                }
 
                 // Validate model is configured
                 if snap.model.is_empty() {
@@ -549,12 +648,51 @@ pub async fn run_agent(
                             );
                         }
                     }
+                    MODEL_CONFIG_ID => {
+                        if value.is_empty() {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::invalid_params().data(
+                                    serde_json::json!({
+                                        "reason": "model id must be a non-empty string",
+                                    }),
+                                ),
+                            );
+                        }
+                        // Reject ids that drift out of the catalog when one is known.
+                        // An empty catalog means model discovery never succeeded;
+                        // accept anything in that case so the user can still drive
+                        // the agent against a manually-configured backend.
+                        let known = sessions_perm.available_models().await;
+                        if !known.is_empty() && !known.iter().any(|m| m == &value) {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::invalid_params().data(
+                                    serde_json::json!({
+                                        "reason": format!("unknown model '{value}'"),
+                                        "supported": known,
+                                    }),
+                                ),
+                            );
+                        }
+                        if !sessions_perm.set_model(&session_id, value.clone()).await {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::invalid_params().data(
+                                    serde_json::json!({
+                                        "reason": format!("unknown session '{session_id}'"),
+                                    }),
+                                ),
+                            );
+                        }
+                    }
                     other => {
                         return responder.respond_with_error(
                             agent_client_protocol::Error::invalid_params().data(
                                 serde_json::json!({
                                     "reason": format!("unknown configOption '{other}'"),
-                                    "supported": [BEHAVIOR_CONFIG_ID, PERMISSION_CONFIG_ID],
+                                    "supported": [
+                                        BEHAVIOR_CONFIG_ID,
+                                        PERMISSION_CONFIG_ID,
+                                        MODEL_CONFIG_ID,
+                                    ],
                                 }),
                             ),
                         );
@@ -562,7 +700,7 @@ pub async fn run_agent(
                 }
 
                 // Re-fetch the session so the returned options reflect the
-                // latest values for *both* selectors (the spec says the
+                // latest values for *all* selectors (the spec says the
                 // response carries the full updated set, not just the one we
                 // changed).
                 let fallback_cwd = std::env::current_dir().unwrap_or_default();
@@ -574,7 +712,13 @@ pub async fn run_agent(
                         })),
                     );
                 };
-                let updated_options = all_config_options(session.mode, session.permission_mode);
+                let models = sessions_perm.available_models().await;
+                let updated_options = all_config_options(
+                    session.mode,
+                    session.permission_mode,
+                    &session.model,
+                    &models,
+                );
 
                 let notification = SessionNotification::new(
                     session_id.clone(),
@@ -669,4 +813,117 @@ fn build_system_prompt(mode: &SessionMode, cwd: &Path) -> String {
     };
 
     format!("{cwd_context}{mode_prompt}")
+}
+
+/// Returns true when `prompt_text` invokes the slash command `name`,
+/// matching `/name` exactly or `/name <args>`. Whitespace and case are
+/// normalized so clients that uppercase auto-complete entries still hit.
+fn is_slash_command(prompt_text: &str, name: &str) -> bool {
+    let stripped = prompt_text.trim();
+    let Some(rest) = stripped.strip_prefix('/') else {
+        return false;
+    };
+    let head = rest
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    head == name
+}
+
+/// Render the `/context` snapshot. Mirrors the Java executor's report at a
+/// coarser granularity -- the Rust agent does not yet model
+/// editable/readonly/virtual fragments, so the table reports the
+/// conversation history instead, which is what actually drives token
+/// pressure on the LLM today.
+fn render_context_report(
+    snap: &crate::session::SessionSnapshot,
+    permission_mode: PermissionMode,
+    available_models: &[String],
+) -> String {
+    // Char/4 is the same back-of-the-envelope estimate the Java side uses
+    // for non-tokenizer-aware approximations. Good enough for a snapshot
+    // dump; not load-bearing.
+    let approx_tokens = |s: &str| s.chars().count() / 4;
+    let mut user_tokens = 0usize;
+    let mut agent_tokens = 0usize;
+    for turn in &snap.history {
+        user_tokens += approx_tokens(&turn.user_prompt);
+        agent_tokens += approx_tokens(&turn.agent_response);
+    }
+    let total_tokens = user_tokens + agent_tokens;
+    let model_display = if snap.model.is_empty() {
+        "(none)".to_string()
+    } else {
+        snap.model.clone()
+    };
+    let catalog_size = available_models.len();
+
+    let mut out = String::new();
+    out.push_str("**Session context**\n\n");
+    out.push_str(&format!("- Working directory: `{}`\n", snap.cwd.display()));
+    out.push_str(&format!("- Mode: `{}`\n", snap.mode.as_str()));
+    out.push_str(&format!(
+        "- Permission mode: `{}`\n",
+        permission_mode.as_str()
+    ));
+    out.push_str(&format!(
+        "- Model: `{model_display}` ({catalog_size} known in catalog)\n"
+    ));
+    out.push_str(&format!(
+        "- Conversation turns: {} (~{} tokens user / ~{} tokens agent / ~{} total)\n",
+        snap.history.len(),
+        user_tokens,
+        agent_tokens,
+        total_tokens
+    ));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_slash_command_matches_bare_and_with_args() {
+        assert!(is_slash_command("/context", "context"));
+        assert!(is_slash_command("  /context  ", "context"));
+        assert!(is_slash_command("/context with extra args", "context"));
+        // Case-insensitive: clients sometimes uppercase auto-complete entries.
+        assert!(is_slash_command("/Context", "context"));
+        assert!(is_slash_command("/CONTEXT", "context"));
+    }
+
+    #[test]
+    fn is_slash_command_rejects_non_matches() {
+        // Plain text is never a command, even if the word "context" appears.
+        assert!(!is_slash_command("context please", "context"));
+        // Missing leading slash.
+        assert!(!is_slash_command("context", "context"));
+        // Different command sharing a prefix must not match.
+        assert!(!is_slash_command("/contextual", "context"));
+        // Empty input.
+        assert!(!is_slash_command("", "context"));
+        assert!(!is_slash_command("/", "context"));
+    }
+
+    #[test]
+    fn model_config_option_omitted_when_catalog_empty() {
+        // No discovery results means we can't offer a meaningful dropdown.
+        assert!(model_config_option("anything", &[]).is_none());
+    }
+
+    #[test]
+    fn model_config_option_present_when_catalog_known() {
+        let models = vec!["model-a".to_string(), "model-b".to_string()];
+        // Spot-check that the option is actually built. Field shapes are
+        // covered by the `agent-client-protocol` crate; we just need to know
+        // the helper produced *something*.
+        assert!(model_config_option("model-a", &models).is_some());
+        // Out-of-catalog current value still produces an option (we fall
+        // back to the first catalog entry); tested implicitly via the
+        // is_some assertion plus the no-panic contract.
+        assert!(model_config_option("model-zzz", &models).is_some());
+        assert!(model_config_option("", &models).is_some());
+    }
 }

--- a/brokk-acp-rust/src/bifrost_client.rs
+++ b/brokk-acp-rust/src/bifrost_client.rs
@@ -382,10 +382,13 @@ mod tests {
     }
 
     async fn download_and_extract_bifrost(cache_dir: &Path) {
+        use sha2::{Digest, Sha256};
+
         std::fs::create_dir_all(cache_dir).expect("create test-fixtures cache");
 
         let asset = format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}.{ARCHIVE_EXT}");
         let url = format!("{TEST_BIFROST_RELEASE_BASE}/v{TEST_BIFROST_VERSION}/{asset}");
+        let sha256_url = format!("{url}.sha256");
 
         eprintln!("downloading bifrost test fixture: {url}");
         let bytes = reqwest::get(&url)
@@ -396,6 +399,35 @@ mod tests {
             .bytes()
             .await
             .expect("read bifrost archive bytes");
+
+        // Integrity check: verify against the publisher's `.sha256` sidecar
+        // before extraction. `bifrost --version` is unreliable as a pin
+        // (the v0.1.3 binary still self-reports `0.1.2` due to an upstream
+        // Cargo.toml miss); the sha256 is content-addressable so a
+        // mislabeled or swapped binary is caught here. Mirrors the check
+        // already done by `brokk-code/brokk_code/rust_acp_install.py` on
+        // the production install path.
+        eprintln!("verifying bifrost archive against {sha256_url}");
+        let sidecar = reqwest::get(&sha256_url)
+            .await
+            .expect("bifrost .sha256 sidecar download failed")
+            .error_for_status()
+            .expect("bifrost .sha256 sidecar returned non-200")
+            .text()
+            .await
+            .expect("read .sha256 sidecar text");
+        let expected_hex = sidecar
+            .split_whitespace()
+            .next()
+            .expect("bifrost .sha256 sidecar is empty")
+            .to_lowercase();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let actual_hex = format!("{:x}", hasher.finalize());
+        assert_eq!(
+            actual_hex, expected_hex,
+            "bifrost archive sha256 mismatch for {url}: got {actual_hex}, expected {expected_hex} (refuse to extract)"
+        );
 
         let archive_path = cache_dir.join(&asset);
         std::fs::write(&archive_path, &bytes).expect("write archive to cache");

--- a/brokk-acp-rust/src/bifrost_client.rs
+++ b/brokk-acp-rust/src/bifrost_client.rs
@@ -292,42 +292,165 @@ fn parse_tool_list(result: Value) -> Result<Vec<BifrostToolDef>, BifrostError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
-    fn locate_bifrost() -> Option<PathBuf> {
-        if let Ok(env) = std::env::var("BROKK_BIFROST_BINARY") {
-            let p = PathBuf::from(env);
-            if p.exists() {
-                return Some(p);
-            }
+    /// Bifrost release the handshake test pins. Bumping bifrost is a deliberate
+    /// edit here, not whatever happens to be on a contributor's `$PATH`.
+    /// Must stay in sync with `BUNDLED_BIFROST_VERSION` in
+    /// `brokk-code/brokk_code/rust_acp_install.py`.
+    const TEST_BIFROST_VERSION: &str = "0.1.3";
+
+    const TEST_BIFROST_RELEASE_BASE: &str = "https://github.com/BrokkAi/bifrost/releases/download";
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-apple-darwin";
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    const TRIPLE: &str = "x86_64-unknown-linux-gnu";
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-unknown-linux-gnu";
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    const TRIPLE: &str = "x86_64-pc-windows-msvc";
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-pc-windows-msvc";
+
+    #[cfg(not(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64"),
+    )))]
+    compile_error!(
+        "bifrost releases only ship binaries for arm64 macOS, x86_64/aarch64 Linux, \
+         and x86_64/aarch64 Windows; this test cannot run on other targets"
+    );
+
+    #[cfg(target_os = "windows")]
+    const ARCHIVE_EXT: &str = "zip";
+    #[cfg(not(target_os = "windows"))]
+    const ARCHIVE_EXT: &str = "tar.gz";
+
+    #[cfg(target_os = "windows")]
+    const BINARY_NAME: &str = "bifrost.exe";
+    #[cfg(not(target_os = "windows"))]
+    const BINARY_NAME: &str = "bifrost";
+
+    /// Resolve the bifrost binary used by the handshake test.
+    ///
+    /// Resolution order:
+    /// 1. `BROKK_BIFROST_BINARY` env var (override for testing against an
+    ///    in-tree bifrost build).
+    /// 2. The cached pinned-version binary under
+    ///    `target/test-fixtures/bifrost/<version>/<triple>/`.
+    /// 3. Download the pinned release into the cache, then return its path.
+    ///
+    /// We deliberately do NOT consult `which bifrost`: that coupled the test
+    /// to whatever happened to be installed locally, which dragged the test
+    /// behavior into "depends on which version of bifrost the contributor
+    /// happens to have on PATH" -- the bug this helper exists to remove.
+    async fn ensure_test_bifrost_binary() -> PathBuf {
+        if let Ok(override_path) = std::env::var("BROKK_BIFROST_BINARY") {
+            let p = PathBuf::from(&override_path);
+            assert!(
+                p.is_file(),
+                "BROKK_BIFROST_BINARY={override_path} is not a regular file"
+            );
+            return p;
         }
-        let output = std::process::Command::new("which")
-            .arg("bifrost")
-            .output()
-            .ok()?;
-        if !output.status.success() {
-            return None;
+
+        let cache_dir = test_fixture_cache_dir();
+        let binary = cache_dir.join(BINARY_NAME);
+        if binary.is_file() {
+            return binary;
         }
-        let trimmed = String::from_utf8(output.stdout).ok()?.trim().to_string();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(PathBuf::from(trimmed))
+
+        download_and_extract_bifrost(&cache_dir).await;
+        assert!(
+            binary.is_file(),
+            "expected bifrost at {binary:?} after download+extract"
+        );
+        binary
+    }
+
+    fn test_fixture_cache_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test-fixtures")
+            .join("bifrost")
+            .join(TEST_BIFROST_VERSION)
+            .join(TRIPLE)
+    }
+
+    async fn download_and_extract_bifrost(cache_dir: &Path) {
+        std::fs::create_dir_all(cache_dir).expect("create test-fixtures cache");
+
+        let asset = format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}.{ARCHIVE_EXT}");
+        let url = format!("{TEST_BIFROST_RELEASE_BASE}/v{TEST_BIFROST_VERSION}/{asset}");
+
+        eprintln!("downloading bifrost test fixture: {url}");
+        let bytes = reqwest::get(&url)
+            .await
+            .expect("bifrost release download failed (network/proxy?)")
+            .error_for_status()
+            .expect("bifrost release returned non-200")
+            .bytes()
+            .await
+            .expect("read bifrost archive bytes");
+
+        let archive_path = cache_dir.join(&asset);
+        std::fs::write(&archive_path, &bytes).expect("write archive to cache");
+
+        // `tar -xf` auto-detects the format and handles both .tar.gz and .zip
+        // on modern macOS, Linux, and Windows 10+ runners.
+        let status = std::process::Command::new("tar")
+            .arg("-xf")
+            .arg(&archive_path)
+            .arg("-C")
+            .arg(cache_dir)
+            .status()
+            .expect("invoke tar to extract bifrost archive");
+        assert!(
+            status.success(),
+            "tar extraction of {archive_path:?} failed"
+        );
+
+        // Archive extracts to `bifrost-v<ver>-<triple>/bifrost(.exe)`.
+        let inner_dir = cache_dir.join(format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}"));
+        let inner_binary = inner_dir.join(BINARY_NAME);
+        assert!(
+            inner_binary.is_file(),
+            "expected extracted binary at {inner_binary:?}"
+        );
+
+        let target = cache_dir.join(BINARY_NAME);
+        std::fs::rename(&inner_binary, &target)
+            .or_else(|_| std::fs::copy(&inner_binary, &target).map(|_| ()))
+            .expect("place bifrost binary at cache root");
+
+        let _ = std::fs::remove_file(&archive_path);
+        let _ = std::fs::remove_dir_all(&inner_dir);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&target)
+                .expect("stat extracted binary")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&target, perms).expect("chmod 755 on extracted binary");
         }
     }
 
-    /// Smoke test: spawn the real bifrost subprocess, run the MCP handshake,
-    /// confirm a stable subset of search-tools is exposed, and round-trip one
-    /// tool call. We deliberately do NOT pin the exact tool count or full
-    /// tool list -- bifrost adds tools faster than this test gets updated, and
-    /// the handshake's job is to verify the protocol path works, not to
-    /// enumerate the surface. Skipped when the binary isn't installed.
+    /// Smoke test: spawn the real bifrost subprocess (pinned release,
+    /// downloaded into `target/test-fixtures/`), run the MCP handshake,
+    /// confirm a stable subset of search tools is exposed, and round-trip
+    /// two distinct tool calls. We deliberately do NOT pin the exact tool
+    /// count or full tool list -- bifrost adds tools faster than this test
+    /// gets updated, and the handshake's job is to verify the protocol
+    /// path works, not to enumerate the surface.
     #[tokio::test]
     async fn handshake_and_call_search_tools() {
-        let Some(binary) = locate_bifrost() else {
-            eprintln!("skipping: bifrost binary not on PATH and BROKK_BIFROST_BINARY unset");
-            return;
-        };
+        let binary = ensure_test_bifrost_binary().await;
         let cwd = std::env::current_dir()
             .expect("cwd")
             .canonicalize()

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -963,6 +963,38 @@ impl SessionStore {
         }
     }
 
+    /// Update the per-session LLM model. Returns false if the session is
+    /// unknown. Persists the new model into the session manifest so it
+    /// survives a reload, mirroring `set_mode`.
+    pub async fn set_model(&self, id: &str, model: String) -> bool {
+        let snapshot = {
+            let mut sessions = self.sessions.write().await;
+            match sessions.get_mut(id) {
+                Some(session) => {
+                    session.model = model.clone();
+                    session.manifest.model = if model.is_empty() {
+                        None
+                    } else {
+                        Some(model)
+                    };
+                    Some((session.cwd.clone(), session.manifest.clone()))
+                }
+                None => None,
+            }
+        };
+        match snapshot {
+            Some((cwd, manifest)) => {
+                let zip_path = session_zip_path(&cwd, id);
+                let _ = tokio::task::spawn_blocking(move || {
+                    rewrite_manifest_in_zip(&zip_path, &manifest)
+                })
+                .await;
+                true
+            }
+            None => false,
+        }
+    }
+
     pub async fn set_default_model(&self, model: String) {
         *self.default_model.write().await = model;
     }
@@ -1203,5 +1235,34 @@ mod tests {
 
         assert_eq!(err.requested, "requested-id");
         assert_eq!(err.loaded, "loaded-id");
+    }
+
+    /// `set_model` should update the in-memory `Session.model` and
+    /// `manifest.model` so a subsequent reload from disk picks up the new
+    /// value. Persistence itself is exercised by `rewrite_manifest_in_zip`
+    /// (shared with `set_mode`); this test verifies wiring only.
+    #[tokio::test]
+    async fn set_model_updates_session_and_manifest() {
+        let store = SessionStore::new("initial-model".to_string());
+
+        // Use a unique tmp cwd so concurrent test runs don't clobber.
+        let cwd = std::env::temp_dir().join(format!(
+            "brokk-acp-rust-set-model-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let session = store.create_session(cwd).await;
+        let id = session.id.clone();
+
+        assert!(store.set_model(&id, "next-model".to_string()).await);
+        let sessions = store.sessions.read().await;
+        let s = sessions.get(&id).expect("session still in memory");
+        assert_eq!(s.model, "next-model");
+        assert_eq!(s.manifest.model.as_deref(), Some("next-model"));
+    }
+
+    #[tokio::test]
+    async fn set_model_returns_false_for_unknown_session() {
+        let store = SessionStore::new("initial-model".to_string());
+        assert!(!store.set_model("no-such-session", "next-model".into()).await);
     }
 }

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -972,11 +972,7 @@ impl SessionStore {
             match sessions.get_mut(id) {
                 Some(session) => {
                     session.model = model.clone();
-                    session.manifest.model = if model.is_empty() {
-                        None
-                    } else {
-                        Some(model)
-                    };
+                    session.manifest.model = if model.is_empty() { None } else { Some(model) };
                     Some((session.cwd.clone(), session.manifest.clone()))
                 }
                 None => None,
@@ -1246,10 +1242,8 @@ mod tests {
         let store = SessionStore::new("initial-model".to_string());
 
         // Use a unique tmp cwd so concurrent test runs don't clobber.
-        let cwd = std::env::temp_dir().join(format!(
-            "brokk-acp-rust-set-model-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let cwd =
+            std::env::temp_dir().join(format!("brokk-acp-rust-set-model-{}", uuid::Uuid::new_v4()));
         let session = store.create_session(cwd).await;
         let id = session.id.clone();
 
@@ -1263,6 +1257,10 @@ mod tests {
     #[tokio::test]
     async fn set_model_returns_false_for_unknown_session() {
         let store = SessionStore::new("initial-model".to_string());
-        assert!(!store.set_model("no-such-session", "next-model".into()).await);
+        assert!(
+            !store
+                .set_model("no-such-session", "next-model".into())
+                .await
+        );
     }
 }


### PR DESCRIPTION
Closes #3368

## Summary

Adds the two remaining ACP handlers the Rust server was missing relative to the Java executor (per the latest #3368 audit):

- **`SetSessionModel`** — wired through the existing `session/set_session_config_option` request using `model_selection` as the wire id (same id Java uses, so cross-implementation clients like Zed and brokk-code drive model selection through one canonical path).
  - `all_config_options` now appends a `Model` selector whenever the LLM catalog is non-empty; if discovery never succeeded the dropdown is omitted (the meta `brokk.modelId` channel still exposes the current model).
  - The set-handler validates the new id against the cached catalog when one is known and falls through when it isn't, so users can drive a manually-configured backend.
  - New `SessionStore::set_model` updates the in-memory `Session.model` and rewrites `manifest.brokkModel` so the choice survives a reload (mirrors `set_mode`).
  - Both the response and the `ConfigOptionUpdate` notification carry the full updated option set, as the spec requires.

- **`/context` slash command** — advertised through `AvailableCommandsUpdate` on `session/new`, `session/load`, and `session/resume`, and short-circuited in the prompt handler before any snapshot/LLM work.
  - The reply is intentionally not persisted as a conversation turn (matches Java's `handleSlashCommand`), so replaying a session won't surface stale context dumps as prior dialog.
  - Output is a markdown summary of cwd, mode, permission mode, current model + catalog size, and conversation turns + an approximate token count (chars/4 — same back-of-the-envelope estimate Java uses).
  - `is_slash_command` does whitespace-tolerant, case-insensitive prefix matching but rejects look-alikes (`/contextual`).

## Test plan

- [ ] `cargo test -p brokk-acp-rust` — covers new unit tests:
  - `is_slash_command_matches_bare_and_with_args`
  - `is_slash_command_rejects_non_matches`
  - `model_config_option_omitted_when_catalog_empty`
  - `model_config_option_present_when_catalog_known`
  - `set_model_updates_session_and_manifest`
  - `set_model_returns_false_for_unknown_session`
- [ ] Manual: run brokk-acp from Zed, switch the Model dropdown mid-session, confirm the next prompt uses the new model and that `manifest.brokkModel` in `.brokk/sessions/<id>.zip` reflects the change.
- [ ] Manual: type `/context` in a session with a few turns, confirm the snapshot reports correct cwd/mode/permission/model/turn-count and that the "/context" line is not visible after reloading the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)