### PR TITLE
Default 'Vendor for other models' to OpenAI - Codex on sign-in

### DIFF
--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -2105,13 +2105,20 @@ public class BrokkAcpAgent {
                 } finally {
                     MainProject.removeSettingsChangeListener(this);
                 }
-                pushSessionMessage(sessionId, "Codex sign-in successful.");
                 logger.info("ACP /codex-login completed for session {}", sessionId);
                 // Mirror SettingsGlobalPanel.maybeRunCodexAutoSetup so ACP and GUI converge after
-                // sign-in: install Codex favorites, then reload Service so getAvailableModels
-                // sees the new OAuth-only catalog. Run off the OAuth callback thread.
+                // sign-in: install Codex favorites and switch the "Vendor for other models" default,
+                // then reload Service so getAvailableModels sees the new OAuth-only catalog. Run off
+                // the OAuth callback thread.
                 LoggingFuture.runVirtual(() -> {
-                    MainProject.saveFavoriteModels(ModelProperties.CODEX_OAUTH_FAVORITES);
+                    var previousVendor = MainProject.applyCodexSignInAutoSetup();
+                    var msg = "Codex sign-in successful."
+                            + previousVendor
+                                    .map(prev -> String.format(
+                                            "%n%n\"Vendor for other models\" was switched to \"%s\" (was: %s). To change it, open the Brokk GUI Settings > Advanced > Model Roles and pick a different entry from the \"Vendor for other models\" dropdown.",
+                                            ModelProperties.CODEX_VENDOR, prev.isBlank() ? "Default" : prev))
+                                    .orElse("");
+                    pushSessionMessage(sessionId, msg);
                     var bundle = bundleBySession.get(sessionId);
                     if (bundle != null) {
                         bundle.cm().reloadService();
@@ -2209,6 +2216,7 @@ public class BrokkAcpAgent {
             var error = Service.disconnectCodexOauth();
             if (error == null) {
                 MainProject.setOpenAiCodexOauthConnected(false);
+                MainProject.revertCodexAutoSetupVendor();
                 // Drop any in-flight login on this JVM so its listener cannot fire a phantom
                 // "successful" message on a future unrelated reconnection.
                 var pending = pendingLogin.get();

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -2215,8 +2215,11 @@ public class BrokkAcpAgent {
         LoggingFuture.runVirtual(() -> {
             var error = Service.disconnectCodexOauth();
             if (error == null) {
-                MainProject.setOpenAiCodexOauthConnected(false);
+                // Revert vendor preference before flipping the connected flag, otherwise
+                // listeners on openAiOauthConnectionChanged observe the stale OpenAI - Codex
+                // vendor while connected=false.
                 MainProject.revertCodexAutoSetupVendor();
+                MainProject.setOpenAiCodexOauthConnected(false);
                 // Drop any in-flight login on this JVM so its listener cannot fire a phantom
                 // "successful" message on a future unrelated reconnection.
                 var pending = pendingLogin.get();

--- a/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
+++ b/app/src/main/java/ai/brokk/acp/BrokkAcpAgent.java
@@ -2106,19 +2106,13 @@ public class BrokkAcpAgent {
                     MainProject.removeSettingsChangeListener(this);
                 }
                 logger.info("ACP /codex-login completed for session {}", sessionId);
-                // Mirror SettingsGlobalPanel.maybeRunCodexAutoSetup so ACP and GUI converge after
-                // sign-in: install Codex favorites and switch the "Vendor for other models" default,
-                // then reload Service so getAvailableModels sees the new OAuth-only catalog. Run off
-                // the OAuth callback thread.
+                pushSessionMessage(sessionId, "Codex sign-in successful.");
+                MainProject.getCodexAutoSetupPreviousVendorPreference()
+                        .ifPresent(prev ->
+                                pushSessionMessage(sessionId, MainProject.formatCodexAutoSetupVendorMessage(prev)));
+                // Mirror SettingsGlobalPanel.maybeShowCodexAutoSetupDialog so ACP and GUI converge after
+                // sign-in: reload Service so getAvailableModels sees the new OAuth-only catalog.
                 LoggingFuture.runVirtual(() -> {
-                    var previousVendor = MainProject.applyCodexSignInAutoSetup();
-                    var msg = "Codex sign-in successful."
-                            + previousVendor
-                                    .map(prev -> String.format(
-                                            "%n%n\"Vendor for other models\" was switched to \"%s\" (was: %s). To change it, open the Brokk GUI Settings > Advanced > Model Roles and pick a different entry from the \"Vendor for other models\" dropdown.",
-                                            ModelProperties.CODEX_VENDOR, prev.isBlank() ? "Default" : prev))
-                                    .orElse("");
-                    pushSessionMessage(sessionId, msg);
                     var bundle = bundleBySession.get(sessionId);
                     if (bundle != null) {
                         bundle.cm().reloadService();
@@ -2215,18 +2209,21 @@ public class BrokkAcpAgent {
         LoggingFuture.runVirtual(() -> {
             var error = Service.disconnectCodexOauth();
             if (error == null) {
-                // Revert vendor preference before flipping the connected flag, otherwise
-                // listeners on openAiOauthConnectionChanged observe the stale OpenAI - Codex
-                // vendor while connected=false.
-                MainProject.revertCodexAutoSetupVendor();
-                MainProject.setOpenAiCodexOauthConnected(false);
+                var restoredVendor = MainProject.setOpenAiCodexOauthConnected(false);
                 // Drop any in-flight login on this JVM so its listener cannot fire a phantom
                 // "successful" message on a future unrelated reconnection.
                 var pending = pendingLogin.get();
                 if (pending != null) {
                     cancelPending(pending);
                 }
-                pushSessionMessage(sessionId, "Codex sign-in disconnected.");
+                pushSessionMessage(
+                        sessionId,
+                        "Codex sign-in disconnected."
+                                + restoredVendor
+                                        .map(vendor -> String.format(
+                                                "%n%n%s",
+                                                MainProject.formatCodexDisconnectVendorRestoreMessage(vendor)))
+                                        .orElse(""));
                 logger.info("ACP /codex-login disconnect succeeded");
             } else {
                 pushSessionMessage(sessionId, "Failed to disconnect Codex: " + error);

--- a/app/src/main/java/ai/brokk/cli/CliArgParser.java
+++ b/app/src/main/java/ai/brokk/cli/CliArgParser.java
@@ -151,7 +151,7 @@ public final class CliArgParser {
             MainProject.setOtherModelsVendorPreference("");
             logger.info("Cleared other-models vendor preference and internal role overrides");
         } else {
-            if ("OpenAI - Codex".equals(canonicalVendor) && !MainProject.isOpenAiCodexOauthConnected()) {
+            if (ModelProperties.CODEX_VENDOR.equals(canonicalVendor) && !MainProject.isOpenAiCodexOauthConnected()) {
                 throw new IllegalArgumentException(
                         "OpenAI - Codex selected but Codex OAuth is not connected; connect/login first.");
             }

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsAdvancedPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsAdvancedPanel.java
@@ -419,7 +419,7 @@ public class SettingsAdvancedPanel extends JPanel implements ThemeAware {
         vendors.addAll(ModelProperties.getAvailableVendors());
 
         if (!MainProject.isOpenAiCodexOauthConnected()) {
-            vendors.remove("OpenAI - Codex");
+            vendors.remove(ModelProperties.CODEX_VENDOR);
         }
 
         otherModelsVendorCombo.setModel(new DefaultComboBoxModel<>(vendors.toArray(new String[0])));
@@ -896,7 +896,8 @@ public class SettingsAdvancedPanel extends JPanel implements ThemeAware {
         defaultsRolesButton.addActionListener(e -> {
             boolean codexConnected = MainProject.isOpenAiCodexOauthConnected();
 
-            otherModelsVendorCombo.setSelectedItem(codexConnected ? "OpenAI - Codex" : ModelProperties.DEFAULT_VENDOR);
+            otherModelsVendorCombo.setSelectedItem(
+                    codexConnected ? ModelProperties.CODEX_VENDOR : ModelProperties.DEFAULT_VENDOR);
 
             // OAuth-connected: use the Codex OAuth preset; else fall back to ModelProperties defaults.
             var architectConfig = codexConnected

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -2435,6 +2435,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
             SwingUtilities.invokeLater(() -> {
                 if (error == null) {
                     MainProject.setOpenAiCodexOauthConnected(false);
+                    MainProject.revertCodexAutoSetupVendor();
                     MaterialOptionPane.showConfirmDialog(
                             SettingsGlobalPanel.this,
                             "Successfully disconnected from OpenAI.",
@@ -2470,27 +2471,31 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
     private void maybeRunCodexAutoSetup() {
         if (MainProject.isOpenAiCodexOauthConnected()) {
-            logger.info("Codex OAuth connected; installing Codex favorites preset.");
+            logger.info("Codex OAuth connected; installing Codex favorites preset and default vendor.");
 
-            MainProject.saveFavoriteModels(ModelProperties.CODEX_OAUTH_FAVORITES);
-            logger.info("Replaced favorites list with Codex OAuth models");
+            var previousVendor = MainProject.applyCodexSignInAutoSetup();
 
             chrome.getContextManager().reloadService();
 
             SwingUtilities.invokeLater(() -> {
+                String vendorLine = previousVendor
+                        .map(prev -> String.format(
+                                "%n%n\"Vendor for other models\" was switched to \"%s\" (was: %s). To change it, open Settings > Advanced > Model Roles and pick a different entry from the \"Vendor for other models\" dropdown.",
+                                ModelProperties.CODEX_VENDOR, prev.isBlank() ? "Default" : prev))
+                        .orElse("");
                 String message =
                         """
                         Codex OAuth is connected. While the OAuth-only restriction is enabled
                         (Settings > Global), all model roles route to Codex models automatically
                         without overwriting your saved preferences. The favorites list has been
-                        updated with Codex presets.
-                        """
-                                .stripIndent();
+                        updated with Codex presets."""
+                                        .stripIndent()
+                                + vendorLine;
 
                 MaterialOptionPane.showConfirmDialog(
                         parentDialog,
                         message,
-                        "Codex Setup Complete",
+                        "Codex Sign-in Complete",
                         JOptionPane.DEFAULT_OPTION,
                         JOptionPane.INFORMATION_MESSAGE);
 

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -2433,16 +2434,19 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
         chrome.getContextManager().submitBackgroundTask("Disconnecting OpenAI", () -> {
             String error = Service.disconnectCodexOauth();
-            SwingUtilities.invokeLater(() -> {
+            var restoredVendor = error == null
+                    ? MainProject.setOpenAiCodexOauthConnected(false)
+                    : Optional.<String>empty();
+            SwingUtil.runOnEdt(() -> {
                 if (error == null) {
-                    // Revert vendor preference before flipping the connected flag, otherwise
-                    // listeners on openAiOauthConnectionChanged observe the stale OpenAI - Codex
-                    // vendor while connected=false.
-                    MainProject.revertCodexAutoSetupVendor();
-                    MainProject.setOpenAiCodexOauthConnected(false);
+                    String message = "Successfully disconnected from OpenAI."
+                            + restoredVendor
+                                    .map(vendor -> String.format(
+                                            "%n%n%s", MainProject.formatCodexDisconnectVendorRestoreMessage(vendor)))
+                                    .orElse("");
                     MaterialOptionPane.showConfirmDialog(
                             SettingsGlobalPanel.this,
-                            "Successfully disconnected from OpenAI.",
+                            message,
                             "OpenAI Disconnected",
                             JOptionPane.DEFAULT_OPTION,
                             JOptionPane.INFORMATION_MESSAGE);
@@ -2468,28 +2472,25 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
     public void openAiOauthConnectionChanged() {
         SwingUtilities.invokeLater(() -> {
             updateOpenAiConnectionUi();
-            chrome.getContextManager().reloadService();
-            maybeRunCodexAutoSetup();
+            maybeShowCodexAutoSetupDialog();
         });
     }
 
-    private void maybeRunCodexAutoSetup() {
+    private void maybeShowCodexAutoSetupDialog() {
         if (!MainProject.isOpenAiCodexOauthConnected()) {
             return;
         }
-        logger.info("Codex OAuth connected; installing Codex favorites preset and default vendor.");
+        logger.info("Codex OAuth connected; reloading service and reporting Codex defaults.");
 
-        // Disk I/O (favorites + vendor preference writes) plus Service.reloadService must run off
+        // Disk I/O (vendor preference reads) plus Service.reloadService must run off
         // the EDT; the user-facing dialog has to run back on the EDT once the work is done.
-        chrome.getContextManager().submitBackgroundTask("Setting up Codex defaults", () -> {
-            var previousVendor = MainProject.applyCodexSignInAutoSetup();
+        chrome.getContextManager().submitBackgroundTask("Reloading Codex defaults", () -> {
+            var previousVendor = MainProject.getCodexAutoSetupPreviousVendorPreference();
             chrome.getContextManager().reloadService();
 
             SwingUtil.runOnEdt(() -> {
                 String vendorLine = previousVendor
-                        .map(prev -> String.format(
-                                "%n%n\"Vendor for other models\" was switched to \"%s\" (was: %s). To change it, open Settings > Advanced > Model Roles and pick a different entry from the \"Vendor for other models\" dropdown.",
-                                ModelProperties.CODEX_VENDOR, prev.isBlank() ? "Default" : prev))
+                        .map(prev -> String.format("%n%n%s", MainProject.formatCodexAutoSetupVendorMessage(prev)))
                         .orElse("");
                 String message =
                         """

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -7,6 +7,7 @@ import ai.brokk.SettingsChangeListener;
 import ai.brokk.gui.Chrome;
 import ai.brokk.gui.ExceptionAwareSwingWorker;
 import ai.brokk.gui.MaterialOptionPane;
+import ai.brokk.gui.SwingUtil;
 import ai.brokk.gui.SwingUtil.ThemedIcon;
 import ai.brokk.gui.components.BrowserLabel;
 import ai.brokk.gui.components.MaterialButton;
@@ -2434,8 +2435,11 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
             String error = Service.disconnectCodexOauth();
             SwingUtilities.invokeLater(() -> {
                 if (error == null) {
-                    MainProject.setOpenAiCodexOauthConnected(false);
+                    // Revert vendor preference before flipping the connected flag, otherwise
+                    // listeners on openAiOauthConnectionChanged observe the stale OpenAI - Codex
+                    // vendor while connected=false.
                     MainProject.revertCodexAutoSetupVendor();
+                    MainProject.setOpenAiCodexOauthConnected(false);
                     MaterialOptionPane.showConfirmDialog(
                             SettingsGlobalPanel.this,
                             "Successfully disconnected from OpenAI.",
@@ -2470,14 +2474,18 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
     }
 
     private void maybeRunCodexAutoSetup() {
-        if (MainProject.isOpenAiCodexOauthConnected()) {
-            logger.info("Codex OAuth connected; installing Codex favorites preset and default vendor.");
+        if (!MainProject.isOpenAiCodexOauthConnected()) {
+            return;
+        }
+        logger.info("Codex OAuth connected; installing Codex favorites preset and default vendor.");
 
+        // Disk I/O (favorites + vendor preference writes) plus Service.reloadService must run off
+        // the EDT; the user-facing dialog has to run back on the EDT once the work is done.
+        chrome.getContextManager().submitBackgroundTask("Setting up Codex defaults", () -> {
             var previousVendor = MainProject.applyCodexSignInAutoSetup();
-
             chrome.getContextManager().reloadService();
 
-            SwingUtilities.invokeLater(() -> {
+            SwingUtil.runOnEdt(() -> {
                 String vendorLine = previousVendor
                         .map(prev -> String.format(
                                 "%n%n\"Vendor for other models\" was switched to \"%s\" (was: %s). To change it, open Settings > Advanced > Model Roles and pick a different entry from the \"Vendor for other models\" dropdown.",
@@ -2486,9 +2494,8 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
                 String message =
                         """
                         Codex OAuth is connected. While the OAuth-only restriction is enabled
-                        (Settings > Global), all model roles route to Codex models automatically
-                        without overwriting your saved preferences. The favorites list has been
-                        updated with Codex presets."""
+                        (Settings > Global), all model roles route to Codex models automatically.
+                        The favorites list has been updated with Codex presets."""
                                         .stripIndent()
                                 + vendorLine;
 
@@ -2501,7 +2508,7 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
                 parentDialog.reloadSettingsAndSelectTab(SettingsAdvancedPanel.MODEL_ROLES_TAB_TITLE);
             });
-        }
+        });
     }
 
     @Override

--- a/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
+++ b/app/src/main/java/ai/brokk/gui/dialogs/SettingsGlobalPanel.java
@@ -24,7 +24,6 @@ import ai.brokk.mcpclient.McpUtils;
 import ai.brokk.mcpclient.StdioMcpServer;
 import ai.brokk.openai.OpenAiOAuthService;
 import ai.brokk.project.MainProject;
-import ai.brokk.project.ModelProperties;
 import ai.brokk.util.Environment;
 import ai.brokk.util.GlobalUiSettings;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -2434,9 +2433,8 @@ public class SettingsGlobalPanel extends JPanel implements ThemeAware, SettingsC
 
         chrome.getContextManager().submitBackgroundTask("Disconnecting OpenAI", () -> {
             String error = Service.disconnectCodexOauth();
-            var restoredVendor = error == null
-                    ? MainProject.setOpenAiCodexOauthConnected(false)
-                    : Optional.<String>empty();
+            var restoredVendor =
+                    error == null ? MainProject.setOpenAiCodexOauthConnected(false) : Optional.<String>empty();
             SwingUtil.runOnEdt(() -> {
                 if (error == null) {
                     String message = "Successfully disconnected from OpenAI."

--- a/app/src/main/java/ai/brokk/project/MainProject.java
+++ b/app/src/main/java/ai/brokk/project/MainProject.java
@@ -13,6 +13,7 @@ import ai.brokk.analyzer.Language;
 import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.concurrent.AtomicWrites;
+import ai.brokk.exception.GlobalExceptionHandler;
 import ai.brokk.git.GitRepo;
 import ai.brokk.git.GitRepoFactory;
 import ai.brokk.git.IGitRepo;
@@ -1105,18 +1106,30 @@ public final class MainProject extends AbstractProject {
         return Boolean.parseBoolean(props.getProperty(OPENAI_CODEX_OAUTH_CONNECTED_KEY, "false"));
     }
 
-    public static void setOpenAiCodexOauthConnected(boolean connected) {
-        var props = loadGlobalProperties();
-        boolean currentValue = Boolean.parseBoolean(props.getProperty(OPENAI_CODEX_OAUTH_CONNECTED_KEY, "false"));
-        if (currentValue != connected) {
+    @Blocking
+    public static Optional<String> setOpenAiCodexOauthConnected(boolean connected) {
+        Optional<String> restoredVendor = Optional.empty();
+        synchronized (MainProject.class) {
+            var props = loadGlobalProperties();
+            boolean currentValue = Boolean.parseBoolean(props.getProperty(OPENAI_CODEX_OAUTH_CONNECTED_KEY, "false"));
+            if (currentValue == connected) {
+                return Optional.empty();
+            }
             if (connected) {
+                try {
+                    applyCodexSignInAutoSetup(props);
+                } catch (RuntimeException e) {
+                    GlobalExceptionHandler.handle(e);
+                }
                 props.setProperty(OPENAI_CODEX_OAUTH_CONNECTED_KEY, "true");
             } else {
+                restoredVendor = revertCodexAutoSetupVendor(props).restoredVendor();
                 props.remove(OPENAI_CODEX_OAUTH_CONNECTED_KEY);
             }
             saveGlobalProperties(props);
-            notifyOpenAiOauthConnectionChanged();
         }
+        notifyOpenAiOauthConnectionChanged();
+        return restoredVendor;
     }
 
     public static boolean isRestrictToOauthModelsWhenConnected() {
@@ -1499,6 +1512,7 @@ public final class MainProject extends AbstractProject {
     private static final String TERMINAL_FONT_SIZE_KEY = "terminalFontSize";
     private static final String STARTUP_OPEN_MODE_KEY = "startupOpenMode";
     private static final String OTHER_MODELS_VENDOR_KEY = "otherModelsVendor";
+    private static final String OTHER_MODELS_VENDOR_PRE_CODEX_KEY = "otherModelsVendorBeforeCodexAutoSetup";
 
     public static String getUiScalePref() {
         var props = loadGlobalProperties();
@@ -1566,8 +1580,9 @@ public final class MainProject extends AbstractProject {
         return props.getProperty(OTHER_MODELS_VENDOR_KEY, "");
     }
 
-    public static void setOtherModelsVendorPreference(String vendor) {
+    public static synchronized void setOtherModelsVendorPreference(String vendor) {
         var props = loadGlobalProperties();
+        props.remove(OTHER_MODELS_VENDOR_PRE_CODEX_KEY);
         if (vendor.isBlank()) {
             props.remove(OTHER_MODELS_VENDOR_KEY);
         } else {
@@ -1883,46 +1898,104 @@ public final class MainProject extends AbstractProject {
     }
 
     /**
-     * Applies the post-Codex-sign-in defaults: installs the Codex favorites preset and switches
-     * the "Vendor for other models" preference to {@link ModelProperties#CODEX_VENDOR}. Both the
-     * GUI ({@code SettingsGlobalPanel.maybeRunCodexAutoSetup}) and ACP {@code /codex-login} flows
-     * call this so the persisted state is identical regardless of entry point.
+     * Applies the post-Codex-sign-in defaults: installs the Codex favorites preset, switches the
+     * "Vendor for other models" preference to {@link ModelProperties#CODEX_VENDOR}, and remembers
+     * the replaced vendor so disconnect can restore it.
      *
      * @return the previous vendor preference if it differed from {@link ModelProperties#CODEX_VENDOR}
      *         (so callers can mention it in user-facing messaging); empty otherwise.
      */
     @Blocking
-    public static Optional<String> applyCodexSignInAutoSetup() {
-        saveFavoriteModels(ModelProperties.CODEX_OAUTH_FAVORITES);
-        String previousVendor = getOtherModelsVendorPreference();
-        if (ModelProperties.CODEX_VENDOR.equals(previousVendor)) {
-            return Optional.empty();
+    public static synchronized Optional<String> applyCodexSignInAutoSetup() {
+        var props = loadGlobalProperties();
+        var result = applyCodexSignInAutoSetup(props);
+        if (result.changed()) {
+            saveGlobalProperties(props);
         }
-        setOtherModelsVendorPreference(ModelProperties.CODEX_VENDOR);
+        return result.previousVendor();
+    }
+
+    private static CodexAutoSetupResult applyCodexSignInAutoSetup(Properties props) {
+        boolean changed = ModelProperties.saveFavoriteModels(props, ModelProperties.CODEX_OAUTH_FAVORITES);
+        String previousVendor = props.getProperty(OTHER_MODELS_VENDOR_KEY, "");
+        if (ModelProperties.CODEX_VENDOR.equals(previousVendor)) {
+            return new CodexAutoSetupResult(Optional.empty(), changed);
+        }
+        props.setProperty(OTHER_MODELS_VENDOR_PRE_CODEX_KEY, previousVendor);
+        props.setProperty(OTHER_MODELS_VENDOR_KEY, ModelProperties.CODEX_VENDOR);
         logger.info(
                 "Codex auto-setup: switched 'Vendor for other models' from '{}' to '{}'",
                 previousVendor.isBlank() ? "(default)" : previousVendor,
                 ModelProperties.CODEX_VENDOR);
-        return Optional.of(previousVendor);
+        return new CodexAutoSetupResult(Optional.of(previousVendor), true);
     }
 
     /**
-     * Reverts the {@link ModelProperties#CODEX_VENDOR} vendor preference back to the default if it
-     * is currently selected. Mirrors {@link #applyCodexSignInAutoSetup()} so disconnecting Codex
-     * does not leave the user pinned to a vendor that the UI hides while disconnected.
+     * Restores the vendor preference that {@link #applyCodexSignInAutoSetup()} replaced, if Codex
+     * auto-setup is still responsible for the current Codex vendor selection.
      *
-     * @return {@code true} if the preference was reset.
+     * @return the restored vendor preference, empty if no auto-setup vendor was restored.
      */
     @Blocking
-    public static boolean revertCodexAutoSetupVendor() {
-        if (!ModelProperties.CODEX_VENDOR.equals(getOtherModelsVendorPreference())) {
-            return false;
+    public static synchronized Optional<String> revertCodexAutoSetupVendor() {
+        var props = loadGlobalProperties();
+        var result = revertCodexAutoSetupVendor(props);
+        if (result.changed()) {
+            saveGlobalProperties(props);
         }
-        setOtherModelsVendorPreference("");
-        logger.info(
-                "Codex disconnect: reset 'Vendor for other models' from '{}' to default", ModelProperties.CODEX_VENDOR);
-        return true;
+        return result.restoredVendor();
     }
+
+    private static CodexVendorRestoreResult revertCodexAutoSetupVendor(Properties props) {
+        String previousVendor = props.getProperty(OTHER_MODELS_VENDOR_PRE_CODEX_KEY);
+        if (previousVendor == null) {
+            return new CodexVendorRestoreResult(Optional.empty(), false);
+        }
+        props.remove(OTHER_MODELS_VENDOR_PRE_CODEX_KEY);
+        if (!ModelProperties.CODEX_VENDOR.equals(props.getProperty(OTHER_MODELS_VENDOR_KEY, ""))) {
+            logger.info(
+                    "Codex disconnect: cleared stale pre-Codex vendor '{}' because current vendor is '{}'",
+                    previousVendor.isBlank() ? "(default)" : previousVendor,
+                    props.getProperty(OTHER_MODELS_VENDOR_KEY, ""));
+            return new CodexVendorRestoreResult(Optional.empty(), true);
+        }
+        if (previousVendor.isBlank()) {
+            props.remove(OTHER_MODELS_VENDOR_KEY);
+        } else {
+            props.setProperty(OTHER_MODELS_VENDOR_KEY, previousVendor);
+        }
+        logger.info(
+                "Codex disconnect: restored 'Vendor for other models' from '{}' to '{}'",
+                ModelProperties.CODEX_VENDOR,
+                previousVendor.isBlank() ? "(default)" : previousVendor);
+        return new CodexVendorRestoreResult(Optional.of(previousVendor), true);
+    }
+
+    @Blocking
+    public static synchronized Optional<String> getCodexAutoSetupPreviousVendorPreference() {
+        var props = loadGlobalProperties();
+        if (!ModelProperties.CODEX_VENDOR.equals(props.getProperty(OTHER_MODELS_VENDOR_KEY, ""))) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(props.getProperty(OTHER_MODELS_VENDOR_PRE_CODEX_KEY));
+    }
+
+    public static String formatCodexAutoSetupVendorMessage(String previousVendor) {
+        return String.format(
+                "\"Vendor for other models\" was switched to \"%s\" (was: %s). To change it, open Settings > Advanced > Model Roles and pick a different entry from the \"Vendor for other models\" dropdown.",
+                ModelProperties.CODEX_VENDOR,
+                previousVendor.isBlank() ? "Default" : previousVendor);
+    }
+
+    public static String formatCodexDisconnectVendorRestoreMessage(String restoredVendor) {
+        return String.format(
+                "\"Vendor for other models\" was restored to %s.",
+                restoredVendor.isBlank() ? "Default" : "\"" + restoredVendor + "\"");
+    }
+
+    private record CodexAutoSetupResult(Optional<String> previousVendor, boolean changed) {}
+
+    private record CodexVendorRestoreResult(Optional<String> restoredVendor, boolean changed) {}
 
     private static Properties loadProjectsProperties() {
         var props = new Properties();

--- a/app/src/main/java/ai/brokk/project/MainProject.java
+++ b/app/src/main/java/ai/brokk/project/MainProject.java
@@ -1891,6 +1891,7 @@ public final class MainProject extends AbstractProject {
      * @return the previous vendor preference if it differed from {@link ModelProperties#CODEX_VENDOR}
      *         (so callers can mention it in user-facing messaging); empty otherwise.
      */
+    @Blocking
     public static Optional<String> applyCodexSignInAutoSetup() {
         saveFavoriteModels(ModelProperties.CODEX_OAUTH_FAVORITES);
         String previousVendor = getOtherModelsVendorPreference();
@@ -1912,6 +1913,7 @@ public final class MainProject extends AbstractProject {
      *
      * @return {@code true} if the preference was reset.
      */
+    @Blocking
     public static boolean revertCodexAutoSetupVendor() {
         if (!ModelProperties.CODEX_VENDOR.equals(getOtherModelsVendorPreference())) {
             return false;

--- a/app/src/main/java/ai/brokk/project/MainProject.java
+++ b/app/src/main/java/ai/brokk/project/MainProject.java
@@ -1882,6 +1882,46 @@ public final class MainProject extends AbstractProject {
         }
     }
 
+    /**
+     * Applies the post-Codex-sign-in defaults: installs the Codex favorites preset and switches
+     * the "Vendor for other models" preference to {@link ModelProperties#CODEX_VENDOR}. Both the
+     * GUI ({@code SettingsGlobalPanel.maybeRunCodexAutoSetup}) and ACP {@code /codex-login} flows
+     * call this so the persisted state is identical regardless of entry point.
+     *
+     * @return the previous vendor preference if it differed from {@link ModelProperties#CODEX_VENDOR}
+     *         (so callers can mention it in user-facing messaging); empty otherwise.
+     */
+    public static Optional<String> applyCodexSignInAutoSetup() {
+        saveFavoriteModels(ModelProperties.CODEX_OAUTH_FAVORITES);
+        String previousVendor = getOtherModelsVendorPreference();
+        if (ModelProperties.CODEX_VENDOR.equals(previousVendor)) {
+            return Optional.empty();
+        }
+        setOtherModelsVendorPreference(ModelProperties.CODEX_VENDOR);
+        logger.info(
+                "Codex auto-setup: switched 'Vendor for other models' from '{}' to '{}'",
+                previousVendor.isBlank() ? "(default)" : previousVendor,
+                ModelProperties.CODEX_VENDOR);
+        return Optional.of(previousVendor);
+    }
+
+    /**
+     * Reverts the {@link ModelProperties#CODEX_VENDOR} vendor preference back to the default if it
+     * is currently selected. Mirrors {@link #applyCodexSignInAutoSetup()} so disconnecting Codex
+     * does not leave the user pinned to a vendor that the UI hides while disconnected.
+     *
+     * @return {@code true} if the preference was reset.
+     */
+    public static boolean revertCodexAutoSetupVendor() {
+        if (!ModelProperties.CODEX_VENDOR.equals(getOtherModelsVendorPreference())) {
+            return false;
+        }
+        setOtherModelsVendorPreference("");
+        logger.info(
+                "Codex disconnect: reset 'Vendor for other models' from '{}' to default", ModelProperties.CODEX_VENDOR);
+        return true;
+    }
+
     private static Properties loadProjectsProperties() {
         var props = new Properties();
         Path projectsPath = getProjectsPropertiesPath();

--- a/app/src/main/java/ai/brokk/project/MainProject.java
+++ b/app/src/main/java/ai/brokk/project/MainProject.java
@@ -1983,8 +1983,7 @@ public final class MainProject extends AbstractProject {
     public static String formatCodexAutoSetupVendorMessage(String previousVendor) {
         return String.format(
                 "\"Vendor for other models\" was switched to \"%s\" (was: %s). To change it, open Settings > Advanced > Model Roles and pick a different entry from the \"Vendor for other models\" dropdown.",
-                ModelProperties.CODEX_VENDOR,
-                previousVendor.isBlank() ? "Default" : previousVendor);
+                ModelProperties.CODEX_VENDOR, previousVendor.isBlank() ? "Default" : previousVendor);
     }
 
     public static String formatCodexDisconnectVendorRestoreMessage(String restoredVendor) {

--- a/app/src/main/java/ai/brokk/project/ModelProperties.java
+++ b/app/src/main/java/ai/brokk/project/ModelProperties.java
@@ -70,6 +70,9 @@ public final class ModelProperties {
     // Default vendor selection for "Other Models" settings
     public static final String DEFAULT_VENDOR = "Default";
 
+    /** Canonical "Vendor for other models" entry that routes to the Codex OAuth model catalog. */
+    public static final String CODEX_VENDOR = "OpenAI - Codex";
+
     /**
      * Current version for model settings. Increment this to force a reset of favorite models,
      * code model, and architect model to their current defaults on the next app upgrade.
@@ -191,7 +194,7 @@ public final class ModelProperties {
                             ModelType.SEARCH, codex5_3,
                             ModelType.BUILD_PROCESSOR, gpt5_4NanoHigh));
             map.put(
-                    "OpenAI - Codex",
+                    CODEX_VENDOR,
                     Map.of(
                             ModelType.SUMMARIZE, gpt5_3CodexOauthDefault,
                             ModelType.USAGES, gpt5_3CodexOauthDefault,
@@ -263,7 +266,7 @@ public final class ModelProperties {
             case ARCHITECT -> CODEX_OAUTH_ARCHITECT_CONFIG;
             default -> {
                 var codexMap =
-                        requireNonNull(getVendorModelMap().get("OpenAI - Codex"), "OpenAI - Codex vendor map missing");
+                        requireNonNull(getVendorModelMap().get(CODEX_VENDOR), "OpenAI - Codex vendor map missing");
                 yield requireNonNull(
                         codexMap.get(modelType), "OpenAI - Codex vendor map missing entry for " + modelType);
             }

--- a/app/src/test/java/ai/brokk/project/CodexAutoSetupTest.java
+++ b/app/src/test/java/ai/brokk/project/CodexAutoSetupTest.java
@@ -2,7 +2,6 @@ package ai.brokk.project;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -189,19 +188,89 @@ class CodexAutoSetupTest {
     }
 
     @Test
-    void testRevertCodexAutoSetupVendorOnlyTouchesCodex(@TempDir Path tempDir) {
+    void testRevertCodexAutoSetupVendorRestoresOriginalVendor(@TempDir Path tempDir) {
         System.setProperty("brokk.test.mode", "true");
         System.setProperty("brokk.test.sandbox.root", tempDir.toString());
         MainProject.resetGlobalConfigCachesForTests();
 
-        // No-op when preference is already not-Codex.
         MainProject.setOtherModelsVendorPreference("Anthropic");
-        assertFalse(MainProject.revertCodexAutoSetupVendor(), "Should not touch a non-Codex vendor");
+
+        Optional<String> previous = MainProject.applyCodexSignInAutoSetup();
+        assertEquals(Optional.of("Anthropic"), previous);
+        assertEquals(ModelProperties.CODEX_VENDOR, MainProject.getOtherModelsVendorPreference());
+
+        Optional<String> restored = MainProject.revertCodexAutoSetupVendor();
+        assertEquals(Optional.of("Anthropic"), restored);
         assertEquals("Anthropic", MainProject.getOtherModelsVendorPreference());
 
-        // Reverts when preference is Codex.
+        MainProject.resetGlobalConfigCachesForTests();
+        assertEquals("Anthropic", MainProject.getOtherModelsVendorPreference());
+    }
+
+    @Test
+    void testRevertCodexAutoSetupVendorRestoresDefaultVendor(@TempDir Path tempDir) {
+        System.setProperty("brokk.test.mode", "true");
+        System.setProperty("brokk.test.sandbox.root", tempDir.toString());
+        MainProject.resetGlobalConfigCachesForTests();
+
+        Optional<String> previous = MainProject.applyCodexSignInAutoSetup();
+        assertEquals(Optional.of(""), previous);
+        assertEquals(ModelProperties.CODEX_VENDOR, MainProject.getOtherModelsVendorPreference());
+
+        Optional<String> restored = MainProject.revertCodexAutoSetupVendor();
+        assertEquals(Optional.of(""), restored);
+        assertEquals("", MainProject.getOtherModelsVendorPreference(), "Codex should restore the empty default");
+    }
+
+    @Test
+    void testRevertCodexAutoSetupVendorPreservesExplicitCodexChoice(@TempDir Path tempDir) {
+        System.setProperty("brokk.test.mode", "true");
+        System.setProperty("brokk.test.sandbox.root", tempDir.toString());
+        MainProject.resetGlobalConfigCachesForTests();
+
         MainProject.setOtherModelsVendorPreference(ModelProperties.CODEX_VENDOR);
-        assertTrue(MainProject.revertCodexAutoSetupVendor(), "Should revert when on Codex");
-        assertEquals("", MainProject.getOtherModelsVendorPreference(), "Codex should reset to default");
+        assertTrue(MainProject.revertCodexAutoSetupVendor().isEmpty(), "Should not touch an explicit Codex vendor");
+        assertEquals(ModelProperties.CODEX_VENDOR, MainProject.getOtherModelsVendorPreference());
+    }
+
+    @Test
+    void testManualVendorChangeAfterAutoSetupClearsRestoreMarker(@TempDir Path tempDir) {
+        System.setProperty("brokk.test.mode", "true");
+        System.setProperty("brokk.test.sandbox.root", tempDir.toString());
+        MainProject.resetGlobalConfigCachesForTests();
+
+        MainProject.setOtherModelsVendorPreference("Anthropic");
+        assertEquals(Optional.of("Anthropic"), MainProject.applyCodexSignInAutoSetup());
+
+        MainProject.setOtherModelsVendorPreference(ModelProperties.CODEX_VENDOR);
+        assertTrue(MainProject.revertCodexAutoSetupVendor().isEmpty());
+        assertEquals(ModelProperties.CODEX_VENDOR, MainProject.getOtherModelsVendorPreference());
+    }
+
+    @Test
+    void testSetConnectedAppliesCodexAutoSetupWithoutSettingsPanelListener(@TempDir Path tempDir) {
+        System.setProperty("brokk.test.mode", "true");
+        System.setProperty("brokk.test.sandbox.root", tempDir.toString());
+        MainProject.resetGlobalConfigCachesForTests();
+
+        MainProject.setOtherModelsVendorPreference("Anthropic");
+        MainProject.setOpenAiCodexOauthConnected(true);
+
+        assertEquals(ModelProperties.CODEX_VENDOR, MainProject.getOtherModelsVendorPreference());
+        assertEquals(Optional.of("Anthropic"), MainProject.getCodexAutoSetupPreviousVendorPreference());
+
+        Optional<String> restored = MainProject.setOpenAiCodexOauthConnected(false);
+        assertEquals(Optional.of("Anthropic"), restored);
+        assertEquals("Anthropic", MainProject.getOtherModelsVendorPreference());
+    }
+
+    @Test
+    void testCodexAutoSetupMessagesUseSharedWording() {
+        assertEquals(
+                "\"Vendor for other models\" was switched to \"OpenAI - Codex\" (was: Anthropic). To change it, open Settings > Advanced > Model Roles and pick a different entry from the \"Vendor for other models\" dropdown.",
+                MainProject.formatCodexAutoSetupVendorMessage("Anthropic"));
+        assertEquals(
+                "\"Vendor for other models\" was restored to \"Anthropic\".",
+                MainProject.formatCodexDisconnectVendorRestoreMessage("Anthropic"));
     }
 }

--- a/app/src/test/java/ai/brokk/project/CodexAutoSetupTest.java
+++ b/app/src/test/java/ai/brokk/project/CodexAutoSetupTest.java
@@ -2,6 +2,7 @@ package ai.brokk.project;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,6 +10,7 @@ import ai.brokk.AbstractService.ModelConfig;
 import ai.brokk.project.ModelProperties.ModelType;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -144,5 +146,62 @@ class CodexAutoSetupTest {
         // Persistence sanity: substitution never wrote anything to disk.
         MainProject.resetGlobalConfigCachesForTests();
         assertEquals("claude-sonnet-4-6", project.getModelConfig(ModelType.CODE).name());
+    }
+
+    @Test
+    void testApplyCodexSignInAutoSetupSwitchesVendorAndReportsPrevious(@TempDir Path tempDir) {
+        System.setProperty("brokk.test.mode", "true");
+        System.setProperty("brokk.test.sandbox.root", tempDir.toString());
+        MainProject.resetGlobalConfigCachesForTests();
+
+        // Pre-condition: no vendor preference set yet.
+        assertEquals("", MainProject.getOtherModelsVendorPreference());
+
+        Optional<String> previous = MainProject.applyCodexSignInAutoSetup();
+        assertTrue(previous.isPresent(), "Helper should report a vendor change occurred");
+        assertEquals("", previous.get(), "Previous vendor should be the empty default");
+        assertEquals(
+                ModelProperties.CODEX_VENDOR,
+                MainProject.getOtherModelsVendorPreference(),
+                "Vendor preference should switch to OpenAI - Codex");
+
+        // Idempotent: re-running when already on Codex reports no change.
+        Optional<String> repeat = MainProject.applyCodexSignInAutoSetup();
+        assertTrue(repeat.isEmpty(), "Helper should report no change when already on Codex");
+
+        // Persistence: survives a cache reset.
+        MainProject.resetGlobalConfigCachesForTests();
+        assertEquals(ModelProperties.CODEX_VENDOR, MainProject.getOtherModelsVendorPreference());
+    }
+
+    @Test
+    void testApplyCodexSignInAutoSetupReportsExplicitPreviousVendor(@TempDir Path tempDir) {
+        System.setProperty("brokk.test.mode", "true");
+        System.setProperty("brokk.test.sandbox.root", tempDir.toString());
+        MainProject.resetGlobalConfigCachesForTests();
+
+        MainProject.setOtherModelsVendorPreference("Anthropic");
+
+        Optional<String> previous = MainProject.applyCodexSignInAutoSetup();
+        assertTrue(previous.isPresent(), "Helper should report a vendor change occurred");
+        assertEquals("Anthropic", previous.get(), "Previous vendor should be reported verbatim");
+        assertEquals(ModelProperties.CODEX_VENDOR, MainProject.getOtherModelsVendorPreference());
+    }
+
+    @Test
+    void testRevertCodexAutoSetupVendorOnlyTouchesCodex(@TempDir Path tempDir) {
+        System.setProperty("brokk.test.mode", "true");
+        System.setProperty("brokk.test.sandbox.root", tempDir.toString());
+        MainProject.resetGlobalConfigCachesForTests();
+
+        // No-op when preference is already not-Codex.
+        MainProject.setOtherModelsVendorPreference("Anthropic");
+        assertFalse(MainProject.revertCodexAutoSetupVendor(), "Should not touch a non-Codex vendor");
+        assertEquals("Anthropic", MainProject.getOtherModelsVendorPreference());
+
+        // Reverts when preference is Codex.
+        MainProject.setOtherModelsVendorPreference(ModelProperties.CODEX_VENDOR);
+        assertTrue(MainProject.revertCodexAutoSetupVendor(), "Should revert when on Codex");
+        assertEquals("", MainProject.getOtherModelsVendorPreference(), "Codex should reset to default");
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #3539. When a user signs into Codex (Sign in with ChatGPT), the persisted "Vendor for other models" preference now switches to **OpenAI - Codex** instead of leaving them on whatever vendor (often `Default`) was selected before. The post-sign-in dialog (GUI) and ACP message report the switch and tell the user how to change it back via Settings > Advanced > Model Roles.
- Centralizes the vendor-switch + favorites-save pair in `MainProject.applyCodexSignInAutoSetup()` so the GUI listener (`SettingsGlobalPanel.maybeRunCodexAutoSetup`) and the ACP `/codex-login` flow (`BrokkAcpAgent.startCodexLogin`) share one code path.
- For symmetry, the disconnect paths now revert the vendor preference if it is currently `OpenAI - Codex`, via `MainProject.revertCodexAutoSetupVendor()`. Without this the persisted value lingers on a vendor the UI hides while disconnected.
- Introduces `ModelProperties.CODEX_VENDOR` and routes the four existing `"OpenAI - Codex"` literal references through it.

## Test plan
- [x] `./gradlew :app:spotlessApply` clean
- [x] `./gradlew :app:compileJava :app:compileTestJava` (errorprone + NullAway clean)
- [x] `./gradlew :app:test --tests "ai.brokk.project.CodexAutoSetupTest"` — 6 tests pass, including 3 new ones covering: (a) initial default switches to Codex and reports `""` previous, (b) explicit prior vendor is reported verbatim and persisted, (c) revert helper only touches Codex and resets to default
- [x] `./gradlew :app:test --tests "ai.brokk.acp.BrokkAcpAgentTest"` — pass
- [x] `./gradlew :app:test --tests "ai.brokk.project.*"` — pass
- [ ] Manual: sign into Codex via the GUI Connect button, verify the "Codex Sign-in Complete" dialog now mentions the vendor switch and that Settings > Advanced > Model Roles shows `OpenAI - Codex` selected after reload
- [ ] Manual: run `/codex-login` over ACP, verify the success message includes the vendor-switch note
- [ ] Manual: disconnect Codex (GUI + ACP), verify the persisted preference is cleared back to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)