### PR TITLE
util/Messages: cap parseLegacyFraming depth, fix Javadoc contract

### DIFF
--- a/app/src/main/java/ai/brokk/util/Messages.java
+++ b/app/src/main/java/ai/brokk/util/Messages.java
@@ -287,6 +287,8 @@ public class Messages {
 
     private static final Pattern LEGACY_SECTION_LABEL = Pattern.compile("(?m)^(?:Reasoning|Text|Tool calls):\\s*$");
 
+    private static final int MAX_FRAMING_DEPTH = 32;
+
     /**
      * Parses task markdown that may contain legacy {@code <message type=X>...</message>} framing
      * (produced by {@link #format(List)}) into a list of structured segments.
@@ -296,9 +298,13 @@ public class Messages {
      * messages are no longer available on the fragment but the persisted markdown still carries them.
      *
      * <p>Uses a line-based stack scanner so it correctly handles empty bodies and arbitrarily nested
-     * framing (e.g. {@code <message type=custom>} wrapping a full {@code <message type=user>...</message>}).
-     * When framing is nested only the inner segment is emitted, since the outer wrap carries no
-     * meaningful content of its own.
+     * framing. Each closing tag emits a segment if its accumulated content is non-empty after cleaning;
+     * nested wrappers contribute additional segments only when they carry their own content outside the
+     * inner blocks. Emission order follows close-tag order (inner blocks emit before their parent).
+     *
+     * <p>If the open-tag depth exceeds {@value #MAX_FRAMING_DEPTH}, the parser falls back to a single
+     * CUSTOM segment containing the original markdown to prevent unbounded allocation on adversarial
+     * input.
      */
     public static List<FramedSegment> parseLegacyFraming(String markdown) {
         if (markdown.isEmpty()) {
@@ -313,6 +319,12 @@ public class Messages {
         for (var line : markdown.split("\n", -1)) {
             var openMatcher = LEGACY_OPEN_TAG.matcher(line);
             if (openMatcher.matches()) {
+                if (typeStack.size() >= MAX_FRAMING_DEPTH) {
+                    logger.warn(
+                            "parseLegacyFraming: depth limit {} exceeded; falling back to CUSTOM segment",
+                            MAX_FRAMING_DEPTH);
+                    return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
+                }
                 ChatMessageType type;
                 try {
                     type = ChatMessageType.valueOf(openMatcher.group(1).toUpperCase(Locale.ROOT));

--- a/app/src/test/java/ai/brokk/util/MessagesLegacyFramingTest.java
+++ b/app/src/test/java/ai/brokk/util/MessagesLegacyFramingTest.java
@@ -142,4 +142,39 @@ class MessagesLegacyFramingTest {
         assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
         assertEquals(malformed, segments.get(0).content());
     }
+
+    @Test
+    void emitsBothOuterAndInnerWhenOuterHasOwnContent() {
+        // Locks in the actual emission contract: a nested wrap whose outer frame carries text
+        // outside the inner block emits two segments (inner first, then outer with the surrounding
+        // text). The Javadoc previously claimed only the inner was emitted, which was misleading.
+        var input =
+                """
+                <message type=custom>
+                  prefix
+                  <message type=user>
+                    question
+                  </message>
+                  suffix
+                </message>
+                """;
+        var segments = Messages.parseLegacyFraming(input);
+        assertEquals(2, segments.size());
+        assertEquals(ChatMessageType.USER, segments.get(0).type());
+        assertEquals("question", segments.get(0).content());
+        assertEquals(ChatMessageType.CUSTOM, segments.get(1).type());
+        assertEquals("prefix\nsuffix", segments.get(1).content());
+    }
+
+    @Test
+    void exceedsMaxDepthFallsBackToSingleCustomSegment() {
+        // 33 unterminated opens trip the MAX_FRAMING_DEPTH=32 cap on the 33rd push attempt and
+        // bail out to a single CUSTOM segment containing the full markdown, preventing unbounded
+        // StringBuilder allocation on adversarial input.
+        var input = "<message type=user>\n".repeat(33) + "content\n";
+        var segments = Messages.parseLegacyFraming(input);
+        assertEquals(1, segments.size());
+        assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
+        assertEquals(input, segments.get(0).content());
+    }
 }


### PR DESCRIPTION
## Summary

Cap `parseLegacyFraming` open-tag depth at `MAX_FRAMING_DEPTH=32` and bail out to the existing CUSTOM fallback (with the original markdown intact) when exceeded — prevents O(N) StringBuilder allocation on adversarial input. Rewrite the misleading Javadoc paragraph that claimed "only the inner segment is emitted" for nested framing; the scanner actually emits a segment for any closed frame whose cleaned content is non-empty. Add lock-in tests for both contracts.

Closes #3469
Closes #3468

## Notes

- Threshold rationale: real legacy data has depth ≤ 2 (custom wrapping user). 32 leaves ample headroom without enabling memory amplification.
- The depth-cap fallback returns the entire input markdown as a single CUSTOM segment — fail-closed, no silent truncation.
- Both issues touched the same method, Javadoc, and test file, so they ship as one PR.

## Test plan

- [x] `./gradlew :app:test --tests ai.brokk.util.MessagesLegacyFramingTest` — 13/13 pass (11 existing + 2 new)
- [x] `./gradlew :app:check` — Spotless + errorprone + NullAway + full suite green (BUILD SUCCESSFUL in 2m 16s, no warnings)
- [ ] CI green on PR
