### PR TITLE
Fix "workspaceComplete" fragment selection matching

### DIFF
--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -506,7 +507,8 @@ public class SearchAgent {
 
     @Tool("Signal workspace preparation is complete.")
     public ToolOutput workspaceComplete(
-            @P("Selected workspace fragments as IDs, or exact fragment descriptions.")
+            @P("Selected workspace fragments. Prefer copying the fragmentid attribute verbatim, "
+                            + "e.g. \"65fda478-c289-4e4e-afb1-d2753af1f080\". Do not paraphrase descriptions.")
                     List<String> fragmentIdsOrDescriptions) {
         var acceptedIds = new LinkedHashSet<String>();
         if (pendingWorkspaceCompleteIds != null) {
@@ -581,10 +583,37 @@ public class SearchAgent {
                 continue;
             }
 
+            var looseMatchingIds = resolveLooseDescriptionSelection(token, descriptionToIds);
+            if (looseMatchingIds.size() == 1) {
+                accepted.add(looseMatchingIds.getFirst());
+                continue;
+            } else if (looseMatchingIds.size() > 1) {
+                bad.add(token + " (ambiguous description, matches multiple IDs: " + looseMatchingIds + ")");
+                continue;
+            }
+
             bad.add(token);
         }
 
         return new FragmentSelectionResolution(List.copyOf(accepted), List.copyOf(bad));
+    }
+
+    private static List<String> resolveLooseDescriptionSelection(
+            String token, Map<String, List<String>> descriptionToIds) {
+        var normalizedToken = normalizeFragmentSelection(token);
+        return descriptionToIds.entrySet().stream()
+                .filter(entry -> {
+                    var normalizedDescription = normalizeFragmentSelection(entry.getKey());
+                    return normalizedDescription.startsWith(normalizedToken)
+                            || normalizedToken.startsWith(normalizedDescription);
+                })
+                .flatMap(entry -> entry.getValue().stream())
+                .distinct()
+                .toList();
+    }
+
+    private static String normalizeFragmentSelection(String value) {
+        return value.trim().toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
     }
 
     private static String jsonWithExplanation(String explanation) {

--- a/app/src/test/java/ai/brokk/agents/SearchAgentTest.java
+++ b/app/src/test/java/ai/brokk/agents/SearchAgentTest.java
@@ -92,6 +92,154 @@ class SearchAgentTest {
     }
 
     @Test
+    void workspaceComplete_acceptsExactFragmentIdAndExactDescription() throws InterruptedException {
+        var cm = new TestContextManager(tempDir, new NoOpConsoleIO());
+        var protocolId = "65fda478-c289-4e4e-afb1-d2753af1f080";
+        ContextFragment fragment = new ContextFragments.StringFragment(
+                protocolId, cm, "protocol source", "Summary of ai.brokk.acp.AcpProtocol class", "text/plain");
+        Context context = new Context(cm).addFragments(fragment);
+        var agent = new SearchAgent(context, "test goal", SearchPrompts.Objective.ANSWER_ONLY, new NoOpConsoleIO());
+        registry = new ToolRegistry().builder().register(agent).build();
+
+        var directive = agent.buildTurnDirective(1, List.of());
+        assertTrue(directive.contains("description=\"Summary of ai.brokk.acp.AcpProtocol class\""));
+        assertTrue(directive.contains("fragmentid=\"" + protocolId + "\""));
+
+        var byId = executeTool(
+                "workspaceComplete",
+                """
+                {"fragmentIdsOrDescriptions":["%s"]}
+                """.formatted(protocolId));
+
+        assertEquals("TerminalStopOutput", byId.result().getClass().getSimpleName());
+        assertJsonEquals(
+                """
+                {
+                  "fragment_ids" : [ "%s" ]
+                }"""
+                        .formatted(protocolId),
+                byId.resultText());
+
+        var byDescription = executeTool(
+                "workspaceComplete",
+                """
+                {"fragmentIdsOrDescriptions":["Summary of ai.brokk.acp.AcpProtocol class"]}
+                """);
+
+        assertEquals("TerminalStopOutput", byDescription.result().getClass().getSimpleName());
+        assertJsonEquals(
+                """
+                {
+                  "fragment_ids" : [ "%s" ]
+                }"""
+                        .formatted(protocolId),
+                byDescription.resultText());
+    }
+
+    @Test
+    void workspaceComplete_acceptsNormalizedDescriptionPrefixFromToc() throws InterruptedException {
+        var cm = new TestContextManager(tempDir, new NoOpConsoleIO());
+        var protocolId = "65fda478-c289-4e4e-afb1-d2753af1f080";
+        ContextFragment fragment = new ContextFragments.StringFragment(
+                protocolId, cm, "protocol source", "Summary of ai.brokk.acp.AcpProtocol class", "text/plain");
+        Context context = new Context(cm).addFragments(fragment);
+        var agent = new SearchAgent(context, "test goal", SearchPrompts.Objective.ANSWER_ONLY, new NoOpConsoleIO());
+        registry = new ToolRegistry().builder().register(agent).build();
+
+        var directive = agent.buildTurnDirective(1, List.of());
+        assertTrue(directive.contains("description=\"Summary of ai.brokk.acp.AcpProtocol class\""));
+        assertTrue(directive.contains("fragmentid=\"" + protocolId + "\""));
+
+        var result = executeTool(
+                "workspaceComplete",
+                """
+                {"fragmentIdsOrDescriptions":["summary   of AI.BROKK.ACP.ACPPROTOCOL"]}
+                """);
+
+        assertEquals("TerminalStopOutput", result.result().getClass().getSimpleName());
+        assertJsonEquals(
+                """
+                {
+                  "fragment_ids" : [ "%s" ]
+                }"""
+                        .formatted(protocolId),
+                result.resultText());
+    }
+
+    @Test
+    void workspaceComplete_rejectsAmbiguousNormalizedDescriptionPrefix() throws InterruptedException {
+        var cm = new TestContextManager(tempDir, new NoOpConsoleIO());
+        var protocolId = "65fda478-c289-4e4e-afb1-d2753af1f080";
+        var protocolTestId = "0a18deaf-2b4d-4a85-8d8a-11f3d7b6c912";
+        ContextFragment protocolFragment = new ContextFragments.StringFragment(
+                protocolId, cm, "protocol source", "Summary of ai.brokk.acp.AcpProtocol class", "text/plain");
+        ContextFragment protocolTestFragment = new ContextFragments.StringFragment(
+                protocolTestId,
+                cm,
+                "protocol test source",
+                "Summary of ai.brokk.acp.AcpProtocolTest class",
+                "text/plain");
+        Context context = new Context(cm).addFragments(protocolFragment).addFragments(protocolTestFragment);
+        var agent = new SearchAgent(context, "test goal", SearchPrompts.Objective.ANSWER_ONLY, new NoOpConsoleIO());
+        registry = new ToolRegistry().builder().register(agent).build();
+
+        var result = executeTool(
+                "workspaceComplete",
+                """
+                {"fragmentIdsOrDescriptions":["summary of ai.brokk.acp.acpprotocol"]}
+                """);
+
+        assertTrue(result.result() instanceof ToolOutput.TextOutput);
+        assertTrue(result.resultText().contains("ambiguous description"));
+        assertTrue(result.resultText().contains(protocolId));
+        assertTrue(result.resultText().contains(protocolTestId));
+    }
+
+    @Test
+    void workspaceComplete_retryPreservesAcceptedIdsAndAcceptsCorrectedId() throws InterruptedException {
+        var cm = new TestContextManager(tempDir, new NoOpConsoleIO());
+        var modelSelectorId = "65fda478-c289-4e4e-afb1-d2753af1f080";
+        var protocolId = "0a18deaf-2b4d-4a85-8d8a-11f3d7b6c912";
+        ContextFragment modelSelectorFragment = new ContextFragments.StringFragment(
+                modelSelectorId,
+                cm,
+                "model selector source",
+                "Summary of ai.brokk.gui.components.ModelSelector class",
+                "text/plain");
+        ContextFragment protocolFragment = new ContextFragments.StringFragment(
+                protocolId, cm, "protocol source", "Summary of ai.brokk.acp.AcpProtocol class", "text/plain");
+        Context context = new Context(cm).addFragments(modelSelectorFragment).addFragments(protocolFragment);
+        var agent = new SearchAgent(context, "test goal", SearchPrompts.Objective.ANSWER_ONLY, new NoOpConsoleIO());
+        registry = new ToolRegistry().builder().register(agent).build();
+
+        var firstResult = executeTool(
+                "workspaceComplete",
+                """
+                {"fragmentIdsOrDescriptions":["%s","missing-fragment"]}
+                """
+                        .formatted(modelSelectorId));
+
+        assertTrue(firstResult.result() instanceof ToolOutput.TextOutput);
+        assertTrue(firstResult.resultText().contains("Accepted selections are saved"));
+        assertTrue(firstResult.resultText().contains(modelSelectorId));
+
+        var secondResult = executeTool(
+                "workspaceComplete",
+                """
+                {"fragmentIdsOrDescriptions":["%s"]}
+                """.formatted(protocolId));
+
+        assertEquals("TerminalStopOutput", secondResult.result().getClass().getSimpleName());
+        assertJsonEquals(
+                """
+                {
+                  "fragment_ids" : [ "%s", "%s" ]
+                }"""
+                        .formatted(modelSelectorId, protocolId),
+                secondResult.resultText());
+    }
+
+    @Test
     void buildTurnDirective_startsWithInitialWorkspaceSummary() {
         var cm = new TestContextManager(tempDir, new NoOpConsoleIO());
         ContextFragment initialFragment =


### PR DESCRIPTION
**Summary**
Solves #3484.
Makes `SearchAgent.workspaceComplete` more robust when the LLM returns description-shaped fragment selections instead of copying `fragmentid` values exactly from the Workspace TOC. Also adds tests for fragment matching.

`app/src/main/java/ai/brokk/agents/SearchAgent.java`
- Clarifies the `workspaceComplete` tool parameter description so the LLM is told to copy the `fragmentid` attribute verbatim, with a UUID-shaped example.
- Preserves the existing strict matching order:
  1. exact fragment ID
  2. exact fragment description
  3. tolerant description fallback
- Adds a more tolerant fallback for description-shaped selections:
  - trims input
  - lowercases with `Locale.ROOT` (new import)
  - collapses repeated whitespace
  - accepts normalized prefix matches only when they resolve to exactly one fragment
- Reports ambiguous tolerant matches as invalid selections with candidate fragment IDs, so the next retry can use a UUID instead of guessing.

`app/src/test/java/ai/brokk/agents/SearchAgentTest.java`
- Adds coverage for exact fragment ID and description matching.
- Adds coverage for normalized/prefix description matching against a real SearchAgent TOC shape.
- Adds coverage for ambiguous normalized/prefix matches.
- Adds coverage confirming retry recovery already preserves accepted IDs: the first call can include one accepted ID plus one invalid selection, and the second call only needs to send the corrected selection.

**Notes**
I did not actually recreate the issue. This PR covers the reported failure mode directly with tests: an LLM returning description-derived strings rather than the UUID-shaped `fragmentid` value from the TOC.

The tolerant matching is intentionally conservative. Loose matching only runs for selections that would previously have been rejected, and it refuses to guess when multiple fragment descriptions match. Some smarter heuristics could be added here, or more aggressive normalization. However, because the instructions now indicate a preference for fragment IDs, those changes are likely unnecessary.