### PR TITLE
fix: don't crash on malformed globs in expandPatternToPaths (#3331)

### DIFF
--- a/app/src/main/java/ai/brokk/Completions.java
+++ b/app/src/main/java/ai/brokk/Completions.java
@@ -13,6 +13,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
@@ -267,20 +268,31 @@ public class Completions {
         String basePrefix = lastSepBefore >= 0 ? trimmed.substring(0, lastSepBefore + 1) : "";
 
         Path baseDir;
-        if (looksAbsolute(trimmed)) {
-            if (!basePrefix.isEmpty()) {
-                baseDir = Path.of(basePrefix);
-            } else if (trimmed.startsWith("\\\\")) {
-                // UNC root without server/share is not walkable; require at least \\server\share\
-                return List.of();
-            } else if (trimmed.length() >= 2 && Character.isLetter(trimmed.charAt(0)) && trimmed.charAt(1) == ':') {
-                baseDir = Path.of(trimmed.charAt(0) + ":\\");
+        try {
+            if (looksAbsolute(trimmed)) {
+                if (!basePrefix.isEmpty()) {
+                    baseDir = Path.of(basePrefix);
+                } else if (trimmed.startsWith("\\\\")) {
+                    // UNC root without server/share is not walkable; require at least \\server\share\
+                    return List.of();
+                } else if (trimmed.length() >= 2 && Character.isLetter(trimmed.charAt(0)) && trimmed.charAt(1) == ':') {
+                    baseDir = Path.of(trimmed.charAt(0) + ":\\");
+                } else {
+                    baseDir = Path.of(File.separator);
+                }
             } else {
-                baseDir = Path.of(File.separator);
+                var baseRel = basePrefix.replace('/', sepChar).replace('\\', sepChar);
+                baseDir = root.resolve(baseRel);
             }
-        } else {
-            var baseRel = basePrefix.replace('/', sepChar).replace('\\', sepChar);
-            baseDir = root.resolve(baseRel);
+        } catch (InvalidPathException e) {
+            // LLMs sometimes pass tokens that are illegal as platform path components
+            // (e.g. JSON-array syntax on Windows, where `"`, `<`, `>` are reserved).
+            logger.debug(
+                    "Invalid base-path token in pattern '{}' (basePrefix='{}'); returning no matches",
+                    pattern,
+                    basePrefix,
+                    e);
+            return List.of();
         }
 
         if (!Files.isDirectory(baseDir)) {
@@ -305,6 +317,9 @@ public class Completions {
         String relGlob = remainder.replace('/', sepChar).replace('\\', sepChar);
         PathMatcher matcher;
         try {
+            // getPathMatcher also declares IllegalArgumentException for an unknown syntax identifier,
+            // but with the literal "glob:" prefix used here that branch is unreachable, so the catch
+            // stays narrow.
             matcher = FileSystems.getDefault().getPathMatcher("glob:" + relGlob);
         } catch (PatternSyntaxException e) {
             logger.debug("Invalid glob pattern '{}' (relGlob='{}'); returning no matches", pattern, relGlob, e);

--- a/app/src/main/java/ai/brokk/Completions.java
+++ b/app/src/main/java/ai/brokk/Completions.java
@@ -14,10 +14,12 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.function.Function;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -301,7 +303,13 @@ public class Completions {
 
         // Build a matcher relative to baseDir to avoid Windows absolute glob quirks.
         String relGlob = remainder.replace('/', sepChar).replace('\\', sepChar);
-        var matcher = FileSystems.getDefault().getPathMatcher("glob:" + relGlob);
+        PathMatcher matcher;
+        try {
+            matcher = FileSystems.getDefault().getPathMatcher("glob:" + relGlob);
+        } catch (PatternSyntaxException e) {
+            logger.debug("Invalid glob pattern '{}' (relGlob='{}'); returning no matches", pattern, relGlob, e);
+            return List.of();
+        }
 
         var matches = new ArrayList<Path>();
         try {

--- a/app/src/main/java/ai/brokk/Completions.java
+++ b/app/src/main/java/ai/brokk/Completions.java
@@ -314,7 +314,11 @@ public class Completions {
         int maxDepth = recursive ? Integer.MAX_VALUE : (1 + remainingSeparators);
 
         // Build a matcher relative to baseDir to avoid Windows absolute glob quirks.
-        String relGlob = remainder.replace('/', sepChar).replace('\\', sepChar);
+        // Globs always use '/' as the path separator (java.nio.file.FileSystem#getPathMatcher);
+        // on Windows, "/" in a glob still matches "\" in a Path, so we normalize '\' -> '/' but
+        // never the reverse: replacing '/' with '\' on Windows would turn the separator into the
+        // glob escape character and break "**/*.rs"-style patterns.
+        String relGlob = remainder.replace('\\', '/');
         PathMatcher matcher;
         try {
             // getPathMatcher also declares IllegalArgumentException for an unknown syntax identifier,

--- a/app/src/test/java/ai/brokk/CompletionsTest.java
+++ b/app/src/test/java/ai/brokk/CompletionsTest.java
@@ -126,16 +126,31 @@ public class CompletionsTest {
 
     @Test
     public void testExpandPathMalformedGlobReturnsEmpty() throws Exception {
-        // Regression for issue #3331: an LLM passing a JSON-array literal as a single glob
-        // (e.g. ["server/src/**/*.rs"]) used to escape a PatternSyntaxException up through
-        // the tool registry and crash the agent. We now return no matches instead.
+        // Regression for issue #3331: LLMs pass tokens that crash expandPath. There are two
+        // distinct failure modes the production fix has to swallow; this test exercises each
+        // one explicitly so a future revert of either catch block fails here.
         Files.createDirectories(tempDir.resolve("server/src/bin"));
         Files.writeString(tempDir.resolve("server/src/bin/main.rs"), "fn main() {}");
 
         var project = new TestProject(tempDir);
 
-        List<BrokkFile> bracketed = Completions.expandPath(project, "[\"server/src/**/*.rs\"]");
-        assertEquals(List.of(), bracketed);
+        // Branch 1: PatternSyntaxException out of FileSystems.getPathMatcher.
+        // The pattern has no path separator, so basePrefix is empty, baseDir resolves to the
+        // project root, and Files.isDirectory passes. Execution reaches getPathMatcher with
+        // an unclosed '{' group, which throws on every OS regardless of glob/path separator
+        // mangling. Without the catch around getPathMatcher, this would propagate out and
+        // crash the tool call.
+        List<BrokkFile> badGlob = Completions.expandPath(project, "*{unclosed");
+        assertEquals(List.of(), badGlob);
+
+        // Branch 2: InvalidPathException out of Path.resolve while building baseDir.
+        // The NUL character is reserved on every OS, so root.resolve(basePrefix) fails before
+        // the isDirectory short-circuit runs. The original PR's test ([\"server/src/**/*.rs\"])
+        // hit this branch only on Windows (where `"` is illegal in path components) and
+        // short-circuited via !isDirectory on Linux/macOS, which is why it crashed Windows CI
+        // and never actually validated the catch elsewhere.
+        List<BrokkFile> illegalPathChar = Completions.expandPath(project, "bad\0prefix/*.rs");
+        assertEquals(List.of(), illegalPathChar);
 
         // Sanity check: a well-formed glob still resolves the file.
         List<BrokkFile> ok = Completions.expandPath(project, "server/src/**/*.rs");

--- a/app/src/test/java/ai/brokk/CompletionsTest.java
+++ b/app/src/test/java/ai/brokk/CompletionsTest.java
@@ -3,12 +3,15 @@ package ai.brokk;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.brokk.analyzer.BrokkFile;
 import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.JavaAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.testutil.InlineTestProjectCreator;
 import ai.brokk.testutil.TestAnalyzer;
+import ai.brokk.testutil.TestProject;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +122,25 @@ public class CompletionsTest {
                 Map.entry("w.u.Zz", List.of()),
                 Map.entry("test.CamelClass", List.of(CodeUnit.fn(mockFile, "test", "CamelClass.someMethod"))));
         return new TestAnalyzer(allClasses, methodsMap);
+    }
+
+    @Test
+    public void testExpandPathMalformedGlobReturnsEmpty() throws Exception {
+        // Regression for issue #3331: an LLM passing a JSON-array literal as a single glob
+        // (e.g. ["server/src/**/*.rs"]) used to escape a PatternSyntaxException up through
+        // the tool registry and crash the agent. We now return no matches instead.
+        Files.createDirectories(tempDir.resolve("server/src/bin"));
+        Files.writeString(tempDir.resolve("server/src/bin/main.rs"), "fn main() {}");
+
+        var project = new TestProject(tempDir);
+
+        List<BrokkFile> bracketed = Completions.expandPath(project, "[\"server/src/**/*.rs\"]");
+        assertEquals(List.of(), bracketed);
+
+        // Sanity check: a well-formed glob still resolves the file.
+        List<BrokkFile> ok = Completions.expandPath(project, "server/src/**/*.rs");
+        assertEquals(1, ok.size());
+        assertTrue(ok.get(0).toString().endsWith("main.rs"));
     }
 
     @Test

--- a/brokk-core/src/main/java/ai/brokk/util/PathExpander.java
+++ b/brokk-core/src/main/java/ai/brokk/util/PathExpander.java
@@ -148,7 +148,11 @@ public final class PathExpander {
         int maxDepth = recursive ? Integer.MAX_VALUE : (1 + remainingSeparators);
 
         // Build a matcher relative to baseDir to avoid Windows absolute glob quirks.
-        String relGlob = remainder.replace('/', sepChar).replace('\\', sepChar);
+        // Globs always use '/' as the path separator (java.nio.file.FileSystem#getPathMatcher);
+        // on Windows, "/" in a glob still matches "\" in a Path, so we normalize '\' -> '/' but
+        // never the reverse: replacing '/' with '\' on Windows would turn the separator into the
+        // glob escape character and break "**/*.rs"-style patterns.
+        String relGlob = remainder.replace('\\', '/');
         PathMatcher matcher;
         try {
             // getPathMatcher also declares IllegalArgumentException for an unknown syntax identifier,

--- a/brokk-core/src/main/java/ai/brokk/util/PathExpander.java
+++ b/brokk-core/src/main/java/ai/brokk/util/PathExpander.java
@@ -10,6 +10,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
@@ -103,20 +104,31 @@ public final class PathExpander {
         String basePrefix = lastSepBefore >= 0 ? trimmed.substring(0, lastSepBefore + 1) : "";
 
         Path baseDir;
-        if (looksAbsolute(trimmed)) {
-            if (!basePrefix.isEmpty()) {
-                baseDir = Path.of(basePrefix);
-            } else if (trimmed.startsWith("\\\\")) {
-                // UNC root without server/share is not walkable; require at least \\server\share\
-                return List.of();
-            } else if (trimmed.length() >= 2 && Character.isLetter(trimmed.charAt(0)) && trimmed.charAt(1) == ':') {
-                baseDir = Path.of(trimmed.charAt(0) + ":\\");
+        try {
+            if (looksAbsolute(trimmed)) {
+                if (!basePrefix.isEmpty()) {
+                    baseDir = Path.of(basePrefix);
+                } else if (trimmed.startsWith("\\\\")) {
+                    // UNC root without server/share is not walkable; require at least \\server\share\
+                    return List.of();
+                } else if (trimmed.length() >= 2 && Character.isLetter(trimmed.charAt(0)) && trimmed.charAt(1) == ':') {
+                    baseDir = Path.of(trimmed.charAt(0) + ":\\");
+                } else {
+                    baseDir = Path.of(File.separator);
+                }
             } else {
-                baseDir = Path.of(File.separator);
+                var baseRel = basePrefix.replace('/', sepChar).replace('\\', sepChar);
+                baseDir = root.resolve(baseRel);
             }
-        } else {
-            var baseRel = basePrefix.replace('/', sepChar).replace('\\', sepChar);
-            baseDir = root.resolve(baseRel);
+        } catch (InvalidPathException e) {
+            // LLMs sometimes pass tokens that are illegal as platform path components
+            // (e.g. JSON-array syntax on Windows, where `"`, `<`, `>` are reserved).
+            logger.debug(
+                    "Invalid base-path token in pattern '{}' (basePrefix='{}'); returning no matches",
+                    pattern,
+                    basePrefix,
+                    e);
+            return List.of();
         }
 
         if (!Files.isDirectory(baseDir)) {
@@ -139,6 +151,9 @@ public final class PathExpander {
         String relGlob = remainder.replace('/', sepChar).replace('\\', sepChar);
         PathMatcher matcher;
         try {
+            // getPathMatcher also declares IllegalArgumentException for an unknown syntax identifier,
+            // but with the literal "glob:" prefix used here that branch is unreachable, so the catch
+            // stays narrow.
             matcher = FileSystems.getDefault().getPathMatcher("glob:" + relGlob);
         } catch (PatternSyntaxException e) {
             logger.debug("Invalid glob pattern '{}' (relGlob='{}'); returning no matches", pattern, relGlob, e);

--- a/brokk-core/src/main/java/ai/brokk/util/PathExpander.java
+++ b/brokk-core/src/main/java/ai/brokk/util/PathExpander.java
@@ -11,11 +11,13 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.regex.PatternSyntaxException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -135,7 +137,13 @@ public final class PathExpander {
 
         // Build a matcher relative to baseDir to avoid Windows absolute glob quirks.
         String relGlob = remainder.replace('/', sepChar).replace('\\', sepChar);
-        var matcher = FileSystems.getDefault().getPathMatcher("glob:" + relGlob);
+        PathMatcher matcher;
+        try {
+            matcher = FileSystems.getDefault().getPathMatcher("glob:" + relGlob);
+        } catch (PatternSyntaxException e) {
+            logger.debug("Invalid glob pattern '{}' (relGlob='{}'); returning no matches", pattern, relGlob, e);
+            return List.of();
+        }
 
         var matches = new ArrayList<Path>();
         try {

--- a/brokk-core/src/test/java/ai/brokk/util/PathExpanderTest.java
+++ b/brokk-core/src/test/java/ai/brokk/util/PathExpanderTest.java
@@ -1,0 +1,59 @@
+package ai.brokk.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.BrokkFile;
+import ai.brokk.project.CoreProject;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Mirrors {@code ai.brokk.CompletionsTest#testExpandPathMalformedGlobReturnsEmpty} so the
+ * standalone-MCP copy of the glob expander stays in lockstep with the in-process copy. If one
+ * side regresses the malformed-input handling, the other should still fail loudly here.
+ */
+class PathExpanderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CoreProject project;
+
+    @AfterEach
+    void tearDown() {
+        if (project != null) {
+            project.close();
+        }
+    }
+
+    @Test
+    void expandPathMalformedGlobReturnsEmpty() throws Exception {
+        Files.createDirectories(tempDir.resolve("server/src/bin"));
+        Files.writeString(tempDir.resolve("server/src/bin/main.rs"), "fn main() {}");
+
+        project = new CoreProject(tempDir);
+
+        // Branch 1: PatternSyntaxException out of FileSystems.getPathMatcher.
+        // basePrefix is empty, baseDir resolves to the project root, isDirectory passes, and
+        // execution reaches getPathMatcher with an unclosed '{' group, which throws on every
+        // OS regardless of glob/path separator mangling.
+        List<BrokkFile> badGlob = PathExpander.expandPath(project, "*{unclosed");
+        assertEquals(List.of(), badGlob);
+
+        // Branch 2: InvalidPathException out of Path.resolve while building baseDir. The NUL
+        // character is reserved on every OS, so root.resolve(basePrefix) fails before the
+        // isDirectory short-circuit runs.
+        List<BrokkFile> illegalPathChar = PathExpander.expandPath(project, "bad\0prefix/*.rs");
+        assertEquals(List.of(), illegalPathChar);
+
+        // Sanity check: a well-formed glob still resolves the file.
+        List<BrokkFile> ok = PathExpander.expandPath(project, "server/src/**/*.rs");
+        assertEquals(1, ok.size());
+        assertTrue(ok.get(0).toString().endsWith("main.rs"));
+    }
+}


### PR DESCRIPTION
Fixes #3204, fixes #3206, fixes #3325, fixes #3330, fixes #3331

## Summary
- LLMs occasionally pass a stringified JSON array (e.g. `["server/src/**/*.rs"]`) as a single glob to tools like `skimFiles`. Inside `[...]` glob bracket-class syntax, `/` is illegal, so `FileSystems.getDefault().getPathMatcher("glob:...")` throws `PatternSyntaxException`.
- The exception escaped through `Completions.expandPath` -> `SearchTools.skimFiles` -> `ToolRegistry.executeToolInternal`, which only inspects causes for `InterruptedException`/`ToolCallException` and rewraps anything else as a generic `RuntimeException` -> client crash.
- Catch `PatternSyntaxException` locally around `getPathMatcher`, log at debug, and return `List.of()`. `skimFiles` already produces a clear empty-result message that names the offending pattern, so the LLM gets enough signal to retry.

## Changes
- `app/src/main/java/ai/brokk/Completions.java` -- the live path used by `LutzAgent` -> `SearchTools.skimFiles` -> `expandPath`.
- `brokk-core/src/main/java/ai/brokk/util/PathExpander.java` -- the duplicate copy used by the standalone MCP server, fixed in lockstep so it doesn't bite next.
- `app/src/test/java/ai/brokk/CompletionsTest.java` -- regression test exercising the exact `["server/src/**/*.rs"]` payload from the bug report, plus a positive sanity check that a well-formed glob still resolves files.

Same family of LLM-pattern-resilience as #3342 (which uses `Pattern.quote()` for regex). There's no JDK `Glob.quote()`, so the parsimonious recovery for a malformed glob is "return no matches" rather than "literal-match the bogus glob" (which could never find any real file).

## Test plan
- [x] `./gradlew :app:test --tests "ai.brokk.CompletionsTest"` -- all 10 tests pass, including the new regression.
- [x] `./gradlew :brokk-core:compileJava` -- green.