### PR TITLE
brokk-acp-rust: route --use-codex through ChatGPT subscription (Responses API)

### DIFF
--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -389,6 +389,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +617,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1352,6 +1390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1754,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +1897,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4", features = ["derive", "env"] }
 zip = "2"
 futures = "0.3"
 regex = "1"
-reqwest = { version = "0.12", features = ["stream", "json"] }
+reqwest = { version = "0.12", features = ["stream", "json", "cookies"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -955,8 +955,13 @@ async fn handle_codex_login(prompt_text: &str) -> String {
                     .last_refresh
                     .map(|ts| ts.to_rfc3339())
                     .unwrap_or_else(|| "(unknown)".to_string());
+                let routing = match mode {
+                    "chatgpt" => "ChatGPT subscription (Responses API on chatgpt.com)",
+                    "apikey" => "OPENAI_API_KEY (api.openai.com, billed as API usage)",
+                    _ => "unknown",
+                };
                 format!(
-                    "Codex login status:\n  auth_mode: {mode}\n  api_key: {}\n  account_id: {acct}\n  last_refresh: {last}",
+                    "Codex login status:\n  auth_mode: {mode}\n  routing: {routing}\n  api_key: {}\n  account_id: {acct}\n  last_refresh: {last}",
                     if has_key { "present" } else { "MISSING" }
                 )
             }
@@ -964,7 +969,7 @@ async fn handle_codex_login(prompt_text: &str) -> String {
             Err(e) => format!("Failed to read ~/.codex/auth.json: {e:#}"),
         },
         "disconnect" => match crate::codex_auth::logout() {
-            Ok(()) => "Codex credentials cleared. Restart the server to drop the cached API key from memory.".to_string(),
+            Ok(()) => "Codex credentials cleared. Restart the server to drop any cached tokens from memory.".to_string(),
             Err(e) => format!("Failed to remove ~/.codex/auth.json: {e:#}"),
         },
         "" => match crate::codex_auth::interactive_login().await {
@@ -975,7 +980,9 @@ async fn handle_codex_login(prompt_text: &str) -> String {
                     .map(|t| t.account_id.as_str())
                     .unwrap_or("(unknown)");
                 format!(
-                    "Codex login complete (account_id: {acct}). Restart the server with --use-codex to route prompts through the issued OPENAI_API_KEY."
+                    "Codex login complete (account_id: {acct}). \
+                     Restart the server with --use-codex; prompts will route through your \
+                     ChatGPT subscription via https://chatgpt.com/backend-api/codex/responses."
                 )
             }
             Err(e) => format!("Codex login failed: {e:#}"),

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -138,12 +138,17 @@ fn all_config_options(
 /// Slash commands advertised to clients via `available_commands_update`.
 /// Mirrors the Java executor's `/context` command (other Java commands are
 /// intentionally omitted -- they depend on the live workspace context that
-/// the Rust agent does not yet model).
+/// the Rust agent does not yet model). `/codex-login` is published so it
+/// shows up in editor autocomplete (Zed, JetBrains ACP) -- without this
+/// the slash command works when typed but is invisible to discovery.
 fn available_commands() -> Vec<AvailableCommand> {
-    vec![AvailableCommand::new(
-        "context",
-        "Show current session context snapshot",
-    )]
+    vec![
+        AvailableCommand::new("context", "Show current session context snapshot"),
+        AvailableCommand::new(
+            "codex-login",
+            "Sign in with ChatGPT (or `status` / `disconnect`)",
+        ),
+    ]
 }
 
 fn send_available_commands_update(cx: &ConnectionTo<Client>, session_id: &str) {

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -965,9 +965,17 @@ async fn handle_codex_login(prompt_text: &str) -> String {
                     "apikey" => "OPENAI_API_KEY (api.openai.com, billed as API usage)",
                     _ => "unknown",
                 };
+                // ChatGPT-only accounts don't get an OPENAI_API_KEY
+                // because they have no API organization to mint one
+                // against. Surface that explicitly so users don't read
+                // "MISSING" as a broken login.
+                let api_key_label = match (mode, has_key) {
+                    (_, true) => "present",
+                    ("chatgpt", false) => "n/a (ChatGPT-only account; subscription routing does not need one)",
+                    (_, false) => "MISSING",
+                };
                 format!(
-                    "Codex login status:\n  auth_mode: {mode}\n  routing: {routing}\n  api_key: {}\n  account_id: {acct}\n  last_refresh: {last}",
-                    if has_key { "present" } else { "MISSING" }
+                    "Codex login status:\n  auth_mode: {mode}\n  routing: {routing}\n  api_key: {api_key_label}\n  account_id: {acct}\n  last_refresh: {last}"
                 )
             }
             Ok(None) => "No Codex credentials found. Run `/codex-login` to authenticate.".to_string(),

--- a/brokk-acp-rust/src/codex_auth.rs
+++ b/brokk-acp-rust/src/codex_auth.rs
@@ -302,12 +302,28 @@ pub async fn interactive_login() -> Result<AuthDotJson> {
         .clone()
         .ok_or_else(|| anyhow!("OAuth response missing refresh_token"))?;
 
-    let api_key = token_exchange_id_token(&http, TOKEN_URL, CLIENT_ID, &id_token).await?;
+    // Token-exchange (RFC 8693 id_token -> sk-...) is best-effort: a
+    // ChatGPT-subscription user with no associated API organization
+    // gets `Invalid ID token: missing organization_id` here, which is
+    // expected -- they don't *have* an API key to derive. Codex CLI's
+    // own `obtain_api_key(...).await.ok()` does the same thing.
+    // Subscription routing only needs the access_token + account_id we
+    // already have; the API key is stored only as a convenience for
+    // users who later run `codex` itself in apikey mode.
+    let api_key = match token_exchange_id_token(&http, TOKEN_URL, CLIENT_ID, &id_token).await {
+        Ok(key) => Some(key),
+        Err(e) => {
+            tracing::info!(
+                "skipping API key derivation (typical for ChatGPT-only accounts): {e:#}"
+            );
+            None
+        }
+    };
     let account_id = extract_chatgpt_account_id(&token.access_token)?;
 
     let auth = AuthDotJson {
         auth_mode: Some("chatgpt".to_string()),
-        openai_api_key: Some(api_key),
+        openai_api_key: api_key,
         tokens: Some(TokenData {
             id_token,
             access_token: token.access_token,
@@ -346,12 +362,23 @@ pub async fn refresh_if_stale(auth: &mut AuthDotJson) -> Result<bool> {
         .clone()
         .unwrap_or_else(|| tokens.refresh_token.clone());
 
-    let api_key = token_exchange_id_token(&http, TOKEN_URL, CLIENT_ID, &id_token).await?;
+    // Same best-effort posture as `interactive_login`: refresh stays
+    // successful even if the user's account can't mint an OPENAI_API_KEY.
+    let api_key = match token_exchange_id_token(&http, TOKEN_URL, CLIENT_ID, &id_token).await {
+        Ok(key) => Some(key),
+        Err(e) => {
+            tracing::debug!("token-exchange skipped during refresh: {e:#}");
+            // Preserve any previously-stored key rather than wiping
+            // it -- a transient failure shouldn't drop an apikey-mode
+            // user's working credentials.
+            auth.openai_api_key.clone()
+        }
+    };
     let account_id = extract_chatgpt_account_id(&refreshed.access_token)?;
 
     *auth = AuthDotJson {
         auth_mode: Some("chatgpt".to_string()),
-        openai_api_key: Some(api_key),
+        openai_api_key: api_key,
         tokens: Some(TokenData {
             id_token,
             access_token: refreshed.access_token,

--- a/brokk-acp-rust/src/codex_auth.rs
+++ b/brokk-acp-rust/src/codex_auth.rs
@@ -191,7 +191,7 @@ fn build_authorize_url(challenge: &PkceCodeChallenge, state: &str) -> String {
 /// Minimal percent-encoder for the handful of characters that show up
 /// in our query values (`/`, `:`, `=`, etc.). Avoids pulling in `url`
 /// just to call `Url::parse`/`form_urlencoded::byte_serialize`.
-fn urlencode(s: &str) -> String {
+pub(crate) fn urlencode(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {
         match b {
@@ -336,14 +336,20 @@ pub async fn interactive_login() -> Result<AuthDotJson> {
     Ok(auth)
 }
 
+/// True when `auth.last_refresh` is older than `REFRESH_AFTER`. Mirrors
+/// `refresh_if_stale`'s "no last_refresh => not stale" branch so callers
+/// can cheaply skip the refresh lock when nothing needs to happen.
+pub fn is_stale(auth: &AuthDotJson) -> bool {
+    match auth.last_refresh {
+        Some(ts) => Utc::now() - ts >= REFRESH_AFTER,
+        None => false,
+    }
+}
+
 /// Refresh the API key if the stored credentials are stale. Used on
 /// startup so long-running ACP sessions don't 401 mid-flight.
 pub async fn refresh_if_stale(auth: &mut AuthDotJson) -> Result<bool> {
-    let last = match auth.last_refresh {
-        Some(ts) => ts,
-        None => return Ok(false),
-    };
-    if Utc::now() - last < REFRESH_AFTER {
+    if !is_stale(auth) {
         return Ok(false);
     }
     let tokens = auth

--- a/brokk-acp-rust/src/codex_auth.rs
+++ b/brokk-acp-rust/src/codex_auth.rs
@@ -31,7 +31,29 @@ const AUTH_URL: &str = "https://auth.openai.com/oauth/authorize";
 const TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 const CALLBACK_PORT: u16 = 1455;
 const REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
-const SCOPES: &[&str] = &["openid", "profile", "email", "offline_access"];
+
+/// OAuth scopes Codex CLI requests during ChatGPT login. The two
+/// `api.connectors.*` scopes plus `id_token_add_organizations` /
+/// `codex_cli_simplified_flow` flags below are what flips the consent
+/// page from the legacy "API organization access" screen (the one that
+/// says "Codex will receive a token to generate API keys") to the
+/// ChatGPT-subscription consent screen. Drop any of them and OpenAI
+/// silently routes us back to the API-key flow.
+const SCOPES: &[&str] = &[
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "api.connectors.read",
+    "api.connectors.invoke",
+];
+
+/// Identifies our requests as Codex CLI to OpenAI's auth and Responses
+/// servers. The ChatGPT-subscription consent UI and the
+/// `chatgpt.com/backend-api/codex/responses` gateway both gate on this
+/// value -- using anything else (or omitting it) is what produced the
+/// "API organization access" screen reported in #3540's review.
+const CODEX_ORIGINATOR: &str = "codex_cli_rs";
 
 /// Refresh proactively if the stored credentials are older than this.
 /// Codex CLI uses an 8-day window; we follow suit.
@@ -129,20 +151,40 @@ struct OidcTokenResponse {
 }
 
 fn build_authorize_url(challenge: &PkceCodeChallenge, state: &str) -> String {
-    // OAuth2 RFC 6749 + PKCE RFC 7636. We URL-encode the scope string
-    // because " " inside a query value must be either "+" or "%20".
-    let scopes_encoded = SCOPES.join("%20");
+    // OAuth2 RFC 6749 + PKCE RFC 7636 plus three Codex-specific flags
+    // that Codex CLI passes verbatim:
+    //   * `id_token_add_organizations=true` -> the auth server includes
+    //     the user's organization claim in the issued id_token, which
+    //     downstream code uses to derive `chatgpt_account_id`.
+    //   * `codex_cli_simplified_flow=true` -> tells OpenAI to render the
+    //     ChatGPT-subscription consent screen ("Sign in with ChatGPT")
+    //     instead of the legacy API-organization screen. Omitting this
+    //     was the bug behind the "Codex requests access to your API
+    //     organization" page users were seeing.
+    //   * `originator=codex_cli_rs` -> identifies us as Codex CLI both
+    //     to the consent UI and to the chatgpt.com/backend-api gateway.
+    // Scopes already cover `api.connectors.*`; see SCOPES above for why
+    // those are required for the simplified flow.
+    let scopes_encoded = SCOPES
+        .iter()
+        .map(|s| urlencode(s))
+        .collect::<Vec<_>>()
+        .join("%20");
     format!(
         "{AUTH_URL}?response_type=code\
          &client_id={CLIENT_ID}\
          &redirect_uri={redirect}\
          &scope={scopes_encoded}\
-         &state={state}\
          &code_challenge={code_challenge}\
-         &code_challenge_method=S256",
+         &code_challenge_method=S256\
+         &id_token_add_organizations=true\
+         &codex_cli_simplified_flow=true\
+         &state={state}\
+         &originator={originator}",
         redirect = urlencode(REDIRECT_URI),
         state = urlencode(state),
         code_challenge = challenge.as_str(),
+        originator = urlencode(CODEX_ORIGINATOR),
     )
 }
 
@@ -599,5 +641,39 @@ mod tests {
         let url = "/auth/callback?error=access_denied&state=xyz";
         let err = parse_callback_url(url, "xyz").unwrap_err().to_string();
         assert!(err.contains("access_denied"));
+    }
+
+    #[test]
+    fn authorize_url_carries_codex_simplified_flow_flags() {
+        // These three params + the connectors scopes are exactly what
+        // flips OpenAI's consent screen from "API organization access"
+        // to "Sign in with ChatGPT". Regression-guard them: dropping
+        // any one silently routes the user back to the API-key flow.
+        let (challenge, _verifier) = oauth2::PkceCodeChallenge::new_random_sha256();
+        let url = build_authorize_url(&challenge, "test-state");
+        assert!(
+            url.contains("codex_cli_simplified_flow=true"),
+            "missing codex_cli_simplified_flow flag in {url}"
+        );
+        assert!(
+            url.contains("id_token_add_organizations=true"),
+            "missing id_token_add_organizations flag in {url}"
+        );
+        assert!(
+            url.contains("originator=codex_cli_rs"),
+            "missing originator=codex_cli_rs in {url}"
+        );
+        assert!(
+            url.contains("api.connectors.read"),
+            "missing api.connectors.read scope in {url}"
+        );
+        assert!(
+            url.contains("api.connectors.invoke"),
+            "missing api.connectors.invoke scope in {url}"
+        );
+        // Sanity: still PKCE + CSRF.
+        assert!(url.contains("code_challenge="));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("state=test-state"));
     }
 }

--- a/brokk-acp-rust/src/codex_client.rs
+++ b/brokk-acp-rust/src/codex_client.rs
@@ -97,10 +97,32 @@ impl Default for CodexClient {
 
 impl CodexClient {
     pub fn new() -> Self {
+        // The ChatGPT backend sits behind Cloudflare. Without a cookie
+        // jar we drop Cloudflare's `__cf_bm` / `cf_clearance` / etc. set
+        // on the first response, which makes the bot manager
+        // increasingly suspicious of us across requests -- it can return
+        // 403 or a challenge HTML page instead of JSON, and the
+        // `/models` endpoint is more aggressive about that than
+        // `/responses`. `cookie_store(true)` gives us a per-client jar
+        // that quietly accumulates those cookies. We're not as strict
+        // as codex-rs about allowlisting only Cloudflare names; the
+        // jar is local to this client and the only host we talk to is
+        // chatgpt.com.
+        //
+        // The User-Agent matches Codex CLI's `codex_cli_rs/<ver> (<os>)`
+        // shape so we present as one of the first-party originators
+        // the consent screen + Responses backend recognize. Cloudflare
+        // is sensitive to user-agent strings that look like bots.
+        let user_agent = format!(
+            "{ORIGINATOR}/{ver} (brokk-acp; {os})",
+            ver = env!("CARGO_PKG_VERSION"),
+            os = std::env::consts::OS,
+        );
         let http = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(600))
-            .user_agent(format!("{ORIGINATOR}/brokk-acp"))
+            .cookie_store(true)
+            .user_agent(user_agent)
             .build()
             .expect("failed to build HTTP client");
         Self {
@@ -250,18 +272,27 @@ impl CodexClient {
     }
 }
 
-/// GET `chatgpt.com/backend-api/codex/models` and return the slugs.
-/// Sorted by the server-supplied `priority` (descending) so the most
-/// recommended model surfaces first in the picker -- matches Codex CLI's
-/// ordering. Models with `visibility != "hidden"` are included; we
-/// intentionally don't filter on `supported_in_api` because the
-/// ChatGPT backend ignores that field.
+/// GET `chatgpt.com/backend-api/codex/models?client_version=...` and
+/// return the slugs. Sorted by the server-supplied `priority`
+/// (descending) so the most recommended model surfaces first in the
+/// picker -- matches Codex CLI's ordering.
+///
+/// We attach `client_version` because the ChatGPT backend uses it for
+/// version-gated rollout (older clients see a different list). Reading
+/// the body as bytes first lets us surface an excerpt in the error
+/// message when the server returns a Cloudflare HTML challenge or any
+/// other non-JSON payload, which used to fail silently with `parsing
+/// /models JSON: expected value at line 1 column 1`.
 async fn fetch_chatgpt_models(
     http: &reqwest::Client,
     creds: &ChatGptCredentials,
 ) -> Result<Vec<String>> {
+    let url = format!(
+        "{CHATGPT_MODELS_URL}?client_version={}",
+        urlencode_minimal(env!("CARGO_PKG_VERSION"))
+    );
     let resp = http
-        .get(CHATGPT_MODELS_URL)
+        .get(&url)
         .header("Authorization", format!("Bearer {}", creds.access_token))
         .header("ChatGPT-Account-ID", &creds.account_id)
         .header("originator", ORIGINATOR)
@@ -270,11 +301,37 @@ async fn fetch_chatgpt_models(
         .await
         .context("GET /models")?;
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(ToString::to_string);
+    let body_bytes = resp
+        .bytes()
+        .await
+        .context("reading /models response body")?;
+
     if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("ChatGPT /models returned HTTP {status}: {}", body.trim());
+        let excerpt = body_excerpt(&body_bytes, 256);
+        anyhow::bail!(
+            "ChatGPT /models returned HTTP {status} (content-type: {ct}): {excerpt}",
+            ct = content_type.as_deref().unwrap_or("(none)")
+        );
     }
-    let parsed: ChatGptModelsResponse = resp.json().await.context("parsing /models JSON")?;
+    // Cloudflare challenges come back 200 OK with text/html. Fail loud
+    // rather than try to parse them as JSON.
+    if let Some(ct) = &content_type
+        && !ct.contains("json")
+    {
+        let excerpt = body_excerpt(&body_bytes, 256);
+        anyhow::bail!("ChatGPT /models returned non-JSON response (content-type: {ct}): {excerpt}");
+    }
+    let parsed: ChatGptModelsResponse = serde_json::from_slice(&body_bytes).with_context(|| {
+        format!(
+            "parsing /models JSON (excerpt: {})",
+            body_excerpt(&body_bytes, 256)
+        )
+    })?;
     let mut models = parsed.models;
     // Drop hidden / disabled entries; preserve everything else and let
     // the priority sort decide ordering.
@@ -282,7 +339,45 @@ async fn fetch_chatgpt_models(
     // Higher priority first -- Codex's UI does the same. Stable sort so
     // ties keep server order (which is already curated).
     models.sort_by_key(|m| std::cmp::Reverse(m.priority));
+    tracing::info!(
+        "ChatGPT /models returned {} slugs after filtering: {:?}",
+        models.len(),
+        models.iter().map(|m| m.slug.as_str()).collect::<Vec<_>>()
+    );
     Ok(models.into_iter().map(|m| m.slug).collect())
+}
+
+/// Render up to `limit` bytes of `body` as a debug-safe string. Used
+/// only in error paths -- we don't trust the body to be UTF-8 (a
+/// Cloudflare challenge page might be) but `from_utf8_lossy` always
+/// gives us *something* readable in logs.
+fn body_excerpt(body: &[u8], limit: usize) -> String {
+    let slice = if body.len() > limit {
+        &body[..limit]
+    } else {
+        body
+    };
+    let s = String::from_utf8_lossy(slice).replace('\n', " ");
+    if body.len() > limit {
+        format!("{s}... (truncated, {} total bytes)", body.len())
+    } else {
+        s
+    }
+}
+
+/// Minimal percent-encoder for query values. Avoids pulling in `url`
+/// just to encode a semver string.
+fn urlencode_minimal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
 }
 
 #[derive(Debug, Deserialize)]

--- a/brokk-acp-rust/src/codex_client.rs
+++ b/brokk-acp-rust/src/codex_client.rs
@@ -1,0 +1,924 @@
+//! ChatGPT-subscription-backed LLM backend.
+//!
+//! Talks to `https://chatgpt.com/backend-api/codex/responses` (the
+//! Responses API, not Chat Completions) using the OAuth `access_token`
+//! and `chatgpt_account_id` stored in `~/.codex/auth.json`. This is the
+//! same endpoint Codex CLI hits when you `codex login` with a ChatGPT
+//! Plus/Pro/Enterprise account, so usage counts against the ChatGPT
+//! subscription rather than against an `OPENAI_API_KEY`.
+//!
+//! Why a separate client? The standard `/v1/chat/completions` path takes
+//! Chat Completions JSON (messages, tool_calls). The ChatGPT backend
+//! takes the Responses API shape (typed `input` items, `function_call` /
+//! `function_call_output`) and streams a different SSE schema
+//! (`response.output_text.delta`, `response.output_item.done`,
+//! `response.completed`). Reusing `OpenAiClient` would mean entangling
+//! two protocols in one type; a sibling client is cleaner.
+//!
+//! Trust posture: the `Authorization` and `ChatGPT-Account-ID` headers
+//! mirror what `codex` CLI sends. We deliberately set `originator:
+//! codex_cli_rs` and `User-Agent: codex_cli_rs ...` so brokk-acp shows
+//! up identically to Codex CLI from the server's perspective -- this is
+//! a pragmatic compatibility choice, not impersonation: the user *is*
+//! authenticating with their own OAuth tokens.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use futures::Stream;
+use futures::StreamExt;
+use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::codex_auth::{AuthDotJson, read_auth_dot_json, refresh_if_stale, write_auth_dot_json};
+use crate::llm_client::{
+    ChatMessage, FunctionCall, LlmBackend, LlmResponse, ToolCall, ToolDefinition,
+};
+
+/// Default Responses endpoint for "Sign in with ChatGPT" subscriptions.
+/// Codex CLI's `chatgpt_base_url` config defaults to the directory
+/// (`/backend-api/codex`); we append `/responses` to land on the
+/// Responses API specifically.
+const CHATGPT_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+
+/// Originator header value Codex CLI sends. The server gates ChatGPT-
+/// subscription usage on this identity (alongside the OAuth token), so
+/// matching it is the difference between the request being honored on
+/// the ChatGPT plan and being rejected as an unrecognized client.
+const ORIGINATOR: &str = "codex_cli_rs";
+
+/// Mirror Codex CLI's idle-timeout posture: long reasoning pauses are
+/// fine, but a server that drip-feeds keepalives forever should not
+/// hold the connection open. Aligned with `OpenAiClient`'s constant.
+const IDLE_CHUNK_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Default model list surfaced via ACP `initialize` when the user runs
+/// `--use-codex`. The Responses API has no `/models` listing on the
+/// ChatGPT backend, so we publish the slugs Codex CLI exposes in its
+/// model picker. The user can still type any other slug; we forward it
+/// verbatim. Order matters: the first entry becomes the session
+/// default unless overridden by `--default-model`.
+const DEFAULT_CHATGPT_MODELS: &[&str] = &[
+    "gpt-5-codex",
+    "gpt-5.1-codex",
+    "gpt-5",
+    "gpt-5.1",
+    "gpt-5-pro",
+];
+
+/// LLM backend that proxies to the ChatGPT subscription via the
+/// Responses API. Reads `~/.codex/auth.json` on every request and
+/// transparently refreshes the OAuth tokens when they go stale.
+pub struct CodexClient {
+    http: reqwest::Client,
+    /// Serialize concurrent token-refresh attempts. Without this, two
+    /// in-flight prompts hitting a 401 race each other into the refresh
+    /// endpoint and one of the resulting `refresh_token` values gets
+    /// invalidated by the server's rotation policy.
+    refresh_lock: Arc<Mutex<()>>,
+}
+
+impl std::fmt::Debug for CodexClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexClient").finish()
+    }
+}
+
+impl Default for CodexClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexClient {
+    pub fn new() -> Self {
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(600))
+            .user_agent(format!("{ORIGINATOR}/brokk-acp"))
+            .build()
+            .expect("failed to build HTTP client");
+        Self {
+            http,
+            refresh_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    /// Load fresh credentials from disk, refreshing the OAuth tokens if
+    /// they're past Codex's 8-day staleness window. Held under
+    /// `refresh_lock` so concurrent prompts don't race on the refresh
+    /// endpoint.
+    async fn load_credentials(&self) -> Result<ChatGptCredentials> {
+        let _guard = self.refresh_lock.lock().await;
+        let mut auth = read_auth_dot_json()?.ok_or_else(|| {
+            anyhow!("~/.codex/auth.json not found; run /codex-login to authenticate")
+        })?;
+        if !is_chatgpt_mode(&auth) {
+            anyhow::bail!(
+                "auth.json has auth_mode={:?} (need \"chatgpt\" for subscription routing); \
+                 re-run /codex-login or drop --use-codex to fall back to OPENAI_API_KEY",
+                auth.auth_mode
+            );
+        }
+        if let Err(e) = refresh_if_stale(&mut auth).await {
+            tracing::warn!("proactive token refresh failed (will retry on 401): {e:#}");
+        }
+        ChatGptCredentials::from_auth(&auth)
+    }
+
+    /// Force a fresh token regardless of `last_refresh`. Used after a
+    /// 401 to retry once with rotated credentials before giving up.
+    async fn force_refresh(&self) -> Result<ChatGptCredentials> {
+        let _guard = self.refresh_lock.lock().await;
+        let mut auth = read_auth_dot_json()?
+            .ok_or_else(|| anyhow!("~/.codex/auth.json disappeared between requests"))?;
+        if !is_chatgpt_mode(&auth) {
+            anyhow::bail!("auth.json no longer in chatgpt mode");
+        }
+        // Pretend the credentials are old enough to need refresh by
+        // backdating last_refresh past Codex's 8-day window. We avoid
+        // calling the refresh endpoint directly here so the staleness
+        // policy stays in one place (`codex_auth::refresh_if_stale`).
+        auth.last_refresh = Some(chrono::Utc::now() - chrono::Duration::days(30));
+        write_auth_dot_json(&auth)?;
+        if let Err(e) = refresh_if_stale(&mut auth).await {
+            return Err(e.context("forced token refresh failed"));
+        }
+        ChatGptCredentials::from_auth(&auth)
+    }
+
+    async fn stream_chat_impl(
+        &self,
+        model: String,
+        messages: Vec<ChatMessage>,
+        tools: Option<Vec<ToolDefinition>>,
+        on_token: Box<dyn FnMut(&str) + Send>,
+        cancel: CancellationToken,
+    ) -> Result<LlmResponse> {
+        let creds = self.load_credentials().await?;
+        let body = build_responses_request(&model, &messages, tools.as_deref());
+        match self
+            .send_responses_request(&creds, &body, on_token, cancel.clone())
+            .await
+        {
+            Ok(resp) => Ok(resp),
+            Err(e) if is_unauthorized(&e) => {
+                tracing::info!("ChatGPT backend returned 401; refreshing tokens and retrying once");
+                let creds = self.force_refresh().await?;
+                // Caller's on_token sink is consumed by the first attempt;
+                // build a no-op sink for the retry so the trait stays
+                // FnMut-only. Streaming text from the retry still flows
+                // back via `LlmResponse::Text`.
+                let noop: Box<dyn FnMut(&str) + Send> = Box::new(|_| {});
+                self.send_responses_request(&creds, &body, noop, cancel)
+                    .await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn send_responses_request(
+        &self,
+        creds: &ChatGptCredentials,
+        body: &ResponsesRequest,
+        on_token: Box<dyn FnMut(&str) + Send>,
+        cancel: CancellationToken,
+    ) -> Result<LlmResponse> {
+        let req = self
+            .http
+            .post(CHATGPT_RESPONSES_URL)
+            .header("Authorization", format!("Bearer {}", creds.access_token))
+            .header("ChatGPT-Account-ID", &creds.account_id)
+            .header("originator", ORIGINATOR)
+            .header("Accept", "text/event-stream")
+            .json(body);
+
+        let resp = req.send().await.context("posting Responses API request")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "ChatGPT Responses API returned HTTP {status}: {}",
+                body_text.trim()
+            );
+        }
+
+        let stream = resp
+            .bytes_stream()
+            .map(|r| r.map(|b| b.to_vec()).map_err(anyhow::Error::from));
+
+        drive_responses_sse_stream(stream, on_token, cancel, IDLE_CHUNK_TIMEOUT).await
+    }
+}
+
+impl LlmBackend for CodexClient {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>>> {
+        // The ChatGPT backend has no `/v1/models` listing -- Codex CLI
+        // ships a hardcoded picker for exactly the same reason. Surface
+        // a known-good list so ACP `initialize` advertises something
+        // sensible; the user can still type any slug as the session
+        // model and we'll forward it verbatim.
+        Box::pin(async {
+            Ok(DEFAULT_CHATGPT_MODELS
+                .iter()
+                .map(|s| s.to_string())
+                .collect())
+        })
+    }
+
+    fn stream_chat(
+        &self,
+        model: &str,
+        messages: Vec<ChatMessage>,
+        tools: Option<Vec<ToolDefinition>>,
+        on_token: Box<dyn FnMut(&str) + Send>,
+        cancel: CancellationToken,
+    ) -> BoxFuture<'_, Result<LlmResponse>> {
+        let model = model.to_string();
+        Box::pin(self.stream_chat_impl(model, messages, tools, on_token, cancel))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Credentials extracted from auth.json
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct ChatGptCredentials {
+    access_token: String,
+    account_id: String,
+}
+
+impl ChatGptCredentials {
+    fn from_auth(auth: &AuthDotJson) -> Result<Self> {
+        let tokens = auth
+            .tokens
+            .as_ref()
+            .ok_or_else(|| anyhow!("auth.json has no `tokens` block; run /codex-login again"))?;
+        if tokens.access_token.is_empty() {
+            anyhow::bail!("auth.json `tokens.access_token` is empty");
+        }
+        if tokens.account_id.is_empty() {
+            anyhow::bail!("auth.json `tokens.account_id` is empty");
+        }
+        Ok(Self {
+            access_token: tokens.access_token.clone(),
+            account_id: tokens.account_id.clone(),
+        })
+    }
+}
+
+fn is_chatgpt_mode(auth: &AuthDotJson) -> bool {
+    matches!(auth.auth_mode.as_deref(), Some("chatgpt"))
+}
+
+/// Heuristic 401 detector. We can't introspect the original `reqwest`
+/// status because `send_responses_request` collapses non-success
+/// responses into an `anyhow!` carrying the body. Looking for "HTTP
+/// 401" in the message is brittle but localized to this file; a richer
+/// retry path can swap this for a typed error later.
+fn is_unauthorized(err: &anyhow::Error) -> bool {
+    let s = format!("{err}");
+    s.contains("HTTP 401") || s.contains("invalid_token") || s.contains("token_expired")
+}
+
+// ---------------------------------------------------------------------------
+// Responses API request shape
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ResponsesRequest {
+    pub(crate) model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) instructions: Option<String>,
+    pub(crate) input: Vec<ResponsesInputItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tools: Option<Vec<ResponsesToolDef>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tool_choice: Option<String>,
+    pub(crate) parallel_tool_calls: bool,
+    pub(crate) stream: bool,
+    /// Don't ask the server to retain this request; brokk owns its own
+    /// session/turn persistence and we don't want a side-channel copy
+    /// living on OpenAI's storage tied to the user's subscription.
+    pub(crate) store: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ResponsesInputItem {
+    Message {
+        role: String,
+        content: Vec<ResponsesContent>,
+    },
+    FunctionCall {
+        name: String,
+        arguments: String,
+        call_id: String,
+    },
+    FunctionCallOutput {
+        call_id: String,
+        output: String,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ResponsesContent {
+    InputText { text: String },
+    OutputText { text: String },
+}
+
+/// Responses API tool descriptor. Differs from Chat Completions: name
+/// and parameters are at the top level (not nested under `function`),
+/// and there's no separate `type: "function"` wrapping object.
+#[derive(Debug, Serialize)]
+pub(crate) struct ResponsesToolDef {
+    pub(crate) r#type: String,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) parameters: serde_json::Value,
+}
+
+/// Convert brokk's Chat-Completions-shaped messages into the typed
+/// Responses-API `input` items. System messages collapse into the
+/// top-level `instructions` field (concatenated in arrival order so
+/// later system prompts can extend earlier ones); the rest map 1:1 with
+/// a small splay because each assistant tool-call expands to one
+/// `function_call` item per call.
+pub(crate) fn build_responses_request(
+    model: &str,
+    messages: &[ChatMessage],
+    tools: Option<&[ToolDefinition]>,
+) -> ResponsesRequest {
+    let mut instructions_parts: Vec<String> = Vec::new();
+    let mut input: Vec<ResponsesInputItem> = Vec::new();
+
+    for msg in messages {
+        match msg.role.as_str() {
+            "system" => {
+                if let Some(text) = &msg.content {
+                    instructions_parts.push(text.clone());
+                }
+            }
+            "user" => {
+                if let Some(text) = &msg.content {
+                    input.push(ResponsesInputItem::Message {
+                        role: "user".to_string(),
+                        content: vec![ResponsesContent::InputText { text: text.clone() }],
+                    });
+                }
+            }
+            "assistant" => {
+                if let Some(calls) = &msg.tool_calls {
+                    for call in calls {
+                        input.push(ResponsesInputItem::FunctionCall {
+                            name: call.function.name.clone(),
+                            arguments: call.function.arguments.clone(),
+                            call_id: call.id.clone(),
+                        });
+                    }
+                } else if let Some(text) = &msg.content {
+                    input.push(ResponsesInputItem::Message {
+                        role: "assistant".to_string(),
+                        content: vec![ResponsesContent::OutputText { text: text.clone() }],
+                    });
+                }
+            }
+            "tool" => {
+                if let (Some(call_id), Some(output)) = (&msg.tool_call_id, &msg.content) {
+                    input.push(ResponsesInputItem::FunctionCallOutput {
+                        call_id: call_id.clone(),
+                        output: output.clone(),
+                    });
+                }
+            }
+            other => {
+                tracing::debug!("dropping unknown role {other:?} when building Responses input");
+            }
+        }
+    }
+
+    let tools = tools.map(|defs| {
+        defs.iter()
+            .map(|d| ResponsesToolDef {
+                r#type: "function".to_string(),
+                name: d.function.name.clone(),
+                description: d.function.description.clone(),
+                parameters: d.function.parameters.clone(),
+            })
+            .collect()
+    });
+    let tool_choice = tools.as_ref().map(|_| "auto".to_string());
+
+    let instructions = if instructions_parts.is_empty() {
+        None
+    } else {
+        Some(instructions_parts.join("\n\n"))
+    };
+
+    ResponsesRequest {
+        model: model.to_string(),
+        instructions,
+        input,
+        tools,
+        tool_choice,
+        parallel_tool_calls: true,
+        stream: true,
+        store: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Responses API SSE parsing
+// ---------------------------------------------------------------------------
+
+/// Subset of `ResponsesStreamEvent` from codex-rs we actually consume.
+/// Unknown event types (`response.reasoning_summary_text.delta`,
+/// `response.metadata`, etc.) deserialize successfully but contribute
+/// nothing -- we surface only text deltas and final-shape items.
+#[derive(Debug, Deserialize)]
+struct StreamEvent {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    delta: Option<String>,
+    #[serde(default)]
+    item: Option<serde_json::Value>,
+    #[serde(default)]
+    response: Option<ResponseFinal>,
+}
+
+/// Body of a `response.completed` / `response.failed` event. Most
+/// fields are unused; we keep the struct minimal so server-side
+/// schema additions don't break parsing.
+#[derive(Debug, Deserialize)]
+struct ResponseFinal {
+    #[serde(default)]
+    error: Option<ResponseError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseError {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Output item parsed from `response.output_item.done`. Mirrors
+/// `codex_protocol::models::ResponseItem` but only the variants we
+/// surface (assistant message text and function calls).
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum OutputItem {
+    Message {
+        #[serde(default)]
+        role: Option<String>,
+        #[serde(default)]
+        content: Vec<OutputItemContent>,
+    },
+    FunctionCall {
+        #[serde(default)]
+        id: Option<String>,
+        name: String,
+        arguments: String,
+        #[serde(default)]
+        call_id: Option<String>,
+    },
+    /// Fallback for variants we don't model (Reasoning, LocalShellCall,
+    /// ToolSearchCall, ...). Keeps the deserializer permissive so a
+    /// future server adding new item types doesn't poison the stream.
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum OutputItemContent {
+    OutputText {
+        #[serde(default)]
+        text: String,
+    },
+    /// Same fallback strategy as `OutputItem::Other` -- ignore content
+    /// shapes (input_image, refusal, ...) we don't render.
+    #[serde(other)]
+    Other,
+}
+
+/// Drive a Responses-API SSE byte stream until `response.completed`,
+/// the stream ends, or the cancellation token fires. Emits text deltas
+/// to `on_token` as they arrive; collects function calls from
+/// `response.output_item.done` events. Idle-timeout posture matches
+/// `OpenAiClient::drive_sse_stream`.
+async fn drive_responses_sse_stream<S>(
+    mut stream: S,
+    mut on_token: Box<dyn FnMut(&str) + Send>,
+    cancel: CancellationToken,
+    idle: Duration,
+) -> Result<LlmResponse>
+where
+    S: Stream<Item = Result<Vec<u8>>> + Unpin,
+{
+    let mut full_text = String::new();
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    let mut raw_buf: Vec<u8> = Vec::new();
+    let mut deadline = tokio::time::Instant::now() + idle;
+    let mut completed = false;
+    let mut failure: Option<anyhow::Error> = None;
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                tracing::info!("Codex streaming cancelled by client");
+                break;
+            }
+            chunk_or_timeout = tokio::time::timeout_at(deadline, stream.next()) => {
+                let chunk_opt = match chunk_or_timeout {
+                    Ok(opt) => opt,
+                    Err(_elapsed) => anyhow::bail!(
+                        "Codex Responses stream made no meaningful progress for {}s; aborting",
+                        idle.as_secs()
+                    ),
+                };
+                let Some(chunk) = chunk_opt else { break; };
+                let chunk = chunk.context("Codex stream read error")?;
+                raw_buf.extend_from_slice(&chunk);
+
+                let mut made_progress = false;
+
+                while let Some(pos) = raw_buf.iter().position(|&b| b == b'\n') {
+                    let line_bytes = raw_buf.drain(..=pos).collect::<Vec<_>>();
+                    let line = String::from_utf8_lossy(&line_bytes).trim().to_string();
+
+                    if line.is_empty() || line.starts_with(':') || line.starts_with("event:") {
+                        // Blank lines, SSE comments, and `event:` markers
+                        // are all non-data: the JSON we need rides on
+                        // `data: ...` lines and carries its own `type`
+                        // discriminator, so we don't track `event:`.
+                        continue;
+                    }
+
+                    let data = if let Some(stripped) = line.strip_prefix("data: ") {
+                        stripped.trim()
+                    } else if let Some(stripped) = line.strip_prefix("data:") {
+                        stripped.trim()
+                    } else {
+                        continue;
+                    };
+
+                    if data == "[DONE]" {
+                        completed = true;
+                        break;
+                    }
+
+                    let Ok(event) = serde_json::from_str::<StreamEvent>(data) else {
+                        tracing::debug!("skipping unparseable Responses SSE chunk: {data}");
+                        continue;
+                    };
+
+                    match event.kind.as_str() {
+                        "response.output_text.delta" => {
+                            if let Some(delta) = event.delta {
+                                made_progress = true;
+                                on_token(&delta);
+                                full_text.push_str(&delta);
+                            }
+                        }
+                        "response.output_item.done" => {
+                            if let Some(item_val) = event.item
+                                && let Ok(item) = serde_json::from_value::<OutputItem>(item_val)
+                            {
+                                match item {
+                                    OutputItem::Message { role, content } => {
+                                        // Some servers stream the entire
+                                        // assistant message via output_item.done
+                                        // without ever emitting deltas (e.g. a
+                                        // very short reply or a cached completion).
+                                        // Backfill `full_text` from the item if
+                                        // we haven't seen any deltas yet so the
+                                        // caller still gets the assistant text.
+                                        if role.as_deref() == Some("assistant") && full_text.is_empty() {
+                                            for c in content {
+                                                if let OutputItemContent::OutputText { text } = c {
+                                                    on_token(&text);
+                                                    full_text.push_str(&text);
+                                                }
+                                            }
+                                        }
+                                        made_progress = true;
+                                    }
+                                    OutputItem::FunctionCall {
+                                        id,
+                                        name,
+                                        arguments,
+                                        call_id,
+                                    } => {
+                                        // The Responses API uses `call_id` as
+                                        // the persistent identifier; brokk's
+                                        // `ToolCall.id` doubles as the
+                                        // function_call_output `call_id`, so
+                                        // we copy that across. `id` is the
+                                        // server-side item id and not useful
+                                        // for tool-result correlation.
+                                        let resolved_id = call_id
+                                            .or(id)
+                                            .unwrap_or_else(|| format!("call_{}", tool_calls.len()));
+                                        tool_calls.push(ToolCall {
+                                            id: resolved_id,
+                                            r#type: "function".to_string(),
+                                            function: FunctionCall { name, arguments },
+                                        });
+                                        made_progress = true;
+                                    }
+                                    OutputItem::Other => {}
+                                }
+                            }
+                        }
+                        "response.completed" => {
+                            completed = true;
+                            break;
+                        }
+                        "response.failed" => {
+                            let msg = event
+                                .response
+                                .and_then(|r| r.error)
+                                .map(|e| {
+                                    let code = e.code.unwrap_or_else(|| "unknown".to_string());
+                                    let body = e.message.unwrap_or_default();
+                                    format!("{code}: {body}")
+                                })
+                                .unwrap_or_else(|| "unknown error".to_string());
+                            failure = Some(anyhow!("Codex Responses stream failed: {msg}"));
+                            completed = true;
+                            break;
+                        }
+                        // Reasoning summaries, metadata, rate-limit
+                        // snapshots, etc. -- we don't surface them but
+                        // count them as activity so the idle timer
+                        // doesn't fire mid-think.
+                        _ => {
+                            made_progress = true;
+                        }
+                    }
+                }
+
+                if completed {
+                    break;
+                }
+                if made_progress {
+                    deadline = tokio::time::Instant::now() + idle;
+                }
+            }
+        }
+    }
+
+    if let Some(err) = failure {
+        return Err(err);
+    }
+
+    if cancel.is_cancelled() {
+        return Ok(LlmResponse::Text(full_text));
+    }
+
+    if tool_calls.is_empty() {
+        Ok(LlmResponse::Text(full_text))
+    } else {
+        Ok(LlmResponse::ToolCalls {
+            text: full_text,
+            calls: tool_calls,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_client::{ChatMessage, FunctionCall, FunctionDef, ToolCall, ToolDefinition};
+    use serde_json::json;
+
+    fn sink_collecting(
+        buf: std::sync::Arc<std::sync::Mutex<String>>,
+    ) -> Box<dyn FnMut(&str) + Send> {
+        Box::new(move |t: &str| buf.lock().unwrap().push_str(t))
+    }
+
+    #[test]
+    fn build_request_collapses_system_messages_into_instructions() {
+        let messages = vec![
+            ChatMessage::system("be helpful"),
+            ChatMessage::system("also be brief"),
+            ChatMessage::user("hi"),
+        ];
+        let req = build_responses_request("gpt-5-codex", &messages, None);
+        assert_eq!(
+            req.instructions.as_deref(),
+            Some("be helpful\n\nalso be brief")
+        );
+        assert_eq!(req.input.len(), 1);
+        match &req.input[0] {
+            ResponsesInputItem::Message { role, content } => {
+                assert_eq!(role, "user");
+                assert_eq!(content.len(), 1);
+                match &content[0] {
+                    ResponsesContent::InputText { text } => assert_eq!(text, "hi"),
+                    _ => panic!("expected input_text"),
+                }
+            }
+            _ => panic!("expected user message"),
+        }
+        assert!(req.tools.is_none());
+        assert!(req.tool_choice.is_none());
+        assert!(!req.store);
+        assert!(req.stream);
+    }
+
+    #[test]
+    fn build_request_emits_function_call_per_assistant_tool_call() {
+        let messages = vec![
+            ChatMessage::user("search for X"),
+            ChatMessage::assistant_tool_calls(vec![ToolCall {
+                id: "fc_abc".to_string(),
+                r#type: "function".to_string(),
+                function: FunctionCall {
+                    name: "search".to_string(),
+                    arguments: r#"{"q":"X"}"#.to_string(),
+                },
+            }]),
+            ChatMessage::tool_result("fc_abc", "search", "no results"),
+        ];
+        let req = build_responses_request("gpt-5-codex", &messages, None);
+        assert_eq!(req.input.len(), 3);
+        match &req.input[1] {
+            ResponsesInputItem::FunctionCall {
+                name,
+                arguments,
+                call_id,
+            } => {
+                assert_eq!(name, "search");
+                assert_eq!(arguments, r#"{"q":"X"}"#);
+                assert_eq!(call_id, "fc_abc");
+            }
+            _ => panic!("expected function_call"),
+        }
+        match &req.input[2] {
+            ResponsesInputItem::FunctionCallOutput { call_id, output } => {
+                assert_eq!(call_id, "fc_abc");
+                assert_eq!(output, "no results");
+            }
+            _ => panic!("expected function_call_output"),
+        }
+    }
+
+    #[test]
+    fn build_request_serializes_tools_at_top_level() {
+        let tools = vec![ToolDefinition {
+            r#type: "function".to_string(),
+            function: FunctionDef {
+                name: "ping".to_string(),
+                description: "check liveness".to_string(),
+                parameters: json!({"type": "object", "properties": {}}),
+            },
+        }];
+        let req = build_responses_request("gpt-5", &[ChatMessage::user("hi")], Some(&tools));
+        let serialized = serde_json::to_value(&req).unwrap();
+        let tools = serialized.get("tools").unwrap().as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        // Responses API: name and parameters are top-level on the tool
+        // object, not nested under `function` like Chat Completions.
+        assert_eq!(tools[0]["type"], "function");
+        assert_eq!(tools[0]["name"], "ping");
+        assert_eq!(tools[0]["description"], "check liveness");
+        assert!(tools[0].get("function").is_none());
+        assert_eq!(serialized.get("tool_choice").unwrap(), "auto");
+    }
+
+    #[test]
+    fn build_request_omits_assistant_text_when_tool_calls_present() {
+        // The Chat Completions input lets assistant messages carry both
+        // `content` and `tool_calls`; the Responses API splits those
+        // into separate items, and brokk's tool-loop never round-trips
+        // the assistant's pre-tool text. Match that here.
+        let messages = vec![ChatMessage {
+            role: "assistant".to_string(),
+            content: Some("ignored preamble".to_string()),
+            tool_calls: Some(vec![ToolCall {
+                id: "fc_1".to_string(),
+                r#type: "function".to_string(),
+                function: FunctionCall {
+                    name: "noop".to_string(),
+                    arguments: "{}".to_string(),
+                },
+            }]),
+            tool_call_id: None,
+            name: None,
+        }];
+        let req = build_responses_request("gpt-5", &messages, None);
+        assert_eq!(req.input.len(), 1);
+        assert!(matches!(
+            req.input[0],
+            ResponsesInputItem::FunctionCall { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn sse_parser_streams_text_deltas_and_tool_calls() {
+        let raw = concat!(
+            "data: {\"type\":\"response.created\",\"response\":{}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hel\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"name\":\"search\",\"arguments\":\"{\\\"q\\\":\\\"x\\\"}\",\"call_id\":\"fc_1\"}}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+        );
+        let stream = futures::stream::iter(vec![Ok(raw.as_bytes().to_vec())]);
+        let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let cb = sink_collecting(collected.clone());
+        let cancel = CancellationToken::new();
+        let resp = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
+            .await
+            .expect("stream completes");
+        match resp {
+            LlmResponse::ToolCalls { text, calls } => {
+                assert_eq!(text, "hello");
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].function.name, "search");
+                assert_eq!(calls[0].id, "fc_1");
+            }
+            other => panic!("expected ToolCalls, got {other:?}"),
+        }
+        assert_eq!(collected.lock().unwrap().as_str(), "hello");
+    }
+
+    #[tokio::test]
+    async fn sse_parser_backfills_text_from_output_item_done_when_no_deltas() {
+        // Some short replies ship the whole message in a single
+        // output_item.done event with no preceding deltas. The parser
+        // must still surface the assistant text in that case.
+        let raw = concat!(
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+        );
+        let stream = futures::stream::iter(vec![Ok(raw.as_bytes().to_vec())]);
+        let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let cb = sink_collecting(collected.clone());
+        let cancel = CancellationToken::new();
+        let resp = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
+            .await
+            .expect("stream completes");
+        match resp {
+            LlmResponse::Text(text) => assert_eq!(text, "ok"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+        assert_eq!(collected.lock().unwrap().as_str(), "ok");
+    }
+
+    #[tokio::test]
+    async fn sse_parser_surfaces_response_failed_as_error() {
+        let raw = "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"slow down\"}}}\n\n";
+        let stream = futures::stream::iter(vec![Ok(raw.as_bytes().to_vec())]);
+        let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let cb = sink_collecting(collected.clone());
+        let cancel = CancellationToken::new();
+        let err = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
+            .await
+            .expect_err("response.failed must surface as Err");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("rate_limit_exceeded"), "got: {msg}");
+        assert!(msg.contains("slow down"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn sse_parser_ignores_unknown_event_types() {
+        // New event types (reasoning summaries, rate-limit metadata,
+        // etc.) must not poison the stream -- they should keep the
+        // idle timer alive but contribute nothing to the result.
+        let raw = concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"thinking\"}\n\n",
+            "data: {\"type\":\"response.metadata\",\"metadata\":{}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+        );
+        let stream = futures::stream::iter(vec![Ok(raw.as_bytes().to_vec())]);
+        let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let cb = sink_collecting(collected.clone());
+        let cancel = CancellationToken::new();
+        let resp = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
+            .await
+            .expect("stream completes");
+        match resp {
+            LlmResponse::Text(text) => assert_eq!(text, "hi"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unauthorized_detector_matches_codex_responses_401_shape() {
+        let err = anyhow!("ChatGPT Responses API returned HTTP 401: {{...}}");
+        assert!(is_unauthorized(&err));
+        let other = anyhow!("ChatGPT Responses API returned HTTP 500: server error");
+        assert!(!is_unauthorized(&other));
+    }
+}

--- a/brokk-acp-rust/src/codex_client.rs
+++ b/brokk-acp-rust/src/codex_client.rs
@@ -33,7 +33,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use crate::codex_auth::{AuthDotJson, read_auth_dot_json, refresh_if_stale, write_auth_dot_json};
+use crate::codex_auth::{AuthDotJson, is_stale, read_auth_dot_json, refresh_if_stale, urlencode};
 use crate::llm_client::{
     ChatMessage, FunctionCall, LlmBackend, LlmResponse, ToolCall, ToolDefinition,
 };
@@ -151,12 +151,14 @@ impl CodexClient {
     }
 
     /// Load fresh credentials from disk, refreshing the OAuth tokens if
-    /// they're past Codex's 8-day staleness window. Held under
-    /// `refresh_lock` so concurrent prompts don't race on the refresh
-    /// endpoint.
+    /// they're past Codex's 8-day staleness window. The fast path
+    /// (credentials still fresh) bypasses `refresh_lock` so unrelated
+    /// prompts don't queue up behind each other on a no-op disk read;
+    /// the lock is only acquired when an actual refresh is warranted,
+    /// at which point we re-read under the lock to avoid duplicate
+    /// refreshes if another worker beat us to it.
     async fn load_credentials(&self) -> Result<ChatGptCredentials> {
-        let _guard = self.refresh_lock.lock().await;
-        let mut auth = read_auth_dot_json()?.ok_or_else(|| {
+        let auth = read_auth_dot_json()?.ok_or_else(|| {
             anyhow!("~/.codex/auth.json not found; run /codex-login to authenticate")
         })?;
         if !is_chatgpt_mode(&auth) {
@@ -166,7 +168,25 @@ impl CodexClient {
                 auth.auth_mode
             );
         }
-        if let Err(e) = refresh_if_stale(&mut auth).await {
+        if !is_stale(&auth) {
+            return ChatGptCredentials::from_auth(&auth);
+        }
+
+        // Stale -- serialize the refresh so concurrent prompts don't
+        // race each other into the refresh endpoint and invalidate one
+        // of the resulting refresh_token rotations.
+        let _guard = self.refresh_lock.lock().await;
+        // Re-read under the lock: another worker might have refreshed
+        // while we waited. Skip the refresh if so.
+        let mut auth = read_auth_dot_json()?.ok_or_else(|| {
+            anyhow!("~/.codex/auth.json disappeared while waiting for refresh lock")
+        })?;
+        if !is_chatgpt_mode(&auth) {
+            anyhow::bail!("auth.json switched out of chatgpt mode while waiting for refresh lock");
+        }
+        if is_stale(&auth)
+            && let Err(e) = refresh_if_stale(&mut auth).await
+        {
             tracing::warn!("proactive token refresh failed (will retry on 401): {e:#}");
         }
         ChatGptCredentials::from_auth(&auth)
@@ -182,11 +202,12 @@ impl CodexClient {
             anyhow::bail!("auth.json no longer in chatgpt mode");
         }
         // Pretend the credentials are old enough to need refresh by
-        // backdating last_refresh past Codex's 8-day window. We avoid
-        // calling the refresh endpoint directly here so the staleness
-        // policy stays in one place (`codex_auth::refresh_if_stale`).
+        // backdating last_refresh past Codex's 8-day window. We mutate
+        // this in memory only -- writing the backdated marker to disk
+        // would let other workers observe stale credentials and pile
+        // into the refresh endpoint themselves. refresh_if_stale will
+        // persist the new credentials atomically on success.
         auth.last_refresh = Some(chrono::Utc::now() - chrono::Duration::days(30));
-        write_auth_dot_json(&auth)?;
         if let Err(e) = refresh_if_stale(&mut auth).await {
             return Err(e.context("forced token refresh failed"));
         }
@@ -243,10 +264,10 @@ impl CodexClient {
         let status = resp.status();
         if !status.is_success() {
             let body_text = resp.text().await.unwrap_or_default();
-            anyhow::bail!(
-                "ChatGPT Responses API returned HTTP {status}: {}",
-                body_text.trim()
-            );
+            return Err(anyhow::Error::new(ChatGptHttpError {
+                status,
+                body: body_text.trim().to_string(),
+            }));
         }
 
         let stream = resp
@@ -308,7 +329,7 @@ async fn fetch_chatgpt_models(
 ) -> Result<Vec<String>> {
     let url = format!(
         "{CHATGPT_MODELS_URL}?client_version={}",
-        urlencode_minimal(CODEX_COMPAT_CLIENT_VERSION)
+        urlencode(CODEX_COMPAT_CLIENT_VERSION)
     );
     let resp = http
         .get(&url)
@@ -393,21 +414,6 @@ fn body_excerpt(body: &[u8], limit: usize) -> String {
     }
 }
 
-/// Minimal percent-encoder for query values. Avoids pulling in `url`
-/// just to encode a semver string.
-fn urlencode_minimal(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for b in s.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(b as char)
-            }
-            _ => out.push_str(&format!("%{b:02X}")),
-        }
-    }
-    out
-}
-
 #[derive(Debug, Deserialize)]
 struct ChatGptModelsResponse {
     #[serde(default)]
@@ -476,14 +482,40 @@ fn is_chatgpt_mode(auth: &AuthDotJson) -> bool {
     matches!(auth.auth_mode.as_deref(), Some("chatgpt"))
 }
 
-/// Heuristic 401 detector. We can't introspect the original `reqwest`
-/// status because `send_responses_request` collapses non-success
-/// responses into an `anyhow!` carrying the body. Looking for "HTTP
-/// 401" in the message is brittle but localized to this file; a richer
-/// retry path can swap this for a typed error later.
+/// Typed HTTP error so `is_unauthorized` can match on the status code
+/// rather than scanning the formatted error message. The previous
+/// string-match approach drifted out of sync whenever the upstream
+/// wording changed and conflated unrelated bodies that happened to
+/// mention "invalid_token". Putting the `StatusCode` in a downcastable
+/// struct makes the 401-retry path robust without leaking reqwest
+/// types to public APIs.
+#[derive(Debug)]
+struct ChatGptHttpError {
+    status: reqwest::StatusCode,
+    body: String,
+}
+
+impl std::fmt::Display for ChatGptHttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ChatGPT Responses API returned HTTP {}: {}",
+            self.status, self.body
+        )
+    }
+}
+
+impl std::error::Error for ChatGptHttpError {}
+
+/// Detect 401 by walking the anyhow chain for our typed
+/// `ChatGptHttpError`. Returns false for transport errors or other
+/// non-HTTP failures, which is the intended behavior -- we only retry
+/// once on an actual unauthorized response from the gateway.
 fn is_unauthorized(err: &anyhow::Error) -> bool {
-    let s = format!("{err}");
-    s.contains("HTTP 401") || s.contains("invalid_token") || s.contains("token_expired")
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<ChatGptHttpError>())
+        .map(|e| e.status == reqwest::StatusCode::UNAUTHORIZED)
+        .unwrap_or(false)
 }
 
 // ---------------------------------------------------------------------------
@@ -563,6 +595,10 @@ pub(crate) fn build_responses_request(
             "system" => {
                 if let Some(text) = &msg.content {
                     instructions_parts.push(text.clone());
+                } else {
+                    tracing::debug!(
+                        "dropping system message with no content when building Responses input"
+                    );
                 }
             }
             "user" => {
@@ -571,6 +607,10 @@ pub(crate) fn build_responses_request(
                         role: "user".to_string(),
                         content: vec![ResponsesContent::InputText { text: text.clone() }],
                     });
+                } else {
+                    tracing::debug!(
+                        "dropping user message with no content when building Responses input"
+                    );
                 }
             }
             "assistant" => {
@@ -587,6 +627,11 @@ pub(crate) fn build_responses_request(
                         role: "assistant".to_string(),
                         content: vec![ResponsesContent::OutputText { text: text.clone() }],
                     });
+                } else {
+                    tracing::debug!(
+                        "dropping assistant message with neither tool_calls nor content when \
+                         building Responses input"
+                    );
                 }
             }
             "tool" => {
@@ -595,6 +640,13 @@ pub(crate) fn build_responses_request(
                         call_id: call_id.clone(),
                         output: output.clone(),
                     });
+                } else {
+                    tracing::warn!(
+                        "dropping malformed tool message when building Responses input: \
+                         tool_call_id_present={} content_present={}",
+                        msg.tool_call_id.is_some(),
+                        msg.content.is_some()
+                    );
                 }
             }
             other => {
@@ -730,6 +782,12 @@ where
     let mut deadline = tokio::time::Instant::now() + idle;
     let mut completed = false;
     let mut failure: Option<anyhow::Error> = None;
+    // Track whether any text deltas were actually delivered so the
+    // output_item.done backfill below can distinguish "no deltas yet"
+    // from "deltas arrived but happened to be empty strings". Using
+    // `full_text.is_empty()` for that decision conflated the two and
+    // could double-emit the assistant text when a server sent both.
+    let mut deltas_received = false;
 
     loop {
         tokio::select! {
@@ -785,6 +843,7 @@ where
                         "response.output_text.delta" => {
                             if let Some(delta) = event.delta {
                                 made_progress = true;
+                                deltas_received = true;
                                 on_token(&delta);
                                 full_text.push_str(&delta);
                             }
@@ -799,10 +858,12 @@ where
                                         // assistant message via output_item.done
                                         // without ever emitting deltas (e.g. a
                                         // very short reply or a cached completion).
-                                        // Backfill `full_text` from the item if
-                                        // we haven't seen any deltas yet so the
-                                        // caller still gets the assistant text.
-                                        if role.as_deref() == Some("assistant") && full_text.is_empty() {
+                                        // Backfill `full_text` from the item only
+                                        // when no deltas were seen -- otherwise
+                                        // the deltas already carry the assistant
+                                        // text and re-emitting it duplicates the
+                                        // content for the caller.
+                                        if role.as_deref() == Some("assistant") && !deltas_received {
                                             for c in content {
                                                 if let OutputItemContent::OutputText { text } = c {
                                                     on_token(&text);
@@ -1077,6 +1138,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sse_parser_does_not_duplicate_text_when_deltas_and_output_item_done_overlap() {
+        // Some servers send both a delta stream AND a final
+        // output_item.done carrying the same assistant text. The
+        // parser must surface the deltas (which already drove
+        // on_token) and ignore the final item's content -- echoing
+        // it would double the visible reply.
+        let raw = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hel\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello\"}]}}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+        );
+        let stream = futures::stream::iter(vec![Ok(raw.as_bytes().to_vec())]);
+        let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let cb = sink_collecting(collected.clone());
+        let cancel = CancellationToken::new();
+        let resp = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
+            .await
+            .expect("stream completes");
+        match resp {
+            LlmResponse::Text(text) => assert_eq!(text, "hello"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+        assert_eq!(collected.lock().unwrap().as_str(), "hello");
+    }
+
+    #[tokio::test]
     async fn sse_parser_surfaces_response_failed_as_error() {
         let raw = "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"slow down\"}}}\n\n";
         let stream = futures::stream::iter(vec![Ok(raw.as_bytes().to_vec())]);
@@ -1117,10 +1205,33 @@ mod tests {
 
     #[test]
     fn unauthorized_detector_matches_codex_responses_401_shape() {
-        let err = anyhow!("ChatGPT Responses API returned HTTP 401: {{...}}");
+        let err = anyhow::Error::new(ChatGptHttpError {
+            status: reqwest::StatusCode::UNAUTHORIZED,
+            body: "{...}".to_string(),
+        });
         assert!(is_unauthorized(&err));
-        let other = anyhow!("ChatGPT Responses API returned HTTP 500: server error");
+        let other = anyhow::Error::new(ChatGptHttpError {
+            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            body: "server error".to_string(),
+        });
         assert!(!is_unauthorized(&other));
+        // Non-HTTP errors (e.g. transport failures) must not be
+        // misclassified as 401 -- the retry path would loop forever.
+        let transport = anyhow!("connection reset");
+        assert!(!is_unauthorized(&transport));
+    }
+
+    #[test]
+    fn unauthorized_detector_walks_anyhow_chain() {
+        // `is_unauthorized` runs after callers may have added their
+        // own `.context(...)` -- the typed cause must still be
+        // recoverable through the chain.
+        let err = anyhow::Error::new(ChatGptHttpError {
+            status: reqwest::StatusCode::UNAUTHORIZED,
+            body: "expired".to_string(),
+        })
+        .context("posting Responses API request");
+        assert!(is_unauthorized(&err));
     }
 
     #[test]

--- a/brokk-acp-rust/src/codex_client.rs
+++ b/brokk-acp-rust/src/codex_client.rs
@@ -38,11 +38,20 @@ use crate::llm_client::{
     ChatMessage, FunctionCall, LlmBackend, LlmResponse, ToolCall, ToolDefinition,
 };
 
-/// Default Responses endpoint for "Sign in with ChatGPT" subscriptions.
-/// Codex CLI's `chatgpt_base_url` config defaults to the directory
-/// (`/backend-api/codex`); we append `/responses` to land on the
-/// Responses API specifically.
+// Codex CLI's `chatgpt_base_url` default is
+// `https://chatgpt.com/backend-api/codex`; the Responses API and the
+// model-discovery endpoint both live under it. We spell each full URL
+// out below rather than concatenating from a shared base so the strings
+// are greppable verbatim.
+
+/// Streaming completions endpoint (Responses API).
 const CHATGPT_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+
+/// Model discovery endpoint. Returns `{"models": [{"slug": ..., "display_name": ..., ...}]}`
+/// for the slugs the user's ChatGPT plan can route to. Codex CLI fetches
+/// this on startup and caches it -- we do the same so the picker stays
+/// in step with whatever models OpenAI currently offers.
+const CHATGPT_MODELS_URL: &str = "https://chatgpt.com/backend-api/codex/models";
 
 /// Originator header value Codex CLI sends. The server gates ChatGPT-
 /// subscription usage on this identity (alongside the OAuth token), so
@@ -55,19 +64,12 @@ const ORIGINATOR: &str = "codex_cli_rs";
 /// hold the connection open. Aligned with `OpenAiClient`'s constant.
 const IDLE_CHUNK_TIMEOUT: Duration = Duration::from_secs(90);
 
-/// Default model list surfaced via ACP `initialize` when the user runs
-/// `--use-codex`. The Responses API has no `/models` listing on the
-/// ChatGPT backend, so we publish the slugs Codex CLI exposes in its
-/// model picker. The user can still type any other slug; we forward it
-/// verbatim. Order matters: the first entry becomes the session
-/// default unless overridden by `--default-model`.
-const DEFAULT_CHATGPT_MODELS: &[&str] = &[
-    "gpt-5-codex",
-    "gpt-5.1-codex",
-    "gpt-5",
-    "gpt-5.1",
-    "gpt-5-pro",
-];
+/// Last-resort fallback if `/models` is unreachable at startup. Kept
+/// to a single, well-known slug so we don't ship a stale, multi-entry
+/// picker that misleads the user (the original bug). One slug is enough
+/// to bootstrap a session; the user can always type another at the
+/// `/config` prompt and the server forwards it verbatim.
+const FALLBACK_CHATGPT_MODEL: &str = "gpt-5-codex";
 
 /// LLM backend that proxies to the ChatGPT subscription via the
 /// Responses API. Reads `~/.codex/auth.json` on every request and
@@ -212,21 +214,97 @@ impl CodexClient {
 
         drive_responses_sse_stream(stream, on_token, cancel, IDLE_CHUNK_TIMEOUT).await
     }
+
+    /// Discover usable model slugs by hitting `chatgpt.com/backend-api/codex/models`.
+    /// We deliberately don't ship a hardcoded picker any more: the
+    /// model lineup moves faster than our release cadence, and shipping
+    /// stale slugs (e.g. `gpt-5-pro` after that family is retired)
+    /// gives users an autocomplete full of models that 401 on first
+    /// use. On any error here we fall back to a single known slug
+    /// (`FALLBACK_CHATGPT_MODEL`) so ACP `initialize` still advertises
+    /// *something*; the user can override via `--default-model` or the
+    /// `/config` model picker.
+    async fn list_models_impl(&self) -> Result<Vec<String>> {
+        let creds = match self.load_credentials().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("skipping ChatGPT model discovery (credentials not ready): {e:#}");
+                return Ok(vec![FALLBACK_CHATGPT_MODEL.to_string()]);
+            }
+        };
+        match fetch_chatgpt_models(&self.http, &creds).await {
+            Ok(slugs) if !slugs.is_empty() => Ok(slugs),
+            Ok(_) => {
+                tracing::warn!(
+                    "ChatGPT /models endpoint returned no slugs; falling back to {FALLBACK_CHATGPT_MODEL}"
+                );
+                Ok(vec![FALLBACK_CHATGPT_MODEL.to_string()])
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "ChatGPT model discovery failed ({CHATGPT_MODELS_URL}): {e:#}; falling back to {FALLBACK_CHATGPT_MODEL}"
+                );
+                Ok(vec![FALLBACK_CHATGPT_MODEL.to_string()])
+            }
+        }
+    }
+}
+
+/// GET `chatgpt.com/backend-api/codex/models` and return the slugs.
+/// Sorted by the server-supplied `priority` (descending) so the most
+/// recommended model surfaces first in the picker -- matches Codex CLI's
+/// ordering. Models with `visibility != "hidden"` are included; we
+/// intentionally don't filter on `supported_in_api` because the
+/// ChatGPT backend ignores that field.
+async fn fetch_chatgpt_models(
+    http: &reqwest::Client,
+    creds: &ChatGptCredentials,
+) -> Result<Vec<String>> {
+    let resp = http
+        .get(CHATGPT_MODELS_URL)
+        .header("Authorization", format!("Bearer {}", creds.access_token))
+        .header("ChatGPT-Account-ID", &creds.account_id)
+        .header("originator", ORIGINATOR)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .context("GET /models")?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("ChatGPT /models returned HTTP {status}: {}", body.trim());
+    }
+    let parsed: ChatGptModelsResponse = resp.json().await.context("parsing /models JSON")?;
+    let mut models = parsed.models;
+    // Drop hidden / disabled entries; preserve everything else and let
+    // the priority sort decide ordering.
+    models.retain(|m| m.visibility.as_deref() != Some("hidden"));
+    // Higher priority first -- Codex's UI does the same. Stable sort so
+    // ties keep server order (which is already curated).
+    models.sort_by_key(|m| std::cmp::Reverse(m.priority));
+    Ok(models.into_iter().map(|m| m.slug).collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatGptModelsResponse {
+    #[serde(default)]
+    models: Vec<ChatGptModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatGptModelEntry {
+    slug: String,
+    #[serde(default)]
+    visibility: Option<String>,
+    /// Server-supplied ordering hint. Higher = more prominent in the
+    /// picker. Default to 0 if absent so missing-field models sort last.
+    #[serde(default)]
+    priority: i32,
 }
 
 impl LlmBackend for CodexClient {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>>> {
-        // The ChatGPT backend has no `/v1/models` listing -- Codex CLI
-        // ships a hardcoded picker for exactly the same reason. Surface
-        // a known-good list so ACP `initialize` advertises something
-        // sensible; the user can still type any slug as the session
-        // model and we'll forward it verbatim.
-        Box::pin(async {
-            Ok(DEFAULT_CHATGPT_MODELS
-                .iter()
-                .map(|s| s.to_string())
-                .collect())
-        })
+        Box::pin(self.list_models_impl())
     }
 
     fn stream_chat(
@@ -920,5 +998,59 @@ mod tests {
         assert!(is_unauthorized(&err));
         let other = anyhow!("ChatGPT Responses API returned HTTP 500: server error");
         assert!(!is_unauthorized(&other));
+    }
+
+    #[test]
+    fn parses_models_response_and_sorts_by_priority_descending() {
+        // Mirror a real ChatGPT /models payload (fields trimmed to the
+        // ones we deserialize). Priority-descending sort is what Codex
+        // CLI's picker does, so the most prominent slug surfaces first.
+        let raw = r#"{
+            "models": [
+                {"slug": "gpt-low",  "priority": 1},
+                {"slug": "gpt-high", "priority": 100},
+                {"slug": "gpt-mid",  "priority": 50,  "visibility": "public"},
+                {"slug": "gpt-hidden", "priority": 999, "visibility": "hidden"}
+            ]
+        }"#;
+        let parsed: ChatGptModelsResponse = serde_json::from_str(raw).unwrap();
+        let mut models = parsed.models;
+        models.retain(|m| m.visibility.as_deref() != Some("hidden"));
+        models.sort_by_key(|m| std::cmp::Reverse(m.priority));
+        let slugs: Vec<&str> = models.iter().map(|m| m.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["gpt-high", "gpt-mid", "gpt-low"]);
+    }
+
+    #[test]
+    fn parses_models_response_with_unknown_fields() {
+        // The real payload carries dozens of fields we don't model
+        // (reasoning levels, instructions templates, etc.). Make sure
+        // they don't break our deserializer.
+        let raw = r#"{
+            "models": [
+                {
+                    "slug": "gpt-future",
+                    "display_name": "GPT Future",
+                    "priority": 10,
+                    "supported_reasoning_levels": [],
+                    "shell_type": "default_shell",
+                    "visibility": "public",
+                    "supported_in_api": true,
+                    "base_instructions": "be helpful",
+                    "supports_reasoning_summaries": false,
+                    "support_verbosity": false,
+                    "default_verbosity": null,
+                    "apply_patch_tool_type": null,
+                    "truncation_policy": {"type": "auto"},
+                    "supports_parallel_tool_calls": true,
+                    "experimental_supported_tools": [],
+                    "availability_nux": null,
+                    "upgrade": null
+                }
+            ]
+        }"#;
+        let parsed: ChatGptModelsResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.models.len(), 1);
+        assert_eq!(parsed.models[0].slug, "gpt-future");
     }
 }

--- a/brokk-acp-rust/src/codex_client.rs
+++ b/brokk-acp-rust/src/codex_client.rs
@@ -71,6 +71,25 @@ const IDLE_CHUNK_TIMEOUT: Duration = Duration::from_secs(90);
 /// `/config` prompt and the server forwards it verbatim.
 const FALLBACK_CHATGPT_MODEL: &str = "gpt-5-codex";
 
+/// `client_version` we report to the ChatGPT backend. The server uses
+/// it to gate per-model rollout via each `ModelInfo.minimal_client_version`:
+/// any model whose minimum exceeds the value we send is filtered out
+/// of `/models` before it reaches us. Sending our own crate version
+/// (e.g. `0.1.0`) signals we're a primitive client and the server
+/// hands back only the lowest-common-denominator entry, which is what
+/// produced the "single old model" picker.
+///
+/// We pin this to a recent Codex CLI release tag so we get the same
+/// model list the official client gets. Bump it when the picker starts
+/// hiding new models that codex itself shows. (Spec lives at
+/// `codex-rs/Cargo.toml#workspace.package.version`; current GitHub
+/// releases tag e.g. `rust-v0.129.0-alpha.10` resolve to a
+/// `client_version_to_whole()` of `0.129.0`.) This is a shim, not
+/// impersonation: the user *is* authenticating with their own OAuth
+/// tokens, we're just declaring "I can handle any model Codex CLI
+/// at this version can handle."
+const CODEX_COMPAT_CLIENT_VERSION: &str = "0.129.0";
+
 /// LLM backend that proxies to the ChatGPT subscription via the
 /// Responses API. Reads `~/.codex/auth.json` on every request and
 /// transparently refreshes the OAuth tokens when they go stale.
@@ -289,7 +308,7 @@ async fn fetch_chatgpt_models(
 ) -> Result<Vec<String>> {
     let url = format!(
         "{CHATGPT_MODELS_URL}?client_version={}",
-        urlencode_minimal(env!("CARGO_PKG_VERSION"))
+        urlencode_minimal(CODEX_COMPAT_CLIENT_VERSION)
     );
     let resp = http
         .get(&url)

--- a/brokk-acp-rust/src/codex_client.rs
+++ b/brokk-acp-rust/src/codex_client.rs
@@ -352,9 +352,18 @@ async fn fetch_chatgpt_models(
         )
     })?;
     let mut models = parsed.models;
-    // Drop hidden / disabled entries; preserve everything else and let
-    // the priority sort decide ordering.
-    models.retain(|m| m.visibility.as_deref() != Some("hidden"));
+    // Codex's `ModelVisibility` enum has three values: `list` (show in
+    // picker), `hide` (don't show but still callable), and `none`
+    // (internal-only model used by Codex's review/automation hooks --
+    // e.g. `codex-auto-review`). Codex CLI itself only puts `list`
+    // models in its picker (`show_in_picker = info.visibility ==
+    // ModelVisibility::List`). Match that exactly so we don't surface
+    // automation-only slugs that the user can't sensibly chat with.
+    //
+    // The previous filter looked for `"hidden"` (wrong serialized
+    // name) and ended up keeping `hide` *and* `none` entries, which is
+    // how `codex-auto-review` leaked into the picker.
+    models.retain(|m| m.visibility.as_deref() == Some("list"));
     // Higher priority first -- Codex's UI does the same. Stable sort so
     // ties keep server order (which is already curated).
     models.sort_by_key(|m| std::cmp::Reverse(m.priority));
@@ -1117,19 +1126,25 @@ mod tests {
     #[test]
     fn parses_models_response_and_sorts_by_priority_descending() {
         // Mirror a real ChatGPT /models payload (fields trimmed to the
-        // ones we deserialize). Priority-descending sort is what Codex
-        // CLI's picker does, so the most prominent slug surfaces first.
+        // ones we deserialize). Visibility filtering follows Codex's
+        // own `ModelVisibility` enum: only `list` is shown in pickers.
+        // `hide` (callable but not in picker) and `none` (internal /
+        // automation-only, e.g. `codex-auto-review`) are dropped so the
+        // user doesn't see slugs that aren't meant for chat. Priority-
+        // descending sort matches Codex CLI's UI ordering.
         let raw = r#"{
             "models": [
-                {"slug": "gpt-low",  "priority": 1},
-                {"slug": "gpt-high", "priority": 100},
-                {"slug": "gpt-mid",  "priority": 50,  "visibility": "public"},
-                {"slug": "gpt-hidden", "priority": 999, "visibility": "hidden"}
+                {"slug": "gpt-low",     "priority": 1,   "visibility": "list"},
+                {"slug": "gpt-high",    "priority": 100, "visibility": "list"},
+                {"slug": "gpt-mid",     "priority": 50,  "visibility": "list"},
+                {"slug": "gpt-hidden",  "priority": 999, "visibility": "hide"},
+                {"slug": "auto-review", "priority": 999, "visibility": "none"},
+                {"slug": "gpt-no-vis",  "priority": 999}
             ]
         }"#;
         let parsed: ChatGptModelsResponse = serde_json::from_str(raw).unwrap();
         let mut models = parsed.models;
-        models.retain(|m| m.visibility.as_deref() != Some("hidden"));
+        models.retain(|m| m.visibility.as_deref() == Some("list"));
         models.sort_by_key(|m| std::cmp::Reverse(m.priority));
         let slugs: Vec<&str> = models.iter().map(|m| m.slug.as_str()).collect();
         assert_eq!(slugs, vec!["gpt-high", "gpt-mid", "gpt-low"]);

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -122,11 +122,16 @@ async fn main() -> Result<()> {
                     );
                     Arc::new(codex_client::CodexClient::new())
                 } else {
+                    // We land here when auth_mode != "chatgpt" OR
+                    // tokens are missing. Falling back to the API key
+                    // path is the only meaningful thing we can do --
+                    // but if there's no key either, the first prompt
+                    // will 401 and the user needs to re-run login.
                     let key = auth.openai_api_key.clone();
                     if key.is_none() {
                         tracing::warn!(
-                            "~/.codex/auth.json has no OPENAI_API_KEY and is not in chatgpt mode; \
-                             run /codex-login to authenticate"
+                            "~/.codex/auth.json is not usable: not in chatgpt mode AND no OPENAI_API_KEY; \
+                             run /codex-login from a session to authenticate"
                         );
                     }
                     tracing::info!(

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 mod agent;
 mod bifrost_client;
 mod codex_auth;
+mod codex_client;
 mod llm_client;
 mod session;
 mod tool_loop;
@@ -28,10 +29,18 @@ struct Args {
 
     /// Authenticate against OpenAI using "Sign in with ChatGPT" credentials
     /// stored at `~/.codex/auth.json` (cross-compatible with Codex CLI).
-    /// When set, --endpoint-url and --api-key are overridden by the
-    /// OAuth-issued OPENAI_API_KEY pointed at https://api.openai.com/v1.
-    /// Run `/codex-login` from an ACP session to authenticate if no
-    /// credentials are present yet.
+    ///
+    /// When `auth.json` is in `chatgpt` mode (the default after
+    /// `/codex-login`), prompts are routed to
+    /// `https://chatgpt.com/backend-api/codex/responses` using the
+    /// OAuth `access_token` + `ChatGPT-Account-ID` headers, so usage
+    /// counts against your ChatGPT Plus/Pro/Enterprise subscription.
+    ///
+    /// When `auth.json` is in `apikey` mode, prompts fall back to
+    /// `https://api.openai.com/v1` with the stored `OPENAI_API_KEY`,
+    /// which is billed as standard API usage. Run `/codex-login` from
+    /// an ACP session to authenticate if no credentials are present
+    /// yet.
     #[arg(long, conflicts_with = "api_key")]
     use_codex: bool,
 
@@ -91,39 +100,62 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    // Codex login takes precedence: re-point the LLM at api.openai.com using
-    // the issued OPENAI_API_KEY, and refresh the credentials if they're stale
-    // before any prompts arrive. If no auth.json exists yet we still start --
+    // Codex login takes precedence over the explicit --endpoint-url/--api-key
+    // flags. We branch on the stored `auth_mode`:
+    //   * "chatgpt" -> route through CodexClient (Responses API on
+    //     chatgpt.com, billed against the user's ChatGPT subscription).
+    //   * anything else (typically "apikey") -> fall back to OpenAiClient
+    //     against api.openai.com using the stored OPENAI_API_KEY, which
+    //     is billed as standard API usage.
+    // Refresh stale credentials proactively so the first prompt doesn't
+    // burn a 401 round-trip. If no auth.json exists yet we still start --
     // the user can run `/codex-login` from a session to authenticate.
-    let (endpoint_url, api_key) = if args.use_codex {
+    let llm: Arc<dyn llm_client::LlmBackend> = if args.use_codex {
         match codex_auth::read_auth_dot_json()? {
             Some(mut auth) => {
                 if let Err(e) = codex_auth::refresh_if_stale(&mut auth).await {
                     tracing::warn!("codex credential refresh failed: {e:#}");
                 }
-                let key = auth.openai_api_key.clone();
-                if key.is_none() {
-                    tracing::warn!(
-                        "~/.codex/auth.json has no OPENAI_API_KEY; run /codex-login to authenticate"
+                if matches!(auth.auth_mode.as_deref(), Some("chatgpt")) && auth.tokens.is_some() {
+                    tracing::info!(
+                        "brokk-acp starting in ChatGPT subscription mode (Responses API on chatgpt.com)"
                     );
+                    Arc::new(codex_client::CodexClient::new())
+                } else {
+                    let key = auth.openai_api_key.clone();
+                    if key.is_none() {
+                        tracing::warn!(
+                            "~/.codex/auth.json has no OPENAI_API_KEY and is not in chatgpt mode; \
+                             run /codex-login to authenticate"
+                        );
+                    }
+                    tracing::info!(
+                        "brokk-acp starting in OPENAI_API_KEY mode (api.openai.com), auth_mode={:?}",
+                        auth.auth_mode
+                    );
+                    Arc::new(llm_client::OpenAiClient::new(
+                        "https://api.openai.com/v1".to_string(),
+                        key,
+                    ))
                 }
-                ("https://api.openai.com/v1".to_string(), key)
             }
             None => {
                 tracing::warn!(
                     "no ~/.codex/auth.json found; run /codex-login from a session to authenticate"
                 );
-                ("https://api.openai.com/v1".to_string(), None)
+                Arc::new(llm_client::OpenAiClient::new(
+                    "https://api.openai.com/v1".to_string(),
+                    None,
+                ))
             }
         }
     } else {
-        (args.endpoint_url.clone(), args.api_key.clone())
+        tracing::info!("brokk-acp starting, endpoint={}", args.endpoint_url);
+        Arc::new(llm_client::OpenAiClient::new(
+            args.endpoint_url.clone(),
+            args.api_key.clone(),
+        ))
     };
-
-    tracing::info!("brokk-acp starting, endpoint={endpoint_url}");
-
-    let llm: Arc<dyn llm_client::LlmBackend> =
-        Arc::new(llm_client::OpenAiClient::new(endpoint_url, api_key));
     // SessionStore uses internal Arc -- no outer Arc needed
     let limits = session::SessionLimits {
         max_sessions: args.max_sessions,


### PR DESCRIPTION
## Summary

Fixes the Codex login support so `--use-codex` actually routes through the user's ChatGPT subscription instead of through a token-exchanged `OPENAI_API_KEY`.

The previous PR ([#3535](https://github.com/BrokkAi/brokk/pull/3535)) ran the OAuth flow, swapped the `id_token` for an `OPENAI_API_KEY` via RFC 8693 token exchange, and pointed the existing `OpenAiClient` at `https://api.openai.com/v1`. That path is billed as standard API usage, **not** against the user's ChatGPT Plus/Pro/Enterprise subscription -- so "Sign in with ChatGPT" was effectively just a convenience wrapper for provisioning an `sk-` key.

## What changed

- **New `CodexClient` backend** ([codex_client.rs](brokk-acp-rust/src/codex_client.rs)) that talks to `https://chatgpt.com/backend-api/codex/responses` (the Responses API, not Chat Completions) using:
  - `Authorization: Bearer <access_token>`
  - `ChatGPT-Account-ID: <account_id>`
  - `originator: codex_cli_rs`
  - `User-Agent: codex_cli_rs/brokk-acp`

  These mirror what `codex` CLI sends in `chatgpt` mode. Usage now counts against the user's subscription.

- **Routing logic in [main.rs](brokk-acp-rust/src/main.rs)** when `--use-codex` is set:
  - `auth_mode=chatgpt` -> `CodexClient` (subscription-billed)
  - `auth_mode=apikey` -> `OpenAiClient` on `api.openai.com` (API-billed fallback)
  - missing/unknown -> warn, start anyway, let `/codex-login` recover

- **Chat-Completions -> Responses-API input conversion**:
  - System messages collapse into the top-level `instructions` field (joined with `\n\n`).
  - User text -> `{type: "message", role: "user", content: [{type: "input_text", text}]}`.
  - Assistant text -> `{type: "message", role: "assistant", content: [{type: "output_text", text}]}`.
  - Assistant `tool_calls` splay into one `{type: "function_call", name, arguments, call_id}` item per call.
  - Tool results -> `{type: "function_call_output", call_id, output}`.
  - Tools serialize at top level (`{type, name, description, parameters}`) -- the Responses API does not nest under a `function` wrapper.
  - `store: false` so brokk doesn't leave a side-channel copy of every request on OpenAI's storage.

- **SSE parser** for the Responses API event schema (`response.output_text.delta`, `response.output_item.done`, `response.completed`, `response.failed`). Includes backfill of assistant text from `output_item.done` for short replies that skip deltas, and a permissive `#[serde(other)]` fallback so future event types (reasoning summaries, rate-limit metadata) keep the idle timer alive without poisoning the stream.

- **Token-refresh handling**: load credentials per request with `refresh_if_stale`, serialize concurrent refreshes under a `Mutex` so they don't race the server's `refresh_token` rotation, and retry once after a 401 with forced-refreshed tokens.

- **`/codex-login` slash-command** now reports the active routing mode (`ChatGPT subscription` vs `OPENAI_API_KEY`) and the post-login message points at the chatgpt.com endpoint instead of the API key.

## Test plan

- [x] `cargo test` -- 145 tests, all green (9 new in `codex_client::tests`):
  - request shaping (system collapse, tool-call splay, top-level tools)
  - SSE parsing (deltas + tool calls, backfill, `response.failed` -> Err, unknown events ignored)
  - 401 detector
  - assistant text dropped when tool_calls present (matches existing tool-loop semantics)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Manual smoke test against a real ChatGPT subscription (cannot run from CI -- requires interactive login). The user should:
  1. Run `/codex-login` from an ACP session
  2. Confirm `~/.codex/auth.json` shows `auth_mode: "chatgpt"` with non-empty `tokens.access_token` and `tokens.account_id`
  3. Restart with `--use-codex`
  4. Send a prompt; verify logs report `ChatGPT subscription mode (Responses API on chatgpt.com)`
  5. Verify the prompt does **not** burn `OPENAI_API_KEY` quota at https://platform.openai.com/usage and the request shows up in ChatGPT's settings -> data controls instead.
