### PR TITLE
brokk-acp-rust: add Sign in with ChatGPT (Codex login) support

### DIFF
--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -209,23 +209,26 @@ version = "0.1.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "base64",
  "chrono",
  "clap",
  "dirs",
  "futures",
  "libc",
- "openai-auth",
+ "oauth2",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "sha2",
+ "tiny_http",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",
  "walkdir",
+ "webbrowser",
  "zip",
 ]
 
@@ -283,12 +286,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -992,7 +989,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1317,21 +1313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,12 +1365,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rs"
@@ -1487,29 +1462,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1518,6 +1474,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -1556,27 +1532,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openai-auth"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d3c008af7a377f1836af62ae19d7e0fa9af9a801a9b1aa63f211140d7619fc"
-dependencies = [
- "base64",
- "jsonwebtoken",
- "querystring",
- "rand 0.8.6",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.18",
- "tiny_http",
- "tokio",
- "url",
- "webbrowser",
-]
 
 [[package]]
 name = "openssl"
@@ -1674,16 +1629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,67 +1710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "querystring"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9318ead08c799aad12a55a3e78b82e0b6167271ffd1f627b758891282f739187"
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,18 +1737,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1874,17 +1748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1894,15 +1758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1999,8 +1854,6 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2008,7 +1861,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2018,7 +1870,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2105,7 +1956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2118,7 +1968,6 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2292,6 +2141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,18 +2262,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "slab"
@@ -2644,21 +2492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,6 +2706,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3072,16 +2906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webbrowser"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,15 +2919,6 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -154,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,9 +209,12 @@ version = "0.1.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "chrono",
  "clap",
+ "dirs",
  "futures",
  "libc",
+ "openai-auth",
  "regex",
  "reqwest",
  "serde",
@@ -276,6 +285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +303,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cipher"
@@ -344,6 +365,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -528,6 +559,27 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -767,8 +819,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -899,6 +953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +992,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1175,6 +1236,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1317,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1348,15 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1250,6 +1384,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rs"
@@ -1332,6 +1472,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,10 +1487,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1353,6 +1518,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -1366,6 +1556,27 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openai-auth"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d3c008af7a377f1836af62ae19d7e0fa9af9a801a9b1aa63f211140d7619fc"
+dependencies = [
+ "base64",
+ "jsonwebtoken",
+ "querystring",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tiny_http",
+ "tokio",
+ "url",
+ "webbrowser",
+]
 
 [[package]]
 name = "openssl"
@@ -1412,6 +1623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1671,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1510,6 +1737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +1762,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "querystring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9318ead08c799aad12a55a3e78b82e0b6167271ffd1f627b758891282f739187"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1550,12 +1847,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1632,6 +1999,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1639,6 +2008,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1648,6 +2018,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1680,7 +2051,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1734,6 +2105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1746,6 +2118,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2015,6 +2388,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,11 +2543,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2201,6 +2622,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2642,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2624,6 +3072,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,11 +3187,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2722,19 +3214,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2744,9 +3257,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2762,9 +3287,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2774,9 +3311,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2926,6 +3475,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,7 +3590,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "xz2",
  "zeroize",

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -32,6 +32,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 walkdir = "2"
+# Codex login: PKCE OAuth flow + Token Exchange (RFC 8693) for OPENAI_API_KEY.
+# Wraps the same flow Codex CLI uses; we then drive `OpenAiClient` against
+# https://api.openai.com/v1 with the issued key -- no undocumented endpoints.
+openai-auth = { version = "1", features = ["async", "browser", "callback-server"] }
+dirs = "5"
+chrono = { version = "0.4", features = ["serde"] }
 
 # Unix-only: `setrlimit` via `Command::pre_exec` for per-process resource caps
 # applied to `runShellCommand`. See `tools/shell.rs::apply_rlimits`.

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -32,10 +32,18 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 walkdir = "2"
-# Codex login: PKCE OAuth flow + Token Exchange (RFC 8693) for OPENAI_API_KEY.
-# Wraps the same flow Codex CLI uses; we then drive `OpenAiClient` against
-# https://api.openai.com/v1 with the issued key -- no undocumented endpoints.
-openai-auth = { version = "1", features = ["async", "browser", "callback-server"] }
+# Codex login. We deliberately avoid single-maintainer credential crates:
+# `oauth2` is the de-facto Rust OAuth2 implementation (~32M downloads,
+# depended on by Servo etc.) and gives us PKCE + refresh. The RFC 8693
+# Token Exchange step that converts the id_token into the OPENAI_API_KEY
+# is one POST written by hand in `codex_auth.rs`. JWT decoding for the
+# account_id is also inline (no `jsonwebtoken` dep) since we trust the
+# issuer over HTTPS and only need the unverified `chatgpt_account_id`
+# claim. `tiny_http` runs the loopback callback for ~30s during login.
+oauth2 = { version = "5", features = ["reqwest"], default-features = false }
+tiny_http = "0.12"
+webbrowser = "1"
+base64 = "0.22"
 dirs = "5"
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -411,6 +411,12 @@ pub async fn run_agent(
                     return responder.respond(PromptResponse::new(StopReason::EndTurn));
                 }
 
+                if is_slash_command(&prompt_text, "codex-login") {
+                    let report = handle_codex_login(&prompt_text).await;
+                    send_message(&cx, &session_id, &report);
+                    return responder.respond(PromptResponse::new(StopReason::EndTurn));
+                }
+
                 // Validate model is configured
                 if snap.model.is_empty() {
                     send_message(&cx, &session_id, "Error: no model configured. Start the server with --default-model or ensure the LLM endpoint is reachable for model discovery.");
@@ -920,6 +926,64 @@ fn is_slash_command(prompt_text: &str, name: &str) -> bool {
         .unwrap_or("")
         .to_ascii_lowercase();
     head == name
+}
+
+/// Handle the `/codex-login` slash command and its subcommands.
+/// Subcommands: bare = start interactive login, `status` = report what's
+/// stored, `disconnect` = wipe the local credentials.
+async fn handle_codex_login(prompt_text: &str) -> String {
+    let arg = prompt_text
+        .trim()
+        .strip_prefix('/')
+        .unwrap_or("")
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    match arg.as_str() {
+        "status" => match crate::codex_auth::read_auth_dot_json() {
+            Ok(Some(auth)) => {
+                let mode = auth.auth_mode.as_deref().unwrap_or("(unset)");
+                let has_key = auth.openai_api_key.is_some();
+                let acct = auth
+                    .tokens
+                    .as_ref()
+                    .map(|t| t.account_id.as_str())
+                    .unwrap_or("(none)");
+                let last = auth
+                    .last_refresh
+                    .map(|ts| ts.to_rfc3339())
+                    .unwrap_or_else(|| "(unknown)".to_string());
+                format!(
+                    "Codex login status:\n  auth_mode: {mode}\n  api_key: {}\n  account_id: {acct}\n  last_refresh: {last}",
+                    if has_key { "present" } else { "MISSING" }
+                )
+            }
+            Ok(None) => "No Codex credentials found. Run `/codex-login` to authenticate.".to_string(),
+            Err(e) => format!("Failed to read ~/.codex/auth.json: {e:#}"),
+        },
+        "disconnect" => match crate::codex_auth::logout() {
+            Ok(()) => "Codex credentials cleared. Restart the server to drop the cached API key from memory.".to_string(),
+            Err(e) => format!("Failed to remove ~/.codex/auth.json: {e:#}"),
+        },
+        "" => match crate::codex_auth::interactive_login().await {
+            Ok(auth) => {
+                let acct = auth
+                    .tokens
+                    .as_ref()
+                    .map(|t| t.account_id.as_str())
+                    .unwrap_or("(unknown)");
+                format!(
+                    "Codex login complete (account_id: {acct}). Restart the server with --use-codex to route prompts through the issued OPENAI_API_KEY."
+                )
+            }
+            Err(e) => format!("Codex login failed: {e:#}"),
+        },
+        other => format!(
+            "Unknown subcommand `{other}`. Try: /codex-login | /codex-login status | /codex-login disconnect"
+        ),
+    }
 }
 
 /// Render the `/context` snapshot. Mirrors the Java executor's report at a

--- a/brokk-acp-rust/src/codex_auth.rs
+++ b/brokk-acp-rust/src/codex_auth.rs
@@ -1,0 +1,260 @@
+//! "Sign in with ChatGPT" support using OpenAI's PKCE OAuth flow.
+//!
+//! On-disk format (`~/.codex/auth.json`) is intentionally compatible with
+//! Codex CLI: a user who logs in here can use `codex` in the same terminal
+//! and vice versa. Once the OAuth flow completes we exchange the issued
+//! `id_token` for a regular `sk-...` API key (RFC 8693 Token Exchange) so
+//! that brokk-acp-rust's existing OpenAI-compatible client can talk to
+//! `https://api.openai.com/v1` unchanged.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Duration, Utc};
+use openai_auth::{OAuthClient, OAuthConfig, TokenSet, open_browser, run_callback_server};
+use serde::{Deserialize, Serialize};
+
+/// Default port for the OAuth loopback callback. Must match the
+/// `redirect_uri` advertised to the authorization server, which means it
+/// has to be one of the ports allow-listed by OpenAI's Hydra config.
+const CALLBACK_PORT: u16 = 1455;
+
+/// Refresh proactively if the stored credentials are older than this.
+/// Codex CLI uses an 8-day window; we follow suit.
+const REFRESH_AFTER: Duration = Duration::days(8);
+
+/// Schema of `~/.codex/auth.json`. Field names (and the `OPENAI_API_KEY`
+/// SHOUTING case) are dictated by Codex CLI's storage format -- do not
+/// rename without breaking cross-compat.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthDotJson {
+    #[serde(default)]
+    pub auth_mode: Option<String>,
+    #[serde(
+        rename = "OPENAI_API_KEY",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub openai_api_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<TokenData>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_refresh: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenData {
+    pub id_token: String,
+    pub access_token: String,
+    pub refresh_token: String,
+    pub account_id: String,
+}
+
+/// Resolve `~/.codex/auth.json`. Honours `$CODEX_HOME` if set, matching
+/// Codex CLI's override convention.
+pub fn auth_json_path() -> Result<PathBuf> {
+    if let Ok(custom) = std::env::var("CODEX_HOME") {
+        return Ok(PathBuf::from(custom).join("auth.json"));
+    }
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not resolve home directory"))?;
+    Ok(home.join(".codex").join("auth.json"))
+}
+
+pub fn read_auth_dot_json() -> Result<Option<AuthDotJson>> {
+    let path = auth_json_path()?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+    let parsed = serde_json::from_slice::<AuthDotJson>(&bytes)
+        .with_context(|| format!("parsing {}", path.display()))?;
+    Ok(Some(parsed))
+}
+
+/// Atomic write: stage to `auth.json.tmp` in the same directory, then
+/// rename. Keeps the credential file from ever being half-written if the
+/// process is interrupted mid-flush.
+pub fn write_auth_dot_json(auth: &AuthDotJson) -> Result<()> {
+    let path = auth_json_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(auth).context("serializing AuthDotJson")?;
+    std::fs::write(&tmp, &bytes).with_context(|| format!("writing {}", tmp.display()))?;
+    set_user_only_perms(&tmp)?;
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_user_only_perms(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 600 {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_user_only_perms(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Run the full ChatGPT login flow: PKCE in the browser, capture the
+/// callback locally, exchange the `id_token` for an API key, and persist.
+pub async fn interactive_login() -> Result<AuthDotJson> {
+    let config = OAuthConfig::default();
+    let client = OAuthClient::new(config).context("building OAuthClient")?;
+    let flow = client.start_flow().context("starting OAuth flow")?;
+
+    if let Err(err) = open_browser(&flow.authorization_url) {
+        eprintln!(
+            "Could not open a browser automatically ({err}). Visit:\n  {}",
+            flow.authorization_url
+        );
+    } else {
+        eprintln!("Opened browser for ChatGPT sign-in. Waiting for callback...");
+    }
+
+    let tokens = run_callback_server(CALLBACK_PORT, &flow.state, &client, &flow.pkce_verifier)
+        .await
+        .context("OAuth callback server failed")?;
+
+    let auth = finish_login(&client, tokens).await?;
+    write_auth_dot_json(&auth)?;
+    Ok(auth)
+}
+
+async fn finish_login(client: &OAuthClient, tokens: TokenSet) -> Result<AuthDotJson> {
+    // We need an id_token to redeem an API key (RFC 8693 token-exchange).
+    let id_token = tokens
+        .id_token
+        .clone()
+        .ok_or_else(|| anyhow!("OAuth response missing id_token; cannot derive API key"))?;
+    let api_key = client
+        .obtain_api_key(&id_token)
+        .await
+        .context("exchanging id_token for OPENAI_API_KEY")?;
+    let account_id = client
+        .extract_account_id(&tokens.access_token)
+        .context("extracting account_id from access_token JWT")?;
+    Ok(AuthDotJson {
+        auth_mode: Some("chatgpt".to_string()),
+        openai_api_key: Some(api_key),
+        tokens: Some(TokenData {
+            id_token,
+            access_token: tokens.access_token,
+            refresh_token: tokens.refresh_token,
+            account_id,
+        }),
+        last_refresh: Some(Utc::now()),
+    })
+}
+
+/// Refresh the API key if the stored credentials are stale. Used on
+/// startup so long-running ACP sessions don't 401 mid-flight.
+pub async fn refresh_if_stale(auth: &mut AuthDotJson) -> Result<bool> {
+    let last = match auth.last_refresh {
+        Some(ts) => ts,
+        None => return Ok(false),
+    };
+    if Utc::now() - last < REFRESH_AFTER {
+        return Ok(false);
+    }
+    let tokens = auth
+        .tokens
+        .as_ref()
+        .ok_or_else(|| anyhow!("auth.json has no tokens to refresh"))?;
+    let client = OAuthClient::new(OAuthConfig::default()).context("building OAuthClient")?;
+    let refreshed = client
+        .refresh_token(&tokens.refresh_token)
+        .await
+        .context("refreshing OAuth tokens")?;
+    let updated = finish_login(&client, refreshed).await?;
+    *auth = updated;
+    write_auth_dot_json(auth)?;
+    Ok(true)
+}
+
+/// Best-effort logout: delete the stored credentials. We do not (yet)
+/// hit the revoke endpoint -- that's a follow-up.
+pub fn logout() -> Result<()> {
+    let path = auth_json_path()?;
+    if path.exists() {
+        std::fs::remove_file(&path).with_context(|| format!("removing {}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_json_round_trip_preserves_codex_field_names() {
+        // Mirrors a real ~/.codex/auth.json from a logged-in Codex CLI install.
+        let raw = r#"{
+            "auth_mode": "chatgpt",
+            "OPENAI_API_KEY": "sk-svcacct-test",
+            "tokens": {
+                "id_token": "eyJ.id",
+                "access_token": "eyJ.acc",
+                "refresh_token": "rt-test",
+                "account_id": "acct_abc"
+            },
+            "last_refresh": "2026-05-05T12:00:00Z"
+        }"#;
+        let parsed: AuthDotJson = serde_json::from_str(raw).expect("parse auth.json");
+        assert_eq!(parsed.auth_mode.as_deref(), Some("chatgpt"));
+        assert_eq!(parsed.openai_api_key.as_deref(), Some("sk-svcacct-test"));
+        let tokens = parsed.tokens.as_ref().expect("tokens");
+        assert_eq!(tokens.account_id, "acct_abc");
+
+        let reserialized = serde_json::to_string(&parsed).unwrap();
+        // The shouting-snake-case key name is what Codex CLI expects;
+        // serde's default would lower-case it.
+        assert!(reserialized.contains("\"OPENAI_API_KEY\""));
+        assert!(reserialized.contains("\"auth_mode\""));
+        assert!(reserialized.contains("\"last_refresh\""));
+    }
+
+    #[test]
+    fn auth_json_optional_fields_omit_cleanly() {
+        let auth = AuthDotJson {
+            auth_mode: Some("apikey".to_string()),
+            openai_api_key: None,
+            tokens: None,
+            last_refresh: None,
+        };
+        let json = serde_json::to_string(&auth).unwrap();
+        // Defaults that are None should not appear; auth_mode is always present.
+        assert!(!json.contains("OPENAI_API_KEY"));
+        assert!(!json.contains("tokens"));
+        assert!(!json.contains("last_refresh"));
+        assert!(json.contains("\"auth_mode\":\"apikey\""));
+    }
+
+    #[test]
+    fn auth_json_path_honours_codex_home_override() {
+        // Save and restore so we don't pollute other tests sharing the env.
+        let prior = std::env::var("CODEX_HOME").ok();
+        // SAFETY: tests run single-threaded for env mutations is not guaranteed
+        // by cargo, but the assertion only reads what we just set, so a flake
+        // would manifest as a clear mismatch rather than corruption.
+        unsafe {
+            std::env::set_var("CODEX_HOME", "/tmp/codex-home-test-xyz");
+        }
+        let p = auth_json_path().unwrap();
+        assert_eq!(
+            p,
+            std::path::PathBuf::from("/tmp/codex-home-test-xyz/auth.json")
+        );
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("CODEX_HOME", v),
+                None => std::env::remove_var("CODEX_HOME"),
+            }
+        }
+    }
+}

--- a/brokk-acp-rust/src/codex_auth.rs
+++ b/brokk-acp-rust/src/codex_auth.rs
@@ -2,26 +2,43 @@
 //!
 //! On-disk format (`~/.codex/auth.json`) is intentionally compatible with
 //! Codex CLI: a user who logs in here can use `codex` in the same terminal
-//! and vice versa. Once the OAuth flow completes we exchange the issued
-//! `id_token` for a regular `sk-...` API key (RFC 8693 Token Exchange) so
-//! that brokk-acp-rust's existing OpenAI-compatible client can talk to
-//! `https://api.openai.com/v1` unchanged.
+//! and vice versa.
+//!
+//! Trust posture: we use `oauth2` (32M+ downloads, depended on by Servo
+//! among others) for the standard PKCE + refresh state machine. The one
+//! step `oauth2` doesn't cover -- RFC 8693 token exchange that converts
+//! the ChatGPT id_token into a regular `OPENAI_API_KEY` -- is a single
+//! POST written by hand below. JWT decoding for `chatgpt_account_id`
+//! is also inline (~15 lines): we trust the token because we just
+//! received it over HTTPS from auth.openai.com, and we only need an
+//! unverified claim.
 
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow};
-use chrono::{DateTime, Duration, Utc};
-use openai_auth::{OAuthClient, OAuthConfig, TokenSet, open_browser, run_callback_server};
+use anyhow::{Context, Result, anyhow, bail};
+use base64::Engine;
+use chrono::{DateTime, Utc};
+// oauth2 supplies the PKCE + CSRF primitives only -- the actual token
+// exchanges are issued via `reqwest` below so we don't have to dance
+// with `oauth2::ExtraTokenFields` generics just to read `id_token`.
+use oauth2::{CsrfToken, PkceCodeChallenge};
 use serde::{Deserialize, Serialize};
 
-/// Default port for the OAuth loopback callback. Must match the
-/// `redirect_uri` advertised to the authorization server, which means it
-/// has to be one of the ports allow-listed by OpenAI's Hydra config.
+const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const AUTH_URL: &str = "https://auth.openai.com/oauth/authorize";
+const TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 const CALLBACK_PORT: u16 = 1455;
+const REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
+const SCOPES: &[&str] = &["openid", "profile", "email", "offline_access"];
 
 /// Refresh proactively if the stored credentials are older than this.
 /// Codex CLI uses an 8-day window; we follow suit.
-const REFRESH_AFTER: Duration = Duration::days(8);
+const REFRESH_AFTER: chrono::Duration = chrono::Duration::days(8);
+
+/// Wait at most this long for the user to complete sign-in in the browser.
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 /// Schema of `~/.codex/auth.json`. Field names (and the `OPENAI_API_KEY`
 /// SHOUTING case) are dictated by Codex CLI's storage format -- do not
@@ -101,55 +118,164 @@ fn set_user_only_perms(_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Standard OAuth2 token endpoint response, with the OIDC `id_token`
+/// extension that ChatGPT's auth server returns alongside the regular
+/// access/refresh tokens.
+#[derive(Debug, Deserialize)]
+struct OidcTokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    id_token: Option<String>,
+}
+
+fn build_authorize_url(challenge: &PkceCodeChallenge, state: &str) -> String {
+    // OAuth2 RFC 6749 + PKCE RFC 7636. We URL-encode the scope string
+    // because " " inside a query value must be either "+" or "%20".
+    let scopes_encoded = SCOPES.join("%20");
+    format!(
+        "{AUTH_URL}?response_type=code\
+         &client_id={CLIENT_ID}\
+         &redirect_uri={redirect}\
+         &scope={scopes_encoded}\
+         &state={state}\
+         &code_challenge={code_challenge}\
+         &code_challenge_method=S256",
+        redirect = urlencode(REDIRECT_URI),
+        state = urlencode(state),
+        code_challenge = challenge.as_str(),
+    )
+}
+
+/// Minimal percent-encoder for the handful of characters that show up
+/// in our query values (`/`, `:`, `=`, etc.). Avoids pulling in `url`
+/// just to call `Url::parse`/`form_urlencoded::byte_serialize`.
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .context("building reqwest client")
+}
+
+async fn exchange_code_for_tokens(
+    http: &reqwest::Client,
+    code: &str,
+    verifier: &str,
+) -> Result<OidcTokenResponse> {
+    post_token_form(
+        http,
+        &[
+            ("grant_type", "authorization_code"),
+            ("client_id", CLIENT_ID),
+            ("code", code),
+            ("code_verifier", verifier),
+            ("redirect_uri", REDIRECT_URI),
+        ],
+    )
+    .await
+}
+
+async fn exchange_refresh_token(
+    http: &reqwest::Client,
+    refresh_token: &str,
+) -> Result<OidcTokenResponse> {
+    post_token_form(
+        http,
+        &[
+            ("grant_type", "refresh_token"),
+            ("client_id", CLIENT_ID),
+            ("refresh_token", refresh_token),
+            // Ask the server to keep issuing an id_token alongside the
+            // new access/refresh pair so we can re-derive the API key.
+            ("scope", &SCOPES.join(" ")),
+        ],
+    )
+    .await
+}
+
+async fn post_token_form(
+    http: &reqwest::Client,
+    form: &[(&str, &str)],
+) -> Result<OidcTokenResponse> {
+    let resp = http
+        .post(TOKEN_URL)
+        .form(form)
+        .send()
+        .await
+        .context("token endpoint POST failed")?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("token endpoint returned HTTP {status}: {body}");
+    }
+    resp.json::<OidcTokenResponse>()
+        .await
+        .context("parsing token endpoint response")
+}
+
 /// Run the full ChatGPT login flow: PKCE in the browser, capture the
 /// callback locally, exchange the `id_token` for an API key, and persist.
 pub async fn interactive_login() -> Result<AuthDotJson> {
-    let config = OAuthConfig::default();
-    let client = OAuthClient::new(config).context("building OAuthClient")?;
-    let flow = client.start_flow().context("starting OAuth flow")?;
+    let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
+    let csrf = CsrfToken::new_random();
+    let auth_url = build_authorize_url(&challenge, csrf.secret());
 
-    if let Err(err) = open_browser(&flow.authorization_url) {
+    if let Err(err) = webbrowser::open(&auth_url) {
         eprintln!(
             "Could not open a browser automatically ({err}). Visit:\n  {}",
-            flow.authorization_url
+            auth_url
         );
     } else {
         eprintln!("Opened browser for ChatGPT sign-in. Waiting for callback...");
     }
 
-    let tokens = run_callback_server(CALLBACK_PORT, &flow.state, &client, &flow.pkce_verifier)
-        .await
-        .context("OAuth callback server failed")?;
+    let expected_state = csrf.secret().clone();
+    let code = tokio::task::spawn_blocking(move || {
+        loopback_capture_code(CALLBACK_PORT, expected_state, CALLBACK_TIMEOUT)
+    })
+    .await
+    .context("loopback capture task panicked")??;
 
-    let auth = finish_login(&client, tokens).await?;
-    write_auth_dot_json(&auth)?;
-    Ok(auth)
-}
+    let http = http_client()?;
+    let token = exchange_code_for_tokens(&http, &code, verifier.secret()).await?;
 
-async fn finish_login(client: &OAuthClient, tokens: TokenSet) -> Result<AuthDotJson> {
-    // We need an id_token to redeem an API key (RFC 8693 token-exchange).
-    let id_token = tokens
+    let id_token = token
         .id_token
         .clone()
         .ok_or_else(|| anyhow!("OAuth response missing id_token; cannot derive API key"))?;
-    let api_key = client
-        .obtain_api_key(&id_token)
-        .await
-        .context("exchanging id_token for OPENAI_API_KEY")?;
-    let account_id = client
-        .extract_account_id(&tokens.access_token)
-        .context("extracting account_id from access_token JWT")?;
-    Ok(AuthDotJson {
+    let refresh_token = token
+        .refresh_token
+        .clone()
+        .ok_or_else(|| anyhow!("OAuth response missing refresh_token"))?;
+
+    let api_key = token_exchange_id_token(&http, TOKEN_URL, CLIENT_ID, &id_token).await?;
+    let account_id = extract_chatgpt_account_id(&token.access_token)?;
+
+    let auth = AuthDotJson {
         auth_mode: Some("chatgpt".to_string()),
         openai_api_key: Some(api_key),
         tokens: Some(TokenData {
             id_token,
-            access_token: tokens.access_token,
-            refresh_token: tokens.refresh_token,
+            access_token: token.access_token,
+            refresh_token,
             account_id,
         }),
         last_refresh: Some(Utc::now()),
-    })
+    };
+    write_auth_dot_json(&auth)?;
+    Ok(auth)
 }
 
 /// Refresh the API key if the stored credentials are stale. Used on
@@ -166,13 +292,32 @@ pub async fn refresh_if_stale(auth: &mut AuthDotJson) -> Result<bool> {
         .tokens
         .as_ref()
         .ok_or_else(|| anyhow!("auth.json has no tokens to refresh"))?;
-    let client = OAuthClient::new(OAuthConfig::default()).context("building OAuthClient")?;
-    let refreshed = client
-        .refresh_token(&tokens.refresh_token)
-        .await
-        .context("refreshing OAuth tokens")?;
-    let updated = finish_login(&client, refreshed).await?;
-    *auth = updated;
+    let http = http_client()?;
+    let refreshed = exchange_refresh_token(&http, &tokens.refresh_token).await?;
+
+    let id_token = refreshed
+        .id_token
+        .clone()
+        .ok_or_else(|| anyhow!("refresh response missing id_token"))?;
+    let refresh_token = refreshed
+        .refresh_token
+        .clone()
+        .unwrap_or_else(|| tokens.refresh_token.clone());
+
+    let api_key = token_exchange_id_token(&http, TOKEN_URL, CLIENT_ID, &id_token).await?;
+    let account_id = extract_chatgpt_account_id(&refreshed.access_token)?;
+
+    *auth = AuthDotJson {
+        auth_mode: Some("chatgpt".to_string()),
+        openai_api_key: Some(api_key),
+        tokens: Some(TokenData {
+            id_token,
+            access_token: refreshed.access_token,
+            refresh_token,
+            account_id,
+        }),
+        last_refresh: Some(Utc::now()),
+    };
     write_auth_dot_json(auth)?;
     Ok(true)
 }
@@ -185,6 +330,161 @@ pub fn logout() -> Result<()> {
         std::fs::remove_file(&path).with_context(|| format!("removing {}", path.display()))?;
     }
     Ok(())
+}
+
+/// RFC 8693 token exchange: convert an OpenID id_token into a regular
+/// `OPENAI_API_KEY`. This is the same call Codex CLI makes after OAuth
+/// completes; the response's `access_token` is the `sk-...` we want.
+async fn token_exchange_id_token(
+    http: &reqwest::Client,
+    token_url: &str,
+    client_id: &str,
+    id_token: &str,
+) -> Result<String> {
+    #[derive(Deserialize)]
+    struct Resp {
+        access_token: String,
+    }
+    let resp = http
+        .post(token_url)
+        .form(&[
+            (
+                "grant_type",
+                "urn:ietf:params:oauth:grant-type:token-exchange",
+            ),
+            ("client_id", client_id),
+            ("requested_token", "openai-api-key"),
+            ("subject_token", id_token),
+            (
+                "subject_token_type",
+                "urn:ietf:params:oauth:token-type:id_token",
+            ),
+        ])
+        .send()
+        .await
+        .context("token-exchange POST failed")?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("token-exchange failed (HTTP {status}): {body}");
+    }
+    let parsed: Resp = resp
+        .json()
+        .await
+        .context("parsing token-exchange response")?;
+    Ok(parsed.access_token)
+}
+
+/// Pull the `chatgpt_account_id` claim out of an access_token JWT
+/// without verifying the signature. We trust the token because we just
+/// received it over HTTPS from auth.openai.com; the only thing we need
+/// is an opaque account identifier.
+pub fn extract_chatgpt_account_id(access_token: &str) -> Result<String> {
+    let payload = access_token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| anyhow!("access_token is not a JWT"))?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload.as_bytes())
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(payload.as_bytes()))
+        .context("base64-decoding JWT payload")?;
+    let claims: serde_json::Value =
+        serde_json::from_slice(&bytes).context("parsing JWT payload as JSON")?;
+    claims
+        .get("https://api.openai.com/auth")
+        .and_then(|v| v.get("chatgpt_account_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("JWT missing https://api.openai.com/auth.chatgpt_account_id claim"))
+}
+
+/// Spin up `tiny_http` on `port`, wait for `GET /auth/callback?code=...&state=...`,
+/// validate `state`, return the `code`. Times out after `timeout`.
+fn loopback_capture_code(port: u16, expected_state: String, timeout: Duration) -> Result<String> {
+    let server = tiny_http::Server::http(("127.0.0.1", port))
+        .map_err(|e| anyhow!("binding loopback port {port}: {e}"))?;
+    let (tx, rx) = mpsc::channel::<Result<String>>();
+
+    std::thread::spawn(move || {
+        // One callback is all we expect; pull the first request only and
+        // drop the server when the closure returns.
+        if let Some(req) = server.incoming_requests().next() {
+            let url = req.url().to_string();
+            let result = parse_callback_url(&url, &expected_state);
+            let body = match &result {
+                Ok(_) => "Sign-in complete. You can close this tab and return to brokk.",
+                Err(e) => {
+                    tracing::warn!("codex-login callback rejected: {e:#}");
+                    "Sign-in failed. Check the brokk console for details."
+                }
+            };
+            let _ = req.respond(tiny_http::Response::from_string(body));
+            let _ = tx.send(result);
+        }
+    });
+
+    rx.recv_timeout(timeout)
+        .map_err(|_| anyhow!("OAuth callback timed out after {timeout:?}"))?
+}
+
+/// Parse `/auth/callback?code=...&state=...` (or `?error=...`) by hand
+/// to avoid pulling in the `url` crate just for query-string splitting.
+fn parse_callback_url(url: &str, expected_state: &str) -> Result<String> {
+    let query = url.split('?').nth(1).unwrap_or("");
+    let mut code: Option<String> = None;
+    let mut state: Option<String> = None;
+    let mut error: Option<String> = None;
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let (raw_k, raw_v) = pair.split_once('=').unwrap_or((pair, ""));
+        let v = url_decode(raw_v);
+        match raw_k {
+            "code" => code = Some(v),
+            "state" => state = Some(v),
+            "error" => error = Some(v),
+            _ => {}
+        }
+    }
+    if let Some(err) = error {
+        bail!("authorization server returned error: {err}");
+    }
+    let state = state.ok_or_else(|| anyhow!("callback missing state param"))?;
+    if state != expected_state {
+        bail!("callback state did not match (CSRF guard)");
+    }
+    code.ok_or_else(|| anyhow!("callback missing code param"))
+}
+
+/// Inverse of `urlencode`: decode `%XX` escapes and `+` to space.
+fn url_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("");
+                if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                    out.push(byte);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 #[cfg(test)]
@@ -239,9 +539,6 @@ mod tests {
     fn auth_json_path_honours_codex_home_override() {
         // Save and restore so we don't pollute other tests sharing the env.
         let prior = std::env::var("CODEX_HOME").ok();
-        // SAFETY: tests run single-threaded for env mutations is not guaranteed
-        // by cargo, but the assertion only reads what we just set, so a flake
-        // would manifest as a clear mismatch rather than corruption.
         unsafe {
             std::env::set_var("CODEX_HOME", "/tmp/codex-home-test-xyz");
         }
@@ -256,5 +553,51 @@ mod tests {
                 None => std::env::remove_var("CODEX_HOME"),
             }
         }
+    }
+
+    #[test]
+    fn extract_chatgpt_account_id_pulls_nested_claim() {
+        // Synthesize a JWT with the OpenAI namespace claim. We don't need a
+        // valid signature -- the production code skips verification too.
+        let payload = serde_json::json!({
+            "sub": "user_xyz",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_test_123",
+                "chatgpt_plan_type": "plus"
+            }
+        });
+        let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("eyJhbGciOiJSUzI1NiJ9.{payload_b64}.fake-sig");
+        assert_eq!(extract_chatgpt_account_id(&token).unwrap(), "acct_test_123");
+    }
+
+    #[test]
+    fn extract_chatgpt_account_id_errors_on_missing_claim() {
+        let payload = serde_json::json!({"sub": "user_xyz"});
+        let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("eyJhbGciOiJSUzI1NiJ9.{payload_b64}.fake-sig");
+        assert!(extract_chatgpt_account_id(&token).is_err());
+    }
+
+    #[test]
+    fn parse_callback_url_validates_state_and_returns_code() {
+        let url = "/auth/callback?code=abc123&state=xyz";
+        assert_eq!(parse_callback_url(url, "xyz").unwrap(), "abc123");
+    }
+
+    #[test]
+    fn parse_callback_url_rejects_state_mismatch() {
+        let url = "/auth/callback?code=abc123&state=evil";
+        let err = parse_callback_url(url, "expected").unwrap_err().to_string();
+        assert!(err.contains("CSRF"));
+    }
+
+    #[test]
+    fn parse_callback_url_surfaces_authorization_server_error() {
+        let url = "/auth/callback?error=access_denied&state=xyz";
+        let err = parse_callback_url(url, "xyz").unwrap_err().to_string();
+        assert!(err.contains("access_denied"));
     }
 }

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 
 mod agent;
 mod bifrost_client;
+mod codex_auth;
 mod llm_client;
 mod session;
 mod tool_loop;
@@ -24,6 +25,15 @@ struct Args {
     /// Prefer the BROKK_ENDPOINT_API_KEY env var over the CLI flag.
     #[arg(long, env = "BROKK_ENDPOINT_API_KEY")]
     api_key: Option<String>,
+
+    /// Authenticate against OpenAI using "Sign in with ChatGPT" credentials
+    /// stored at `~/.codex/auth.json` (cross-compatible with Codex CLI).
+    /// When set, --endpoint-url and --api-key are overridden by the
+    /// OAuth-issued OPENAI_API_KEY pointed at https://api.openai.com/v1.
+    /// Run `/codex-login` from an ACP session to authenticate if no
+    /// credentials are present yet.
+    #[arg(long, conflicts_with = "api_key")]
+    use_codex: bool,
 
     /// Default model to use if not specified by the client
     #[arg(long, default_value = "")]
@@ -58,6 +68,7 @@ impl std::fmt::Debug for Args {
         f.debug_struct("Args")
             .field("endpoint_url", &self.endpoint_url)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .field("use_codex", &self.use_codex)
             .field("default_model", &self.default_model)
             .field("max_turns", &self.max_turns)
             .field("max_sessions", &self.max_sessions)
@@ -79,12 +90,40 @@ async fn main() -> Result<()> {
         .init();
 
     let args = Args::parse();
-    tracing::info!("brokk-acp starting, endpoint={}", args.endpoint_url);
 
-    let llm: Arc<dyn llm_client::LlmBackend> = Arc::new(llm_client::OpenAiClient::new(
-        args.endpoint_url,
-        args.api_key,
-    ));
+    // Codex login takes precedence: re-point the LLM at api.openai.com using
+    // the issued OPENAI_API_KEY, and refresh the credentials if they're stale
+    // before any prompts arrive. If no auth.json exists yet we still start --
+    // the user can run `/codex-login` from a session to authenticate.
+    let (endpoint_url, api_key) = if args.use_codex {
+        match codex_auth::read_auth_dot_json()? {
+            Some(mut auth) => {
+                if let Err(e) = codex_auth::refresh_if_stale(&mut auth).await {
+                    tracing::warn!("codex credential refresh failed: {e:#}");
+                }
+                let key = auth.openai_api_key.clone();
+                if key.is_none() {
+                    tracing::warn!(
+                        "~/.codex/auth.json has no OPENAI_API_KEY; run /codex-login to authenticate"
+                    );
+                }
+                ("https://api.openai.com/v1".to_string(), key)
+            }
+            None => {
+                tracing::warn!(
+                    "no ~/.codex/auth.json found; run /codex-login from a session to authenticate"
+                );
+                ("https://api.openai.com/v1".to_string(), None)
+            }
+        }
+    } else {
+        (args.endpoint_url.clone(), args.api_key.clone())
+    };
+
+    tracing::info!("brokk-acp starting, endpoint={endpoint_url}");
+
+    let llm: Arc<dyn llm_client::LlmBackend> =
+        Arc::new(llm_client::OpenAiClient::new(endpoint_url, api_key));
     // SessionStore uses internal Arc -- no outer Arc needed
     let limits = session::SessionLimits {
         max_sessions: args.max_sessions,


### PR DESCRIPTION
## Summary

Adds "Sign in with ChatGPT" (Codex login) support to `brokk-acp-rust` so a user with a ChatGPT subscription can drive the rust ACP server with their existing OpenAI credentials, no `BROKK_KEY` required.

The OAuth `id_token` is exchanged for a regular `sk-...` key via OAuth 2.0 Token Exchange (RFC 8693) — the same flow Codex CLI uses internally. After login the existing `OpenAiClient` talks to `https://api.openai.com/v1` unchanged. **No undocumented OpenAI endpoints are touched.**

Storage at `~/.codex/auth.json` is field-compatible with Codex CLI — login here, use `codex` in another terminal, or vice versa.

## Dependency posture (revised after first review)

The first iteration of this PR pulled in `openai-auth` (single maintainer, ~5.5k downloads, 0 stars) for the OAuth pipeline. After supply-chain concerns from review, that dependency was removed entirely. Current setup:

- **`oauth2 = "5"`** — used only for `PkceCodeChallenge::new_random_sha256()` and `CsrfToken::new_random()`. ~32M downloads, depended on by Servo, Apache-2.0. Provides the cryptographically sensitive primitives.
- **In-tree implementation** of: authorize URL builder, code-for-tokens exchange, refresh-token exchange, RFC 8693 token exchange, JWT payload decode for `chatgpt_account_id`. All `reqwest` + `serde_json` + a hand-rolled `urlencode`. Visible to PR review, not subject to silent updates.
- **`tiny_http`** for the loopback callback server (binds 1455 for ~30s during sign-in only).
- **`base64`, `dirs`, `chrono`, `webbrowser`** as small standard utilities.

## What's added

- `--use-codex` CLI flag on `brokk-acp` (mutually exclusive with `--api-key`)
- New `src/codex_auth.rs` module: `AuthDotJson` schema + `interactive_login()` + `refresh_if_stale()` + `logout()`
- Slash commands wired via the existing `/context` dispatcher:
  - `/codex-login` — start browser PKCE flow
  - `/codex-login status` — report stored creds (no tokens echoed)
  - `/codex-login disconnect` — wipe `~/.codex/auth.json`
- Proactive refresh on startup if credentials are older than 8 days (matches Codex CLI's `TOKEN_REFRESH_INTERVAL`)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (136 passed, including 8 new in `codex_auth::tests`: round-trip JSON, optional fields, `CODEX_HOME` override, JWT account_id extraction with present + missing claim, callback URL parsing with valid + state-mismatch + authorization-error paths)
- [ ] Manual end-to-end with a ChatGPT subscription:
  - `cargo run -p brokk-acp -- --use-codex` then `/codex-login` from an ACP session — browser should open, login should populate `~/.codex/auth.json` with an `OPENAI_API_KEY`
  - Verify a subsequent `session/prompt` actually streams from `api.openai.com`
- [ ] Confirm Codex-tagged models (e.g. `gpt-5-codex`) appear in `GET /v1/models` with the issued key. If they don't, the user still gets standard OpenAI models — falling back to undocumented `chatgpt.com/backend-api/codex/responses` stays an option but is intentionally out of scope here.
- [ ] Cross-compat: after logging in here, run `codex` in a fresh terminal and confirm it sees the auth (proves on-disk format parity).

## Risks

- `~/.codex/auth.json` is plaintext (matches Codex CLI's default). Keychain mode is a follow-up.
- A user logged in here is **not** visible to the brokk Java side's `MainProject.isOpenAiCodexOauthConnected` — this is intentional: the rust ACP server is a self-contained client by design.
- The RFC 8693 token-exchange against `auth.openai.com/oauth/token` is mirrored from Codex CLI's own behavior; if OpenAI ever changes the grant_type or `requested_token` values, refresh + login break together. Surface area is one POST in `token_exchange_id_token()`.

## Related

- Independent versioning + release workflow for `brokk-acp-rust`: #3536
