### PR TITLE
ci: add brokk-acp-rust release workflow with independent tag prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build-and-release:
-    if: "!startsWith(github.ref_name, 'brokk-code-')"
+    if: "!startsWith(github.ref_name, 'brokk-code-') && !startsWith(github.ref_name, 'brokk-acp-rust-')"
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/rust-acp-release.yml
+++ b/.github/workflows/rust-acp-release.yml
@@ -20,10 +20,6 @@ jobs:
             target: aarch64-apple-darwin
             asset_name: brokk-acp-macos-aarch64
             binary_name: brokk-acp
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            asset_name: brokk-acp-macos-x86_64
-            binary_name: brokk-acp
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             asset_name: brokk-acp-windows-x86_64.exe

--- a/.github/workflows/rust-acp-release.yml
+++ b/.github/workflows/rust-acp-release.yml
@@ -20,7 +20,7 @@ jobs:
             target: aarch64-apple-darwin
             asset_name: brokk-acp-macos-aarch64
             binary_name: brokk-acp
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             asset_name: brokk-acp-macos-x86_64
             binary_name: brokk-acp

--- a/.github/workflows/rust-acp-release.yml
+++ b/.github/workflows/rust-acp-release.yml
@@ -1,0 +1,102 @@
+name: Rust ACP Release
+
+on:
+  push:
+    tags:
+      - 'brokk-acp-rust-*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset_name: brokk-acp-linux-x86_64
+            binary_name: brokk-acp
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset_name: brokk-acp-macos-aarch64
+            binary_name: brokk-acp
+          - os: macos-13
+            target: x86_64-apple-darwin
+            asset_name: brokk-acp-macos-x86_64
+            binary_name: brokk-acp
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset_name: brokk-acp-windows-x86_64.exe
+            binary_name: brokk-acp.exe
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            brokk-acp-rust/target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('brokk-acp-rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-release-
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+      - name: Verify tag matches Cargo.toml version
+        if: github.event_name == 'push'
+        shell: bash
+        working-directory: brokk-acp-rust
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          EXPECTED_VERSION="${TAG#brokk-acp-rust-}"
+          CARGO_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
+          if [ "$EXPECTED_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Tag version ($EXPECTED_VERSION) does not match brokk-acp-rust/Cargo.toml version ($CARGO_VERSION). Bump Cargo.toml before tagging."
+            exit 1
+          fi
+          echo "Tag and Cargo.toml versions match: $CARGO_VERSION"
+
+      - name: Build release binary
+        working-directory: brokk-acp-rust
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir -p staging
+          cp "brokk-acp-rust/target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "staging/${{ matrix.asset_name }}"
+
+      - name: Smoke-test --version
+        shell: bash
+        run: |
+          "./staging/${{ matrix.asset_name }}" --version
+
+      - name: Upload to GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: staging/${{ matrix.asset_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifact (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: staging/${{ matrix.asset_name }}
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Closes #3536. Adds an independent release lifecycle for `brokk-acp-rust` so binary releases of `brokk-acp` can ship without dragging the Java/jdeploy release along.

- **`.github/workflows/release.yml`**: extend the existing `if:` guard so the Java release also skips `brokk-acp-rust-*` tags (was already skipping `brokk-code-*`).
- **`.github/workflows/rust-acp-release.yml`** (new): triggers on `brokk-acp-rust-*` tags (and `workflow_dispatch` for dry-runs). Builds `brokk-acp` on the four-target matrix from the issue (`ubuntu-latest` / `macos-latest` arm64 / `macos-13` x86_64 / `windows-latest`), caches cargo per OS+target, then attaches one binary per platform to a GitHub Release via `softprops/action-gh-release@v2` (create-or-attach idempotent on `tag_name`).

### Tag → version contract

Per the issue's recommendation, **`Cargo.toml` drives the tag** (option 2). A guard step extracts `${tag#brokk-acp-rust-}` and fails the workflow if it disagrees with `brokk-acp-rust/Cargo.toml`'s `version =`. Since `src/main.rs` already declares `#[command(name = "brokk-acp", version, about)]`, clap pulls `CARGO_PKG_VERSION` into `brokk-acp --version`, so once the guard passes the embedded version is the tag — no mid-CI mutation of `Cargo.toml`.

A `Smoke-test --version` step runs the produced binary on each runner (all builds are native — no cross-compilation — so the artifact is directly executable on its build runner).

### Out of scope (per issue)

- Linux ARM64 build (open question, deferred to v1+).
- macOS signing / notarization (unsigned for v1).
- crates.io publication.
- Auto-bump PR after release.

## Test plan

- [ ] Push branch and confirm `rust-acp-release.yml` shows up in the Actions tab.
- [ ] Trigger `rust-acp-release.yml` via `workflow_dispatch` on this branch and verify all four matrix jobs build green and the `Smoke-test --version` step succeeds.
- [ ] After merge, push a real `brokk-acp-rust-0.1.0` tag (matching the current `Cargo.toml`) and verify:
  - [ ] `release.yml` (Java) does **not** start.
  - [ ] `rust-acp-release.yml` runs to completion.
  - [ ] A GitHub Release at `https://github.com/BrokkAi/brokk/releases/tag/brokk-acp-rust-0.1.0` exists with four assets attached.
  - [ ] Each downloaded asset reports the matching version via `brokk-acp --version`.
- [ ] Push a deliberately-mismatched tag (e.g. `brokk-acp-rust-9.9.9` while `Cargo.toml` is `0.1.0`) and confirm the guard step fails fast with the expected error message.
- [ ] Confirm `rust-acp.yml` (PR/master CI) is unaffected by these changes.
