### PR TITLE
util: extract LegacyFramingParser from Messages to isolate transitional code

### DIFF
--- a/app/src/main/java/ai/brokk/TaskEntry.java
+++ b/app/src/main/java/ai/brokk/TaskEntry.java
@@ -7,6 +7,7 @@ import ai.brokk.context.ContextFragment;
 import ai.brokk.context.ContextFragments;
 import ai.brokk.context.ContextOutputFragments;
 import ai.brokk.util.FragmentUtils;
+import ai.brokk.util.LegacyFramingParser;
 import ai.brokk.util.Messages;
 import dev.langchain4j.data.message.ChatMessage;
 import java.util.Collection;
@@ -266,7 +267,7 @@ public final class TaskEntry {
         // display-side renderers receive properly typed bubbles instead of one big CustomMessage
         // whose text leaks framing tags to the user.
         if (mopMarkdown != null) {
-            return Messages.parseLegacyFraming(mopMarkdown).stream()
+            return LegacyFramingParser.parse(mopMarkdown).stream()
                     .map(seg -> Messages.create(seg.content(), seg.type()))
                     .toList();
         }

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -33,6 +33,7 @@ import ai.brokk.project.MainProject;
 import ai.brokk.project.ModelProperties;
 import ai.brokk.tasks.TaskList;
 import ai.brokk.util.Environment;
+import ai.brokk.util.LegacyFramingParser;
 import ai.brokk.util.Messages;
 import ai.brokk.util.ShellConfig;
 import com.agentclientprotocol.sdk.spec.AcpSchema;
@@ -1724,7 +1725,7 @@ public class BrokkAcpAgent {
                     // Send agent response as AgentMessageChunk
                     var mopMarkdown = task.mopMarkdown();
                     var rawText = mopMarkdown != null ? mopMarkdown : task.summary();
-                    var responseText = rawText == null ? null : Messages.stripLegacyFraming(rawText);
+                    var responseText = rawText == null ? null : LegacyFramingParser.strip(rawText);
                     if (responseText != null && !responseText.isBlank()) {
                         sender.sendSessionUpdate(sessionId, AcpRequestContext.agentMessageChunk(responseText));
                     }

--- a/app/src/main/java/ai/brokk/gui/mop/webview/MOPBridge.java
+++ b/app/src/main/java/ai/brokk/gui/mop/webview/MOPBridge.java
@@ -12,7 +12,7 @@ import ai.brokk.gui.mop.FilePathLookupService;
 import ai.brokk.gui.mop.SymbolLookupService;
 import ai.brokk.project.MainProject;
 import ai.brokk.util.Environment;
-import ai.brokk.util.Messages;
+import ai.brokk.util.LegacyFramingParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -235,7 +235,7 @@ public final class MOPBridge {
             var text = taskFragment.text().join();
             // Persisted task markdown may still contain legacy <message type=X>...</message> framing;
             // parse it into per-segment bubbles so framing tags never reach the webview.
-            for (var segment : Messages.parseLegacyFraming(text)) {
+            for (var segment : LegacyFramingParser.parse(text)) {
                 messages.add(new BrokkEvent.HistoryTask.Message(segment.content(), segment.type(), false, true));
             }
         }

--- a/app/src/main/java/ai/brokk/util/LegacyFramingParser.java
+++ b/app/src/main/java/ai/brokk/util/LegacyFramingParser.java
@@ -1,0 +1,130 @@
+package ai.brokk.util;
+
+import dev.langchain4j.data.message.ChatMessageType;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Parses task markdown that contains legacy {@code <message type=X>...</message>} framing
+ * (produced by {@link Messages#format(java.util.List)}) into structured segments.
+ *
+ * <p><b>TODO(#3462):</b> remove once tasks are persisted as structured messages instead of
+ * pre-rendered markdown blobs. This is a transitional shim for data persisted by #3324-era code;
+ * once {@code TaskFragmentDto} carries a structured message list, the three call sites
+ * ({@link ai.brokk.TaskEntry}, {@link ai.brokk.gui.mop.webview.MOPBridge},
+ * {@link ai.brokk.acp.BrokkAcpAgent}) can drop their {@link #parse}/{@link #strip} calls and
+ * this class can be removed wholesale.
+ */
+public final class LegacyFramingParser {
+    private static final Logger logger = LogManager.getLogger(LegacyFramingParser.class);
+
+    private LegacyFramingParser() {}
+
+    /** One slice of pre-rendered task markdown after legacy framing has been stripped. */
+    public record FramedSegment(ChatMessageType type, String content) {}
+
+    private static final Pattern OPEN_TAG = Pattern.compile("^\\s*<message type=(\\w+)>\\s*$");
+
+    private static final Pattern CLOSE_TAG = Pattern.compile("^\\s*</message>\\s*$");
+
+    private static final Pattern SECTION_LABEL = Pattern.compile("(?m)^(?:Reasoning|Text|Tool calls):\\s*$");
+
+    private static final int MAX_FRAMING_DEPTH = 32;
+
+    /**
+     * Parses task markdown that may contain legacy {@code <message type=X>...</message>} framing
+     * into a list of structured segments.
+     *
+     * <p>If no framing is detected the whole markdown is returned as a single CUSTOM segment so that
+     * post-fix data flows through unchanged. This is meant for display-side replay where structured
+     * messages are no longer available on the fragment but the persisted markdown still carries them.
+     *
+     * <p>Uses a line-based stack scanner so it correctly handles empty bodies and arbitrarily nested
+     * framing. Each closing tag emits a segment if its accumulated content is non-empty after cleaning;
+     * nested wrappers contribute additional segments only when they carry their own content outside the
+     * inner blocks. Emission order follows close-tag order (inner blocks emit before their parent).
+     *
+     * <p>If the open-tag depth exceeds {@value #MAX_FRAMING_DEPTH}, the parser falls back to a single
+     * CUSTOM segment containing the original markdown to prevent unbounded allocation on adversarial
+     * input.
+     */
+    public static List<FramedSegment> parse(String markdown) {
+        if (markdown.isEmpty()) {
+            return List.of();
+        }
+        if (!markdown.contains("<message type=")) {
+            return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
+        }
+        var typeStack = new ArrayDeque<ChatMessageType>();
+        var contentStack = new ArrayDeque<StringBuilder>();
+        var result = new ArrayList<FramedSegment>();
+        for (var line : markdown.split("\n", -1)) {
+            var openMatcher = OPEN_TAG.matcher(line);
+            if (openMatcher.matches()) {
+                if (typeStack.size() >= MAX_FRAMING_DEPTH) {
+                    logger.warn(
+                            "parse: depth limit {} exceeded; falling back to CUSTOM segment", MAX_FRAMING_DEPTH);
+                    return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
+                }
+                ChatMessageType type;
+                try {
+                    type = ChatMessageType.valueOf(openMatcher.group(1).toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException ex) {
+                    type = ChatMessageType.CUSTOM;
+                }
+                typeStack.push(type);
+                contentStack.push(new StringBuilder());
+                continue;
+            }
+            if (CLOSE_TAG.matcher(line).matches()) {
+                if (typeStack.isEmpty()) {
+                    continue;
+                }
+                var type = typeStack.pop();
+                var cleaned = cleanFramedContent(contentStack.pop().toString());
+                if (!cleaned.isEmpty()) {
+                    result.add(new FramedSegment(type, cleaned));
+                }
+                continue;
+            }
+            if (!contentStack.isEmpty()) {
+                contentStack.peek().append(line).append('\n');
+            }
+        }
+        if (result.isEmpty()) {
+            return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
+        }
+        return result;
+    }
+
+    /** Strips legacy framing while preserving readable content; used where per-segment structure isn't needed. */
+    public static String strip(String markdown) {
+        return parse(markdown).stream().map(FramedSegment::content).collect(Collectors.joining("\n\n"));
+    }
+
+    private static String cleanFramedContent(String content) {
+        if (content.isEmpty()) {
+            return "";
+        }
+        var minIndent = content.lines()
+                .filter(line -> !line.isBlank())
+                .mapToInt(line -> {
+                    int n = 0;
+                    while (n < line.length() && line.charAt(n) == ' ') n++;
+                    return n;
+                })
+                .min()
+                .orElse(0);
+        var deindented = content.lines()
+                .map(line -> line.length() >= minIndent ? line.substring(minIndent) : line)
+                .collect(Collectors.joining("\n"));
+        var withoutLabels = SECTION_LABEL.matcher(deindented).replaceAll("");
+        return withoutLabels.replaceAll("\\n{3,}", "\n\n").strip();
+    }
+}

--- a/app/src/main/java/ai/brokk/util/Messages.java
+++ b/app/src/main/java/ai/brokk/util/Messages.java
@@ -9,13 +9,11 @@ import ai.brokk.context.ContextFragment;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.*;
 import dev.langchain4j.model.openai.OpenAiTokenCountEstimator;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -273,111 +271,5 @@ public class Messages {
                 .map(Messages::getReprForDisplay)
                 .filter(s -> !s.isBlank())
                 .collect(Collectors.joining("\n\n"));
-    }
-
-    /**
-     * One slice of pre-rendered task markdown after legacy framing has been stripped.
-     * Produced by {@link #parseLegacyFraming(String)}.
-     */
-    public record FramedSegment(ChatMessageType type, String content) {}
-
-    private static final Pattern LEGACY_OPEN_TAG = Pattern.compile("^\\s*<message type=(\\w+)>\\s*$");
-
-    private static final Pattern LEGACY_CLOSE_TAG = Pattern.compile("^\\s*</message>\\s*$");
-
-    private static final Pattern LEGACY_SECTION_LABEL = Pattern.compile("(?m)^(?:Reasoning|Text|Tool calls):\\s*$");
-
-    private static final int MAX_FRAMING_DEPTH = 32;
-
-    /**
-     * Parses task markdown that may contain legacy {@code <message type=X>...</message>} framing
-     * (produced by {@link #format(List)}) into a list of structured segments.
-     *
-     * <p>If no framing is detected the whole markdown is returned as a single CUSTOM segment so that
-     * post-fix data flows through unchanged. This is meant for display-side replay where structured
-     * messages are no longer available on the fragment but the persisted markdown still carries them.
-     *
-     * <p>Uses a line-based stack scanner so it correctly handles empty bodies and arbitrarily nested
-     * framing. Each closing tag emits a segment if its accumulated content is non-empty after cleaning;
-     * nested wrappers contribute additional segments only when they carry their own content outside the
-     * inner blocks. Emission order follows close-tag order (inner blocks emit before their parent).
-     *
-     * <p>If the open-tag depth exceeds {@value #MAX_FRAMING_DEPTH}, the parser falls back to a single
-     * CUSTOM segment containing the original markdown to prevent unbounded allocation on adversarial
-     * input.
-     */
-    public static List<FramedSegment> parseLegacyFraming(String markdown) {
-        if (markdown.isEmpty()) {
-            return List.of();
-        }
-        if (!markdown.contains("<message type=")) {
-            return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
-        }
-        var typeStack = new ArrayDeque<ChatMessageType>();
-        var contentStack = new ArrayDeque<StringBuilder>();
-        var result = new ArrayList<FramedSegment>();
-        for (var line : markdown.split("\n", -1)) {
-            var openMatcher = LEGACY_OPEN_TAG.matcher(line);
-            if (openMatcher.matches()) {
-                if (typeStack.size() >= MAX_FRAMING_DEPTH) {
-                    logger.warn(
-                            "parseLegacyFraming: depth limit {} exceeded; falling back to CUSTOM segment",
-                            MAX_FRAMING_DEPTH);
-                    return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
-                }
-                ChatMessageType type;
-                try {
-                    type = ChatMessageType.valueOf(openMatcher.group(1).toUpperCase(Locale.ROOT));
-                } catch (IllegalArgumentException ex) {
-                    type = ChatMessageType.CUSTOM;
-                }
-                typeStack.push(type);
-                contentStack.push(new StringBuilder());
-                continue;
-            }
-            if (LEGACY_CLOSE_TAG.matcher(line).matches()) {
-                if (typeStack.isEmpty()) {
-                    continue;
-                }
-                var type = typeStack.pop();
-                var cleaned = cleanFramedContent(contentStack.pop().toString());
-                if (!cleaned.isEmpty()) {
-                    result.add(new FramedSegment(type, cleaned));
-                }
-                continue;
-            }
-            if (!contentStack.isEmpty()) {
-                contentStack.peek().append(line).append('\n');
-            }
-        }
-        if (result.isEmpty()) {
-            return List.of(new FramedSegment(ChatMessageType.CUSTOM, markdown));
-        }
-        return result;
-    }
-
-    private static String cleanFramedContent(String content) {
-        if (content.isEmpty()) {
-            return "";
-        }
-        var minIndent = content.lines()
-                .filter(line -> !line.isBlank())
-                .mapToInt(line -> {
-                    int n = 0;
-                    while (n < line.length() && line.charAt(n) == ' ') n++;
-                    return n;
-                })
-                .min()
-                .orElse(0);
-        var deindented = content.lines()
-                .map(line -> line.length() >= minIndent ? line.substring(minIndent) : line)
-                .collect(Collectors.joining("\n"));
-        var withoutLabels = LEGACY_SECTION_LABEL.matcher(deindented).replaceAll("");
-        return withoutLabels.replaceAll("\\n{3,}", "\n\n").strip();
-    }
-
-    /** Strips legacy framing while preserving readable content; used where per-segment structure isn't needed. */
-    public static String stripLegacyFraming(String markdown) {
-        return parseLegacyFraming(markdown).stream().map(FramedSegment::content).collect(Collectors.joining("\n\n"));
     }
 }

--- a/app/src/test/java/ai/brokk/util/LegacyFramingParserTest.java
+++ b/app/src/test/java/ai/brokk/util/LegacyFramingParserTest.java
@@ -9,17 +9,17 @@ import dev.langchain4j.data.message.UserMessage;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class MessagesLegacyFramingTest {
+class LegacyFramingParserTest {
 
     @Test
     void emptyInputReturnsEmptyList() {
-        assertEquals(List.of(), Messages.parseLegacyFraming(""));
+        assertEquals(List.of(), LegacyFramingParser.parse(""));
     }
 
     @Test
     void cleanMarkdownPassesThroughAsCustomSegment() {
         var clean = "Some clean **markdown** with no framing.";
-        var segments = Messages.parseLegacyFraming(clean);
+        var segments = LegacyFramingParser.parse(clean);
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
         assertEquals(clean, segments.get(0).content());
@@ -30,7 +30,7 @@ class MessagesLegacyFramingTest {
         List<ChatMessage> messages = List.of(new UserMessage("hello"), new AiMessage("hi there"));
         var framed = Messages.format(messages);
 
-        var segments = Messages.parseLegacyFraming(framed);
+        var segments = LegacyFramingParser.parse(framed);
 
         assertEquals(2, segments.size());
         assertEquals(ChatMessageType.USER, segments.get(0).type());
@@ -43,7 +43,7 @@ class MessagesLegacyFramingTest {
     void stripsAiSectionLabelsFromReasoningAndToolCalls() {
         var ai = new AiMessage("", "thinking out loud"); // text empty, reasoning set
         var framed = Messages.format(List.of(ai));
-        var segments = Messages.parseLegacyFraming(framed);
+        var segments = LegacyFramingParser.parse(framed);
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.AI, segments.get(0).type());
         // After stripping the "Reasoning:" label and de-indenting, only the reasoning body remains.
@@ -58,7 +58,7 @@ class MessagesLegacyFramingTest {
                   payload
                 </message>
                 """;
-        var segments = Messages.parseLegacyFraming(framed);
+        var segments = LegacyFramingParser.parse(framed);
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
         assertEquals("payload", segments.get(0).content());
@@ -68,13 +68,13 @@ class MessagesLegacyFramingTest {
     void stripLegacyFramingJoinsSegments() {
         List<ChatMessage> messages = List.of(new UserMessage("hello"), new AiMessage("hi there"));
         var framed = Messages.format(messages);
-        assertEquals("hello\n\nhi there", Messages.stripLegacyFraming(framed));
+        assertEquals("hello\n\nhi there", LegacyFramingParser.strip(framed));
     }
 
     @Test
     void stripLegacyFramingPreservesCleanMarkdown() {
         var clean = "Already clean";
-        assertEquals(clean, Messages.stripLegacyFraming(clean));
+        assertEquals(clean, LegacyFramingParser.strip(clean));
     }
 
     @Test
@@ -89,7 +89,7 @@ class MessagesLegacyFramingTest {
                   </message>
                 </message>
                 """;
-        var segments = Messages.parseLegacyFraming(nested);
+        var segments = LegacyFramingParser.parse(nested);
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.USER, segments.get(0).type());
         assertEquals("can you list all the acp related issues?", segments.get(0).content());
@@ -111,7 +111,7 @@ class MessagesLegacyFramingTest {
                   thought
                 </message>
                 """;
-        var segments = Messages.parseLegacyFraming(input);
+        var segments = LegacyFramingParser.parse(input);
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.AI, segments.get(0).type());
         assertEquals("thought", segments.get(0).content());
@@ -128,7 +128,7 @@ class MessagesLegacyFramingTest {
                   </message>
                 </message>
                 """;
-        var segments = Messages.parseLegacyFraming(input);
+        var segments = LegacyFramingParser.parse(input);
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.USER, segments.get(0).type());
         assertEquals("deeply indented user text", segments.get(0).content());
@@ -137,7 +137,7 @@ class MessagesLegacyFramingTest {
     @Test
     void parseReturnsCustomFallbackWhenFramingTokenPresentButMalformed() {
         var malformed = "<message type=user> not a real block";
-        var segments = Messages.parseLegacyFraming(malformed);
+        var segments = LegacyFramingParser.parse(malformed);
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
         assertEquals(malformed, segments.get(0).content());
@@ -158,7 +158,7 @@ class MessagesLegacyFramingTest {
                   suffix
                 </message>
                 """;
-        var segments = Messages.parseLegacyFraming(input);
+        var segments = LegacyFramingParser.parse(input);
         assertEquals(2, segments.size());
         assertEquals(ChatMessageType.USER, segments.get(0).type());
         assertEquals("question", segments.get(0).content());
@@ -172,7 +172,7 @@ class MessagesLegacyFramingTest {
         // bail out to a single CUSTOM segment containing the full markdown, preventing unbounded
         // StringBuilder allocation on adversarial input.
         var input = "<message type=user>\n".repeat(33) + "content\n";
-        var segments = Messages.parseLegacyFraming(input);
+        var segments = LegacyFramingParser.parse(input);
         assertEquals(1, segments.size());
         assertEquals(ChatMessageType.CUSTOM, segments.get(0).type());
         assertEquals(input, segments.get(0).content());


### PR DESCRIPTION
## Summary

Closes #3465.

Pure code-motion. Moves the legacy `<message type=X>...</message>` framing parser introduced in #3463 (`parseLegacyFraming`, `stripLegacyFraming`, `cleanFramedContent`, `FramedSegment`, three `Pattern` constants, `MAX_FRAMING_DEPTH`) out of `Messages.java` into a dedicated `ai.brokk.util.LegacyFramingParser` class.

### Why

`Messages.java` already mixes two concerns — LLM-side rendering (`format`, `getRepr`) and display-side rendering (`formatForDisplay`, `getReprForDisplay`). The legacy parser is a third concern: **inverse parsing of a deprecated persisted format**, with a planned removal point (#3462). Co-locating it with the permanent rendering API made the class harder to navigate and obscured which symbols are transitional vs core.

When #3462 lands, cleanup is now a single `git rm` of the parser class plus removing the three call-site invocations.

### Public API on the new class

| Old | New |
|-----|-----|
| `Messages.parseLegacyFraming(String)` | `LegacyFramingParser.parse(String)` |
| `Messages.stripLegacyFraming(String)` | `LegacyFramingParser.strip(String)` |
| `Messages.FramedSegment` | `LegacyFramingParser.FramedSegment` |

Class-level javadoc documents the transitional nature with a `TODO(#3462)` removal note.

### Call sites updated

- `TaskEntry.mopMessages` → `LegacyFramingParser.parse`
- `MOPBridge.sendHistoryTask` → `LegacyFramingParser.parse`
- `BrokkAcpAgent.scheduleConversationReplay` → `LegacyFramingParser.strip`

### Other touch-ups
- Test class renamed `MessagesLegacyFramingTest` → `LegacyFramingParserTest`.
- `ArrayDeque` + `Pattern` imports removed from `Messages.java` (now unused).
- The pattern names lose their `LEGACY_` prefix on the new class (`LEGACY_OPEN_TAG` → `OPEN_TAG`, etc.) since the prefix is redundant when the whole class is `LegacyFramingParser`.

### Out of scope (per the issue)

- Renaming the methods further (e.g. `unformat`, `parseFramed`).
- Replacing the parser entirely — that's #3462.
- The `cleanFramedContent` perf cleanup tracked in #3467 (separate PR).

## Test plan

- [x] `./gradlew :app:compileJava :app:compileTestJava` — clean.
- [x] `./gradlew :app:test --tests ai.brokk.util.LegacyFramingParserTest --tests ai.brokk.TaskEntryTest` — 21/21 pass on the moved test class + TaskEntry suite, with no behavioral changes to assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)