### PR TITLE
ci: split brokk-acp-rust into dedicated workflow with paths filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,50 +68,6 @@ jobs:
       - name: Check code formatting
         run: ./gradlew spotlessCheck
 
-  rust-acp:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Install bubblewrap (Linux sandbox runtime)
-      if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y bubblewrap
-
-    - name: Cache cargo registry and build
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          brokk-acp-rust/target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('brokk-acp-rust/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-
-    - name: Build Rust ACP server
-      working-directory: brokk-acp-rust
-      run: cargo build --release
-
-    - name: Run Rust ACP tests
-      working-directory: brokk-acp-rust
-      run: cargo test
-
-    - name: Check Rust formatting
-      working-directory: brokk-acp-rust
-      run: cargo fmt --check
-
-    - name: Run Clippy lints
-      working-directory: brokk-acp-rust
-      run: cargo clippy --all-targets -- -D warnings
-
   dependency-analysis:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust-acp.yml
+++ b/.github/workflows/rust-acp.yml
@@ -1,0 +1,60 @@
+name: Rust ACP CI
+
+on:
+  push:
+    branches: [ 'master', 'ci/**' ]
+    paths:
+      - 'brokk-acp-rust/**'
+      - '.github/workflows/rust-acp.yml'
+  pull_request:
+    branches: [ 'master' ]
+    paths:
+      - 'brokk-acp-rust/**'
+      - '.github/workflows/rust-acp.yml'
+
+jobs:
+  rust-acp:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Install bubblewrap (Linux sandbox runtime)
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
+    - name: Cache cargo registry and build
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          brokk-acp-rust/target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('brokk-acp-rust/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    - name: Check Rust formatting
+      working-directory: brokk-acp-rust
+      run: cargo fmt --check
+
+    - name: Run Clippy lints
+      working-directory: brokk-acp-rust
+      run: cargo clippy --all-targets -- -D warnings
+
+    - name: Build Rust ACP server
+      working-directory: brokk-acp-rust
+      run: cargo build --release
+
+    - name: Run Rust ACP tests
+      working-directory: brokk-acp-rust
+      run: cargo test


### PR DESCRIPTION
## Summary
- Move the `rust-acp` matrix job out of `ci.yml` and into a new `.github/workflows/rust-acp.yml`.
- Gate the workflow on `brokk-acp-rust/**` (and the workflow file itself) for both `push` and `pull_request`, so Rust CI only runs when relevant files change.
- Keep the same Linux/macOS/Windows matrix and the same step set: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, `cargo test`. Reorder so fmt/clippy fail fast before the longer build/test steps. Explicitly request `rustfmt` and `clippy` components from `dtolnay/rust-toolchain@stable`.

Closes #3365.

The optional `cargo-deny` step from the original issue is intentionally left for a follow-up, matching the issue author's suggestion in the comments.

## Test plan
- [x] `Rust ACP CI` workflow runs on this PR (it touches `.github/workflows/rust-acp.yml`).
- [ ] Confirm the `rust-acp` job no longer appears under the `CI` workflow.
- [ ] Sanity check: a follow-up PR that only touches Java/Gradle does not trigger `Rust ACP CI`.

Generated with [Claude Code](https://claude.com/claude-code)