### PR TITLE
brokk-code: drop spurious '--' separator before JBang user params (#3547)

### DIFF
--- a/brokk-code/brokk_code/mcp_launcher.py
+++ b/brokk-code/brokk_code/mcp_launcher.py
@@ -127,11 +127,6 @@ def _run_mcp(
         )
         launcher = command[0]
         if passthrough_args:
-            # JBang requires '--' before arguments intended for the Java main class
-            # to distinguish them from JBang's own options.
-            # _build_direct_mcp_command always starts with 'java'.
-            if launcher != "java":
-                command.append("--")
             command.extend(passthrough_args)
 
         os.chdir(resolved_workspace_dir)

--- a/brokk-code/tests/test_mcp_launcher.py
+++ b/brokk-code/tests/test_mcp_launcher.py
@@ -146,10 +146,13 @@ def test_run_mcp_server_reports_missing_runtime(monkeypatch, tmp_path, capsys) -
     assert "Unable to launch MCP runtime" in capsys.readouterr().err
 
 
-def test_run_mcp_server_appends_passthrough_args_with_separator_for_jbang(
+def test_run_mcp_server_appends_passthrough_args_directly_for_jbang(
     monkeypatch, tmp_path
 ) -> None:
-    """Verify JBang launches include '--' before passthrough args."""
+    """JBang's `jbang run [OPTS] <script> [<userParams>...]` grammar has no `--`
+    separator: anything after the script/jar URL is passed straight to the Java
+    main. Adding `--` shows up as `args[0]` to the main class and trips
+    `CliArgParser`'s `unknown argument --` warning (issue #3547)."""
     captured: dict[str, object] = {}
 
     def fake_execvpe(binary: str, command: list[str], env: dict[str, str]) -> None:
@@ -173,8 +176,8 @@ def test_run_mcp_server_appends_passthrough_args_with_separator_for_jbang(
     command = captured["command"]
     assert isinstance(command, list)
     assert command[0] == "/usr/local/bin/jbang"
-    # For JBang, we expect -- before passthrough args
-    assert command[-3:] == ["--", "--help", "--verbose"]
+    assert command[-2:] == ["--help", "--verbose"]
+    assert "--" not in command
 
 
 def test_run_mcp_server_appends_passthrough_args_directly_for_java(monkeypatch, tmp_path) -> None:
@@ -307,7 +310,7 @@ def test_run_mcp_core_server_falls_back_to_jbang(monkeypatch, tmp_path) -> None:
     assert any("brokk-core-0.99.0.jar" in arg for arg in command)
 
 
-def test_run_mcp_core_server_passthrough_args_with_jbang_separator(monkeypatch, tmp_path) -> None:
+def test_run_mcp_core_server_passthrough_args_directly_for_jbang(monkeypatch, tmp_path) -> None:
     captured: dict[str, object] = {}
 
     def fake_execvpe(binary: str, command: list[str], env: dict[str, str]) -> None:
@@ -329,7 +332,8 @@ def test_run_mcp_core_server_passthrough_args_with_jbang_separator(monkeypatch, 
         )
 
     command = captured["command"]
-    assert command[-2:] == ["--", "--verbose"]
+    assert command[-1] == "--verbose"
+    assert "--" not in command
 
 
 def test_run_mcp_core_server_passthrough_args_direct_java_no_separator(

--- a/brokk-code/tests/test_mcp_launcher.py
+++ b/brokk-code/tests/test_mcp_launcher.py
@@ -146,9 +146,7 @@ def test_run_mcp_server_reports_missing_runtime(monkeypatch, tmp_path, capsys) -
     assert "Unable to launch MCP runtime" in capsys.readouterr().err
 
 
-def test_run_mcp_server_appends_passthrough_args_directly_for_jbang(
-    monkeypatch, tmp_path
-) -> None:
+def test_run_mcp_server_appends_passthrough_args_directly_for_jbang(monkeypatch, tmp_path) -> None:
     """JBang's `jbang run [OPTS] <script> [<userParams>...]` grammar has no `--`
     separator: anything after the script/jar URL is passed straight to the Java
     main. Adding `--` shows up as `args[0]` to the main class and trips
@@ -336,9 +334,7 @@ def test_run_mcp_core_server_passthrough_args_directly_for_jbang(monkeypatch, tm
     assert "--" not in command
 
 
-def test_run_mcp_core_server_passthrough_args_direct_java_no_separator(
-    monkeypatch, tmp_path
-) -> None:
+def test_run_mcp_core_server_passthrough_args_directly_for_java(monkeypatch, tmp_path) -> None:
     captured: dict[str, object] = {}
     dummy_jar = tmp_path / "brokk-core.jar"
     dummy_jar.write_text("dummy")
@@ -479,3 +475,37 @@ def test_run_acp_server_passthrough_with_explicit_executor_version_still_uses_ja
     assert str(dummy_jar) in command
     assert not any("9.9.9" in part for part in command)
     assert not any("brokk-releases" in part for part in command)
+
+
+def test_run_acp_server_passthrough_args_directly_for_jbang(monkeypatch, tmp_path) -> None:
+    """`brokk acp` (no --jar) must launch via JBang and append passthrough args
+    such as `--workspace-dir <path>` directly to the command, with no `--`
+    separator before them. This is the exact production scenario from issue
+    #3547: the spurious `--` would otherwise show up as `args[0]` to the Java
+    main and trip `CliArgParser`'s `unknown argument --` warning."""
+    captured: dict[str, object] = {}
+
+    def fake_execvpe(binary: str, command: list[str], env: dict[str, str]) -> None:
+        captured["binary"] = binary
+        captured["command"] = command
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "chdir", lambda _path: None)
+    monkeypatch.setattr(os, "execvpe", fake_execvpe)
+    monkeypatch.setattr(mcp_launcher, "git_toplevel_for", lambda _path: None)
+    monkeypatch.setattr(mcp_launcher, "ensure_jbang_ready", lambda: "/usr/local/bin/jbang")
+
+    with pytest.raises(RuntimeError, match="stop"):
+        mcp_launcher.run_acp_server(
+            workspace_dir=tmp_path,
+            jar_path=None,
+            executor_version=None,
+            passthrough_args=["--workspace-dir", str(tmp_path)],
+        )
+
+    command = captured["command"]
+    assert captured["binary"] == "/usr/local/bin/jbang"
+    assert "ai.brokk.acp.AcpServerMain" in command
+    assert command[-2:] == ["--workspace-dir", str(tmp_path)]
+    assert "--" not in command


### PR DESCRIPTION
## Summary

Closes #3547.

`mcp_launcher._run_mcp` was inserting a `--` token before passthrough args whenever the launcher was JBang. JBang's grammar is `jbang run [OPTIONS] <scriptOrFile> [<userParams>...]` — there is no `--` separator; everything after the script/jar URL is passed straight to the Java main. The injected `--` showed up as `args[0]` and tripped `CliArgParser`'s `Warning: unknown argument --` on every ACP/MCP startup. On Windows it's the most visible output before stdin EOF, so the server looked like it crashed.

Affects `brokk acp`, `brokk mcp`, and `brokk mcp-core` — all three commands route through `_run_mcp`, so removing five lines fixes them in one place.

## Test plan

- [x] `uv run pytest brokk-code/tests/test_mcp_launcher.py` — 18 passed.
- [x] `uv run ruff check brokk_code/mcp_launcher.py tests/test_mcp_launcher.py` — clean.
- [x] Two existing tests asserted the broken behavior (`command[-3:] == ["--", "--help", "--verbose"]` and `command[-2:] == ["--", "--verbose"]`); flipped to `"--" not in command` so the contract now reflects reality. Renamed accordingly.
- [ ] Manual: `brokk acp` and `brokk mcp` start cleanly on Linux/Windows with no `unknown argument --` warning in stderr.