### PR TITLE
fix(brokk-acp-rust): make Codex backend installable mid-session (#3555)

### DIFF
--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -20,6 +20,7 @@ use agent_client_protocol::{
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::llm_client::{ChatMessage, LlmBackend};
+use crate::multi_backend::MultiBackend;
 use crate::session::{
     ConversationTurn, PermissionMode, SessionMode, SessionSnapshot, SessionStore,
 };
@@ -162,7 +163,7 @@ fn send_available_commands_update(cx: &ConnectionTo<Client>, session_id: &str) {
 
 /// Build and run the ACP agent over stdio.
 pub async fn run_agent(
-    llm: Arc<dyn LlmBackend>,
+    llm: Arc<MultiBackend>,
     sessions: SessionStore,
     max_turns: usize,
     bifrost_binary: Option<PathBuf>,
@@ -184,7 +185,9 @@ pub async fn run_agent(
     let sessions_list = sessions.clone();
 
     let llm_prompt = llm.clone();
+    let llm_login = llm.clone();
     let sessions_prompt = sessions.clone();
+    let sessions_login = sessions.clone();
     let bifrost_binary_prompt = bifrost_binary.clone();
 
     let sessions_cancel = sessions.clone();
@@ -461,7 +464,8 @@ pub async fn run_agent(
                 }
 
                 if is_slash_command(&prompt_text, "codex-login") {
-                    let report = handle_codex_login(&prompt_text).await;
+                    let report =
+                        handle_codex_login(&prompt_text, &llm_login, &sessions_login).await;
                     send_message(&cx, &session_id, &report);
                     return responder.respond(PromptResponse::new(StopReason::EndTurn));
                 }
@@ -490,7 +494,12 @@ pub async fn run_agent(
                 // The tool loop calls `block_task()` to await `session/request_permission`,
                 // which is only safe when run inside `cx.spawn` (per the ACP SDK docs --
                 // calling it directly from a request handler can deadlock the dispatch loop).
-                let llm_for_loop = llm_prompt.clone();
+                //
+                // The tool loop only needs the trait, so coerce the
+                // concrete `Arc<MultiBackend>` here -- keeping the
+                // multi-backend specific surface (e.g. `install_codex`)
+                // out of the generic chat path.
+                let llm_for_loop: Arc<dyn crate::llm_client::LlmBackend> = llm_prompt.clone();
                 let sessions_for_loop = sessions_prompt.clone();
                 let cx_for_loop = cx.clone();
                 let session_id_for_loop = session_id.clone();
@@ -980,7 +989,19 @@ fn is_slash_command(prompt_text: &str, name: &str) -> bool {
 /// Handle the `/codex-login` slash command and its subcommands.
 /// Subcommands: bare = start interactive login, `status` = report what's
 /// stored, `disconnect` = wipe the local credentials.
-async fn handle_codex_login(prompt_text: &str) -> String {
+///
+/// On a successful bare login we install the freshly-built Codex
+/// backend into `MultiBackend` so the next `session/new` (and any
+/// subsequent `codex::*` route) picks it up without a server restart.
+/// Without this, the empty-at-startup `Option` captured at
+/// construction would remain `None` forever and the new credentials
+/// would be unreachable until restart -- the behaviour issue #3555
+/// reported.
+async fn handle_codex_login(
+    prompt_text: &str,
+    llm: &Arc<MultiBackend>,
+    sessions: &SessionStore,
+) -> String {
     let arg = prompt_text
         .trim()
         .strip_prefix('/')
@@ -1036,12 +1057,49 @@ async fn handle_codex_login(prompt_text: &str) -> String {
                     .as_ref()
                     .map(|t| t.account_id.as_str())
                     .unwrap_or("(unknown)");
-                format!(
-                    "Codex login complete (account_id: {acct}). \
-                     Restart the server (or create a new session to refresh discovery) and \
-                     pick a `codex::*` model from the picker; prompts route through your \
-                     ChatGPT subscription via https://chatgpt.com/backend-api/codex/responses."
-                )
+                // Install the new backend so this session (and any
+                // future ones) can route `codex::*` and bare model ids
+                // immediately. We only install when the auth payload
+                // resolves to a usable backend -- a malformed auth.json
+                // (e.g. apikey mode with no key) leaves the slot empty
+                // and the user-facing message stays honest about it.
+                match crate::codex_backend_from_auth(&auth) {
+                    Some(backend) => {
+                        llm.install_codex(backend);
+                        // Refresh the cached model catalog in the
+                        // background so the picker picks Codex up on
+                        // the next `session/new` without waiting for
+                        // an unrelated discovery trigger.
+                        let llm_refresh = llm.clone();
+                        let sessions_refresh = sessions.clone();
+                        tokio::spawn(async move {
+                            match llm_refresh.list_models().await {
+                                Ok(models) => {
+                                    sessions_refresh.set_available_models(models).await;
+                                }
+                                Err(e) => {
+                                    tracing::debug!(
+                                        "post-login model-catalog refresh failed: {e:#}"
+                                    );
+                                }
+                            }
+                        });
+                        format!(
+                            "Codex login complete (account_id: {acct}). \
+                             Codex is now active -- create a new session \
+                             (or wait for the next discovery refresh) and \
+                             pick a `codex::*` model from the picker; \
+                             prompts route through your ChatGPT subscription \
+                             via https://chatgpt.com/backend-api/codex/responses."
+                        )
+                    }
+                    None => format!(
+                        "Codex login completed but the saved credentials are not usable \
+                         (auth_mode={:?}, no OPENAI_API_KEY). Re-run `/codex-login` or \
+                         inspect ~/.codex/auth.json.",
+                        auth.auth_mode
+                    ),
+                }
             }
             Err(e) => format!("Codex login failed: {e:#}"),
         },

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -161,6 +161,42 @@ fn send_available_commands_update(cx: &ConnectionTo<Client>, session_id: &str) {
     }
 }
 
+/// Spawn a background discovery refresh that updates the session
+/// store's cached model catalog. Throttled by `refresh_lock`: if a
+/// previous refresh is still in flight the call is a no-op (the
+/// in-flight one will seed the cache anyway). Shared by `session/new`
+/// and the `/codex-login` post-install path so the two can never race.
+fn spawn_throttled_refresh(
+    refresh_lock: Arc<tokio::sync::Mutex<()>>,
+    llm: Arc<MultiBackend>,
+    sessions: SessionStore,
+) {
+    if let Ok(guard) = refresh_lock.try_lock_owned() {
+        tokio::spawn(async move {
+            // Hold the guard for the duration of the refresh so the
+            // next try_lock observes "in flight". Drop is implicit at
+            // the end of the spawned future.
+            let _refresh_guard = guard;
+            match llm.list_models().await {
+                Ok(models) => {
+                    tracing::debug!(
+                        count = models.len(),
+                        "background model-catalog refresh complete"
+                    );
+                    sessions.set_available_models(models).await;
+                }
+                Err(e) => {
+                    tracing::debug!("background model-catalog refresh failed: {e:#}");
+                }
+            }
+        });
+    } else {
+        tracing::trace!(
+            "skipping background model-catalog refresh: another refresh is already in flight"
+        );
+    }
+}
+
 /// Build and run the ACP agent over stdio.
 pub async fn run_agent(
     llm: Arc<MultiBackend>,
@@ -178,7 +214,13 @@ pub async fn run_agent(
     // pile up redundant probes against /api/tags and /codex/models. We
     // hold this owned Mutex via try_lock_owned: when a refresh is already
     // in flight, the next try_lock returns None and we skip the spawn.
-    let refresh_lock_new = Arc::new(tokio::sync::Mutex::new(()));
+    //
+    // The same lock is shared with the `/codex-login` post-install
+    // refresh below so an immediate session/new after login doesn't race
+    // a second probe through the discovery path.
+    let refresh_lock = Arc::new(tokio::sync::Mutex::new(()));
+    let refresh_lock_new = refresh_lock.clone();
+    let refresh_lock_login = refresh_lock.clone();
 
     let sessions_load = sessions.clone();
     let sessions_resume = sessions.clone();
@@ -248,36 +290,11 @@ pub async fn run_agent(
                 // returns immediately with the cached list -- the refresh seeds
                 // the cache for the next call so we don't pay the discovery RTT
                 // here on the synchronous path.
-                //
-                // Throttled via `refresh_lock_new`: if a prior refresh is still
-                // running we skip this one rather than queueing it, since the
-                // outcome would be near-identical anyway.
-                if let Ok(guard) = refresh_lock_new.clone().try_lock_owned() {
-                    let llm_refresh = llm_new.clone();
-                    let sessions_refresh = sessions_new.clone();
-                    tokio::spawn(async move {
-                        // Hold the guard for the duration of the refresh so
-                        // the next try_lock observes "in flight". Drop is
-                        // implicit at the end of the spawned future.
-                        let _refresh_guard = guard;
-                        match llm_refresh.list_models().await {
-                            Ok(models) => {
-                                tracing::debug!(
-                                    count = models.len(),
-                                    "background model-catalog refresh complete"
-                                );
-                                sessions_refresh.set_available_models(models).await;
-                            }
-                            Err(e) => {
-                                tracing::debug!("background model-catalog refresh failed: {e:#}");
-                            }
-                        }
-                    });
-                } else {
-                    tracing::trace!(
-                        "skipping background model-catalog refresh: another refresh is already in flight"
-                    );
-                }
+                spawn_throttled_refresh(
+                    refresh_lock_new.clone(),
+                    llm_new.clone(),
+                    sessions_new.clone(),
+                );
 
                 // Use the cached list populated at init; fall back to the session's own model.
                 let mut models = sessions_new.available_models().await;
@@ -464,8 +481,13 @@ pub async fn run_agent(
                 }
 
                 if is_slash_command(&prompt_text, "codex-login") {
-                    let report =
-                        handle_codex_login(&prompt_text, &llm_login, &sessions_login).await;
+                    let report = handle_codex_login(
+                        &prompt_text,
+                        &llm_login,
+                        &sessions_login,
+                        &refresh_lock_login,
+                    )
+                    .await;
                     send_message(&cx, &session_id, &report);
                     return responder.respond(PromptResponse::new(StopReason::EndTurn));
                 }
@@ -1001,6 +1023,7 @@ async fn handle_codex_login(
     prompt_text: &str,
     llm: &Arc<MultiBackend>,
     sessions: &SessionStore,
+    refresh_lock: &Arc<tokio::sync::Mutex<()>>,
 ) -> String {
     let arg = prompt_text
         .trim()
@@ -1036,18 +1059,33 @@ async fn handle_codex_login(
                 // "MISSING" as a broken login.
                 let api_key_label = match (mode, has_key) {
                     (_, true) => "present",
-                    ("chatgpt", false) => "n/a (ChatGPT-only account; subscription routing does not need one)",
+                    ("chatgpt", false) => {
+                        "n/a (ChatGPT-only account; subscription routing does not need one)"
+                    }
                     (_, false) => "MISSING",
                 };
                 format!(
                     "Codex login status:\n  auth_mode: {mode}\n  routing: {routing}\n  api_key: {api_key_label}\n  account_id: {acct}\n  last_refresh: {last}"
                 )
             }
-            Ok(None) => "No Codex credentials found. Run `/codex-login` to authenticate.".to_string(),
+            Ok(None) => {
+                "No Codex credentials found. Run `/codex-login` to authenticate.".to_string()
+            }
             Err(e) => format!("Failed to read ~/.codex/auth.json: {e:#}"),
         },
         "disconnect" => match crate::codex_auth::logout() {
-            Ok(()) => "Codex credentials cleared. Restart the server to drop any cached tokens from memory.".to_string(),
+            Ok(()) => {
+                // Drop the in-memory backend so subsequent `codex::*`
+                // routes fail loudly (and identically to a no-auth
+                // startup) instead of firing requests against now-missing
+                // credentials. Refresh the cached catalog so the picker
+                // stops offering Codex models.
+                llm.uninstall_codex();
+                spawn_throttled_refresh(refresh_lock.clone(), llm.clone(), sessions.clone());
+                "Codex credentials cleared and the in-memory backend was unloaded; \
+                 the picker will only show Ollama models until you re-run `/codex-login`."
+                    .to_string()
+            }
             Err(e) => format!("Failed to remove ~/.codex/auth.json: {e:#}"),
         },
         "" => match crate::codex_auth::interactive_login().await {
@@ -1069,21 +1107,15 @@ async fn handle_codex_login(
                         // Refresh the cached model catalog in the
                         // background so the picker picks Codex up on
                         // the next `session/new` without waiting for
-                        // an unrelated discovery trigger.
-                        let llm_refresh = llm.clone();
-                        let sessions_refresh = sessions.clone();
-                        tokio::spawn(async move {
-                            match llm_refresh.list_models().await {
-                                Ok(models) => {
-                                    sessions_refresh.set_available_models(models).await;
-                                }
-                                Err(e) => {
-                                    tracing::debug!(
-                                        "post-login model-catalog refresh failed: {e:#}"
-                                    );
-                                }
-                            }
-                        });
+                        // an unrelated discovery trigger. Shares the
+                        // same throttle as `session/new` so an
+                        // immediate session creation right after login
+                        // doesn't race a second probe.
+                        spawn_throttled_refresh(
+                            refresh_lock.clone(),
+                            llm.clone(),
+                            sessions.clone(),
+                        );
                         format!(
                             "Codex login complete (account_id: {acct}). \
                              Codex is now active -- create a new session \

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -94,6 +94,36 @@ impl std::fmt::Debug for Args {
     }
 }
 
+/// Build a Codex backend from already-loaded credentials. Returns
+/// `None` for the same "credentials are unusable" cases the startup
+/// path treats as no-Codex (apikey mode without an API key, etc.) so
+/// the picker stays honest.
+///
+/// Shared by the startup path (`build_codex_backend`) and the
+/// post-`/codex-login` install path in `agent.rs`. Keeps the
+/// `auth.auth_mode + tokens` decision tree in one place so the two
+/// callers can't drift.
+pub fn codex_backend_from_auth(auth: &codex_auth::AuthDotJson) -> Option<Arc<dyn LlmBackend>> {
+    // ChatGPT-subscription routing requires both `auth_mode == "chatgpt"`
+    // AND a usable `tokens` block. Anything else falls through to the
+    // OPENAI_API_KEY path -- including `chatgpt` mode with no tokens
+    // (which can happen if a refresh just blew them away), `apikey` mode
+    // (the documented API-billed fallback), and any unrecognized mode
+    // string from a future codex-cli version. If we hit the apikey path
+    // with no key, the prompt would 401 -- skip in that case so the
+    // picker is honest about what's available.
+    if matches!(auth.auth_mode.as_deref(), Some("chatgpt")) && auth.tokens.is_some() {
+        return Some(Arc::new(codex_client::CodexClient::new()));
+    }
+    let key = auth.openai_api_key.clone();
+    key.map(|k| {
+        Arc::new(llm_client::OpenAiClient::new(
+            "https://api.openai.com/v1".to_string(),
+            Some(k),
+        )) as Arc<dyn LlmBackend>
+    })
+}
+
 /// Build the Codex backend if `~/.codex/auth.json` is present. Returns
 /// `None` when the file is missing or unreadable. Stale credentials
 /// are refreshed proactively so the first prompt doesn't burn a 401
@@ -115,37 +145,28 @@ async fn build_codex_backend() -> Option<Arc<dyn LlmBackend>> {
     if let Err(e) = codex_auth::refresh_if_stale(&mut auth).await {
         tracing::warn!("codex credential refresh failed: {e:#}");
     }
-    // ChatGPT-subscription routing requires both `auth_mode == "chatgpt"`
-    // AND a usable `tokens` block. Anything else falls through to the
-    // OPENAI_API_KEY path -- including `chatgpt` mode with no tokens
-    // (which can happen if a refresh just blew them away), `apikey` mode
-    // (the documented API-billed fallback), and any unrecognized mode
-    // string from a future codex-cli version. If we hit the apikey path
-    // with no key, the prompt would 401 -- skip in that case so the
-    // picker is honest about what's available.
-    if matches!(auth.auth_mode.as_deref(), Some("chatgpt")) && auth.tokens.is_some() {
-        tracing::info!(
-            "Codex backend enabled in ChatGPT subscription mode (Responses API on chatgpt.com)"
-        );
-        return Some(Arc::new(codex_client::CodexClient::new()));
+    let backend = codex_backend_from_auth(&auth);
+    match (&backend, auth.auth_mode.as_deref(), auth.tokens.is_some()) {
+        (Some(_), Some("chatgpt"), true) => {
+            tracing::info!(
+                "Codex backend enabled in ChatGPT subscription mode (Responses API on chatgpt.com)"
+            );
+        }
+        (Some(_), mode, _) => {
+            tracing::info!(
+                "Codex backend enabled in OPENAI_API_KEY mode (api.openai.com), auth_mode={:?}",
+                mode
+            );
+        }
+        (None, mode, _) => {
+            tracing::warn!(
+                "~/.codex/auth.json is unusable (auth_mode={:?}, no OPENAI_API_KEY); \
+                 skipping Codex backend. Run /codex-login to re-authenticate.",
+                mode
+            );
+        }
     }
-    let key = auth.openai_api_key.clone();
-    if key.is_none() {
-        tracing::warn!(
-            "~/.codex/auth.json is unusable (auth_mode={:?}, no OPENAI_API_KEY); \
-             skipping Codex backend. Run /codex-login to re-authenticate.",
-            auth.auth_mode
-        );
-        return None;
-    }
-    tracing::info!(
-        "Codex backend enabled in OPENAI_API_KEY mode (api.openai.com), auth_mode={:?}",
-        auth.auth_mode
-    );
-    Some(Arc::new(llm_client::OpenAiClient::new(
-        "https://api.openai.com/v1".to_string(),
-        key,
-    )))
+    backend
 }
 
 /// Build the Ollama chat backend. Always pointed at the default
@@ -202,11 +223,12 @@ async fn main() -> Result<()> {
     if codex_backend.is_none() {
         tracing::info!(
             "Codex backend not available; the picker will only show Ollama models. \
-             Run /codex-login from a session to add Codex (a server restart picks up the new auth)."
+             Run /codex-login from a session to add Codex -- the new credentials \
+             are picked up on the next discovery refresh, no restart required."
         );
     }
 
-    let llm: Arc<dyn LlmBackend> = Arc::new(MultiBackend::new(codex_backend, ollama_backend));
+    let llm: Arc<MultiBackend> = Arc::new(MultiBackend::new(codex_backend, ollama_backend));
 
     let limits = session::SessionLimits {
         max_sessions: args.max_sessions,

--- a/brokk-acp-rust/src/multi_backend.rs
+++ b/brokk-acp-rust/src/multi_backend.rs
@@ -14,7 +14,7 @@
 //! `/config` model picker would get a "no backend for model" error even
 //! though the picker also offers `ollama::llama3:latest`.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use futures::future::BoxFuture;
@@ -30,36 +30,60 @@ use crate::llm_client::{ChatMessage, LlmBackend, LlmResponse, ToolDefinition};
 /// backend may be absent (e.g. no `auth.json`, or no Ollama on the
 /// default port); calls for a source whose backend isn't configured
 /// return a clear error rather than silently falling through.
+///
+/// The Codex slot is held behind a `RwLock` so a successful
+/// `/codex-login` mid-session can install a backend without a server
+/// restart. The lock is only ever held for the duration of a synchronous
+/// `Option<Arc<...>>` clone -- we never hold it across an `.await`.
 pub struct MultiBackend {
-    codex: Option<Arc<dyn LlmBackend>>,
+    codex: RwLock<Option<Arc<dyn LlmBackend>>>,
     ollama: Option<Arc<dyn LlmBackend>>,
-    /// Source to use when a chat request arrives with no `<source>::` prefix.
-    /// Picked at construction so `stream_chat` is purely synchronous w.r.t.
-    /// configuration.
-    fallback_source: Option<ModelSource>,
 }
 
 impl MultiBackend {
     pub fn new(codex: Option<Arc<dyn LlmBackend>>, ollama: Option<Arc<dyn LlmBackend>>) -> Self {
-        // Prefer Codex when both are configured -- it's the more capable
-        // backend and more likely to be the user's intent for a bare model
-        // id like "gpt-5-codex". Falls back to Ollama if Codex is absent.
-        let fallback_source = match (codex.is_some(), ollama.is_some()) {
-            (true, _) => Some(ModelSource::Codex),
-            (false, true) => Some(ModelSource::Ollama),
-            (false, false) => None,
-        };
         Self {
-            codex,
+            codex: RwLock::new(codex),
             ollama,
-            fallback_source,
         }
     }
 
-    fn pick(&self, source: ModelSource) -> Option<&Arc<dyn LlmBackend>> {
+    /// Install (or replace) the Codex backend at runtime. Called from
+    /// the `/codex-login` handler so the next discovery refresh and any
+    /// subsequent `codex::*` route picks it up without a server restart.
+    pub fn install_codex(&self, backend: Arc<dyn LlmBackend>) {
+        // unwrap: the only way the lock gets poisoned is a panic while
+        // holding it, and the only sites that hold it are tiny clones of
+        // an Option<Arc> -- not panickable in practice.
+        *self.codex.write().unwrap() = Some(backend);
+    }
+
+    /// Snapshot the current Codex backend, if any. Cloning the inner Arc
+    /// lets callers release the read lock immediately; they can then
+    /// `.await` the backend without holding a guard.
+    fn codex_snapshot(&self) -> Option<Arc<dyn LlmBackend>> {
+        self.codex.read().unwrap().clone()
+    }
+
+    fn pick(&self, source: ModelSource) -> Option<Arc<dyn LlmBackend>> {
         match source {
-            ModelSource::Codex => self.codex.as_ref(),
-            ModelSource::Ollama => self.ollama.as_ref(),
+            ModelSource::Codex => self.codex_snapshot(),
+            ModelSource::Ollama => self.ollama.clone(),
+        }
+    }
+
+    /// Source to use when a chat request arrives with no `<source>::` prefix.
+    /// Computed on demand (rather than cached at construction) so a Codex
+    /// login mid-session promotes Codex to the preferred fallback.
+    fn fallback_source(&self) -> Option<ModelSource> {
+        let codex_present = self.codex.read().unwrap().is_some();
+        match (codex_present, self.ollama.is_some()) {
+            // Prefer Codex when both are configured -- it's the more
+            // capable backend and more likely to be the user's intent
+            // for a bare model id like "gpt-5-codex".
+            (true, _) => Some(ModelSource::Codex),
+            (false, true) => Some(ModelSource::Ollama),
+            (false, false) => None,
         }
     }
 
@@ -67,18 +91,15 @@ impl MultiBackend {
     /// `<source>::` prefix) route to the fallback source.
     fn resolve(&self, wire_model: &str) -> Result<(Arc<dyn LlmBackend>, String)> {
         if let Some((source, bare)) = split_wire_id(wire_model) {
-            let backend = self
-                .pick(source)
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "model {wire_model} requires the {} backend, which is not configured",
-                        source.as_str()
-                    )
-                })?
-                .clone();
+            let backend = self.pick(source).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "model {wire_model} requires the {} backend, which is not configured",
+                    source.as_str()
+                )
+            })?;
             return Ok((backend, bare.to_string()));
         }
-        let source = self.fallback_source.ok_or_else(|| {
+        let source = self.fallback_source().ok_or_else(|| {
             anyhow::anyhow!(
                 "no LLM backend is configured (neither Codex nor Ollama discovered \
                  any models, and no `<source>::<id>` wire prefix was provided)"
@@ -86,8 +107,7 @@ impl MultiBackend {
         })?;
         let backend = self
             .pick(source)
-            .expect("fallback_source is set only when its backend exists")
-            .clone();
+            .expect("fallback_source returns Some only when its backend exists");
         Ok((backend, wire_model.to_string()))
     }
 }
@@ -99,7 +119,10 @@ impl LlmBackend for MultiBackend {
             // Codex lookup is delegated to the configured backend's own
             // `list_models` so we keep auth-mode handling, fallback slugs,
             // and Cloudflare cookie state where they already live.
-            let codex = self.codex.clone();
+            // Snapshotting under the read lock and dropping the guard
+            // before the discovery future means a concurrent
+            // `install_codex` call still observes a consistent state.
+            let codex = self.codex_snapshot();
             let codex_lookup = || async move {
                 match codex {
                     Some(c) => c.list_models().await,
@@ -302,6 +325,100 @@ mod tests {
         assert!(
             msg.contains("no LLM backend is configured"),
             "error must explain the empty-backend case: {msg}"
+        );
+    }
+
+    /// Regression for the `/codex-login` lifecycle (issue #3555): the
+    /// server starts with no Codex backend (auth.json absent), the user
+    /// runs `/codex-login`, and the new backend is installed at
+    /// runtime. Subsequent `codex::*` routing must succeed -- previously
+    /// it kept returning the "backend not configured" error because the
+    /// `None` was captured permanently at construction.
+    #[tokio::test]
+    async fn codex_installed_after_login_is_routable() {
+        // Start with no Codex (mirrors the empty-auth.json startup path).
+        let multi = MultiBackend::new(None, None);
+
+        // Pre-install: a `codex::*` request must fail loudly.
+        let err = multi
+            .stream_chat(
+                "codex::gpt-5-codex",
+                vec![],
+                None,
+                Box::new(|_| {}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect_err("codex route must fail before install");
+        assert!(format!("{err:#}").contains("codex"));
+
+        // User runs `/codex-login` successfully -- the handler installs
+        // a freshly-built Codex backend.
+        let (codex_backend, codex_last) = recording("codex");
+        multi.install_codex(codex_backend);
+
+        // Now the same request routes through Codex with the prefix
+        // stripped, exactly as if the credentials had been there at
+        // startup.
+        let _ = multi
+            .stream_chat(
+                "codex::gpt-5-codex",
+                vec![],
+                None,
+                Box::new(|_| {}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("codex route must succeed after install");
+        assert_eq!(codex_last.lock().unwrap().as_deref(), Some("gpt-5-codex"));
+    }
+
+    /// Bare ids must also start routing to Codex once it's installed.
+    /// Before the fix, `fallback_source` was frozen at construction --
+    /// so even after `install_codex` a bare `gpt-5-codex` would error
+    /// out with "no LLM backend is configured" because the cached
+    /// fallback was still `None`.
+    #[tokio::test]
+    async fn bare_id_falls_back_to_codex_after_install() {
+        let multi = MultiBackend::new(None, None);
+
+        let (codex_backend, codex_last) = recording("codex");
+        multi.install_codex(codex_backend);
+
+        let _ = multi
+            .stream_chat(
+                "gpt-5-codex",
+                vec![],
+                None,
+                Box::new(|_| {}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("bare id must route to newly-installed codex");
+        assert_eq!(codex_last.lock().unwrap().as_deref(), Some("gpt-5-codex"));
+    }
+
+    /// `list_models` must consult the currently-installed Codex backend,
+    /// not the one captured at construction. Without this, a successful
+    /// `/codex-login` followed by a discovery refresh (e.g. on
+    /// `session/new`) would keep returning an empty Codex list and the
+    /// model picker would never show Codex models.
+    #[tokio::test]
+    async fn list_models_reflects_installed_codex() {
+        let multi = MultiBackend::new(None, None);
+        let (codex_backend, _codex_last) = recording("codex");
+        multi.install_codex(codex_backend);
+
+        // RecordingBackend::list_models returns ["codex-stub"]. We can't
+        // exercise the live Cloudflare-fronted /codex/models path here
+        // -- the discovery wrapper falls back to the closure's output
+        // when its native probe fails or returns nothing, so the
+        // "codex-stub" id surfacing through `discover_all` is enough to
+        // prove the freshly-installed backend was consulted.
+        let models = multi.list_models().await.expect("discovery must succeed");
+        assert!(
+            models.iter().any(|m| m.contains("codex-stub")),
+            "installed codex backend must contribute to discovery: got {models:?}"
         );
     }
 }

--- a/brokk-acp-rust/src/multi_backend.rs
+++ b/brokk-acp-rust/src/multi_backend.rs
@@ -51,11 +51,30 @@ impl MultiBackend {
     /// Install (or replace) the Codex backend at runtime. Called from
     /// the `/codex-login` handler so the next discovery refresh and any
     /// subsequent `codex::*` route picks it up without a server restart.
+    ///
+    /// Replacing an existing backend is safe: any in-flight request
+    /// holding a clone of the old `Arc<CodexClient>` finishes against
+    /// that instance and then drops it. Note that the new backend
+    /// starts with an empty `reqwest` cookie jar and `refresh_lock`, so
+    /// the first request after replacement may have to re-acquire any
+    /// Cloudflare cookies (`__cf_bm`, `cf_clearance`) the previous
+    /// instance had already accumulated; this is a one-request cost.
     pub fn install_codex(&self, backend: Arc<dyn LlmBackend>) {
         // unwrap: the only way the lock gets poisoned is a panic while
         // holding it, and the only sites that hold it are tiny clones of
         // an Option<Arc> -- not panickable in practice.
         *self.codex.write().unwrap() = Some(backend);
+    }
+
+    /// Drop the currently-installed Codex backend, if any. Called from
+    /// `/codex-login disconnect` after the on-disk credentials are
+    /// wiped so a subsequent `codex::*` request fails with the same
+    /// "backend not configured" error a fresh-no-auth.json startup
+    /// would give, instead of firing requests with credentials that
+    /// will now 401. In-flight requests holding an `Arc` to the old
+    /// backend complete against that captured instance.
+    pub fn uninstall_codex(&self) {
+        *self.codex.write().unwrap() = None;
     }
 
     /// Snapshot the current Codex backend, if any. Cloning the inner Arc
@@ -409,16 +428,60 @@ mod tests {
         let (codex_backend, _codex_last) = recording("codex");
         multi.install_codex(codex_backend);
 
-        // RecordingBackend::list_models returns ["codex-stub"]. We can't
-        // exercise the live Cloudflare-fronted /codex/models path here
-        // -- the discovery wrapper falls back to the closure's output
-        // when its native probe fails or returns nothing, so the
-        // "codex-stub" id surfacing through `discover_all` is enough to
-        // prove the freshly-installed backend was consulted.
+        // RecordingBackend::list_models returns ["codex-stub"].
+        // `discover_all` delegates Codex discovery entirely to the
+        // closure (the only Codex source it has -- there is no separate
+        // native probe), so the "codex-stub" id surfacing through it
+        // proves the freshly-installed backend was consulted by the
+        // refresh path rather than the empty `None` captured at
+        // construction.
         let models = multi.list_models().await.expect("discovery must succeed");
         assert!(
             models.iter().any(|m| m.contains("codex-stub")),
             "installed codex backend must contribute to discovery: got {models:?}"
+        );
+    }
+
+    /// `/codex-login disconnect` calls `uninstall_codex` after wiping
+    /// auth.json. Subsequent `codex::*` routing must fail with the same
+    /// "backend not configured" error a fresh-no-auth.json startup
+    /// gives -- otherwise a wire id picked from a stale `availableModels`
+    /// list would fire a request against credentials that no longer
+    /// exist on disk.
+    #[tokio::test]
+    async fn codex_uninstall_unroutes_codex_requests() {
+        let multi = MultiBackend::new(None, None);
+        let (codex_backend, _codex_last) = recording("codex");
+        multi.install_codex(codex_backend);
+
+        // Sanity check: routable while installed.
+        let _ = multi
+            .stream_chat(
+                "codex::gpt-5-codex",
+                vec![],
+                None,
+                Box::new(|_| {}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("codex route must succeed while installed");
+
+        // Disconnect path drops the backend.
+        multi.uninstall_codex();
+
+        let err = multi
+            .stream_chat(
+                "codex::gpt-5-codex",
+                vec![],
+                None,
+                Box::new(|_| {}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect_err("codex route must fail after uninstall");
+        assert!(
+            format!("{err:#}").contains("codex"),
+            "error must mention codex backend"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3555. `brokk-acp-rust` now treats the Codex backend slot as installable at runtime, so a successful `/codex-login` mid-session is picked up without a server restart.

The previous code captured `Option<Arc<dyn LlmBackend>>` once at startup. Even after the user authenticated, `MultiBackend::list_models` and `MultiBackend::resolve` kept consulting that frozen `None`, so `codex::*` never routed and bare ids errored out -- contradicting the "create a new session to refresh discovery" guidance the login handler printed.

## Changes

- `MultiBackend` holds the Codex slot in a `RwLock<Option<Arc<dyn LlmBackend>>>` and exposes `install_codex(...)`. The lock is only held during a synchronous `Option<Arc>` clone -- never across an `.await`.
- `fallback_source` is computed on demand so a freshly-installed Codex is promoted to the preferred fallback without a restart.
- `codex_backend_from_auth` is extracted from `build_codex_backend` so the startup path and the `/codex-login` install path share the auth-mode decision tree.
- After `interactive_login` succeeds, the handler installs the new backend and kicks off a background discovery refresh so the next `session/new` shows Codex models.
- Startup log and user-facing `/codex-login` message no longer claim a restart is required.

## Test plan

- [x] `cargo test --bin brokk-acp` -- 162 tests, all green
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] New regression tests in `multi_backend.rs`:
  - `codex_installed_after_login_is_routable` -- empty-at-startup -> install_codex -> `codex::*` routes
  - `bare_id_falls_back_to_codex_after_install` -- bare id starts routing to Codex after install
  - `list_models_reflects_installed_codex` -- discovery consults the freshly-installed backend
