### PR TITLE
ToolRegistry: surface tool exception cause to LLM

### DIFF
--- a/app/src/main/java/ai/brokk/tools/ToolRegistry.java
+++ b/app/src/main/java/ai/brokk/tools/ToolRegistry.java
@@ -279,7 +279,16 @@ public class ToolRegistry {
                     };
                 }
             }
-            throw new RuntimeException(e);
+            // Unhandled tool exception: log the full stack so operators can see it,
+            // and surface the actual cause's class + message to the LLM instead of
+            // a useless "InvocationTargetException".
+            GlobalExceptionHandler.handle(e);
+            var cause = e.getCause() != null ? e.getCause() : e;
+            var causeMsg = cause.getMessage();
+            var msg = causeMsg == null
+                    ? cause.getClass().getName()
+                    : "%s: %s".formatted(cause.getClass().getName(), causeMsg);
+            return ToolExecutionResult.internalError(request, msg, elapsedMs(startNanos));
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/app/src/main/java/ai/brokk/tools/ToolRegistry.java
+++ b/app/src/main/java/ai/brokk/tools/ToolRegistry.java
@@ -1,5 +1,7 @@
 package ai.brokk.tools;
 
+import static java.util.Objects.requireNonNull;
+
 import ai.brokk.exception.GlobalExceptionHandler;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -280,14 +282,23 @@ public class ToolRegistry {
                 }
             }
             // Unhandled tool exception: log the full stack so operators can see it,
-            // and surface the actual cause's class + message to the LLM instead of
+            // and surface the actual root cause's class + message to the LLM instead of
             // a useless "InvocationTargetException".
             GlobalExceptionHandler.handle(e);
-            var cause = e.getCause() != null ? e.getCause() : e;
-            var causeMsg = cause.getMessage();
+            // Method.invoke() always wraps with a non-null cause; walk the full chain
+            // (matching the sibling InterruptedException/ToolCallException loop above)
+            // so wrapped diagnostics like RuntimeException("wrapper", real) aren't hidden.
+            Throwable root = requireNonNull(e.getCause());
+            while (root.getCause() != null && root.getCause() != root) {
+                root = root.getCause();
+            }
+            var causeMsg = root.getMessage();
+            // Unlike the sibling error paths in this method (which surface only the
+            // message), include the class name so the LLM still has a concrete handle
+            // when the exception carries no message at all.
             var msg = causeMsg == null
-                    ? cause.getClass().getName()
-                    : "%s: %s".formatted(cause.getClass().getName(), causeMsg);
+                    ? root.getClass().getName()
+                    : "%s: %s".formatted(root.getClass().getName(), causeMsg);
             return ToolExecutionResult.internalError(request, msg, elapsedMs(startNanos));
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);

--- a/app/src/test/java/ai/brokk/tools/ToolRegistryTest.java
+++ b/app/src/test/java/ai/brokk/tools/ToolRegistryTest.java
@@ -261,8 +261,7 @@ class ToolRegistryTest {
                 "result text should not leak the reflection wrapper, was: " + result.resultText());
         assertTrue(
                 result.resultText().contains("NullPointerException"),
-                "result text should name the actual cause class even without a message, was: "
-                        + result.resultText());
+                "result text should name the actual cause class even without a message, was: " + result.resultText());
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/tools/ToolRegistryTest.java
+++ b/app/src/test/java/ai/brokk/tools/ToolRegistryTest.java
@@ -262,6 +262,11 @@ class ToolRegistryTest {
         assertTrue(
                 result.resultText().contains("NullPointerException"),
                 "result text should name the actual cause class even without a message, was: " + result.resultText());
+        // Guard against a regression to "NullPointerException: null" — when there is no
+        // message, the formatter should emit only the class name, never a literal "null".
+        assertFalse(
+                result.resultText().contains("null"),
+                "result text should not contain the literal substring 'null', was: " + result.resultText());
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/tools/ToolRegistryTest.java
+++ b/app/src/test/java/ai/brokk/tools/ToolRegistryTest.java
@@ -225,6 +225,47 @@ class ToolRegistryTest {
     }
 
     @Test
+    void executeTool_UnhandledExceptionSurfacesRootCauseToLlm() throws Exception {
+        var req = ToolExecutionRequest.builder()
+                .name("throwingTool")
+                .arguments("{}")
+                .build();
+
+        var result = registry.executeTool(req);
+
+        assertEquals(ToolExecutionResult.Status.INTERNAL_ERROR, result.status());
+        // The LLM must see the actual cause, not "java.lang.reflect.InvocationTargetException".
+        assertFalse(
+                result.resultText().contains("InvocationTargetException"),
+                "result text should not leak the reflection wrapper, was: " + result.resultText());
+        assertTrue(
+                result.resultText().contains("IllegalStateException"),
+                "result text should name the actual cause class, was: " + result.resultText());
+        assertTrue(
+                result.resultText().contains("kaboom"),
+                "result text should include the cause message, was: " + result.resultText());
+    }
+
+    @Test
+    void executeTool_UnhandledExceptionWithoutMessageStillUsesCauseClass() throws Exception {
+        var req = ToolExecutionRequest.builder()
+                .name("throwingToolNoMessage")
+                .arguments("{}")
+                .build();
+
+        var result = registry.executeTool(req);
+
+        assertEquals(ToolExecutionResult.Status.INTERNAL_ERROR, result.status());
+        assertFalse(
+                result.resultText().contains("InvocationTargetException"),
+                "result text should not leak the reflection wrapper, was: " + result.resultText());
+        assertTrue(
+                result.resultText().contains("NullPointerException"),
+                "result text should name the actual cause class even without a message, was: "
+                        + result.resultText());
+    }
+
+    @Test
     void executeTool_ValidationFailureReturnsRequestErrorWithTextOutput() throws Exception {
         var map = new LinkedHashMap<String, Object>();
         map.put("classNames", List.of("com.a.A"));
@@ -379,6 +420,16 @@ class ToolRegistryTest {
         @Tool("Tool with map param")
         public String mapParamTool(@P("arbitrary args") Map<String, Object> args) {
             return "";
+        }
+
+        @Tool("Tool that throws an unchecked exception with a message")
+        public String throwingTool() {
+            throw new IllegalStateException("kaboom");
+        }
+
+        @Tool("Tool that throws an unchecked exception with no message")
+        public String throwingToolNoMessage() {
+            throw new NullPointerException();
         }
     }
 


### PR DESCRIPTION
## Summary

- When a `@Tool` method throws an unchecked exception that is neither `InterruptedException` nor `ToolCallException`, `ToolRegistry.executeToolInternal` was wrapping the `InvocationTargetException` in `new RuntimeException(e)` and letting the outer catch derive a message via `e.getMessage()`. Because `RuntimeException(Throwable)` adopts the cause's `toString()` as its detail message, the LLM (and any auto-filed `[Client Exception]` issue) saw only the meaningless string `java.lang.reflect.InvocationTargetException` — losing the actual cause class and message entirely.
- Now we call `GlobalExceptionHandler.handle(e)` directly (preserving the existing `Uncaught exception on thread ...` log line) and return `internalError` with `"<causeClass>: <causeMessage>"` derived from `e.getCause()`.
- Net effect: when a tool blows up, the LLM transcript shows what actually happened (e.g. `java.lang.UnsupportedOperationException: ...` or `java.lang.IllegalStateException: kaboom`) instead of an opaque reflection wrapper.

## Visible behavior change

**Before** (verbatim from issue #3427's report):
> Reason: Terminal tool 'callCodeAgent' failed with status INTERNAL_ERROR: java.lang.reflect.InvocationTargetException

**After**:
> Reason: Terminal tool 'callCodeAgent' failed with status INTERNAL_ERROR: java.lang.UnsupportedOperationException: ...

## Why this matters

Issue #3427 is a representative example: the user reporting it had to dig through `~/.brokk/debug.log` to discover the real cause was `UnsupportedOperationException` at `IAppContextManager.getCodeModel:201`. With this fix, the cause would have been visible in the LUTZ transcript itself — saving the round-trip to the debug log.

It also means the auto-filed `[Client Exception]` reports stop collapsing into the same opaque title. The currently-open `java.lang.RuntimeException: java.lang.reflect.InvocationTargetException` issues — #2681, #3204, #3206, #3325, #3330, #3331 — almost certainly represent six *different* underlying crashes. Going forward, each will key off its actual cause class and message and become individually triageable.

## Test plan

- [x] `./gradlew :app:test --tests 'ai.brokk.tools.ToolRegistryTest.executeTool_UnhandledExceptionSurfacesRootCauseToLlm' --tests 'ai.brokk.tools.ToolRegistryTest.executeTool_UnhandledExceptionWithoutMessageStillUsesCauseClass'` — both pass.
- [ ] Trigger a tool failure end-to-end (e.g. force a `@Tool` to throw `IllegalStateException`) and confirm the agent transcript shows the cause class + message instead of `InvocationTargetException`.
- [ ] Confirm `~/.brokk/debug.log` still receives the `Uncaught exception on thread ...` line with the full stacktrace (no regression in operator visibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)