### PR TITLE
[codex] Fix ACP component installer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://blog.brokk.ai">Blog</a> •
   <a href="https://www.youtube.com/@Brokk_AI">YouTube</a> •
   <a href="https://github.com/BrokkAi/brokk/releases">Download</a> •
+  <a href="#install">Install</a> •
   <a href="#getting-started">Getting Started</a>
 </p>
 
@@ -30,6 +31,36 @@ Brokk keeps LLMs on-task in large codebases with fragment-level context, code in
 <p align="center">
   <img src="docs/media/brokk-hero.gif" alt="Brokk Lutz Mode: collect relevant fragments -> prune -> note/discard -> workspace ready" width="1080">
 </p>
+
+## Install
+
+Most users should install the Brokk desktop app from GitHub Releases:
+
+- Download Brokk: https://github.com/BrokkAi/brokk/releases
+- Alternative jDeploy install page: https://www.jdeploy.com/gh/BrokkAi/brokk
+
+The app installer is the normal way to run Brokk. It includes the Java desktop application and handles platform-specific packaging.
+
+### ACP support components
+
+The scripts under `installer/` do **not** install the Brokk desktop app. They install only the standalone agent support components:
+
+- `bifrost`: the auth proxy
+- `brokk-acp`: the Rust ACP server
+
+Use this only when you need those command-line components for ACP/Codex-style integrations:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.sh | bash
+```
+
+On Windows, run this in PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.ps1 | iex
+```
+
+The component installer downloads the latest GitHub release assets for your platform, installs them to a per-user bin directory, and adds that directory to `PATH`. See [installer/README.md](installer/README.md) for options, pinned versions, supported platforms, and security notes.
 
 ## Why Brokk is different
 
@@ -64,26 +95,6 @@ This gives a quick "fitness for this task" indicator so you can choose the best 
 <p align="center">
   <img src="docs/media/screenshot-bpr-meter.png" alt="In-app BPR meter above the Instructions panel" width="800">
 </p>
-
-## Claude Code Plugin
-
-Brokk is available as a [Claude Code plugin](claude-plugin/README.md) that adds semantic code intelligence -- symbol navigation, cross-reference analysis, and structural code understanding. See the [plugin README](claude-plugin/README.md) for installation instructions.
-
-## Terminal UI (Python Client)
-
-The `brokk-code/` directory contains the **Python (Textual) terminal UI client**. This is an interactive TUI that launches and manages a **local Java executor** subprocess.
-
-- **Main Product**: The core Brokk engine (executor) is Java-based.
-- **TUI Client**: The Python project is a separate client that communicates with the executor via a local HTTP API.
-- **Documentation**:
-  - See [brokk-code/README.md](brokk-code/README.md) for instructions on running and configuring the TUI.
-  - See [brokk-code/AGENTS.md](brokk-code/AGENTS.md) for Python-specific contributor guidance.
-
-**Common Confusion:**
-- **Builds**: Java components use Gradle; the TUI uses Python (`uv` or `pip`). Build them independently.
-- **Execution**: Run TUI commands (like `uv run brokk-code`) from the `brokk-code/` directory.
-- **Executor JAR**: The TUI automatically downloads the required Java executor JAR to `~/.brokk/` on first run, so you don't need to build the Java project manually just to use the client.
-- **Authentication**: The TUI handles authentication by generating a transient bearer token to secure the local communication with the executor subprocess.
 
 ## How it works (20 seconds)
 
@@ -176,6 +187,7 @@ The `brokk-code/` directory contains the **Python (Textual) terminal UI client**
        ```
      - All platforms and installers: https://www.jdeploy.com/gh/BrokkAi/brokk
      - Requires Java 21+. On Windows, use the Releases installers or the jDeploy page.
+   - Optional ACP support components: use the `bifrost` + `brokk-acp` installer above only if you need those standalone command-line services.
 
 3. Launch and sign in
    - Start Brokk and paste your API key when prompted.
@@ -183,6 +195,14 @@ The `brokk-code/` directory contains the **Python (Textual) terminal UI client**
 4. Requirements
    - For building from source: JDK 21 or newer (JetBrains Runtime recommended).
    - Supported platforms: recent macOS, Windows, and Linux distributions.
+
+## Related Tools
+
+These are optional companion projects, not the main desktop app install path:
+
+- [Claude Code plugin](claude-plugin/README.md): adds Brokk-powered semantic code intelligence to Claude Code.
+- [Terminal UI](brokk-code/README.md): a Python/Textual client that launches a local Java executor subprocess.
+- [ACP support components](installer/README.md): installs only `bifrost` and `brokk-acp` for ACP/Codex-style integrations.
 
 ## Staging Environment
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,24 +1,25 @@
-# Brokk Installer
+# Brokk ACP Component Installer
 
-One-line installers that download and install [bifrost](https://github.com/BrokkAi/bifrost)
-(the auth proxy) and `brokk-acp` (the Rust ACP server) together.
+One-line installers for the standalone ACP support components:
+[bifrost](https://github.com/BrokkAi/bifrost) (the auth proxy) and
+`brokk-acp` (the Rust ACP server).
+
+These scripts do **not** install the Brokk desktop app. To install the app,
+download a platform installer from https://github.com/BrokkAi/brokk/releases.
 
 ## Quick install
 
 ### Linux / macOS
 
 ```sh
-curl -sSL https://install.brokk.ai | bash
+curl -fsSL https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.sh | bash
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-irm https://install.brokk.ai/install.ps1 | iex
+irm https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.ps1 | iex
 ```
-
-> If you do not yet have the `install.brokk.ai` redirect set up, you can
-> always invoke the scripts directly from this repo's raw content URL.
 
 ## Supported platforms
 
@@ -71,7 +72,7 @@ Equivalent environment variables: `BROKK_INSTALL_DIR`, `BIFROST_VERSION`,
 To pass arguments through `curl | bash`, use the `bash -s --` form:
 
 ```sh
-curl -sSL https://install.brokk.ai | bash -s -- --install-dir ~/bin
+curl -fsSL https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.sh | bash -s -- --install-dir ~/bin
 ```
 
 ### `install.ps1`
@@ -92,7 +93,7 @@ To pass arguments to the script you need to download it first, since
 `irm | iex` cannot forward arguments:
 
 ```powershell
-irm https://install.brokk.ai/install.ps1 -OutFile install.ps1
+irm https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.ps1 -OutFile install.ps1
 .\install.ps1 -InstallDir 'C:\tools\brokk'
 ```
 
@@ -100,7 +101,7 @@ You can also set env vars before piping:
 
 ```powershell
 $env:BROKK_INSTALL_DIR = 'C:\tools\brokk'
-irm https://install.brokk.ai/install.ps1 | iex
+irm https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.ps1 | iex
 ```
 
 ## Windows execution policy

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -30,11 +30,11 @@
     Print the installer version and exit.
 
 .EXAMPLE
-    irm https://install.brokk.ai/install.ps1 | iex
+    irm https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.ps1 | iex
 
 .EXAMPLE
     # With options, download then run:
-    irm https://install.brokk.ai/install.ps1 -OutFile install.ps1
+    irm https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.ps1 -OutFile install.ps1
     .\install.ps1 -InstallDir C:\tools\brokk
 
 .NOTES
@@ -167,6 +167,33 @@ function Get-LatestPrefixedTag($repo, $prefix) {
     Die "No release found for $repo with tag prefix '$prefix'. Pin a version with -AcpVersion or `$env:BROKK_ACP_VERSION."
 }
 
+function Get-ReleaseByTag($repo, $tag) {
+    $url = "https://api.github.com/repos/$repo/releases/tags/$tag"
+    try {
+        return Invoke-DownloadJson $url
+    } catch {
+        Die "Could not fetch release $tag for ${repo}: $_"
+    }
+}
+
+function Find-AssetUrl {
+    param(
+        [Parameter(Mandatory)] $Release,
+        [Parameter(Mandatory)] [string] $AssetName,
+        [switch] $Optional
+    )
+    $asset = $Release.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+    if (-not $asset) {
+        if ($Optional) { return $null }
+        Die "Release $($Release.tag_name) is missing expected asset: $AssetName"
+    }
+    if (-not $asset.browser_download_url) {
+        if ($Optional) { return $null }
+        Die "Release $($Release.tag_name) asset $AssetName has no browser_download_url."
+    }
+    return $asset.browser_download_url
+}
+
 # ---- install helpers -----------------------------------------------------
 
 function Test-Sha256 {
@@ -203,7 +230,8 @@ function Install-Bifrost {
     }
     $target = 'x86_64-pc-windows-msvc'
     $archiveName = "bifrost-$Version-$target.zip"
-    $url = "https://github.com/$BifrostRepo/releases/download/$Version/$archiveName"
+    $release = Get-ReleaseByTag $BifrostRepo $Version
+    $url = Find-AssetUrl -Release $release -AssetName $archiveName
 
     Write-Step "Downloading bifrost $Version ($target)"
     $tmp = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ("brokk-installer-" + [guid]::NewGuid())) -Force
@@ -211,13 +239,17 @@ function Install-Bifrost {
         $archivePath = Join-Path $tmp.FullName $archiveName
         Invoke-Download -Url $url -Destination $archivePath
 
-        $shaUrl = "$url.sha256"
+        $shaUrl = Find-AssetUrl -Release $release -AssetName "$archiveName.sha256" -Optional
         $shaPath = "$archivePath.sha256"
         $shaOk = $false
-        try {
-            Invoke-Download -Url $shaUrl -Destination $shaPath
-            $shaOk = $true
-        } catch {
+        if ($shaUrl) {
+            try {
+                Invoke-Download -Url $shaUrl -Destination $shaPath
+                $shaOk = $true
+            } catch {
+                Write-Warn2 "Could not download sha256 sidecar for bifrost $Version; skipping checksum verification."
+            }
+        } else {
             Write-Warn2 "No sha256 sidecar for bifrost $Version; skipping checksum verification."
         }
         if ($shaOk) {
@@ -253,7 +285,8 @@ function Install-BrokkAcp {
         Die "Internal: no brokk-acp asset for Windows $Arch"
     }
     $assetName = 'brokk-acp-windows-x86_64.exe'
-    $url = "https://github.com/$BrokkRepo/releases/download/$AcpTagPrefix$Version/$assetName"
+    $release = Get-ReleaseByTag $BrokkRepo "$AcpTagPrefix$Version"
+    $url = Find-AssetUrl -Release $release -AssetName $assetName
 
     Write-Step "Downloading brokk-acp $Version (windows-x86_64)"
     $tmp = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ("brokk-installer-" + [guid]::NewGuid())) -Force

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -3,10 +3,10 @@
 # Brokk installer: bifrost (auth proxy) + brokk-acp (Rust ACP server).
 #
 # Quick start:
-#   curl -sSL https://install.brokk.ai | bash
+#   curl -fsSL https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.sh | bash
 #
 # Or with options:
-#   curl -sSL https://install.brokk.ai | bash -s -- --install-dir ~/bin
+#   curl -fsSL https://raw.githubusercontent.com/BrokkAi/brokk/master/installer/install.sh | bash -s -- --install-dir ~/bin
 #
 # Supported platforms (intersection of bifrost and brokk-acp builds):
 #   - Linux x86_64
@@ -150,6 +150,30 @@ get_latest_prefixed_tag() {
     printf '%s\n' "$tag"
 }
 
+download_release_by_tag() {
+    local repo="$1" tag="$2" dest="$3"
+    if ! download "https://api.github.com/repos/${repo}/releases/tags/${tag}" "$dest"; then
+        err "Could not fetch release ${tag} for ${repo}."
+    fi
+}
+
+get_asset_url() {
+    local release_json="$1" asset="$2" url
+    url="$(awk -v asset="$asset" '
+        /"name"[[:space:]]*:/ {
+            in_asset = ($0 ~ "\"name\"[[:space:]]*:[[:space:]]*\"" asset "\"")
+        }
+        in_asset && /"browser_download_url"[[:space:]]*:/ {
+            sub(/^.*"browser_download_url"[[:space:]]*:[[:space:]]*"/, "")
+            sub(/".*$/, "")
+            print
+            exit
+        }
+    ' "$release_json")"
+    [ -n "$url" ] || err "Release is missing expected asset: ${asset}"
+    printf '%s\n' "$url"
+}
+
 # ---- install helpers -----------------------------------------------------
 
 verify_sha256() {
@@ -182,26 +206,31 @@ install_file() {
 
 install_bifrost() {
     local os="$1" arch="$2" install_dir="$3" version="$4"
-    local target tarball url tmp expected_sha bin_path
+    local target tarball url release_json tmp expected_sha bin_path sha_url
 
     target="$(bifrost_target "$os" "$arch")"
     tarball="bifrost-${version}-${target}.tar.gz"
-    url="https://github.com/${BIFROST_REPO}/releases/download/${version}/${tarball}"
+    release_json="$(mktemp)"
+    download_release_by_tag "$BIFROST_REPO" "$version" "$release_json"
+    url="$(get_asset_url "$release_json" "$tarball")"
 
     log "==> Downloading bifrost ${version} (${target})"
     tmp="$(mktemp -d)"
     if ! download "$url" "${tmp}/${tarball}"; then
+        rm -f "$release_json"
         rm -rf "$tmp"
         err "Failed to download ${url}"
     fi
 
     # Verify checksum if upstream provides .sha256 sidecar (bifrost does).
-    if download "${url}.sha256" "${tmp}/${tarball}.sha256" 2>/dev/null; then
+    if sha_url="$(get_asset_url "$release_json" "${tarball}.sha256" 2>/dev/null)" \
+        && download "$sha_url" "${tmp}/${tarball}.sha256" 2>/dev/null; then
         expected_sha="$(awk '{print $1}' "${tmp}/${tarball}.sha256")"
         verify_sha256 "${tmp}/${tarball}" "$expected_sha"
     else
         warn "No sha256 sidecar for bifrost ${version}; skipping checksum verification."
     fi
+    rm -f "$release_json"
 
     ( cd "$tmp" && tar -xzf "$tarball" )
     # Tarball layout varies (binary at root vs. inside a dir): search for it.
@@ -217,17 +246,21 @@ install_bifrost() {
 
 install_brokk_acp() {
     local os="$1" arch="$2" install_dir="$3" version="$4"
-    local asset url tmp
+    local asset release_json url tmp
 
     asset="$(acp_asset_name "$os" "$arch")"
-    url="https://github.com/${BROKK_REPO}/releases/download/${ACP_TAG_PREFIX}${version}/${asset}"
+    release_json="$(mktemp)"
+    download_release_by_tag "$BROKK_REPO" "${ACP_TAG_PREFIX}${version}" "$release_json"
+    url="$(get_asset_url "$release_json" "$asset")"
 
     log "==> Downloading brokk-acp ${version} (${os}-${arch})"
     tmp="$(mktemp -d)"
     if ! download "$url" "${tmp}/${asset}"; then
+        rm -f "$release_json"
         rm -rf "$tmp"
         err "Failed to download ${url}"
     fi
+    rm -f "$release_json"
 
     install_file "${tmp}/${asset}" "${install_dir}/brokk-acp"
     rm -rf "$tmp"


### PR DESCRIPTION
## Summary

- Replace the hallucinated `install.brokk.ai` installer examples with real `raw.githubusercontent.com` URLs.
- Put the main Brokk desktop app install path front and center in the root README.
- Reframe `installer/` as an ACP component installer only, not the Brokk desktop app installer.
- Resolve installer asset URLs through GitHub release metadata before downloading, so missing or renamed assets fail explicitly instead of relying on hand-built URLs.

## Root Cause

The previous installer documentation treated `installer/` like the primary Brokk install path and referenced a vanity URL that was not actually set up. That made the install story misleading and made the installer scripts feel suspect because they manufactured release asset URLs directly.

## Validation

- `bash -n installer/install.sh`
- `installer/install.sh --help`
- `git diff --check`
- Real macOS/aarch64 install smoke test to `/private/tmp/brokk-installer-test/bin`
- `/private/tmp/brokk-installer-test/bin/bifrost --version` -> `bifrost 0.2.0`
- `/private/tmp/brokk-installer-test/bin/brokk-acp --version` -> `brokk-acp 0.2.0`

PowerShell is not installed in this environment, so `install.ps1` was reviewed statically but not executed locally.