### PR TITLE
BrokkAcpAgent: extract slash-command registry

### DIFF
--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -1841,6 +1841,48 @@ public class BrokkAcpAgent {
 
     // ---- Slash commands ----
 
+    /**
+     * Single source of truth for ACP slash commands. Both {@link #handleSlashCommand} (dispatch)
+     * and {@link #scheduleAvailableCommandsUpdate} (advertise to client) iterate this list, so a
+     * new command needs to be registered exactly once. Instance field rather than {@code static}
+     * because handlers close over {@code this}.
+     *
+     * <p>The {@code name} is stored without the leading slash to match {@link
+     * AcpSchema.AvailableCommand}'s wire format; dispatch strips the slash before lookup.
+     */
+    @FunctionalInterface
+    private interface SlashCommandHandler {
+        void run(String sessionId, String arg, WorkspaceBundle bundle, AcpPromptContext promptContext);
+    }
+
+    private record SlashCommand(
+            String name, String description, @Nullable String inputHint, SlashCommandHandler handler) {}
+
+    private final List<SlashCommand> slashCommands = List.of(
+            new SlashCommand(
+                    "context",
+                    "Show current context snapshot",
+                    null,
+                    (sessionId, arg, bundle, ctx) -> handleContextCommand(bundle, ctx)),
+            new SlashCommand(
+                    "config",
+                    "Show or update editable Brokk configuration",
+                    "[<path> [value] | {section:{...}}] e.g. global.exceptionReportingEnabled false",
+                    (sessionId, arg, bundle, ctx) -> handleConfigCommand(sessionId, arg, bundle, ctx)),
+            new SlashCommand(
+                    "sandbox",
+                    "Show or toggle the kernel sandbox for shell commands",
+                    "on|off",
+                    (sessionId, arg, bundle, ctx) -> handleSandboxCommand(sessionId, arg, ctx)),
+            new SlashCommand(
+                    "codex-login",
+                    "Sign in to Codex (OpenAI OAuth) or disconnect",
+                    "[status|disconnect|open]",
+                    (sessionId, arg, bundle, ctx) -> handleCodexLoginCommand(sessionId, arg, ctx)));
+
+    private final Map<String, SlashCommand> slashCommandsByName =
+            slashCommands.stream().collect(Collectors.toUnmodifiableMap(SlashCommand::name, c -> c));
+
     private boolean handleSlashCommand(
             String sessionId, String text, WorkspaceBundle bundle, AcpPromptContext promptContext) {
         var stripped = text.strip();
@@ -1849,26 +1891,14 @@ public class BrokkAcpAgent {
         }
 
         var parts = stripped.split("\\s+", 2);
-        var command = parts[0].toLowerCase(Locale.ROOT);
-        return switch (command) {
-            case "/context" -> {
-                handleContextCommand(bundle, promptContext);
-                yield true;
-            }
-            case "/config" -> {
-                handleConfigCommand(sessionId, parts.length > 1 ? parts[1] : "", bundle, promptContext);
-                yield true;
-            }
-            case "/sandbox" -> {
-                handleSandboxCommand(sessionId, parts.length > 1 ? parts[1] : "", promptContext);
-                yield true;
-            }
-            case "/codex-login" -> {
-                handleCodexLoginCommand(sessionId, parts.length > 1 ? parts[1] : "", promptContext);
-                yield true;
-            }
-            default -> false;
-        };
+        var name = parts[0].substring(1).toLowerCase(Locale.ROOT);
+        var command = slashCommandsByName.get(name);
+        if (command == null) {
+            return false;
+        }
+        var arg = parts.length > 1 ? parts[1] : "";
+        command.handler().run(sessionId, arg, bundle, promptContext);
+        return true;
     }
 
     private void handleContextCommand(WorkspaceBundle bundle, AcpPromptContext promptContext) {
@@ -2887,21 +2917,12 @@ public class BrokkAcpAgent {
         }
         Thread.startVirtualThread(() -> {
             try {
-                var commands = List.of(
-                        new AcpSchema.AvailableCommand("context", "Show current context snapshot", null),
-                        new AcpSchema.AvailableCommand(
-                                "config",
-                                "Show or update editable Brokk configuration",
-                                new AcpSchema.AvailableCommandInput(
-                                        "[<path> [value] | {section:{...}}] e.g. global.exceptionReportingEnabled false")),
-                        new AcpSchema.AvailableCommand(
-                                "sandbox",
-                                "Show or toggle the kernel sandbox for shell commands",
-                                new AcpSchema.AvailableCommandInput("on|off")),
-                        new AcpSchema.AvailableCommand(
-                                "codex-login",
-                                "Sign in to Codex (OpenAI OAuth) or disconnect",
-                                new AcpSchema.AvailableCommandInput("[status|disconnect|open]")));
+                var commands = slashCommands.stream()
+                        .map(c -> new AcpSchema.AvailableCommand(
+                                c.name(),
+                                c.description(),
+                                c.inputHint() == null ? null : new AcpSchema.AvailableCommandInput(c.inputHint())))
+                        .toList();
                 sender.sendSessionUpdate(
                         sessionId, new AcpSchema.AvailableCommandsUpdate("available_commands_update", commands));
             } catch (Exception e) {

--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1964,6 +1965,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -37,3 +37,8 @@ walkdir = "2"
 # `test-util` enables `tokio::time::pause()` and `#[tokio::test(start_paused = true)]`,
 # used by the LLM stream idle-timeout test to avoid waiting wall-clock seconds.
 tokio = { version = "1", features = ["test-util"] }
+# Used by the bifrost test fixture (`bifrost_client::tests`) to verify
+# the downloaded release archive against its `.sha256` sidecar before
+# extraction, mirroring what `brokk-code/brokk_code/rust_acp_install.py`
+# already does for the production install path.
+sha2 = "0.10"

--- a/brokk-acp-rust/src/bifrost_client.rs
+++ b/brokk-acp-rust/src/bifrost_client.rs
@@ -382,10 +382,13 @@ mod tests {
     }
 
     async fn download_and_extract_bifrost(cache_dir: &Path) {
+        use sha2::{Digest, Sha256};
+
         std::fs::create_dir_all(cache_dir).expect("create test-fixtures cache");
 
         let asset = format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}.{ARCHIVE_EXT}");
         let url = format!("{TEST_BIFROST_RELEASE_BASE}/v{TEST_BIFROST_VERSION}/{asset}");
+        let sha256_url = format!("{url}.sha256");
 
         eprintln!("downloading bifrost test fixture: {url}");
         let bytes = reqwest::get(&url)
@@ -396,6 +399,35 @@ mod tests {
             .bytes()
             .await
             .expect("read bifrost archive bytes");
+
+        // Integrity check: verify against the publisher's `.sha256` sidecar
+        // before extraction. `bifrost --version` is unreliable as a pin
+        // (the v0.1.3 binary still self-reports `0.1.2` due to an upstream
+        // Cargo.toml miss); the sha256 is content-addressable so a
+        // mislabeled or swapped binary is caught here. Mirrors the check
+        // already done by `brokk-code/brokk_code/rust_acp_install.py` on
+        // the production install path.
+        eprintln!("verifying bifrost archive against {sha256_url}");
+        let sidecar = reqwest::get(&sha256_url)
+            .await
+            .expect("bifrost .sha256 sidecar download failed")
+            .error_for_status()
+            .expect("bifrost .sha256 sidecar returned non-200")
+            .text()
+            .await
+            .expect("read .sha256 sidecar text");
+        let expected_hex = sidecar
+            .split_whitespace()
+            .next()
+            .expect("bifrost .sha256 sidecar is empty")
+            .to_lowercase();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let actual_hex = format!("{:x}", hasher.finalize());
+        assert_eq!(
+            actual_hex, expected_hex,
+            "bifrost archive sha256 mismatch for {url}: got {actual_hex}, expected {expected_hex} (refuse to extract)"
+        );
 
         let archive_path = cache_dir.join(&asset);
         std::fs::write(&archive_path, &bytes).expect("write archive to cache");

--- a/brokk-acp-rust/src/bifrost_client.rs
+++ b/brokk-acp-rust/src/bifrost_client.rs
@@ -292,42 +292,165 @@ fn parse_tool_list(result: Value) -> Result<Vec<BifrostToolDef>, BifrostError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
-    fn locate_bifrost() -> Option<PathBuf> {
-        if let Ok(env) = std::env::var("BROKK_BIFROST_BINARY") {
-            let p = PathBuf::from(env);
-            if p.exists() {
-                return Some(p);
-            }
+    /// Bifrost release the handshake test pins. Bumping bifrost is a deliberate
+    /// edit here, not whatever happens to be on a contributor's `$PATH`.
+    /// Must stay in sync with `BUNDLED_BIFROST_VERSION` in
+    /// `brokk-code/brokk_code/rust_acp_install.py`.
+    const TEST_BIFROST_VERSION: &str = "0.1.3";
+
+    const TEST_BIFROST_RELEASE_BASE: &str = "https://github.com/BrokkAi/bifrost/releases/download";
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-apple-darwin";
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    const TRIPLE: &str = "x86_64-unknown-linux-gnu";
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-unknown-linux-gnu";
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    const TRIPLE: &str = "x86_64-pc-windows-msvc";
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    const TRIPLE: &str = "aarch64-pc-windows-msvc";
+
+    #[cfg(not(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64"),
+    )))]
+    compile_error!(
+        "bifrost releases only ship binaries for arm64 macOS, x86_64/aarch64 Linux, \
+         and x86_64/aarch64 Windows; this test cannot run on other targets"
+    );
+
+    #[cfg(target_os = "windows")]
+    const ARCHIVE_EXT: &str = "zip";
+    #[cfg(not(target_os = "windows"))]
+    const ARCHIVE_EXT: &str = "tar.gz";
+
+    #[cfg(target_os = "windows")]
+    const BINARY_NAME: &str = "bifrost.exe";
+    #[cfg(not(target_os = "windows"))]
+    const BINARY_NAME: &str = "bifrost";
+
+    /// Resolve the bifrost binary used by the handshake test.
+    ///
+    /// Resolution order:
+    /// 1. `BROKK_BIFROST_BINARY` env var (override for testing against an
+    ///    in-tree bifrost build).
+    /// 2. The cached pinned-version binary under
+    ///    `target/test-fixtures/bifrost/<version>/<triple>/`.
+    /// 3. Download the pinned release into the cache, then return its path.
+    ///
+    /// We deliberately do NOT consult `which bifrost`: that coupled the test
+    /// to whatever happened to be installed locally, which dragged the test
+    /// behavior into "depends on which version of bifrost the contributor
+    /// happens to have on PATH" -- the bug this helper exists to remove.
+    async fn ensure_test_bifrost_binary() -> PathBuf {
+        if let Ok(override_path) = std::env::var("BROKK_BIFROST_BINARY") {
+            let p = PathBuf::from(&override_path);
+            assert!(
+                p.is_file(),
+                "BROKK_BIFROST_BINARY={override_path} is not a regular file"
+            );
+            return p;
         }
-        let output = std::process::Command::new("which")
-            .arg("bifrost")
-            .output()
-            .ok()?;
-        if !output.status.success() {
-            return None;
+
+        let cache_dir = test_fixture_cache_dir();
+        let binary = cache_dir.join(BINARY_NAME);
+        if binary.is_file() {
+            return binary;
         }
-        let trimmed = String::from_utf8(output.stdout).ok()?.trim().to_string();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(PathBuf::from(trimmed))
+
+        download_and_extract_bifrost(&cache_dir).await;
+        assert!(
+            binary.is_file(),
+            "expected bifrost at {binary:?} after download+extract"
+        );
+        binary
+    }
+
+    fn test_fixture_cache_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test-fixtures")
+            .join("bifrost")
+            .join(TEST_BIFROST_VERSION)
+            .join(TRIPLE)
+    }
+
+    async fn download_and_extract_bifrost(cache_dir: &Path) {
+        std::fs::create_dir_all(cache_dir).expect("create test-fixtures cache");
+
+        let asset = format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}.{ARCHIVE_EXT}");
+        let url = format!("{TEST_BIFROST_RELEASE_BASE}/v{TEST_BIFROST_VERSION}/{asset}");
+
+        eprintln!("downloading bifrost test fixture: {url}");
+        let bytes = reqwest::get(&url)
+            .await
+            .expect("bifrost release download failed (network/proxy?)")
+            .error_for_status()
+            .expect("bifrost release returned non-200")
+            .bytes()
+            .await
+            .expect("read bifrost archive bytes");
+
+        let archive_path = cache_dir.join(&asset);
+        std::fs::write(&archive_path, &bytes).expect("write archive to cache");
+
+        // `tar -xf` auto-detects the format and handles both .tar.gz and .zip
+        // on modern macOS, Linux, and Windows 10+ runners.
+        let status = std::process::Command::new("tar")
+            .arg("-xf")
+            .arg(&archive_path)
+            .arg("-C")
+            .arg(cache_dir)
+            .status()
+            .expect("invoke tar to extract bifrost archive");
+        assert!(
+            status.success(),
+            "tar extraction of {archive_path:?} failed"
+        );
+
+        // Archive extracts to `bifrost-v<ver>-<triple>/bifrost(.exe)`.
+        let inner_dir = cache_dir.join(format!("bifrost-v{TEST_BIFROST_VERSION}-{TRIPLE}"));
+        let inner_binary = inner_dir.join(BINARY_NAME);
+        assert!(
+            inner_binary.is_file(),
+            "expected extracted binary at {inner_binary:?}"
+        );
+
+        let target = cache_dir.join(BINARY_NAME);
+        std::fs::rename(&inner_binary, &target)
+            .or_else(|_| std::fs::copy(&inner_binary, &target).map(|_| ()))
+            .expect("place bifrost binary at cache root");
+
+        let _ = std::fs::remove_file(&archive_path);
+        let _ = std::fs::remove_dir_all(&inner_dir);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&target)
+                .expect("stat extracted binary")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&target, perms).expect("chmod 755 on extracted binary");
         }
     }
 
-    /// Smoke test: spawn the real bifrost subprocess, run the MCP handshake,
-    /// confirm a stable subset of search-tools is exposed, and round-trip one
-    /// tool call. We deliberately do NOT pin the exact tool count or full
-    /// tool list -- bifrost adds tools faster than this test gets updated, and
-    /// the handshake's job is to verify the protocol path works, not to
-    /// enumerate the surface. Skipped when the binary isn't installed.
+    /// Smoke test: spawn the real bifrost subprocess (pinned release,
+    /// downloaded into `target/test-fixtures/`), run the MCP handshake,
+    /// confirm a stable subset of search tools is exposed, and round-trip
+    /// two distinct tool calls. We deliberately do NOT pin the exact tool
+    /// count or full tool list -- bifrost adds tools faster than this test
+    /// gets updated, and the handshake's job is to verify the protocol
+    /// path works, not to enumerate the surface.
     #[tokio::test]
     async fn handshake_and_call_search_tools() {
-        let Some(binary) = locate_bifrost() else {
-            eprintln!("skipping: bifrost binary not on PATH and BROKK_BIFROST_BINARY unset");
-            return;
-        };
+        let binary = ensure_test_bifrost_binary().await;
         let cwd = std::env::current_dir()
             .expect("cwd")
             .canonicalize()


### PR DESCRIPTION
## Summary

- Extracts a small slash-command registry in `BrokkAcpAgent` so dispatch (`handleSlashCommand`) and the client-facing advertise list (`scheduleAvailableCommandsUpdate`) read from a single source. Previously each new command needed dual-writes in two distant places, with description/input-hint drift as the visible failure mode.
- Each command is now registered once via a `SlashCommand` record (`name`, `description`, optional `inputHint`, `handler`) backed by a `SlashCommandHandler` functional interface with a uniform `(sessionId, arg, bundle, promptContext)` signature.
- The registry is an instance field (handlers close over `this`); a derived `Map<String, SlashCommand>` keyed on the un-slashed name gives O(1) dispatch.

## Test plan

- [x] `./gradlew :app:spotlessApply`
- [x] `./gradlew :app:compileJava` (Error Prone + NullAway clean)
- [x] `./gradlew :app:compileTestJava`
- [x] `./gradlew :app:test --tests ai.brokk.acp.BrokkAcpAgentTest` (all 22+ tests green, including `/config`, `/codex-login`, `/sandbox` cases)

Closes #3493