### PR TITLE
Add support for glob patterns to findFilenames tool

### DIFF
--- a/app/src/main/java/ai/brokk/mcpserver/BrokkExternalMcpServer.java
+++ b/app/src/main/java/ai/brokk/mcpserver/BrokkExternalMcpServer.java
@@ -285,13 +285,24 @@ public class BrokkExternalMcpServer {
         Path current = Files.isDirectory(resolved) ? resolved : requireNonNull(resolved.getParent());
 
         for (Path candidate = current; candidate != null; candidate = candidate.getParent()) {
-            Path gitPath = candidate.resolve(".git");
-            if (Files.isDirectory(gitPath) || Files.isRegularFile(gitPath)) {
+            if (hasGitMetadata(candidate)) {
                 return candidate;
             }
         }
 
         return resolved;
+    }
+
+    private static boolean hasGitMetadata(Path candidate) {
+        Path gitPath = candidate.resolve(".git");
+        if (Files.isRegularFile(gitPath)) {
+            try {
+                return Files.readString(gitPath).startsWith("gitdir: ");
+            } catch (IOException e) {
+                return false;
+            }
+        }
+        return Files.isRegularFile(gitPath.resolve("HEAD")) && Files.isRegularFile(gitPath.resolve("config"));
     }
 
     public static List<McpServerFeatures.SyncToolSpecification> toolSpecificationsFrom(

--- a/app/src/main/java/ai/brokk/project/FileFilteringService.java
+++ b/app/src/main/java/ai/brokk/project/FileFilteringService.java
@@ -3,6 +3,7 @@ package ai.brokk.project;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.git.GitRepo;
 import ai.brokk.git.IGitRepo;
+import ai.brokk.util.FilenamePatternMatcher;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -273,38 +274,7 @@ public final class FileFilteringService {
      */
     @VisibleForTesting
     public static Pattern globToRegex(String glob) {
-        var regex = new StringBuilder();
-        int i = 0;
-        while (i < glob.length()) {
-            char c = glob.charAt(i);
-            if (c == '*') {
-                if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
-                    // ** matches anything including path separators
-                    regex.append(".*");
-                    i += 2;
-                    // Skip trailing / after **
-                    if (i < glob.length() && glob.charAt(i) == '/') {
-                        regex.append("/?");
-                        i++;
-                    }
-                } else {
-                    // * matches anything except path separator
-                    regex.append("[^/]*");
-                    i++;
-                }
-            } else if (c == '?') {
-                regex.append("[^/]");
-                i++;
-            } else if (".^$+[]{}()|\\".indexOf(c) >= 0) {
-                // Escape regex metacharacters
-                regex.append('\\').append(c);
-                i++;
-            } else {
-                regex.append(c);
-                i++;
-            }
-        }
-        return Pattern.compile(regex.toString());
+        return FilenamePatternMatcher.globToRegex(glob);
     }
 
     private MatchResult checkIgnoreFile(Path ignoreFile, String pathToCheck, boolean isDirectory) {

--- a/app/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/app/src/main/java/ai/brokk/tools/SearchTools.java
@@ -24,6 +24,7 @@ import ai.brokk.git.IGitRepo;
 import ai.brokk.io.ProjectFiles;
 import ai.brokk.util.AlmostGrep;
 import ai.brokk.util.FileTargetHeuristic;
+import ai.brokk.util.FilenamePatternMatcher;
 import ai.brokk.util.Lines;
 import ai.brokk.util.Messages;
 import ai.brokk.util.SearchToolSupport;
@@ -2291,12 +2292,12 @@ public class SearchTools {
     @Tool(
             """
                     Returns filenames (relative to the project root) that match the given patterns.
-                    Accepts regex or literal strings; invalid regex is automatically treated as a literal match.
+                    Accepts regex patterns; invalid regex is automatically treated as a glob pattern.
                     Matching is always case-insensitive.
                     Use this to find configuration files, test data, or source files when you know part of their name.
                     """)
     public String findFilenames(
-            @P("Patterns to match against filenames (regex or literal string).") List<String> patterns,
+            @P("Patterns to match against filenames. Invalid regex falls back to glob matching.") List<String> patterns,
             @P("Maximum number of filenames to return (capped at 100).") int limit) {
         if (patterns.isEmpty()) {
             throw new IllegalArgumentException("Cannot search filenames: patterns list is empty");
@@ -2304,50 +2305,8 @@ public class SearchTools {
 
         logger.debug("Searching filenames for patterns: {}", patterns);
 
-        final List<Pattern> compiledPatterns;
-        try {
-            List<Pattern> matchingPatterns = new ArrayList<>();
-            List<String> compileErrors = new ArrayList<>();
-            for (String pattern : patterns) {
-                boolean hasBackslash = pattern.contains("\\");
-                boolean normalizedCompiled = false;
-
-                try {
-                    matchingPatterns.addAll(compilePatternsWithFlags(
-                            List.of(toUnixPath(pattern)), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
-                    normalizedCompiled = true;
-                } catch (IllegalArgumentException e) {
-                    if (!hasBackslash) {
-                        compileErrors.add(
-                                e.getMessage() != null
-                                        ? e.getMessage()
-                                        : e.getClass().getSimpleName());
-                    }
-                }
-
-                if (hasBackslash) {
-                    try {
-                        matchingPatterns.addAll(compilePatternsWithFlags(
-                                List.of(pattern), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
-                    } catch (IllegalArgumentException e) {
-                        if (!normalizedCompiled) {
-                            compileErrors.add(
-                                    e.getMessage() != null
-                                            ? e.getMessage()
-                                            : e.getClass().getSimpleName());
-                        }
-                    }
-                }
-            }
-
-            if (!compileErrors.isEmpty()) {
-                throw new IllegalArgumentException(String.join("; ", compileErrors));
-            }
-
-            compiledPatterns = List.copyOf(matchingPatterns);
-        } catch (IllegalArgumentException e) {
-            return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-        }
+        final var compiledPatterns =
+                FilenamePatternMatcher.compilePatterns(patterns, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
         if (compiledPatterns.isEmpty()) {
             throw new IllegalArgumentException("No valid patterns provided");
@@ -2358,8 +2317,8 @@ public class SearchTools {
             allMatches = contextManager.getProject().getAllFiles().stream()
                     .filter(pf -> {
                         String filePath = toUnixPath(pf.toString());
-                        for (Pattern pattern : compiledPatterns) {
-                            if (AlmostGrep.findWithOverflowGuard(pattern, filePath)) {
+                        for (var pattern : compiledPatterns) {
+                            if (pattern.matches(filePath)) {
                                 return true;
                             }
                         }

--- a/app/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/app/src/main/java/ai/brokk/tools/SearchTools.java
@@ -2292,12 +2292,13 @@ public class SearchTools {
     @Tool(
             """
                     Returns filenames (relative to the project root) that match the given patterns.
-                    Accepts regex patterns; invalid regex is automatically treated as a glob pattern.
+                    Accepts regex and glob patterns; glob-looking patterns are matched both ways.
                     Matching is always case-insensitive.
                     Use this to find configuration files, test data, or source files when you know part of their name.
                     """)
     public String findFilenames(
-            @P("Patterns to match against filenames. Invalid regex falls back to glob matching.") List<String> patterns,
+            @P("Patterns to match against filenames. Glob-looking patterns also use glob matching.")
+                    List<String> patterns,
             @P("Maximum number of filenames to return (capped at 100).") int limit) {
         if (patterns.isEmpty()) {
             throw new IllegalArgumentException("Cannot search filenames: patterns list is empty");

--- a/app/src/test/java/ai/brokk/mcpserver/BrokkExternalMcpServerProjectRootTest.java
+++ b/app/src/test/java/ai/brokk/mcpserver/BrokkExternalMcpServerProjectRootTest.java
@@ -11,7 +11,9 @@ class BrokkExternalMcpServerProjectRootTest {
     @Test
     void resolveProjectRoot_returnsNearestGitAncestorForNestedDirectory() throws Exception {
         Path repoRoot = Files.createTempDirectory("mcp-root");
-        Files.createDirectory(repoRoot.resolve(".git"));
+        Path gitDir = Files.createDirectory(repoRoot.resolve(".git"));
+        Files.writeString(gitDir.resolve("HEAD"), "ref: refs/heads/main\n");
+        Files.writeString(gitDir.resolve("config"), "[core]\n");
         Path nestedDir =
                 Files.createDirectories(repoRoot.resolve("a").resolve("b").resolve("c"));
 
@@ -36,6 +38,17 @@ class BrokkExternalMcpServerProjectRootTest {
     @Test
     void resolveProjectRoot_returnsResolvedPathWhenNoGitMarkerExists() throws Exception {
         Path directory = Files.createTempDirectory("mcp-no-git");
+
+        Path resolved = BrokkExternalMcpServer.resolveProjectRoot(directory);
+
+        assertEquals(directory.toAbsolutePath().normalize(), resolved);
+    }
+
+    @Test
+    void resolveProjectRoot_ignoresInvalidGitAncestor() throws Exception {
+        Path parent = Files.createTempDirectory("mcp-invalid-git-parent");
+        Files.createDirectory(parent.resolve(".git"));
+        Path directory = Files.createDirectories(parent.resolve("no-git"));
 
         Path resolved = BrokkExternalMcpServer.resolveProjectRoot(directory);
 

--- a/app/src/test/java/ai/brokk/tools/SearchToolsTest.java
+++ b/app/src/test/java/ai/brokk/tools/SearchToolsTest.java
@@ -259,6 +259,37 @@ public class SearchToolsTest {
     }
 
     @Test
+    void testfindFilenames_validRegexAlsoMatchesGlob() throws Exception {
+        Path eventFile = projectRoot.resolve("lib/events/report.go");
+        Files.createDirectories(eventFile.getParent());
+        Files.writeString(eventFile, "package events");
+        Path helper = projectRoot.resolve("scripts/foo_bar.py");
+        Files.createDirectories(helper.getParent());
+        Files.writeString(helper, "print('ok')");
+        Path escapedStar = projectRoot.resolve("scripts/foo_star.py");
+        Files.writeString(escapedStar, "print('ok')");
+        Path repository = projectRoot.resolve("persistence/album_repository.go");
+        Files.createDirectories(repository.getParent());
+        Files.writeString(repository, "package persistence");
+
+        mockProjectFiles.add(new ProjectFile(projectRoot, "lib/events/report.go"));
+        mockProjectFiles.add(new ProjectFile(projectRoot, "scripts/foo_bar.py"));
+        mockProjectFiles.add(new ProjectFile(projectRoot, "scripts/foo_star.py"));
+        mockProjectFiles.add(new ProjectFile(projectRoot, "persistence/album_repository.go"));
+
+        String pathGlobResult = searchTools.findFilenames(List.of("lib/events/*.go"), 200);
+        String basenameGlobResult = searchTools.findFilenames(List.of("foo_*.py"), 200);
+        String mixedGlobResult = searchTools.findFilenames(List.of("*_repository\\.go"), 200);
+        String escapedGlobResult = searchTools.findFilenames(List.of("foo\\*.py"), 200);
+
+        assertTrue(pathGlobResult.contains("- report.go"), "Should match valid-regex path glob as a glob");
+        assertTrue(basenameGlobResult.contains("- foo_bar.py"), "Should match valid-regex basename glob as a glob");
+        assertTrue(mixedGlobResult.contains("- album_repository.go"), "Should allow regex-escaped literals in globs");
+        assertTrue(
+                escapedGlobResult.contains("- foo_star.py"), "Should not turn escaped glob chars into path separators");
+    }
+
+    @Test
     void testfindFilenames_limitEnforced() {
         for (int i = 0; i < 10; i++) {
             mockProjectFiles.add(new ProjectFile(projectRoot, "file" + i + ".txt"));

--- a/app/src/test/java/ai/brokk/tools/SearchToolsTest.java
+++ b/app/src/test/java/ai/brokk/tools/SearchToolsTest.java
@@ -220,10 +220,42 @@ public class SearchToolsTest {
     }
 
     @Test
-    void testfindFilenames_invalidRegexFallsBackToLiteral() throws Exception {
-        // Invalid regex should fall back to literal matching, not throw
+    void testfindFilenames_invalidRegexDoesNotReportError() throws Exception {
+        // Invalid regex should fall back instead of reporting a regex error.
         String result = searchTools.findFilenames(List.of("[["), 200);
         assertFalse(result.contains("Invalid regex pattern"), "Should not report regex error after fallback");
+    }
+
+    @Test
+    void testfindFilenames_invalidRegexFallsBackToGlob() throws Exception {
+        Path proto = projectRoot.resolve("rpc/flipt/flipt.proto");
+        Files.createDirectories(proto.getParent());
+        Files.writeString(proto, "syntax = \"proto3\";");
+        Path protocol = projectRoot.resolve("internal/config/testdata/database/missing_protocol.yml");
+        Files.createDirectories(protocol.getParent());
+        Files.writeString(protocol, "protocol: missing");
+
+        mockProjectFiles.add(new ProjectFile(projectRoot, "rpc/flipt/flipt.proto"));
+        mockProjectFiles.add(new ProjectFile(projectRoot, "internal/config/testdata/database/missing_protocol.yml"));
+
+        String result = searchTools.findFilenames(List.of("*.proto"), 200);
+
+        assertTrue(result.contains("# rpc/flipt"), "Should group the proto file by directory");
+        assertTrue(result.contains("- flipt.proto"), "Should match basename glob in nested directories");
+        assertFalse(result.contains("missing_protocol.yml"), "Should not behave like broad substring search");
+    }
+
+    @Test
+    void testfindFilenames_invalidRegexPathGlobFallsBackToGlob() throws Exception {
+        Path proto = projectRoot.resolve("rpc/flipt/flipt.proto");
+        Files.createDirectories(proto.getParent());
+        Files.writeString(proto, "syntax = \"proto3\";");
+        mockProjectFiles.add(new ProjectFile(projectRoot, "rpc/flipt/flipt.proto"));
+
+        String result = searchTools.findFilenames(List.of("rpc/**/*.proto"), 200);
+
+        assertTrue(result.contains("# rpc/flipt"), "Should match recursive path globs");
+        assertTrue(result.contains("- flipt.proto"), "Should include matching proto file");
     }
 
     @Test

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -368,7 +368,8 @@ public class BrokkCoreMcpServer {
                                 "patterns",
                                 arrayProp(
                                         "Patterns to match against filenames. Invalid regex falls back to glob matching, so patterns like *.proto work."),
-                                "limit", intProp("Maximum results to return.")),
+                                "limit",
+                                intProp("Maximum results to return.")),
                         List.of("patterns", "limit")),
                 (exchange, request) -> withReadLock(() -> {
                     var patterns = stringListArg(request, "patterns");

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -374,12 +374,12 @@ public class BrokkCoreMcpServer {
 
         specs.add(tool(
                 "findFilenames",
-                "Search for files by name pattern. Accepts regex patterns; invalid regex is automatically treated as a glob pattern. Patterns are case-insensitive and match anywhere in the filename.",
+                "Search for files by name pattern. Accepts regex and glob patterns; glob-looking patterns are matched both ways. Patterns are case-insensitive.",
                 schema(
                         Map.of(
                                 "patterns",
                                 arrayProp(
-                                        "Patterns to match against filenames. Invalid regex falls back to glob matching, so patterns like *.proto work."),
+                                        "Patterns to match against filenames. Glob-looking patterns like *.proto also use glob matching."),
                                 "limit",
                                 intProp("Maximum results to return.")),
                         List.of("patterns", "limit")),

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -362,10 +362,12 @@ public class BrokkCoreMcpServer {
 
         specs.add(tool(
                 "findFilenames",
-                "Search for files by name pattern. Accepts regex or literal strings; invalid regex is automatically treated as a literal match. Patterns are case-insensitive and match anywhere in the filename.",
+                "Search for files by name pattern. Accepts regex patterns; invalid regex is automatically treated as a glob pattern. Patterns are case-insensitive and match anywhere in the filename.",
                 schema(
                         Map.of(
-                                "patterns", arrayProp("Patterns to match against filenames (regex or literal string)."),
+                                "patterns",
+                                arrayProp(
+                                        "Patterns to match against filenames. Invalid regex falls back to glob matching, so patterns like *.proto work."),
                                 "limit", intProp("Maximum results to return.")),
                         List.of("patterns", "limit")),
                 (exchange, request) -> withReadLock(() -> {

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -198,11 +198,23 @@ public class BrokkCoreMcpServer {
         Path resolved = path.toAbsolutePath().normalize();
         Path current = Files.isDirectory(resolved) ? resolved : requireNonNull(resolved.getParent());
         for (Path candidate = current; candidate != null; candidate = candidate.getParent()) {
-            if (Files.isDirectory(candidate.resolve(".git")) || Files.isRegularFile(candidate.resolve(".git"))) {
+            if (hasGitMetadata(candidate)) {
                 return candidate;
             }
         }
         return resolved;
+    }
+
+    private static boolean hasGitMetadata(Path candidate) {
+        Path gitPath = candidate.resolve(".git");
+        if (Files.isRegularFile(gitPath)) {
+            try {
+                return Files.readString(gitPath).startsWith("gitdir: ");
+            } catch (IOException e) {
+                return false;
+            }
+        }
+        return Files.isRegularFile(gitPath.resolve("HEAD")) && Files.isRegularFile(gitPath.resolve("config"));
     }
 
     private static void initiateStdinEofShutdown(

--- a/brokk-core/src/main/java/ai/brokk/project/FileFilteringService.java
+++ b/brokk-core/src/main/java/ai/brokk/project/FileFilteringService.java
@@ -3,6 +3,7 @@ package ai.brokk.project;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.git.GitRepo;
 import ai.brokk.git.IGitRepo;
+import ai.brokk.util.FilenamePatternMatcher;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -273,38 +274,7 @@ public final class FileFilteringService {
      */
     @VisibleForTesting
     public static Pattern globToRegex(String glob) {
-        var regex = new StringBuilder();
-        int i = 0;
-        while (i < glob.length()) {
-            char c = glob.charAt(i);
-            if (c == '*') {
-                if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
-                    // ** matches anything including path separators
-                    regex.append(".*");
-                    i += 2;
-                    // Skip trailing / after **
-                    if (i < glob.length() && glob.charAt(i) == '/') {
-                        regex.append("/?");
-                        i++;
-                    }
-                } else {
-                    // * matches anything except path separator
-                    regex.append("[^/]*");
-                    i++;
-                }
-            } else if (c == '?') {
-                regex.append("[^/]");
-                i++;
-            } else if (".^$+[]{}()|\\".indexOf(c) >= 0) {
-                // Escape regex metacharacters
-                regex.append('\\').append(c);
-                i++;
-            } else {
-                regex.append(c);
-                i++;
-            }
-        }
-        return Pattern.compile(regex.toString());
+        return FilenamePatternMatcher.globToRegex(glob);
     }
 
     private MatchResult checkIgnoreFile(Path ignoreFile, String pathToCheck, boolean isDirectory) {

--- a/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
@@ -25,6 +25,7 @@ import ai.brokk.git.GitRepoFactory;
 import ai.brokk.git.IGitRepo;
 import ai.brokk.util.AlmostGrep;
 import ai.brokk.util.FileTargetHeuristic;
+import ai.brokk.util.FilenamePatternMatcher;
 import ai.brokk.util.Lines;
 import ai.brokk.util.Messages;
 import ai.brokk.util.PathExpander;
@@ -2161,50 +2162,8 @@ public class SearchTools {
 
         logger.debug("Searching filenames for patterns: {}", patterns);
 
-        final List<Pattern> compiledPatterns;
-        try {
-            List<Pattern> matchingPatterns = new ArrayList<>();
-            List<String> compileErrors = new ArrayList<>();
-            for (String pattern : patterns) {
-                boolean hasBackslash = pattern.contains("\\");
-                boolean normalizedCompiled = false;
-
-                try {
-                    matchingPatterns.addAll(compilePatternsWithFlags(
-                            List.of(toUnixPath(pattern)), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
-                    normalizedCompiled = true;
-                } catch (IllegalArgumentException e) {
-                    if (!hasBackslash) {
-                        compileErrors.add(
-                                e.getMessage() != null
-                                        ? e.getMessage()
-                                        : e.getClass().getSimpleName());
-                    }
-                }
-
-                if (hasBackslash) {
-                    try {
-                        matchingPatterns.addAll(compilePatternsWithFlags(
-                                List.of(pattern), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
-                    } catch (IllegalArgumentException e) {
-                        if (!normalizedCompiled) {
-                            compileErrors.add(
-                                    e.getMessage() != null
-                                            ? e.getMessage()
-                                            : e.getClass().getSimpleName());
-                        }
-                    }
-                }
-            }
-
-            if (!compileErrors.isEmpty()) {
-                throw new IllegalArgumentException(String.join("; ", compileErrors));
-            }
-
-            compiledPatterns = List.copyOf(matchingPatterns);
-        } catch (IllegalArgumentException e) {
-            return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-        }
+        final var compiledPatterns =
+                FilenamePatternMatcher.compilePatterns(patterns, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
         if (compiledPatterns.isEmpty()) {
             throw new IllegalArgumentException("No valid patterns provided");
@@ -2215,8 +2174,8 @@ public class SearchTools {
             allMatches = codeIntelligence.getProject().getAllFiles().stream()
                     .filter(pf -> {
                         String filePath = toUnixPath(pf.toString());
-                        for (Pattern pattern : compiledPatterns) {
-                            if (AlmostGrep.findWithOverflowGuard(pattern, filePath)) {
+                        for (var pattern : compiledPatterns) {
+                            if (pattern.matches(filePath)) {
                                 return true;
                             }
                         }

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -149,6 +149,17 @@ class BrokkCoreMcpServerTest {
         assertEquals(noGitDir.toAbsolutePath().normalize(), resolved);
     }
 
+    @Test
+    void resolveProjectRootIgnoresInvalidGitParent() throws Exception {
+        var parent = tempDir.resolve("invalid-git-parent");
+        Files.createDirectories(parent.resolve(".git"));
+        var noGitDir = parent.resolve("no-git");
+        Files.createDirectories(noGitDir);
+
+        var resolved = BrokkCoreMcpServer.resolveProjectRoot(noGitDir);
+        assertEquals(noGitDir.toAbsolutePath().normalize(), resolved);
+    }
+
     // -- getActiveWorkspace tool test --
 
     @Test

--- a/brokk-core/src/test/java/ai/brokk/tools/SearchToolsTest.java
+++ b/brokk-core/src/test/java/ai/brokk/tools/SearchToolsTest.java
@@ -103,6 +103,45 @@ class SearchToolsTest {
     }
 
     @Test
+    void findFilenames_ValidRegexAlsoMatchesGlob() throws Exception {
+        Path projectRoot = initRepo();
+        commitTrackedFiles(
+                projectRoot,
+                Map.of(
+                        "lib/events/report.go",
+                        "package events",
+                        "scripts/foo_bar.py",
+                        "print('ok')",
+                        "scripts/foo_star.py",
+                        "print('ok')",
+                        "persistence/album_repository.go",
+                        "package persistence"),
+                Instant.parse("2025-01-01T00:00:00Z"),
+                "Add glob target files");
+
+        project = new CoreProject(projectRoot);
+        SearchTools tools = new SearchTools(new StandaloneCodeIntelligence(project, new DisabledAnalyzer(project)));
+
+        String pathGlobResult = tools.findFilenames(List.of("lib/events/*.go"), 10);
+        String basenameGlobResult = tools.findFilenames(List.of("foo_*.py"), 10);
+        String mixedGlobResult = tools.findFilenames(List.of("*_repository\\.go"), 10);
+        String escapedGlobResult = tools.findFilenames(List.of("foo\\*.py"), 10);
+
+        assertTrue(
+                pathGlobResult.contains("- report.go"),
+                "Should match valid-regex path glob as a glob. Result: " + pathGlobResult);
+        assertTrue(
+                basenameGlobResult.contains("- foo_bar.py"),
+                "Should match valid-regex basename glob as a glob. Result: " + basenameGlobResult);
+        assertTrue(
+                mixedGlobResult.contains("- album_repository.go"),
+                "Should allow regex-escaped literals in globs. Result: " + mixedGlobResult);
+        assertTrue(
+                escapedGlobResult.contains("- foo_star.py"),
+                "Should not turn escaped glob chars into path separators. Result: " + escapedGlobResult);
+    }
+
+    @Test
     void searchSymbols_AppendsRelatedContent() throws Exception {
         Path projectRoot = initRepo();
         commitTrackedFiles(

--- a/brokk-core/src/test/java/ai/brokk/tools/SearchToolsTest.java
+++ b/brokk-core/src/test/java/ai/brokk/tools/SearchToolsTest.java
@@ -76,6 +76,33 @@ class SearchToolsTest {
     }
 
     @Test
+    void findFilenames_InvalidRegexFallsBackToGlob() throws Exception {
+        Path projectRoot = initRepo();
+        commitTrackedFiles(
+                projectRoot,
+                Map.of(
+                        "rpc/flipt/flipt.proto",
+                        "syntax = \"proto3\";",
+                        "internal/config/testdata/database/missing_protocol.yml",
+                        "protocol: missing"),
+                Instant.parse("2025-01-01T00:00:00Z"),
+                "Add proto and protocol files");
+
+        project = new CoreProject(projectRoot);
+        SearchTools tools = new SearchTools(new StandaloneCodeIntelligence(project, new DisabledAnalyzer(project)));
+
+        String result = tools.findFilenames(List.of("*.proto"), 10);
+
+        assertTrue(result.contains("# rpc/flipt"), "Should group the proto file by directory. Result: " + result);
+        assertTrue(
+                result.contains("- flipt.proto"),
+                "Should match basename glob in nested directories. Result: " + result);
+        assertFalse(
+                result.contains("missing_protocol.yml"),
+                "Should not behave like broad substring search. Result: " + result);
+    }
+
+    @Test
     void searchSymbols_AppendsRelatedContent() throws Exception {
         Path projectRoot = initRepo();
         commitTrackedFiles(

--- a/brokk-shared/src/main/java/ai/brokk/util/FilenamePatternMatcher.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/FilenamePatternMatcher.java
@@ -1,0 +1,87 @@
+package ai.brokk.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public final class FilenamePatternMatcher {
+    private FilenamePatternMatcher() {}
+
+    public record FilenamePattern(Pattern pattern, boolean glob, boolean matchFullPath) {
+        public boolean matches(String filePath) {
+            if (!glob) {
+                return AlmostGrep.findWithOverflowGuard(pattern, filePath);
+            }
+            String candidate = matchFullPath ? filePath : basename(filePath);
+            return pattern.matcher(candidate).matches();
+        }
+    }
+
+    public static List<FilenamePattern> compilePatterns(List<String> patterns, int flags) {
+        List<String> nonBlank = patterns.stream().filter(p -> !p.isBlank()).toList();
+        if (nonBlank.isEmpty()) {
+            return List.of();
+        }
+
+        List<FilenamePattern> compiled = new ArrayList<>(nonBlank.size());
+        for (String pattern : nonBlank) {
+            compiled.add(compilePattern(toUnixPath(pattern), pattern, flags));
+            if (pattern.contains("\\")) {
+                compiled.add(compilePattern(pattern, pattern, flags));
+            }
+        }
+        return List.copyOf(compiled);
+    }
+
+    public static Pattern globToRegex(String glob) {
+        var regex = new StringBuilder();
+        int i = 0;
+        while (i < glob.length()) {
+            char c = glob.charAt(i);
+            if (c == '*') {
+                if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
+                    regex.append(".*");
+                    i += 2;
+                    if (i < glob.length() && glob.charAt(i) == '/') {
+                        regex.append("/?");
+                        i++;
+                    }
+                } else {
+                    regex.append("[^/]*");
+                    i++;
+                }
+            } else if (c == '?') {
+                regex.append("[^/]");
+                i++;
+            } else if (".^$+[]{}()|\\".indexOf(c) >= 0) {
+                regex.append('\\').append(c);
+                i++;
+            } else {
+                regex.append(c);
+                i++;
+            }
+        }
+        return Pattern.compile(regex.toString());
+    }
+
+    private static FilenamePattern compilePattern(String regexPattern, String globPattern, int flags) {
+        try {
+            return new FilenamePattern(Pattern.compile(regexPattern, flags), false, true);
+        } catch (PatternSyntaxException e) {
+            String normalizedGlob = toUnixPath(globPattern);
+            Pattern globRegex = globToRegex(normalizedGlob);
+            Pattern compiledGlob = Pattern.compile(globRegex.pattern(), flags);
+            return new FilenamePattern(compiledGlob, true, normalizedGlob.contains("/"));
+        }
+    }
+
+    private static String toUnixPath(String path) {
+        return path.replace('\\', '/');
+    }
+
+    private static String basename(String path) {
+        int lastSlash = path.lastIndexOf('/');
+        return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/util/FilenamePatternMatcher.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/FilenamePatternMatcher.java
@@ -24,11 +24,14 @@ public final class FilenamePatternMatcher {
             return List.of();
         }
 
-        List<FilenamePattern> compiled = new ArrayList<>(nonBlank.size());
+        List<FilenamePattern> compiled = new ArrayList<>(nonBlank.size() * 2);
         for (String pattern : nonBlank) {
             compiled.add(compilePattern(toUnixPath(pattern), pattern, flags));
             if (pattern.contains("\\")) {
                 compiled.add(compilePattern(pattern, pattern, flags));
+            }
+            if (hasGlobMetacharacter(pattern)) {
+                compiled.add(compileGlobPattern(pattern, flags));
             }
         }
         return List.copyOf(compiled);
@@ -69,15 +72,50 @@ public final class FilenamePatternMatcher {
         try {
             return new FilenamePattern(Pattern.compile(regexPattern, flags), false, true);
         } catch (PatternSyntaxException e) {
-            String normalizedGlob = toUnixPath(globPattern);
-            Pattern globRegex = globToRegex(normalizedGlob);
-            Pattern compiledGlob = Pattern.compile(globRegex.pattern(), flags);
-            return new FilenamePattern(compiledGlob, true, normalizedGlob.contains("/"));
+            return compileGlobPattern(globPattern, flags);
         }
+    }
+
+    private static FilenamePattern compileGlobPattern(String globPattern, int flags) {
+        String normalizedGlob = normalizeGlobPattern(globPattern);
+        Pattern globRegex = globToRegex(normalizedGlob);
+        Pattern compiledGlob = Pattern.compile(globRegex.pattern(), flags);
+        return new FilenamePattern(compiledGlob, true, normalizedGlob.contains("/"));
+    }
+
+    private static boolean hasGlobMetacharacter(String pattern) {
+        return pattern.indexOf('*') >= 0 || pattern.indexOf('?') >= 0 || pattern.indexOf('[') >= 0;
     }
 
     private static String toUnixPath(String path) {
         return path.replace('\\', '/');
+    }
+
+    private static String normalizeGlobPattern(String pattern) {
+        var normalized = new StringBuilder(pattern.length());
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (c != '\\') {
+                normalized.append(c);
+                continue;
+            }
+            if (i + 1 >= pattern.length()) {
+                normalized.append('/');
+                continue;
+            }
+            char next = pattern.charAt(i + 1);
+            // In glob mode, tolerate regex-style escapes for punctuation that agents commonly mix
+            // into filename globs, e.g. *_repository\.go and foo\*.py. Bare backslashes and
+            // backslashes before letters/digits remain path separators, so src\main normalizes to
+            // src/main. Use forward slashes when combining Windows-style paths with glob segments.
+            if (".^$+{}()|*?[]".indexOf(next) >= 0) {
+                normalized.append(next);
+                i++;
+            } else {
+                normalized.append('/');
+            }
+        }
+        return normalized.toString();
     }
 
     private static String basename(String path) {


### PR DESCRIPTION
During analysis of benchmark results, we found that `findFilenames` accepts only regex and fails on glob patterns, while LLMs try it often with globs. Sometimes models recover, but sometimes they get side-tracked too much during recovery by e.g. providing non-patterned literals that return many unrelated results.

The PR includes:
- Make `findFilenames` fall back to glob matching when a provided regex is invalid, so inputs like `*.proto` work as expected.
- Centralize filename regex/glob matching in shared utility code used by both app and brokk-core.
- Harden MCP project-root detection to ignore invalid parent `.git` directories and only accept real Git metadata (unrelated to tools changes; caused some issues when running tests locally).