### PR TITLE
util/Messages: precompile blank-run regex and fold double lines() pass in cleanFramedContent

### DIFF
--- a/app/src/main/java/ai/brokk/util/Messages.java
+++ b/app/src/main/java/ai/brokk/util/Messages.java
@@ -287,6 +287,8 @@ public class Messages {
 
     private static final Pattern LEGACY_SECTION_LABEL = Pattern.compile("(?m)^(?:Reasoning|Text|Tool calls):\\s*$");
 
+    private static final Pattern BLANK_RUN = Pattern.compile("\\n{3,}");
+
     private static final int MAX_FRAMING_DEPTH = 32;
 
     /**
@@ -360,7 +362,8 @@ public class Messages {
         if (content.isEmpty()) {
             return "";
         }
-        var minIndent = content.lines()
+        var lines = content.lines().toList();
+        int minIndent = lines.stream()
                 .filter(line -> !line.isBlank())
                 .mapToInt(line -> {
                     int n = 0;
@@ -369,11 +372,12 @@ public class Messages {
                 })
                 .min()
                 .orElse(0);
-        var deindented = content.lines()
-                .map(line -> line.length() >= minIndent ? line.substring(minIndent) : line)
+        final int strip = minIndent;
+        var deindented = lines.stream()
+                .map(line -> line.length() >= strip ? line.substring(strip) : line)
                 .collect(Collectors.joining("\n"));
         var withoutLabels = LEGACY_SECTION_LABEL.matcher(deindented).replaceAll("");
-        return withoutLabels.replaceAll("\\n{3,}", "\n\n").strip();
+        return BLANK_RUN.matcher(withoutLabels).replaceAll("\n\n").strip();
     }
 
     /** Strips legacy framing while preserving readable content; used where per-segment structure isn't needed. */

--- a/app/src/main/java/ai/brokk/util/Messages.java
+++ b/app/src/main/java/ai/brokk/util/Messages.java
@@ -363,7 +363,7 @@ public class Messages {
             return "";
         }
         var lines = content.lines().toList();
-        int minIndent = lines.stream()
+        var minIndent = lines.stream()
                 .filter(line -> !line.isBlank())
                 .mapToInt(line -> {
                     int n = 0;
@@ -372,9 +372,8 @@ public class Messages {
                 })
                 .min()
                 .orElse(0);
-        final int strip = minIndent;
         var deindented = lines.stream()
-                .map(line -> line.length() >= strip ? line.substring(strip) : line)
+                .map(line -> line.length() >= minIndent ? line.substring(minIndent) : line)
                 .collect(Collectors.joining("\n"));
         var withoutLabels = LEGACY_SECTION_LABEL.matcher(deindented).replaceAll("");
         return BLANK_RUN.matcher(withoutLabels).replaceAll("\n\n").strip();


### PR DESCRIPTION
## Summary

Closes #3467.

- Hoist the `\n{3,}` blank-run collapse to a static final `BLANK_RUN` `Pattern`, matching the precompilation convention already used by `LEGACY_OPEN_TAG`, `LEGACY_CLOSE_TAG`, and `LEGACY_SECTION_LABEL`. `String.replaceAll(regex, repl)` recompiles the regex on every call.
- Materialize `content.lines()` once into a `List<String>` instead of iterating the `String` spliterator from scratch for both the min-indent computation and the de-indent rewrite.

`cleanFramedContent` is invoked once per framed segment (10–50+ times per parse on historical sessions) and runs on every render that misses the `mopMessages` cache (#3466), so this is the obvious in-method follow-up.

## Test plan

- [x] `./gradlew :app:test --tests ai.brokk.util.MessagesLegacyFramingTest` — 13/13 pass, covering all the indent / nesting / section-label paths through `cleanFramedContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)