### PR TITLE
test/Messages: add call-site coverage and real-data fixture for legacy framing parser

### DIFF
--- a/app/src/test/java/ai/brokk/TaskEntryTest.java
+++ b/app/src/test/java/ai/brokk/TaskEntryTest.java
@@ -126,7 +126,8 @@ class TaskEntryTest {
 
                 <message type=ai>
                   hi
-                </message>""";
+                </message>
+                """;
         var entry = new TaskEntry(7, "desc", framed, framed, null, null);
 
         var msgs = List.copyOf(entry.mopMessages());

--- a/app/src/test/java/ai/brokk/TaskEntryTest.java
+++ b/app/src/test/java/ai/brokk/TaskEntryTest.java
@@ -1,12 +1,18 @@
 package ai.brokk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import ai.brokk.util.Messages;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.CustomMessage;
 import dev.langchain4j.data.message.UserMessage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -103,5 +109,50 @@ class TaskEntryTest {
     void mopMessages_compressed_returnsSystemMessageWithSummary() {
         var entry = TaskEntry.fromCompressed(3, "compressed summary");
         assertEquals(List.of(Messages.customSystem("compressed summary")), entry.mopMessages());
+    }
+
+    @Test
+    void mopMessages_legacyFramedMarkdown_returnsTypedSegments() {
+        // Pre-#3443 sessions persist task content as markdown that already contains
+        // <message type=X>...</message> framing. mopMessages() must parse that back
+        // into per-segment typed ChatMessage instances rather than wrapping the whole
+        // blob in a single CustomMessage (which would leak the literal framing tags
+        // to display-side renderers).
+        var framed =
+                """
+                <message type=user>
+                  hello
+                </message>
+
+                <message type=ai>
+                  hi
+                </message>""";
+        var entry = new TaskEntry(7, "desc", framed, framed, null, null);
+
+        var msgs = List.copyOf(entry.mopMessages());
+
+        assertEquals(2, msgs.size());
+        assertInstanceOf(UserMessage.class, msgs.get(0));
+        assertInstanceOf(AiMessage.class, msgs.get(1));
+    }
+
+    @Test
+    void mopMessages_legacyFramedFromFixture_reconstructsTypedMessages() throws IOException {
+        // Real-data fixture: shaped after a pre-#3443 persisted session that originally
+        // tripped parser regressions (empty leading custom wrapper, AI block with
+        // Reasoning/Text/Tool calls section labels, and a trailing custom tool-result
+        // block). Locks the call-site contract against future parser changes.
+        var fixture = Files.readString(Path.of("src/test/resources/legacy-framing/sample-session.md"));
+        var entry = new TaskEntry(11, "fixture", fixture, fixture, null, null);
+
+        var msgs = List.copyOf(entry.mopMessages());
+
+        assertEquals(4, msgs.size());
+        assertInstanceOf(UserMessage.class, msgs.get(0));
+        assertInstanceOf(AiMessage.class, msgs.get(1));
+        assertInstanceOf(AiMessage.class, msgs.get(2));
+        assertInstanceOf(CustomMessage.class, msgs.get(3));
+        assertEquals("list the open ACP issues in this repo", Messages.getText(msgs.get(0)));
+        assertEquals("Found 17 open issues with the ACP label.", Messages.getText(msgs.get(2)));
     }
 }

--- a/app/src/test/java/ai/brokk/util/MessagesLegacyFramingTest.java
+++ b/app/src/test/java/ai/brokk/util/MessagesLegacyFramingTest.java
@@ -1,11 +1,15 @@
 package ai.brokk.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.UserMessage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -176,5 +180,36 @@ class MessagesLegacyFramingTest {
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
         assertEquals(input, segments.get(0).content());
+    }
+
+    @Test
+    void parseFromFixture_yieldsExpectedSegmentSequence() throws IOException {
+        // Locks parser behavior against a realistic pre-#3443 session blob: leading empty custom
+        // wrapper that must NOT swallow the next block, AI body with Reasoning/Text/Tool calls
+        // section labels, and a trailing custom tool-result block. Catches collapse-into-one
+        // regressions on real-shape input rather than only on hand-written minimal cases.
+        var fixture = Files.readString(Path.of("src/test/resources/legacy-framing/sample-session.md"));
+        var segments = Messages.parseLegacyFraming(fixture);
+
+        assertEquals(4, segments.size());
+        assertEquals(ChatMessageType.USER, segments.get(0).type());
+        assertEquals("list the open ACP issues in this repo", segments.get(0).content());
+        assertEquals(ChatMessageType.AI, segments.get(1).type());
+        assertEquals(ChatMessageType.AI, segments.get(2).type());
+        assertEquals("Found 17 open issues with the ACP label.", segments.get(2).content());
+        assertEquals(ChatMessageType.CUSTOM, segments.get(3).type());
+    }
+
+    @Test
+    void stripLegacyFramingFromFixture_dropsAllFramingTags() throws IOException {
+        // Mirrors the BrokkAcpAgent.scheduleConversationReplay path: it feeds the persisted
+        // mopMarkdown through stripLegacyFraming before emitting an AgentMessageChunk.
+        // Tags must never reach the ACP wire.
+        var fixture = Files.readString(Path.of("src/test/resources/legacy-framing/sample-session.md"));
+        var stripped = Messages.stripLegacyFraming(fixture);
+
+        assertFalse(stripped.contains("<message type="), "stripped output still contains an opening framing tag");
+        assertFalse(stripped.contains("</message>"), "stripped output still contains a closing framing tag");
+        assertFalse(stripped.isBlank(), "stripped output should retain the human-readable body");
     }
 }

--- a/app/src/test/java/ai/brokk/util/MessagesLegacyFramingTest.java
+++ b/app/src/test/java/ai/brokk/util/MessagesLegacyFramingTest.java
@@ -2,6 +2,7 @@ package ai.brokk.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -195,6 +196,19 @@ class MessagesLegacyFramingTest {
         assertEquals(ChatMessageType.USER, segments.get(0).type());
         assertEquals("list the open ACP issues in this repo", segments.get(0).content());
         assertEquals(ChatMessageType.AI, segments.get(1).type());
+        // segments.get(1) is the only block that exercises label stripping + multi-paragraph
+        // de-indenting through cleanFramedContent. Lock both that the literal section labels
+        // are gone and that all three sub-bodies survive without being collapsed together.
+        var aiBody = segments.get(1).content();
+        assertFalse(aiBody.contains("Reasoning:"), "Reasoning: label should be stripped");
+        assertFalse(aiBody.contains("Text:"), "Text: label should be stripped");
+        assertFalse(aiBody.contains("Tool calls:"), "Tool calls: label should be stripped");
+        assertTrue(
+                aiBody.contains("The user wants a filtered view of GitHub issues."), "reasoning body should survive");
+        assertTrue(aiBody.contains("Here are the ACP issues currently open."), "text body should survive");
+        assertTrue(
+                aiBody.contains("listIssues({\"label\": \"ACP\", \"state\": \"open\"})"),
+                "tool-calls body should survive");
         assertEquals(ChatMessageType.AI, segments.get(2).type());
         assertEquals("Found 17 open issues with the ACP label.", segments.get(2).content());
         assertEquals(ChatMessageType.CUSTOM, segments.get(3).type());
@@ -211,5 +225,12 @@ class MessagesLegacyFramingTest {
         assertFalse(stripped.contains("<message type="), "stripped output still contains an opening framing tag");
         assertFalse(stripped.contains("</message>"), "stripped output still contains a closing framing tag");
         assertFalse(stripped.isBlank(), "stripped output should retain the human-readable body");
+        // Positive checks: every parsed segment's human-readable body must survive stripping,
+        // not just some. Pins the contract that BrokkAcpAgent.scheduleConversationReplay can
+        // never silently drop a turn's content while still passing the negative tag checks.
+        assertTrue(stripped.contains("list the open ACP issues in this repo"), "user prompt should survive stripping");
+        assertTrue(stripped.contains("Found 17 open issues with the ACP label."), "AI reply should survive stripping");
+        assertTrue(
+                stripped.contains("listIssues -> [\"#3438\""), "trailing custom tool-result should survive stripping");
     }
 }

--- a/app/src/test/resources/legacy-framing/sample-session.md
+++ b/app/src/test/resources/legacy-framing/sample-session.md
@@ -1,0 +1,24 @@
+<message type=custom>
+
+</message>
+
+<message type=user>
+  list the open ACP issues in this repo
+</message>
+
+<message type=ai>
+  Reasoning:
+  The user wants a filtered view of GitHub issues. I should call the issue list tool with the ACP label.
+  Text:
+  Here are the ACP issues currently open.
+  Tool calls:
+  listIssues({"label": "ACP", "state": "open"})
+</message>
+
+<message type=ai>
+  Found 17 open issues with the ACP label.
+</message>
+
+<message type=custom>
+  listIssues -> ["#3438", "#3437", "#3418", "#3417"]
+</message>


### PR DESCRIPTION
## Summary

Closes #3464.

The legacy framing parser introduced in #3463 had 11 unit tests, all exercising `parseLegacyFraming`/`stripLegacyFraming` on synthetic input produced by `Messages.format`. None of the three call sites (`TaskEntry`, `MOPBridge`, `BrokkAcpAgent`) were covered, and there was no fixture shaped like real persisted session data.

This PR adds:

- **`TaskEntryTest.mopMessages_legacyFramedMarkdown_returnsTypedSegments`** — asserts the legacy-framed branch of `TaskEntry.mopMessages()` reconstructs multiple typed `ChatMessage` instances instead of wrapping the whole blob in a single `CustomMessage`. (Mirrors the test recommended verbatim in the issue.)
- **`TaskEntryTest.mopMessages_legacyFramedFromFixture_reconstructsTypedMessages`** — loads the new `sample-session.md` fixture and asserts segment count, types, and recovered text.
- **`MessagesLegacyFramingTest.parseFromFixture_yieldsExpectedSegmentSequence`** — parser-level fixture coverage of the empty-leading-custom + AI section labels + trailing custom pattern that tripped earlier regressions.
- **`MessagesLegacyFramingTest.stripLegacyFramingFromFixture_dropsAllFramingTags`** — exercises the `BrokkAcpAgent.scheduleConversationReplay` path: guarantees framing tags can never reach the ACP wire when `stripLegacyFraming` is applied to fixture-shape input.
- **`app/src/test/resources/legacy-framing/sample-session.md`** — realistic pre-#3443 session fixture covering the empty-leading-custom wrapper, AI Reasoning/Text/Tool calls section labels, and a trailing custom tool-result block.

### Optional MOPBridge test — deliberately skipped

The bridge's framing-related logic is a one-line segment-to-Message mapping with no transformation:

```java
for (var segment : Messages.parseLegacyFraming(text)) {
    messages.add(new BrokkEvent.HistoryTask.Message(segment.content(), segment.type(), false, true));
}
```

The parser tests already validate every nontrivial behavior, and constructing a real `MOPBridge` would require JavaFX `WebEngine` setup. Skipped to keep this PR scoped to the high-value coverage gaps.

## Test plan

- [x] `./gradlew :app:test --tests ai.brokk.util.MessagesLegacyFramingTest --tests ai.brokk.TaskEntryTest` — 25/25 pass (4 new + 21 existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)