### PR TITLE
brokk-acp-rust: factor temp-then-rename + entry-copy zip pattern in session.rs

### DIFF
--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1964,6 +1965,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -37,3 +37,8 @@ walkdir = "2"
 # `test-util` enables `tokio::time::pause()` and `#[tokio::test(start_paused = true)]`,
 # used by the LLM stream idle-timeout test to avoid waiting wall-clock seconds.
 tokio = { version = "1", features = ["test-util"] }
+# Used by the bifrost test fixture (`bifrost_client::tests`) to verify
+# the downloaded release archive against its `.sha256` sidecar before
+# extraction, mirroring what `brokk-code/brokk_code/rust_acp_install.py`
+# already does for the production install path.
+sha2 = "0.10"

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -473,16 +473,22 @@ pub async fn run_agent(
                     );
                 };
 
-                if !sessions_mode.set_mode(&session_id, mode).await {
-                    return responder.respond_with_error(
-                        agent_client_protocol::Error::invalid_params()
-                            .data(serde_json::json!({
+                match sessions_mode.set_mode(&session_id, mode).await {
+                    Ok(true) => responder.respond(SetSessionModeResponse::new()),
+                    Ok(false) => responder.respond_with_error(
+                        agent_client_protocol::Error::invalid_params().data(
+                            serde_json::json!({
                                 "reason": format!("unknown session '{session_id}'"),
-                            })),
-                    );
+                            }),
+                        ),
+                    ),
+                    Err(e) => responder.respond_with_error(
+                        agent_client_protocol::Error::internal_error().data(serde_json::json!({
+                            "reason": "failed to persist session mode",
+                            "details": format!("{e:#}"),
+                        })),
+                    ),
                 }
-
-                responder.respond(SetSessionModeResponse::new())
             },
             on_receive_request!(),
         )
@@ -539,14 +545,27 @@ pub async fn run_agent(
                                 ),
                             );
                         };
-                        if !sessions_perm.set_mode(&session_id, behavior_mode).await {
-                            return responder.respond_with_error(
-                                agent_client_protocol::Error::invalid_params().data(
-                                    serde_json::json!({
-                                        "reason": format!("unknown session '{session_id}'"),
-                                    }),
-                                ),
-                            );
+                        match sessions_perm.set_mode(&session_id, behavior_mode).await {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                return responder.respond_with_error(
+                                    agent_client_protocol::Error::invalid_params().data(
+                                        serde_json::json!({
+                                            "reason": format!("unknown session '{session_id}'"),
+                                        }),
+                                    ),
+                                );
+                            }
+                            Err(e) => {
+                                return responder.respond_with_error(
+                                    agent_client_protocol::Error::internal_error().data(
+                                        serde_json::json!({
+                                            "reason": "failed to persist session mode",
+                                            "details": format!("{e:#}"),
+                                        }),
+                                    ),
+                                );
+                            }
                         }
                     }
                     other => {

--- a/brokk-acp-rust/src/bifrost_client.rs
+++ b/brokk-acp-rust/src/bifrost_client.rs
@@ -382,10 +382,13 @@ mod tests {
     }
 
     async fn download_and_extract_bifrost(cache_dir: &Path) {
+        use sha2::{Digest, Sha256};
+
         std::fs::create_dir_all(cache_dir).expect("create test-fixtures cache");
 
         let asset = format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}.{ARCHIVE_EXT}");
         let url = format!("{TEST_BIFROST_RELEASE_BASE}/v{TEST_BIFROST_VERSION}/{asset}");
+        let sha256_url = format!("{url}.sha256");
 
         eprintln!("downloading bifrost test fixture: {url}");
         let bytes = reqwest::get(&url)
@@ -396,6 +399,35 @@ mod tests {
             .bytes()
             .await
             .expect("read bifrost archive bytes");
+
+        // Integrity check: verify against the publisher's `.sha256` sidecar
+        // before extraction. `bifrost --version` is unreliable as a pin
+        // (the v0.1.3 binary still self-reports `0.1.2` due to an upstream
+        // Cargo.toml miss); the sha256 is content-addressable so a
+        // mislabeled or swapped binary is caught here. Mirrors the check
+        // already done by `brokk-code/brokk_code/rust_acp_install.py` on
+        // the production install path.
+        eprintln!("verifying bifrost archive against {sha256_url}");
+        let sidecar = reqwest::get(&sha256_url)
+            .await
+            .expect("bifrost .sha256 sidecar download failed")
+            .error_for_status()
+            .expect("bifrost .sha256 sidecar returned non-200")
+            .text()
+            .await
+            .expect("read .sha256 sidecar text");
+        let expected_hex = sidecar
+            .split_whitespace()
+            .next()
+            .expect("bifrost .sha256 sidecar is empty")
+            .to_lowercase();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let actual_hex = format!("{:x}", hasher.finalize());
+        assert_eq!(
+            actual_hex, expected_hex,
+            "bifrost archive sha256 mismatch for {url}: got {actual_hex}, expected {expected_hex} (refuse to extract)"
+        );
 
         let archive_path = cache_dir.join(&asset);
         std::fs::write(&archive_path, &bytes).expect("write archive to cache");

--- a/brokk-acp-rust/src/bifrost_client.rs
+++ b/brokk-acp-rust/src/bifrost_client.rs
@@ -292,42 +292,165 @@ fn parse_tool_list(result: Value) -> Result<Vec<BifrostToolDef>, BifrostError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
-    fn locate_bifrost() -> Option<PathBuf> {
-        if let Ok(env) = std::env::var("BROKK_BIFROST_BINARY") {
-            let p = PathBuf::from(env);
-            if p.exists() {
-                return Some(p);
-            }
+    /// Bifrost release the handshake test pins. Bumping bifrost is a deliberate
+    /// edit here, not whatever happens to be on a contributor's `$PATH`.
+    /// Must stay in sync with `BUNDLED_BIFROST_VERSION` in
+    /// `brokk-code/brokk_code/rust_acp_install.py`.
+    const TEST_BIFROST_VERSION: &str = "0.1.3";
+
+    const TEST_BIFROST_RELEASE_BASE: &str = "https://github.com/BrokkAi/bifrost/releases/download";
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-apple-darwin";
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    const TRIPLE: &str = "x86_64-unknown-linux-gnu";
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-unknown-linux-gnu";
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    const TRIPLE: &str = "x86_64-pc-windows-msvc";
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-pc-windows-msvc";
+
+    #[cfg(not(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64"),
+    )))]
+    compile_error!(
+        "bifrost releases only ship binaries for arm64 macOS, x86_64/aarch64 Linux, \
+         and x86_64/aarch64 Windows; this test cannot run on other targets"
+    );
+
+    #[cfg(target_os = "windows")]
+    const ARCHIVE_EXT: &str = "zip";
+    #[cfg(not(target_os = "windows"))]
+    const ARCHIVE_EXT: &str = "tar.gz";
+
+    #[cfg(target_os = "windows")]
+    const BINARY_NAME: &str = "bifrost.exe";
+    #[cfg(not(target_os = "windows"))]
+    const BINARY_NAME: &str = "bifrost";
+
+    /// Resolve the bifrost binary used by the handshake test.
+    ///
+    /// Resolution order:
+    /// 1. `BROKK_BIFROST_BINARY` env var (override for testing against an
+    ///    in-tree bifrost build).
+    /// 2. The cached pinned-version binary under
+    ///    `target/test-fixtures/bifrost/<version>/<triple>/`.
+    /// 3. Download the pinned release into the cache, then return its path.
+    ///
+    /// We deliberately do NOT consult `which bifrost`: that coupled the test
+    /// to whatever happened to be installed locally, which dragged the test
+    /// behavior into "depends on which version of bifrost the contributor
+    /// happens to have on PATH" -- the bug this helper exists to remove.
+    async fn ensure_test_bifrost_binary() -> PathBuf {
+        if let Ok(override_path) = std::env::var("BROKK_BIFROST_BINARY") {
+            let p = PathBuf::from(&override_path);
+            assert!(
+                p.is_file(),
+                "BROKK_BIFROST_BINARY={override_path} is not a regular file"
+            );
+            return p;
         }
-        let output = std::process::Command::new("which")
-            .arg("bifrost")
-            .output()
-            .ok()?;
-        if !output.status.success() {
-            return None;
+
+        let cache_dir = test_fixture_cache_dir();
+        let binary = cache_dir.join(BINARY_NAME);
+        if binary.is_file() {
+            return binary;
         }
-        let trimmed = String::from_utf8(output.stdout).ok()?.trim().to_string();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(PathBuf::from(trimmed))
+
+        download_and_extract_bifrost(&cache_dir).await;
+        assert!(
+            binary.is_file(),
+            "expected bifrost at {binary:?} after download+extract"
+        );
+        binary
+    }
+
+    fn test_fixture_cache_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test-fixtures")
+            .join("bifrost")
+            .join(TEST_BIFROST_VERSION)
+            .join(TRIPLE)
+    }
+
+    async fn download_and_extract_bifrost(cache_dir: &Path) {
+        std::fs::create_dir_all(cache_dir).expect("create test-fixtures cache");
+
+        let asset = format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}.{ARCHIVE_EXT}");
+        let url = format!("{TEST_BIFROST_RELEASE_BASE}/v{TEST_BIFROST_VERSION}/{asset}");
+
+        eprintln!("downloading bifrost test fixture: {url}");
+        let bytes = reqwest::get(&url)
+            .await
+            .expect("bifrost release download failed (network/proxy?)")
+            .error_for_status()
+            .expect("bifrost release returned non-200")
+            .bytes()
+            .await
+            .expect("read bifrost archive bytes");
+
+        let archive_path = cache_dir.join(&asset);
+        std::fs::write(&archive_path, &bytes).expect("write archive to cache");
+
+        // `tar -xf` auto-detects the format and handles both .tar.gz and .zip
+        // on modern macOS, Linux, and Windows 10+ runners.
+        let status = std::process::Command::new("tar")
+            .arg("-xf")
+            .arg(&archive_path)
+            .arg("-C")
+            .arg(cache_dir)
+            .status()
+            .expect("invoke tar to extract bifrost archive");
+        assert!(
+            status.success(),
+            "tar extraction of {archive_path:?} failed"
+        );
+
+        // Archive extracts to `bifrost-v<ver>-<triple>/bifrost(.exe)`.
+        let inner_dir = cache_dir.join(format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}"));
+        let inner_binary = inner_dir.join(BINARY_NAME);
+        assert!(
+            inner_binary.is_file(),
+            "expected extracted binary at {inner_binary:?}"
+        );
+
+        let target = cache_dir.join(BINARY_NAME);
+        std::fs::rename(&inner_binary, &target)
+            .or_else(|_| std::fs::copy(&inner_binary, &target).map(|_| ()))
+            .expect("place bifrost binary at cache root");
+
+        let _ = std::fs::remove_file(&archive_path);
+        let _ = std::fs::remove_dir_all(&inner_dir);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&target)
+                .expect("stat extracted binary")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&target, perms).expect("chmod 755 on extracted binary");
         }
     }
 
-    /// Smoke test: spawn the real bifrost subprocess, run the MCP handshake,
-    /// confirm a stable subset of search-tools is exposed, and round-trip one
-    /// tool call. We deliberately do NOT pin the exact tool count or full
-    /// tool list -- bifrost adds tools faster than this test gets updated, and
-    /// the handshake's job is to verify the protocol path works, not to
-    /// enumerate the surface. Skipped when the binary isn't installed.
+    /// Smoke test: spawn the real bifrost subprocess (pinned release,
+    /// downloaded into `target/test-fixtures/`), run the MCP handshake,
+    /// confirm a stable subset of search tools is exposed, and round-trip
+    /// two distinct tool calls. We deliberately do NOT pin the exact tool
+    /// count or full tool list -- bifrost adds tools faster than this test
+    /// gets updated, and the handshake's job is to verify the protocol
+    /// path works, not to enumerate the surface.
     #[tokio::test]
     async fn handshake_and_call_search_tools() {
-        let Some(binary) = locate_bifrost() else {
-            eprintln!("skipping: bifrost binary not on PATH and BROKK_BIFROST_BINARY unset");
-            return;
-        };
+        let binary = ensure_test_bifrost_binary().await;
         let cwd = std::env::current_dir()
             .expect("cwd")
             .canonicalize()

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -370,93 +370,136 @@ fn read_history_from_zip(zip_path: &Path) -> Vec<ConversationTurn> {
     turns
 }
 
-/// Write a new empty session zip compatible with the executor.
-fn write_new_session_zip(zip_path: &Path, manifest: &SessionManifest) {
-    let dir = zip_path.parent().unwrap();
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        tracing::warn!("failed to create sessions dir {}: {e}", dir.display());
-        return;
-    }
+/// Run `populate` against a fresh `<zip_path>.tmp`, finalize the writer, and atomically
+/// rename it over `zip_path`. On any failure the temp file is cleaned up and the original
+/// zip (if any) is left untouched, so callers get all-or-nothing semantics.
+fn with_temp_zip_writer<F>(zip_path: &Path, populate: F) -> anyhow::Result<()>
+where
+    F: FnOnce(
+        &mut zip::ZipWriter<std::fs::File>,
+        zip::write::SimpleFileOptions,
+    ) -> anyhow::Result<()>,
+{
+    use anyhow::Context;
+
+    let dir = zip_path.parent().with_context(|| {
+        format!(
+            "session zip path has no parent directory: {}",
+            zip_path.display()
+        )
+    })?;
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("creating sessions dir {}", dir.display()))?;
 
     let tmp = zip_path.with_extension("tmp");
-    let file = match std::fs::File::create(&tmp) {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::warn!("failed to create session zip {}: {e}", tmp.display());
-            return;
-        }
-    };
+    let file = std::fs::File::create(&tmp)
+        .with_context(|| format!("creating temp zip {}", tmp.display()))?;
 
-    let mut zip = zip::ZipWriter::new(file);
+    let mut writer = zip::ZipWriter::new(file);
     let options = zip::write::SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Deflated);
 
-    // manifest.json
-    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_default();
-    if zip.start_file("manifest.json", options).is_ok() {
-        let _ = zip.write_all(manifest_json.as_bytes());
+    if let Err(e) = populate(&mut writer, options) {
+        // Drop the writer (closes its file handle) before unlinking the temp.
+        drop(writer);
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
     }
 
-    // Empty context (one initial context entry)
-    let ctx_id = uuid::Uuid::new_v4().to_string();
-    let context_line = serde_json::json!({
-        "id": ctx_id,
-        "editable": [],
-        "readonly": [],
-        "virtuals": [],
-        "pinned": [],
-        "tasks": [],
-        "parsedOutputId": null
-    });
-    if zip.start_file("contexts.jsonl", options).is_ok() {
-        let line = serde_json::to_string(&context_line).unwrap_or_default();
-        let _ = zip.write_all(line.as_bytes());
-        let _ = zip.write_all(b"\n");
-    }
+    writer
+        .finish()
+        .with_context(|| format!("finalizing temp zip {}", tmp.display()))?;
+    std::fs::rename(&tmp, zip_path)
+        .with_context(|| format!("renaming {} to {}", tmp.display(), zip_path.display()))?;
+    Ok(())
+}
 
-    // Empty fragments
-    let fragments = serde_json::json!({
-        "version": 4,
-        "referenced": {},
-        "virtual": {},
-        "task": {}
-    });
-    if zip.start_file("fragments-v4.json", options).is_ok() {
-        let _ = zip.write_all(
-            serde_json::to_string(&fragments)
-                .unwrap_or_default()
-                .as_bytes(),
-        );
+/// Copy every entry from `archive` into `writer` whose name does not match `skip`.
+/// Per-entry I/O failures bubble up; callers in `with_temp_zip_writer` will discard
+/// the half-written temp zip.
+fn copy_zip_entries_except<F>(
+    archive: &mut zip::ZipArchive<std::fs::File>,
+    writer: &mut zip::ZipWriter<std::fs::File>,
+    options: zip::write::SimpleFileOptions,
+    skip: F,
+) -> anyhow::Result<()>
+where
+    F: Fn(&str) -> bool,
+{
+    use anyhow::Context;
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .with_context(|| format!("reading zip entry at index {i}"))?;
+        let name = entry.name().to_string();
+        if skip(&name) {
+            continue;
+        }
+        let mut buf = Vec::new();
+        entry
+            .read_to_end(&mut buf)
+            .with_context(|| format!("reading zip entry {name}"))?;
+        writer
+            .start_file(&name, options)
+            .with_context(|| format!("starting zip entry {name}"))?;
+        writer
+            .write_all(&buf)
+            .with_context(|| format!("writing zip entry {name}"))?;
     }
+    Ok(())
+}
 
-    // Empty content metadata
-    if zip.start_file("content_metadata.json", options).is_ok() {
-        let _ = zip.write_all(b"{}");
-    }
+/// Write a new empty session zip compatible with the executor.
+fn write_new_session_zip(zip_path: &Path, manifest: &SessionManifest) -> anyhow::Result<()> {
+    use anyhow::Context;
 
-    // Empty group info
-    let group_info = serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
-    if zip.start_file("group_info.json", options).is_ok() {
-        let _ = zip.write_all(
-            serde_json::to_string(&group_info)
-                .unwrap_or_default()
-                .as_bytes(),
-        );
-    }
+    with_temp_zip_writer(zip_path, |zip, options| {
+        // manifest.json
+        let manifest_json =
+            serde_json::to_string_pretty(manifest).context("serializing session manifest")?;
+        zip.start_file("manifest.json", options)?;
+        zip.write_all(manifest_json.as_bytes())?;
 
-    let _ = zip.finish();
-    if let Err(e) = std::fs::rename(&tmp, zip_path) {
-        tracing::warn!("failed to rename session zip: {e}");
-    }
+        // Empty context (one initial context entry)
+        let ctx_id = uuid::Uuid::new_v4().to_string();
+        let context_line = serde_json::json!({
+            "id": ctx_id,
+            "editable": [],
+            "readonly": [],
+            "virtuals": [],
+            "pinned": [],
+            "tasks": [],
+            "parsedOutputId": null
+        });
+        zip.start_file("contexts.jsonl", options)?;
+        zip.write_all(serde_json::to_string(&context_line)?.as_bytes())?;
+        zip.write_all(b"\n")?;
+
+        // Empty fragments
+        let fragments =
+            serde_json::json!({"version": 4, "referenced": {}, "virtual": {}, "task": {}});
+        zip.start_file("fragments-v4.json", options)?;
+        zip.write_all(serde_json::to_string(&fragments)?.as_bytes())?;
+
+        // Empty content metadata
+        zip.start_file("content_metadata.json", options)?;
+        zip.write_all(b"{}")?;
+
+        // Empty group info
+        let group_info = serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
+        zip.start_file("group_info.json", options)?;
+        zip.write_all(serde_json::to_string(&group_info)?.as_bytes())?;
+
+        Ok(())
+    })
 }
 
 /// Update manifest.json and add a conversation turn to an existing session zip.
 ///
-/// Failures of the framing operations (open, archive read, finalize, rename) are
-/// surfaced to the caller so the in-memory `add_turn` can roll back and keep
-/// `memory == disk`. Per-entry write failures inside the zip are still logged
-/// only; if any of those occur the temp zip is incomplete and the rename step
-/// will fail downstream, so callers still see the error.
+/// All framing failures (open, archive read, per-entry copy, finalize, rename) propagate
+/// to the caller so `add_turn` can roll back and keep `memory == disk`. The atomic
+/// temp-then-rename in `with_temp_zip_writer` guarantees the on-disk zip is unchanged
+/// on any failure path.
 fn append_turn_to_zip(
     zip_path: &Path,
     manifest: &SessionManifest,
@@ -464,90 +507,53 @@ fn append_turn_to_zip(
 ) -> anyhow::Result<()> {
     use anyhow::Context;
 
-    // Read the existing zip, rebuild with new content
     let file = std::fs::File::open(zip_path)
         .with_context(|| format!("opening session zip {} for update", zip_path.display()))?;
     let mut archive = zip::ZipArchive::new(file)
         .with_context(|| format!("reading session zip {}", zip_path.display()))?;
 
-    let tmp = zip_path.with_extension("tmp");
-    let out_file = std::fs::File::create(&tmp)
-        .with_context(|| format!("creating temp zip {}", tmp.display()))?;
+    // Pre-read the entries we plan to rewrite. A missing or unparseable entry falls back
+    // to a known-empty default, matching prior behavior; a stale corruption shouldn't
+    // abort persistence of the new turn.
+    let mut existing_fragments: serde_json::Value =
+        serde_json::json!({"version": 4, "referenced": {}, "virtual": {}, "task": {}});
+    if let Ok(mut e) = archive.by_name("fragments-v4.json") {
+        let mut buf = String::new();
+        if e.read_to_string(&mut buf).is_ok()
+            && let Ok(v) = serde_json::from_str(&buf)
+        {
+            existing_fragments = v;
+        }
+    }
+    let mut existing_contexts = String::new();
+    if let Ok(mut e) = archive.by_name("contexts.jsonl") {
+        let _ = e.read_to_string(&mut existing_contexts);
+    }
+    let mut existing_content_metadata: serde_json::Value = serde_json::json!({});
+    if let Ok(mut e) = archive.by_name("content_metadata.json") {
+        let mut buf = String::new();
+        if e.read_to_string(&mut buf).is_ok()
+            && let Ok(v) = serde_json::from_str(&buf)
+        {
+            existing_content_metadata = v;
+        }
+    }
+    let mut existing_group_info: serde_json::Value =
+        serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
+    if let Ok(mut e) = archive.by_name("group_info.json") {
+        let mut buf = String::new();
+        if e.read_to_string(&mut buf).is_ok()
+            && let Ok(v) = serde_json::from_str(&buf)
+        {
+            existing_group_info = v;
+        }
+    }
 
-    let mut zip_writer = zip::ZipWriter::new(out_file);
-    let options = zip::write::SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Deflated);
-
-    // Generate content IDs for this turn
     let user_content_id = uuid::Uuid::new_v4().to_string();
     let response_content_id = uuid::Uuid::new_v4().to_string();
     let task_fragment_id = uuid::Uuid::new_v4().to_string();
     let new_context_id = uuid::Uuid::new_v4().to_string();
 
-    // Read existing fragments and contexts
-    let mut existing_fragments: serde_json::Value = serde_json::json!({
-        "version": 4, "referenced": {}, "virtual": {}, "task": {}
-    });
-    let mut existing_contexts = String::new();
-    let mut existing_content_metadata: serde_json::Value = serde_json::json!({});
-    let mut existing_group_info: serde_json::Value =
-        serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
-
-    // Copy existing entries (except ones we'll rewrite), and read their content
-    for i in 0..archive.len() {
-        let mut entry = match archive.by_index(i) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        let name = entry.name().to_string();
-
-        match name.as_str() {
-            "manifest.json" => { /* we'll rewrite this */ }
-            "fragments-v4.json" => {
-                let mut buf = String::new();
-                if entry.read_to_string(&mut buf).is_ok()
-                    && let Ok(v) = serde_json::from_str(&buf)
-                {
-                    existing_fragments = v;
-                }
-            }
-            "contexts.jsonl" => {
-                let _ = entry.read_to_string(&mut existing_contexts);
-            }
-            "content_metadata.json" => {
-                let mut buf = String::new();
-                if entry.read_to_string(&mut buf).is_ok()
-                    && let Ok(v) = serde_json::from_str(&buf)
-                {
-                    existing_content_metadata = v;
-                }
-            }
-            "group_info.json" => {
-                let mut buf = String::new();
-                if entry.read_to_string(&mut buf).is_ok()
-                    && let Ok(v) = serde_json::from_str(&buf)
-                {
-                    existing_group_info = v;
-                }
-            }
-            _ => {
-                // Copy other entries as-is (content/*.txt, images, etc.)
-                let mut buf = Vec::new();
-                let _ = entry.read_to_end(&mut buf);
-                if zip_writer.start_file(&name, options).is_ok() {
-                    let _ = zip_writer.write_all(&buf);
-                }
-            }
-        }
-    }
-
-    // Write updated manifest.json
-    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_default();
-    if zip_writer.start_file("manifest.json", options).is_ok() {
-        let _ = zip_writer.write_all(manifest_json.as_bytes());
-    }
-
-    // Add the new task fragment referencing the response content
     if let Some(tasks) = existing_fragments
         .get_mut("task")
         .and_then(|t| t.as_object_mut())
@@ -567,16 +573,6 @@ fn append_turn_to_zip(
         );
     }
 
-    // Write updated fragments
-    if zip_writer.start_file("fragments-v4.json", options).is_ok() {
-        let _ = zip_writer.write_all(
-            serde_json::to_string(&existing_fragments)
-                .unwrap_or_default()
-                .as_bytes(),
-        );
-    }
-
-    // Add new context entry referencing the task fragment
     let new_context = serde_json::json!({
         "id": new_context_id,
         "editable": [],
@@ -595,120 +591,72 @@ fn append_turn_to_zip(
         }],
         "parsedOutputId": null
     });
-
     let mut contexts = existing_contexts;
     contexts.push_str(&serde_json::to_string(&new_context).unwrap_or_default());
     contexts.push('\n');
-    if zip_writer.start_file("contexts.jsonl", options).is_ok() {
-        let _ = zip_writer.write_all(contexts.as_bytes());
-    }
 
-    // Write content metadata
-    if zip_writer
-        .start_file("content_metadata.json", options)
-        .is_ok()
-    {
-        let _ = zip_writer.write_all(
-            serde_json::to_string(&existing_content_metadata)
-                .unwrap_or_default()
-                .as_bytes(),
-        );
-    }
+    const REWRITTEN: &[&str] = &[
+        "manifest.json",
+        "fragments-v4.json",
+        "contexts.jsonl",
+        "content_metadata.json",
+        "group_info.json",
+    ];
 
-    // Write group info
-    if zip_writer.start_file("group_info.json", options).is_ok() {
-        let _ = zip_writer.write_all(
-            serde_json::to_string(&existing_group_info)
-                .unwrap_or_default()
-                .as_bytes(),
-        );
-    }
+    with_temp_zip_writer(zip_path, |writer, options| {
+        copy_zip_entries_except(&mut archive, writer, options, |n| REWRITTEN.contains(&n))?;
 
-    // Write new content files
-    let user_content_path = format!("content/{user_content_id}.txt");
-    if zip_writer.start_file(&user_content_path, options).is_ok() {
-        let _ = zip_writer.write_all(turn.user_prompt.as_bytes());
-    }
-    let response_content_path = format!("content/{response_content_id}.txt");
-    if zip_writer
-        .start_file(&response_content_path, options)
-        .is_ok()
-    {
-        let _ = zip_writer.write_all(turn.agent_response.as_bytes());
-    }
+        let manifest_json =
+            serde_json::to_string_pretty(manifest).context("serializing session manifest")?;
+        writer.start_file("manifest.json", options)?;
+        writer.write_all(manifest_json.as_bytes())?;
 
-    zip_writer
-        .finish()
-        .with_context(|| format!("finalizing temp zip {}", tmp.display()))?;
-    std::fs::rename(&tmp, zip_path)
-        .with_context(|| format!("renaming {} to {}", tmp.display(), zip_path.display()))?;
-    Ok(())
+        writer.start_file("fragments-v4.json", options)?;
+        writer.write_all(serde_json::to_string(&existing_fragments)?.as_bytes())?;
+
+        writer.start_file("contexts.jsonl", options)?;
+        writer.write_all(contexts.as_bytes())?;
+
+        writer.start_file("content_metadata.json", options)?;
+        writer.write_all(serde_json::to_string(&existing_content_metadata)?.as_bytes())?;
+
+        writer.start_file("group_info.json", options)?;
+        writer.write_all(serde_json::to_string(&existing_group_info)?.as_bytes())?;
+
+        writer.start_file(format!("content/{user_content_id}.txt"), options)?;
+        writer.write_all(turn.user_prompt.as_bytes())?;
+
+        writer.start_file(format!("content/{response_content_id}.txt"), options)?;
+        writer.write_all(turn.agent_response.as_bytes())?;
+
+        Ok(())
+    })
 }
 
 /// Replace manifest.json in an existing session zip, copying all other entries as-is.
-/// Returns true on success.
-fn rewrite_manifest_in_zip(zip_path: &Path, manifest: &SessionManifest) -> bool {
-    let file = match std::fs::File::open(zip_path) {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::warn!("failed to open session zip for manifest rewrite: {e}");
-            return false;
-        }
-    };
-    let mut archive = match zip::ZipArchive::new(file) {
-        Ok(a) => a,
-        Err(e) => {
-            tracing::warn!("failed to read session zip for manifest rewrite: {e}");
-            return false;
-        }
-    };
+///
+/// Atomic: any failure leaves the on-disk zip untouched, so callers can roll back
+/// in-memory mutations and keep `memory == disk`.
+fn rewrite_manifest_in_zip(zip_path: &Path, manifest: &SessionManifest) -> anyhow::Result<()> {
+    use anyhow::Context;
 
-    let tmp = zip_path.with_extension("tmp");
-    let out_file = match std::fs::File::create(&tmp) {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::warn!("failed to create temp zip for manifest rewrite: {e}");
-            return false;
-        }
-    };
+    let file = std::fs::File::open(zip_path).with_context(|| {
+        format!(
+            "opening session zip {} for manifest rewrite",
+            zip_path.display()
+        )
+    })?;
+    let mut archive = zip::ZipArchive::new(file)
+        .with_context(|| format!("reading session zip {}", zip_path.display()))?;
 
-    let mut zip_writer = zip::ZipWriter::new(out_file);
-    let options = zip::write::SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Deflated);
-
-    for i in 0..archive.len() {
-        let mut entry = match archive.by_index(i) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        let name = entry.name().to_string();
-        if name == "manifest.json" {
-            continue;
-        }
-        let mut buf = Vec::new();
-        if entry.read_to_end(&mut buf).is_err() {
-            continue;
-        }
-        if zip_writer.start_file(&name, options).is_ok() {
-            let _ = zip_writer.write_all(&buf);
-        }
-    }
-
-    let manifest_json = serde_json::to_string_pretty(manifest).unwrap_or_default();
-    if zip_writer.start_file("manifest.json", options).is_ok() {
-        let _ = zip_writer.write_all(manifest_json.as_bytes());
-    }
-
-    if zip_writer.finish().is_err() {
-        return false;
-    }
-    match std::fs::rename(&tmp, zip_path) {
-        Ok(()) => true,
-        Err(e) => {
-            tracing::warn!("failed to rename rewritten session zip: {e}");
-            false
-        }
-    }
+    with_temp_zip_writer(zip_path, |writer, options| {
+        copy_zip_entries_except(&mut archive, writer, options, |n| n == "manifest.json")?;
+        let manifest_json =
+            serde_json::to_string_pretty(manifest).context("serializing session manifest")?;
+        writer.start_file("manifest.json", options)?;
+        writer.write_all(manifest_json.as_bytes())?;
+        Ok(())
+    })
 }
 
 /// List all session manifests from the executor's sessions directory.
@@ -792,10 +740,18 @@ impl SessionStore {
         let session = Session::new(id.clone(), cwd.clone(), model, "New Session".to_string());
 
         // Write to disk on a blocking worker so we don't stall the tokio runtime.
+        // Persistence failures are logged but not surfaced: `create_session` returns
+        // an in-memory session today, and changing the API to `Result` would ripple
+        // through every `session/new` caller. Reload after a write failure simply
+        // returns no manifest from disk.
         let zip_path = session_zip_path(&cwd, &id);
         let manifest = session.manifest.clone();
-        let _ =
-            tokio::task::spawn_blocking(move || write_new_session_zip(&zip_path, &manifest)).await;
+        match tokio::task::spawn_blocking(move || write_new_session_zip(&zip_path, &manifest)).await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(session_id = %id, "failed to write new session zip: {e:#}"),
+            Err(e) => tracing::warn!(session_id = %id, "session zip writer task panicked: {e}"),
+        }
 
         self.sessions.write().await.insert(id, session.clone());
         session
@@ -937,30 +893,60 @@ impl SessionStore {
         }
     }
 
-    pub async fn set_mode(&self, id: &str, mode: SessionMode) -> bool {
+    /// Update the session's behavior mode and persist the new manifest.
+    ///
+    /// Returns `Ok(true)` on success, `Ok(false)` if the session is unknown
+    /// (no-op), or `Err` if persistence failed -- in that case the in-memory
+    /// mutation is rolled back so `memory == disk`, mirroring `add_turn`.
+    pub async fn set_mode(&self, id: &str, mode: SessionMode) -> anyhow::Result<bool> {
         // Update in-memory state and snapshot what we need for persistence.
+        // Capture the pre-mutation mode so we can reverse it on failure.
         let snapshot = {
             let mut sessions = self.sessions.write().await;
             match sessions.get_mut(id) {
                 Some(session) => {
+                    let prev_mode = session.mode;
+                    let prev_manifest_mode = session.manifest.mode.clone();
                     session.mode = mode;
                     session.manifest.mode = Some(mode.as_str().to_string());
-                    Some((session.cwd.clone(), session.manifest.clone()))
+                    Some((
+                        session.cwd.clone(),
+                        session.manifest.clone(),
+                        prev_mode,
+                        prev_manifest_mode,
+                    ))
                 }
                 None => None,
             }
         };
-        match snapshot {
-            Some((cwd, manifest)) => {
-                let zip_path = session_zip_path(&cwd, id);
-                let _ = tokio::task::spawn_blocking(move || {
-                    rewrite_manifest_in_zip(&zip_path, &manifest)
-                })
+        let Some((cwd, manifest, prev_mode, prev_manifest_mode)) = snapshot else {
+            return Ok(false);
+        };
+
+        let zip_path = session_zip_path(&cwd, id);
+        let join_result =
+            tokio::task::spawn_blocking(move || rewrite_manifest_in_zip(&zip_path, &manifest))
                 .await;
-                true
+
+        let persist_result = match join_result {
+            Ok(r) => r,
+            Err(join_err) => Err(anyhow::anyhow!(
+                "session persistence task panicked: {join_err}"
+            )),
+        };
+
+        if let Err(e) = persist_result {
+            tracing::error!(
+                session_id = %id,
+                "failed to persist session mode; rolling back in-memory state: {e:#}"
+            );
+            if let Some(session) = self.sessions.write().await.get_mut(id) {
+                session.mode = prev_mode;
+                session.manifest.mode = prev_manifest_mode;
             }
-            None => false,
+            return Err(e);
         }
+        Ok(true)
     }
 
     pub async fn set_default_model(&self, model: String) {
@@ -1113,6 +1099,47 @@ mod tests {
             s.manifest.modified, pre_modified,
             "rollback should restore the pre-call manifest.modified timestamp"
         );
+    }
+
+    /// `set_mode` must roll back the in-memory mode change when the zip rewrite
+    /// fails, mirroring `add_turn`. Otherwise memory drifts away from disk and
+    /// the next reload silently downgrades the user's selection.
+    #[tokio::test]
+    async fn set_mode_rolls_back_on_persistence_failure() {
+        let store = SessionStore::new("test-model".to_string());
+
+        let id = "set-mode-rollback".to_string();
+        let cwd = std::env::temp_dir().join(format!("brokk-acp-rust-set-mode-{}", id));
+        let session = Session::new(id.clone(), cwd, "test-model".to_string(), "test".into());
+        let pre_mode = session.mode;
+        let pre_manifest_mode = session.manifest.mode.clone();
+        store.sessions.write().await.insert(id.clone(), session);
+
+        let result = store.set_mode(&id, SessionMode::Plan).await;
+        assert!(
+            result.is_err(),
+            "set_mode should fail when the session zip doesn't exist on disk"
+        );
+
+        let sessions = store.sessions.read().await;
+        let s = sessions.get(&id).expect("session still in memory");
+        assert_eq!(
+            s.mode, pre_mode,
+            "rollback should restore the previous in-memory mode"
+        );
+        assert_eq!(
+            s.manifest.mode, pre_manifest_mode,
+            "rollback should restore the previous manifest.mode"
+        );
+    }
+
+    /// `set_mode` on an unknown session id is `Ok(false)` (no-op), distinct
+    /// from `Err`, so callers can return a precise "unknown session" error.
+    #[tokio::test]
+    async fn set_mode_unknown_session_returns_ok_false() {
+        let store = SessionStore::new("test-model".to_string());
+        let result = store.set_mode("no-such-session", SessionMode::Code).await;
+        assert!(matches!(result, Ok(false)));
     }
 
     /// Sanity check that `add_turn` on an unknown session id is a no-op

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -749,7 +749,9 @@ impl SessionStore {
         match tokio::task::spawn_blocking(move || write_new_session_zip(&zip_path, &manifest)).await
         {
             Ok(Ok(())) => {}
-            Ok(Err(e)) => tracing::warn!(session_id = %id, "failed to write new session zip: {e:#}"),
+            Ok(Err(e)) => {
+                tracing::warn!(session_id = %id, "failed to write new session zip: {e:#}")
+            }
             Err(e) => tracing::warn!(session_id = %id, "session zip writer task panicked: {e}"),
         }
 


### PR DESCRIPTION
Closes #3452.

## Summary

Three open-coded variants of the "create `<path>.tmp`, build a `ZipWriter`, populate, finalize, rename atomic" pattern in [brokk-acp-rust/src/session.rs](brokk-acp-rust/src/session.rs) now share two helpers:

- `with_temp_zip_writer` runs a populate closure against a fresh tmp file, finalizes the writer, and renames over the target. On any failure the tmp is unlinked, leaving the original zip untouched.
- `copy_zip_entries_except` walks `archive.by_index`, skipping names a predicate marks for rewrite and propagating per-entry I/O errors via `?`.

## Behavior changes

- **`write_new_session_zip`** now returns `Result<()>`. `create_session` logs persistence failures (the public API still returns `Session` to avoid rippling through every `session/new` caller). A write failure no longer leaves a zero-length tmp next to the sessions dir.
- **`append_turn_to_zip`** keeps its `Result<()>` signature but per-entry copy failures now propagate, so a half-written temp zip is discarded rather than renamed over the original.
- **`rewrite_manifest_in_zip`** switches from `bool` to `Result<()>`, and **`set_mode`** mirrors `add_turn`'s rollback story (PR #3448): persistence errors reverse the in-memory mode mutation and surface to the ACP client as `internal_error` instead of being silently swallowed. The two `set_mode` call sites in `agent.rs` now distinguish `Ok(true)` / `Ok(false)` (unknown session) / `Err` (persistence failure).

## Test plan

- [x] CI green
- [x] New regression test: `set_mode_rolls_back_on_persistence_failure` — rewriting an in-memory-only session must fail, and the previous mode + manifest.mode must be restored.
- [x] New regression test: `set_mode_unknown_session_returns_ok_false` — pins the `Ok(false)` no-op contract callers in `agent.rs` rely on.
- [x] Existing `add_turn_rolls_back_on_persistence_failure` and `add_turn_unknown_session_is_noop_success` still pass against the refactored `append_turn_to_zip`.