### PR TITLE
brokk-foreman: add SQLite migration runner and wire DB at startup

### DIFF
--- a/brokk-foreman/src-tauri/src/db/mod.rs
+++ b/brokk-foreman/src-tauri/src/db/mod.rs
@@ -1,6 +1,200 @@
-//! SQLite state for foreman. Schema lives next to this file as `schema.sql`;
-//! migration runner and concrete queries land in a follow-up.
+//! SQLite state for foreman.
+//!
+//! Schema lives next to this file as `schema.sql`. The migration runner
+//! tracks `PRAGMA user_version` and only applies migrations the database
+//! hasn't seen yet. `PRAGMA foreign_keys = ON;` is applied on every
+//! connection — SQLite's default is OFF and the `ON DELETE CASCADE`
+//! clauses in the schema are silently inactive otherwise.
 
-#![allow(dead_code)]
+use std::path::Path;
+
+use rusqlite::Connection;
+use thiserror::Error;
 
 pub const BASELINE_SCHEMA: &str = include_str!("schema.sql");
+
+/// Latest schema version this binary knows how to produce.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Error)]
+pub enum DbError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("io error preparing database directory: {0}")]
+    Io(#[from] std::io::Error),
+    #[error(
+        "database is at schema v{found}, newer than this binary's v{expected}; refusing to downgrade"
+    )]
+    NewerSchema { found: u32, expected: u32 },
+}
+
+pub type Result<T> = std::result::Result<T, DbError>;
+
+/// Open a SQLite database at `path`, apply per-connection pragmas, and
+/// run any pending migrations. Creates parent directories if needed.
+pub fn open(path: &Path) -> Result<Connection> {
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut conn = Connection::open(path)?;
+    apply_pragmas(&conn)?;
+    migrate(&mut conn)?;
+    Ok(conn)
+}
+
+/// In-memory database with the same pragmas + migrations as [`open`].
+/// Intended for tests and short-lived ephemeral state.
+pub fn open_in_memory() -> Result<Connection> {
+    let mut conn = Connection::open_in_memory()?;
+    apply_pragmas(&conn)?;
+    migrate(&mut conn)?;
+    Ok(conn)
+}
+
+fn apply_pragmas(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;\n\
+         PRAGMA journal_mode = WAL;\n\
+         PRAGMA busy_timeout = 5000;",
+    )?;
+    Ok(())
+}
+
+fn migrate(conn: &mut Connection) -> Result<()> {
+    let current: u32 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+
+    if current > CURRENT_SCHEMA_VERSION {
+        return Err(DbError::NewerSchema {
+            found: current,
+            expected: CURRENT_SCHEMA_VERSION,
+        });
+    }
+    if current == CURRENT_SCHEMA_VERSION {
+        return Ok(());
+    }
+
+    tracing::info!(
+        from = current,
+        to = CURRENT_SCHEMA_VERSION,
+        "applying foreman db migrations"
+    );
+
+    if current < 1 {
+        let tx = conn.transaction()?;
+        tx.execute_batch(BASELINE_SCHEMA)?;
+        tx.pragma_update(None, "user_version", 1u32)?;
+        tx.commit()?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrate_creates_all_tables() {
+        let conn = open_in_memory().unwrap();
+        let names: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        for expected in [
+            "agents",
+            "blocking_edges",
+            "config_kv",
+            "issues",
+            "sessions",
+        ] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "missing table {expected}; got {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_version_set_to_current() {
+        let conn = open_in_memory().unwrap();
+        let v: u32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn migrate_is_idempotent() {
+        let mut conn = open_in_memory().unwrap();
+        migrate(&mut conn).unwrap();
+        migrate(&mut conn).unwrap();
+        let v: u32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn fk_cascade_actually_fires() {
+        let conn = open_in_memory().unwrap();
+        conn.execute(
+            "INSERT INTO issues(id, provider, external_key, title, imported_at, updated_at) \
+             VALUES ('github:42', 'github', '42', 'a', 0, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO issues(id, provider, external_key, title, imported_at, updated_at) \
+             VALUES ('github:43', 'github', '43', 'b', 0, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO blocking_edges(blocker_id, blocked_id, computed_at) \
+             VALUES ('github:42', 'github:43', 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM issues WHERE id = 'github:42'", [])
+            .unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM blocking_edges", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn rejects_newer_schema() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        apply_pragmas(&conn).unwrap();
+        conn.pragma_update(None, "user_version", 999u32).unwrap();
+        let err = migrate(&mut conn).unwrap_err();
+        match err {
+            DbError::NewerSchema { found, expected }
+                if found == 999 && expected == CURRENT_SCHEMA_VERSION => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_creates_parent_dirs() {
+        let tmp = tempfile_dir();
+        let nested = tmp.join("a/b/c/state.db");
+        let conn = open(&nested).unwrap();
+        let v: u32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, CURRENT_SCHEMA_VERSION);
+        assert!(nested.exists());
+    }
+
+    fn tempfile_dir() -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("brokk-foreman-db-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/brokk-foreman/src-tauri/src/lib.rs
+++ b/brokk-foreman/src-tauri/src/lib.rs
@@ -5,6 +5,10 @@ pub mod issues;
 pub mod llm;
 pub mod worktree;
 
+use std::sync::Mutex;
+
+use tauri::Manager;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tracing_subscriber::fmt()
@@ -16,7 +20,15 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .setup(|_app| Ok(()))
+        .setup(|app| {
+            let db_path = config::data_dir()
+                .ok_or("could not resolve user data dir for foreman")?
+                .join("state.db");
+            tracing::info!(path = %db_path.display(), "opening foreman database");
+            let conn = db::open(&db_path)?;
+            app.manage(Mutex::new(conn));
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .unwrap_or_else(|e| {
             tracing::error!(error = ?e, "foreman failed to start");


### PR DESCRIPTION
## Summary

Implements step 2 of `brokk-foreman/PLANS.md`: a SQLite migration runner that consumes `db/schema.sql`, plus the Tauri-side wiring so the database is opened at startup.

- `db::open(&Path)` / `db::open_in_memory()` apply per-connection pragmas (`foreign_keys = ON`, `journal_mode = WAL`, `busy_timeout = 5000`) and run any pending migrations. The `foreign_keys` pragma is the critical one — SQLite defaults to `OFF` and the `ON DELETE CASCADE` clauses in the schema are silently inactive otherwise.
- Migration version is tracked via `PRAGMA user_version`. Baseline DDL plus the version bump run inside one transaction, so a half-applied migration leaves `user_version` at the prior value and the next start retries cleanly.
- `DbError` covers `rusqlite::Error`, `std::io::Error`, and the "database is newer than this binary" case (refuses to silently downgrade).
- `lib.rs` `setup` callback resolves `config::data_dir()`, opens `<data_dir>/state.db`, and stores the `Connection` as managed Tauri state (`Mutex<Connection>`).

## Tests

Six new tests in `db::tests`:

- `migrate_creates_all_tables` — every table from `schema.sql` is present after migration.
- `schema_version_set_to_current` — `PRAGMA user_version` ends at `CURRENT_SCHEMA_VERSION` after first migrate.
- `migrate_is_idempotent` — running `migrate` twice is a no-op.
- `fk_cascade_actually_fires` — canary that inserts two `issues`, links a `blocking_edges`, deletes the blocker, and asserts the edge cascaded away. If anyone removes `PRAGMA foreign_keys = ON` later, this test fails immediately.
- `rejects_newer_schema` — a DB at `user_version = 999` returns `DbError::NewerSchema` rather than running migrations.
- `open_creates_parent_dirs` — `db::open` mkdir-p's the parent directory if it does not exist.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 19/19 pass (6 new db tests + 13 pre-existing registry tests)
- [ ] `cargo tauri dev` smoke: verify `info: opening foreman database path=...` log fires and `state.db` is created on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
