### PR TITLE
brokk-foreman: restart at minimal pure ACP client scope

### DIFF
--- a/brokk-foreman/Cargo.lock
+++ b/brokk-foreman/Cargo.lock
@@ -119,15 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,12 +165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,12 +175,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -254,7 +233,6 @@ dependencies = [
  "directories",
  "flate2",
  "futures",
- "octocrab",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
@@ -385,37 +363,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform 0.1.9",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform 0.3.3",
+ "cargo-platform",
  "semver",
  "serde",
  "serde_json",
@@ -516,12 +470,6 @@ dependencies = [
  "bytes",
  "memchr",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -637,18 +585,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,33 +632,6 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "darling"
@@ -776,17 +685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,7 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -985,65 +882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,22 +963,6 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -1460,7 +1282,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1600,17 +1421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,15 +1521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,9 +1607,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2191,29 +1990,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "10.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
-dependencies = [
- "base64 0.22.1",
- "ed25519-dalek",
- "getrandom 0.2.17",
- "hmac",
- "js-sys",
- "p256",
- "p384",
- "pem",
- "rand 0.8.6",
- "rsa",
- "serde",
- "serde_json",
- "sha2",
- "signature",
- "simple_asn1",
-]
-
-[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,9 +2005,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -2287,12 +2060,6 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2494,56 +2261,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -2552,7 +2273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2773,43 +2493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "octocrab"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce7ace5d83b077dd50ff01214a81feea17e258b8f677590c2286add76dc8238e"
-dependencies = [
- "arc-swap",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "cargo_metadata 0.23.1",
- "cfg-if",
- "chrono",
- "futures",
- "getrandom 0.2.17",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "jsonwebtoken",
- "once_cell",
- "percent-encoding",
- "pin-project",
- "secrecy",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "snafu",
- "tower",
- "tower-http",
- "url",
- "web-time",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,12 +2511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,30 +2524,6 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
 ]
 
 [[package]]
@@ -2947,25 +2600,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64 0.22.1",
- "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3096,27 +2730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,15 +2818,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -3369,8 +2973,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3380,18 +2982,8 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3409,9 +3001,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -3582,16 +3171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,26 +3217,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -3708,25 +3267,12 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -3769,15 +3315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3850,52 +3387,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "selectors"
@@ -3990,17 +3481,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -4186,32 +3666,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -4230,27 +3688,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "snafu"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "socket2"
@@ -4308,22 +3745,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -4731,7 +4152,7 @@ checksum = "55f61d2bf7188fbcf2b0ed095b67a6bc498f713c939314bb19eb700118a573b7"
 dependencies = [
  "anyhow",
  "brotli",
- "cargo_metadata 0.19.2",
+ "cargo_metadata",
  "ctor",
  "dom_query",
  "dunce",
@@ -5071,10 +4492,8 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5093,7 +4512,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5542,7 +4960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
- "serde",
  "wasm-bindgen",
 ]
 

--- a/brokk-foreman/PLANS.md
+++ b/brokk-foreman/PLANS.md
@@ -1,12 +1,12 @@
-# brokk-foreman — design plan
+# brokk-foreman — design plan (v1)
 
-Cross-platform desktop "issue bot" and **pure** ACP client: list GitHub/Jira
-issues, enrich them with code context via a user-chosen ACP agent, detect
-blocking dependencies, run one ACP session per issue in its own git
-worktree, watch them move across a kanban board.
+Cross-platform desktop **pure ACP client**: pick any ACP-compliant agent
+(from the public registry or a user-defined custom command), point it at
+a local repo, and run an interactive session against it.
 
-This document describes the intended end state. The scaffolding is already
-in tree; the rest lands incrementally.
+This document describes the v1 end state. Issue providers, kanban,
+enrichment, blocking analysis, and worktree-per-session are deferred to
+later milestones.
 
 ## Status
 
@@ -15,95 +15,99 @@ Landed in #3520 (initial scaffold):
 - Cargo workspace + Tauri 2 `src-tauri` (Rust 2024, LGPL-3.0).
 - Svelte 5 + Vite SPA frontend.
 - Public ACP registry parser at `src-tauri/src/acp/registry.rs` matching
-  upstream `agent.schema.json`, plus 9 tests against a pinned 35-agent
-  snapshot of the live registry.
-- Module stubs for `acp/`, `issues/`, `llm/`, `worktree`, `db/` with a
-  baseline SQL schema (`src-tauri/src/db/schema.sql`).
+  upstream `agent.schema.json`, plus 11 tests against a pinned snapshot
+  of the live registry.
+- SQLite migration runner at `src-tauri/src/db/mod.rs` with `PRAGMA
+  user_version` tracking, FK cascades, WAL, and 6 tests.
 - 3-OS CI (ubuntu/macos/windows) running `cargo fmt --check`, `cargo
   build`, `cargo test`, `cargo clippy -D warnings`, then `pnpm install
   --frozen-lockfile`, `pnpm check`, `pnpm build`.
 
 Next, in roughly this order:
 
-1. **ACP client wrapper** (`acp/launcher.rs`, `acp/mod.rs`): spawn
-   binary / npx / uvx agents, perform `initialize` + `session/new`, stream
+1. **DB schema simplification** — drop `issues`, `blocking_edges`,
+   `sessions`; keep `agents` and `config_kv`.
+2. **Custom-agent CRUD** — `list_agents`, `add_custom_agent`,
+   `uninstall_agent` against the `agents` table.
+3. **Config** — `get_config` / `set_config` against `config_kv`
+   (repo path + default agent).
+4. **Registry fetch + cache** — extend `acp/registry.rs` with
+   `reqwest` fetch, ETag revalidation, and persistence at
+   `~/.brokk/foreman/registry-cache.json`.
+5. **ACP client core** (`acp/launcher.rs`, `acp/client.rs`) — spawn
+   binary/npx/uvx agents, perform `initialize` + `session/new`, stream
    `SessionUpdate` events to the frontend over Tauri events.
-2. **SQLite migration runner** in `db/mod.rs` consuming `db/schema.sql`.
-3. **GitHub provider** via `octocrab`; then **Jira provider** via
-   `reqwest`.
-4. **Worktree manager** (shell-out to `git worktree`).
-5. **Tauri commands** wired to the frontend.
-6. **Kanban UI** + **issue view**.
-7. **Enrichment-on-import** via ACP.
-8. **Blocking-graph analysis** via ACP.
+6. **Session UI** — `Session.svelte` with prompt input, streaming
+   `SessionUpdate` list, permission modal.
+7. **Install flow** (`acp/installer.rs`) — download + extract binary
+   distributions; verify `npx` / `uvx` on PATH.
+8. **Auth handling** (`acp/auth.rs`) — Agent Auth (delegated) and
+   Terminal Auth (out-of-app spawn via `tauri-plugin-shell`).
 
 ## Context
 
-A new Tauri desktop app, `brokk-foreman`, that acts as a **pure ACP
-client** for managing GitHub/Jira issues against a local git repository.
-Users list issues, let an LLM enrich them with code context and detect
-blocking dependencies, drag them across a kanban board, and start ACP
-sessions per issue (one worktree per session) using **any** ACP-compliant
-agent — picked from the official ACP registry or supplied as a custom
-install.
+A Tauri desktop app, `brokk-foreman`, that acts as a **pure ACP client**
+against a local git repository. Users pick an ACP-compliant agent —
+from the official ACP registry or supplied as a custom install — and
+run one session at a time against a configured repo root. Streaming
+`SessionUpdate` events are surfaced in the UI; permission requests pop
+a modal.
 
-The app does **no** agentic logic of its own. All LLM work — enrichment,
-blocking-graph extraction, the actual coding work on each issue — runs
-through ACP sessions whose backend agent is user-chosen and swappable
-(Brokk, Claude Agent, Gemini, Codex, Goose, etc.).
+The app does **no** agentic logic of its own. All LLM work runs through
+ACP sessions whose backend agent is user-chosen and swappable (Brokk,
+Claude Agent, Gemini, Codex, Goose, etc.). This decouples brokk-foreman
+from any one vendor's stack and aligns with the ACP industry direction:
+Zed and JetBrains shipped registry support in early 2026, and
+brokk-foreman becomes a third client of the same registry.
 
-This decouples brokk-foreman from any one vendor's stack and aligns with
-the ACP industry direction: Zed and JetBrains shipped registry support in
-early 2026, and brokk-foreman becomes a third client of the same registry.
-
-## Non-goals
+## Non-goals (v1)
 
 - No coupling to Brokk's Java backend (`BrokkExternalMcpServer`, Java
   agents, etc.). brokk-foreman runs without brokk installed.
-- No multi-repo support in v1 (one repo per app instance).
-- No mirroring of GitHub Projects boards or Jira sprint state to/from the
-  local kanban — kanban state is local-only.
-- No multi-user or cloud sync.
-- No agent-side auth credential management beyond triggering each agent's
-  own auth flow (the agent stores its own keys).
+- No issue providers (GitHub/Jira). Deferred.
+- No kanban or workflow UI. Deferred.
+- No LLM-driven enrichment or blocking-graph analysis. Deferred.
+- No worktree-per-session. The session runs against the configured repo
+  root directly. **Worktrees are the next milestone after v1 ships.**
+- No multiple concurrent sessions. One at a time.
+- No session persistence across app restarts.
+- No multi-repo support. One repo path per app instance.
+- No agent-side credential management beyond triggering each agent's own
+  auth flow (the agent stores its own keys).
 
 ## Architecture summary
 
 ```
 +-----------------------------------------------------------+
 |                     Tauri main (Rust)                     |
-|  +------------+  +-----------+  +-----------+  +-------+  |
-|  | ACP client |  | Registry  |  | Issue     |  | Git   |  |
-|  | (per       |  | client    |  | providers |  | worktree |
-|  |  session)  |  | + cache   |  | (GH/Jira) |  | runner|  |
-|  +------+-----+  +-----+-----+  +-----+-----+  +---+---+  |
-|         |              |              |            |      |
-|  +------v-------- SQLite (state.db) --v---------+--v---+  |
+|  +------------+  +-----------+  +-----------+             |
+|  | ACP client |  | Registry  |  | Agent     |             |
+|  | (one       |  | client    |  | installer |             |
+|  |  session)  |  | + cache   |  |           |             |
+|  +------+-----+  +-----+-----+  +-----+-----+             |
+|         |              |              |                   |
+|  +------v-------- SQLite (state.db) --v---------+         |
+|         |    (agents + config_kv only)                    |
+|  +------v---- IPC (tauri::Event/Command) --------+        |
 |         |                                                  |
-|  +------v---- IPC (tauri::Event/Command) ----------------+ |
-|         |                                                  |
-|  +------v--- Svelte frontend (Vite, svelte-dnd-action) --+ |
+|  +------v--- Svelte frontend (Vite) -------------+         |
 +-----------------------------------------------------------+
             |                          |
-            v (spawns)                 v (HTTPS)
+            v (spawns one at a time)   v (HTTPS)
    +------------------+        +-------------------+
-   | ACP agent procs  |        | api.github.com,   |
-   | (1..N, stdio JSON|        | <jira host>/rest, |
-   |  -RPC, agent-    |        | cdn.agentclient.. |
-   |  client-protocol |        +-------------------+
-   |  v0.11)          |
+   | ACP agent proc   |        | cdn.agentclient.. |
+   | (stdio JSON-RPC, |        +-------------------+
+   |  kill_on_drop)   |
    +------------------+
 ```
 
 Process boundaries:
 
 - **Tauri main** is one Rust process; it's the only one talking to disk,
-  the registry CDN, the issue REST APIs, and any ACP agent.
+  the registry CDN, and any ACP agent.
 - **Svelte frontend** runs in the system webview. It only talks to the
   Rust backend via Tauri commands and events.
-- **ACP agents** run as child processes of the Rust main. There's
-  typically one per active issue (working session), plus short-lived
-  ephemeral sessions for enrichment and blocking analysis.
+- **ACP agent** runs as a child process of the Rust main, one at a time.
 
 ## Cargo layout
 
@@ -111,9 +115,6 @@ Process boundaries:
 `brokk-acp-rust/`. It is its own Cargo workspace; brokk-acp-rust and
 brokk-foreman do not share runtime code (one is an ACP server, the other
 a client). They could share a small types crate later if needed.
-
-The intended module tree (some files are already stubs in tree, others
-land later):
 
 ```
 brokk-foreman/
@@ -123,48 +124,34 @@ brokk-foreman/
     tauri.conf.json
     build.rs
     src/
-      main.rs                 # Tauri setup, command registration
-      lib.rs                  # module declarations + run()
-      commands.rs             # #[tauri::command] handlers (frontend bridge)
+      main.rs                 # delegates to lib::run()
+      lib.rs                  # Tauri setup, command registration, DB init
+      commands.rs             # #[tauri::command] handlers
       events.rs               # event payload types
+      config.rs               # data dir + config_kv helpers
       acp/
-        mod.rs                # AcpSession, AcpClient, lifecycle
-        registry.rs           # fetch + cache + parse registry.json    [landed]
-        launcher.rs           # binary/npx/uvx launching, auth flows
-        protocol.rs           # thin wrappers over agent-client-protocol crate
-      issues/
-        mod.rs                # IssueProvider trait
-        github.rs             # octocrab-backed
-        jira.rs               # reqwest-backed REST
-      worktree.rs             # git worktree add/remove/list (shell-out)
-      llm/
-        enrich.rs             # one-shot enrichment session via ACP
-        blocking.rs           # cross-issue blocking analysis via ACP
+        mod.rs
+        registry.rs           # fetch + cache + parse registry.json
+        installer.rs          # binary download/extract; npx/uvx verify
+        launcher.rs           # spawn agent process
+        client.rs             # AcpSession wrapping agent_client_protocol
+        auth.rs               # Agent Auth + Terminal Auth
       db/
         mod.rs                # rusqlite, migrations, queries
-        schema.sql            # baseline schema                        [landed]
-      config.rs               # foreman config in ~/.brokk/foreman/config.toml
+        schema.sql            # baseline schema (agents + config_kv)
   src/                        # Svelte frontend
+    App.svelte                # router shell
+    main.ts
     routes/
-      +layout.svelte
-      +page.svelte            # /kanban
-      issues/[id]/+page.svelte
-      agents/+page.svelte
-      settings/+page.svelte
+      Settings.svelte         # repo path + default agent
+      Agents.svelte           # registry browser + custom-agent form
+      Session.svelte          # prompt input + streaming updates
     lib/
-      api.ts                  # typed wrappers for tauri invoke
-      events.ts               # tauri event subscriptions
+      api.ts                  # typed Tauri invoke wrappers
+      events.ts               # Tauri event subscriptions
       stores/
-        issues.ts
         agents.ts
-        sessions.ts
-    components/
-      Kanban.svelte
-      KanbanColumn.svelte
-      IssueCard.svelte
-      SessionPane.svelte
-      AgentPicker.svelte
-      RegistryBrowser.svelte
+        session.ts
   package.json
   vite.config.ts
   svelte.config.js
@@ -180,8 +167,7 @@ Rust (`src-tauri/Cargo.toml`):
 - `agent-client-protocol = "=0.11.1"` (exact pin)
 - `tokio` (full)
 - `serde`, `serde_json`
-- `reqwest` (rustls) for the registry CDN and Jira
-- `octocrab` (rustls) for GitHub
+- `reqwest` (rustls) for the registry CDN
 - `rusqlite` (bundled) for state
 - `directories`, `which`
 - `flate2`, `tar`, `zip` for binary distribution archive extraction
@@ -191,12 +177,9 @@ Rust (`src-tauri/Cargo.toml`):
 Frontend (`package.json`):
 
 - `svelte` 5, `vite`
-- `svelte-dnd-action` for kanban drag-and-drop
 - `@tauri-apps/api`, `@tauri-apps/plugin-shell`
 
 ## Data model (SQLite, `~/.brokk/foreman/state.db`)
-
-Baseline schema is already in tree at `src-tauri/src/db/schema.sql`:
 
 ```sql
 CREATE TABLE agents (
@@ -209,55 +192,16 @@ CREATE TABLE agents (
   enabled         INTEGER NOT NULL DEFAULT 1
 );
 
-CREATE TABLE issues (
-  id              TEXT PRIMARY KEY,    -- "<provider>:<key>"
-  provider        TEXT NOT NULL,       -- 'github' | 'jira'
-  external_key    TEXT NOT NULL,
-  title           TEXT NOT NULL,
-  body            TEXT,
-  url             TEXT,
-  state           TEXT,                -- provider-side state
-  kanban_column   TEXT NOT NULL DEFAULT 'backlog',
-  enrichment      TEXT,                -- JSON blob (see llm/enrich.rs)
-  enriched_at     INTEGER,
-  imported_at     INTEGER NOT NULL,
-  updated_at      INTEGER NOT NULL
-);
-
-CREATE TABLE blocking_edges (
-  blocker_id      TEXT NOT NULL,
-  blocked_id      TEXT NOT NULL,
-  confidence      REAL,
-  rationale       TEXT,
-  computed_at     INTEGER NOT NULL,
-  PRIMARY KEY (blocker_id, blocked_id),
-  FOREIGN KEY (blocker_id) REFERENCES issues(id) ON DELETE CASCADE,
-  FOREIGN KEY (blocked_id) REFERENCES issues(id) ON DELETE CASCADE
-);
-
-CREATE TABLE sessions (
-  id              TEXT PRIMARY KEY,
-  issue_id        TEXT NOT NULL UNIQUE,
-  agent_id        TEXT NOT NULL,
-  worktree_path   TEXT NOT NULL,
-  branch          TEXT NOT NULL,
-  acp_session_id  TEXT,
-  status          TEXT NOT NULL,
-  created_at      INTEGER NOT NULL,
-  closed_at       INTEGER,
-  FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE,
-  FOREIGN KEY (agent_id) REFERENCES agents(id)
-);
-
 CREATE TABLE config_kv (
   key             TEXT PRIMARY KEY,
   value           TEXT NOT NULL
 );
 ```
 
-The migration runner that opens this DB **must** issue `PRAGMA
-foreign_keys = ON;` on every connection — SQLite's default is OFF and the
-`ON DELETE CASCADE` clauses are silently inactive otherwise.
+The migration runner opens the DB with `PRAGMA foreign_keys = ON` and
+`PRAGMA journal_mode = WAL` on every connection. v1 has no FK
+relationships among the remaining tables, but the migration runner keeps
+the pragma for forward compatibility with worktrees / sessions tables.
 
 ## ACP registry integration
 
@@ -268,26 +212,26 @@ foreign_keys = ON;` on every connection — SQLite's default is OFF and the
 - `acp/registry.rs` parses with strict `deny_unknown_fields` on the
   per-agent types so any upstream schema drift breaks tests instead of
   silently dropping fields.
-- `acp/registry.rs` will, in a follow-up commit, fetch with `reqwest`,
-  validate `version == "1.0.0"`, persist the raw JSON at
-  `~/.brokk/foreman/registry-cache.json`, and respect the CDN cache TTL
-  plus an `If-None-Match`/`ETag` revalidation.
+- A follow-up extension fetches with `reqwest`, validates `version ==
+  "1.0.0"`, persists raw JSON at `~/.brokk/foreman/registry-cache.json`,
+  and respects the CDN cache TTL plus `If-None-Match`/`ETag`
+  revalidation.
 - `RegistryAgent` mirrors the upstream schema: `id`, `name`, `version`,
   `description`, `repository`, `website`, `authors`, `license`, `icon`,
   `distribution` with three variants (`binary` / `npx` / `uvx`).
-- `Platform::current()` resolves the running host to one of the registry's
-  six published targets (`darwin-aarch64`, `darwin-x86_64`,
+- `Platform::current()` resolves the running host to one of the
+  registry's six published targets (`darwin-aarch64`, `darwin-x86_64`,
   `linux-aarch64`, `linux-x86_64`, `windows-aarch64`, `windows-x86_64`).
   `RegistryAgent::supported_on_host()` filters the registry browser to
   "things you could install today".
 
 ### Custom agents
 
-A `CustomAgent` is the same shape as a registry entry but tagged
-`source: "custom"`, with a free-form `cmd` / `args` / `env` instead of a
-registry distribution block. Stored in the `agents` table with
-`source='custom'`. UI: an "Add agent" form with name + binary path + args
-+ env editor; this gets stored as a synthetic single-target binary
+A custom agent is the same shape as a registry entry but tagged
+`source: "custom"`, with a free-form `cmd` / `args` / `env` instead of
+a registry distribution block. Stored in the `agents` table with
+`source='custom'`. UI: an "Add agent" form with name + binary path +
+args + env editor; this gets stored as a synthetic single-target binary
 distribution keyed to the current platform (no archive download).
 
 ### Install flow
@@ -296,8 +240,8 @@ distribution keyed to the current platform (no archive download).
   `npx` (or `uvx`) is on PATH at activation time via the `which` crate.
 - For `binary`: download `archive` to
   `~/.brokk/foreman/agents/<id>/<version>.<ext>`, extract to
-  `~/.brokk/foreman/agents/<id>/<version>/`, store the resulting absolute
-  path of `cmd` in `agents.installed_path`. Reject
+  `~/.brokk/foreman/agents/<id>/<version>/`, store the resulting
+  absolute path of `cmd` in `agents.installed_path`. Reject
   `.dmg/.pkg/.deb/.rpm/.msi/.appimage` per the registry spec.
 
 ### Auth handling
@@ -308,225 +252,82 @@ When `session/new` returns `AUTH_REQUIRED`, the response declares either:
   local callback). brokk-foreman just calls `authenticate` per the ACP
   spec and waits.
 - `type: "terminal"` — Terminal Auth: relaunch the agent with the
-  response's `args`/`env` *replacing* the defaults, attached to a TTY. v1
-  spawns Terminal Auth in the user's default terminal app via
+  response's `args`/`env` *replacing* the defaults, attached to a TTY.
+  v1 spawns Terminal Auth in the user's default terminal app via
   `tauri-plugin-shell` and waits for the agent to exit before resuming;
   in-app pty is a v2 enhancement.
 
-## ACP client surface (`acp/mod.rs`, `acp/launcher.rs`)
+## ACP client surface (`acp/client.rs`, `acp/launcher.rs`)
 
 The `agent-client-protocol` crate handles the wire protocol. Our wrapper
 provides:
 
-- `AcpClient::launch(agent: &AgentRecord, cwd: &Path) -> AcpClient` —
+- `AcpSession::start(agent: &AgentRecord, cwd: &Path) -> AcpSession` —
   spawns the configured binary/npx/uvx with `cmd + args + env`, wires
-  stdin/stdout to the protocol's `Connection`, performs `initialize`.
-- `AcpClient::new_session(opts) -> SessionHandle` — calls `session/new`
-  with `cwd` set to the worktree path; returns the ACP session id.
-- `AcpClient::prompt(session, content)` — sends a `prompt` request and
-  returns a stream of `SessionUpdate` events.
-- `AcpClient::cancel(session)` — issues `cancel`.
-- `AcpClient::shutdown()` — drops the connection and `kill_on_drop`
-  cleans up.
+  stdin/stdout to the protocol's `Connection`, performs `initialize`,
+  then calls `session/new` with `cwd` set to the configured repo path.
+- `AcpSession::prompt(text)` — sends a `prompt` request; returns once
+  the turn completes. `SessionUpdate` events are forwarded to the
+  frontend during the turn via Tauri events.
+- `AcpSession::cancel()` — issues `cancel`.
+- `AcpSession::shutdown()` — drops the connection; `kill_on_drop` on
+  the spawned `Child` ensures the subprocess goes away.
 
 Streaming: `SessionUpdate` events are forwarded to the frontend as Tauri
-events on channel `acp:update:<session_id>`. The frontend renders them in
-`SessionPane.svelte`. Permission requests (`requestPermission`) are
-surfaced as a modal in the issue view; the user accepts/rejects and the
-response is forwarded back through the ACP connection. **No auto-accept**
-in v1 — even though brokk-foreman runs locally, silent auto-accept
-defeats the kanban's "I can see what each session is doing" purpose.
+events on channel `acp:update`. The frontend renders them in
+`Session.svelte`. Permission requests (`requestPermission`) are
+surfaced as a modal in the session view; the user accepts/rejects and
+the response is forwarded back through the ACP connection. **No
+auto-accept** in v1.
 
-Reference for stdio JSON-RPC subprocess management: see
-`../brokk-acp-rust/src/bifrost_client.rs` — same line-framed JSON-RPC
-over `tokio::process` with `kill_on_drop(true)` and `BufReader`-wrapped
-`ChildStdout`.
-
-## Issue providers (`issues/`)
-
-Trait:
-
-```rust
-#[async_trait]
-trait IssueProvider {
-    async fn list_issues(&self, filter: ListFilter) -> Result<Vec<Issue>>;
-    async fn fetch_issue(&self, key: &str) -> Result<Issue>;
-    async fn update_state(&self, key: &str, new_state: ProviderState) -> Result<()>;
-}
-```
-
-- **GitHub**: `octocrab` with PAT from `~/.brokk/foreman/config.toml` or
-  `GH_TOKEN` env.
-- **Jira**: `reqwest` against `<host>/rest/api/3/search` and
-  `/issue/{key}`. Basic auth (email + API token) or PAT, configured per
-  host. Reimplemented in Rust — no JNI, no Java dependency.
-
-Both fetch on a manual "Refresh" button and on a configurable interval
-(default 5 min) using a tokio task.
-
-## Worktree manager (`worktree.rs`)
-
-Shells out to `git worktree`, matching the brokk Java convention so the
-same physical layout works whether the user opens the worktree from brokk
-or from foreman:
-
-- Storage root: `~/.brokk/worktrees/<repo-folder-name>/wt<N>` where `<N>`
-  is the next free integer (matches `getNextWorktreePath()` in
-  `../app/src/main/java/ai/brokk/git/GitRepoWorktrees.java`).
-- Branch naming: `foreman/<issue-key>` (slugified). If the branch
-  exists, reuse via `git worktree add <path> <branch>`; otherwise
-  `git worktree add -b <branch> <path>` from the configured base branch
-  (default `main`/`master`).
-- Removal: explicit user action ("Close session" on the kanban card) →
-  `git worktree remove --force <path>` then optional branch delete if not
-  pushed. Same merge-prompt UX brokk uses.
-- All commands run with a 30s timeout via tokio `Command` +
-  `time::timeout`. No JGit; matches the `Environment.runShellCommand`
-  pattern in brokk.
-
-## Enrichment via ACP (`llm/enrich.rs`)
-
-Triggered automatically on each issue import (default agent picked in
-settings). Steps:
-
-1. Spawn the default agent in **read-only mode in the repo root** (no
-   worktree — enrichment doesn't write).
-2. `session/new` with `cwd = <repo-root>`.
-3. `prompt` with a structured request:
-
-   ```
-   You are analyzing a GitHub/Jira issue. Read the codebase as needed and
-   return ONLY a JSON object inside a fenced ```json block, with this
-   shape:
-
-   {
-     "summary": "1-3 sentence plain-English restatement of the issue",
-     "affectedAreas": [{"path": "...", "why": "..."}],
-     "keySymbols": ["ClassName.methodName", ...],
-     "suggestedTests": ["short imperative test names"],
-     "openQuestions": ["..."],
-     "estimatedComplexity": "S" | "M" | "L"
-   }
-
-   Issue title: <title>
-   Issue body:
-   <body>
-   ```
-
-4. Stream `SessionUpdate` events; once the turn completes, parse the last
-   assistant message for the fenced JSON; persist to `issues.enrichment`
-   and move the card from `backlog` → `enriched`.
-5. Close the session.
-
-Failure modes (agent doesn't return parseable JSON, hits a permission
-prompt, etc.) leave the issue in `backlog` with a `last_enrichment_error`
-and a manual "Re-enrich" button. v1 doesn't try to be clever about
-retries.
-
-## Blocking analysis via ACP (`llm/blocking.rs`)
-
-A **manual button** on the kanban (and a debounced auto-trigger when ≥3
-issues become enriched). One ACP session, one prompt that includes the
-title + summary + affectedAreas of every non-Done issue:
-
-```
-Given the following list of open issues with their summaries and
-affectedAreas, identify pairs (A, B) where completing A is prerequisite
-for B (A blocks B). Return ONLY a JSON object: { "edges": [{"blockerId":
-"...", "blockedId": "...", "confidence": 0..1, "rationale": "..."}] }.
-```
-
-Token budgeting: cap at 60 issues per call; if more, partition by
-ownership of `affectedAreas` paths and run multiple calls. Persist edges
-in `blocking_edges`, replacing prior entries fully on each run (keep
-`computed_at` for staleness). Render as a "Blocked by N" badge on each
-card and a flow-arrows overlay when the user toggles it.
-
-## Kanban
-
-Columns (fixed in v1, configurable in v2):
-
-`Backlog` → `Enriched` → `Ready` → `In Progress` → `In Review` → `Done`
-
-Transitions:
-
-- Manual drag-and-drop via `svelte-dnd-action` (always allowed, no FSM
-  enforcement in v1).
-- Automatic: `Backlog` → `Enriched` on successful enrichment;
-  `Ready` → `In Progress` when the user starts a session;
-  `In Progress` → `In Review` if a PR is detected for the branch;
-  `In Review` → `Done` on PR merge. The PR detection is a 60s poll of
-  GitHub's `pulls?head=...` endpoint — Jira-only repos don't get the auto
-  move-to-review.
-
-Local-only `kanban_column` (per the non-goal above). The provider's own
-state is shown as a separate badge but not synced.
+Subprocess pattern: model the spawn after
+`brokk-acp-rust/src/bifrost_client.rs` — `tokio::process::Command` with
+`stdin/stdout/stderr` piped, `kill_on_drop(true)`, `BufReader`-wrapped
+`ChildStdout`. The wire framing is handled by
+`agent_client_protocol::ConnectionTo`; we don't roll our own JSON-RPC.
 
 ## Frontend layout (Svelte 5)
 
-- `/kanban` (default): the board. Filter bar (provider, label, agent),
-  drag-and-drop columns, "Run blocking analysis" button.
-- `/issues/:id`: split view. Top: enrichment block + open questions.
-  Middle: live `SessionPane` (streaming ACP `SessionUpdate` events,
-  permission prompts inline). Bottom: associated worktree path, branch,
-  "Open in editor" buttons.
-- `/agents`: the registry browser (table from cached `registry.json`),
+- `/settings` (default on first run): repo path + default agent.
+- `/agents`: registry browser (table from cached `registry.json`),
   enable/disable, install/uninstall, "Add custom agent" form. Status
   indicator per agent (installed, auth pending, error).
-- `/settings`: GitHub PAT + Jira host/credentials, default agent for
-  enrichment, default agent suggestion list for new sessions, base
-  branch.
+- `/session`: pick an agent (default pre-selected); prompt input
+  textarea; streaming `SessionUpdate` list; permission modal; Cancel +
+  Stop buttons.
 
-State stores (`issues.ts`, `agents.ts`, `sessions.ts`) are each backed by
-a Tauri command for initial load and Tauri events for updates.
+State stores (`agents.ts`, `session.ts`) are each backed by a Tauri
+command for initial load and Tauri events for updates.
 
 ## Tauri commands surfaced to the frontend (`commands.rs`)
 
 ```
-list_issues(filter)               -> Vec<Issue>
-refresh_issues()                  -> ()
-get_issue(id)                     -> IssueDetail
 list_agents()                     -> Vec<AgentRecord>
 fetch_registry(force_refresh)     -> Vec<RegistryAgent>
 install_agent(registry_id)        -> AgentRecord
-uninstall_agent(id)                -> ()
+uninstall_agent(id)               -> ()
 add_custom_agent(spec)            -> AgentRecord
-start_session(issue_id, agent_id) -> SessionRecord
-stop_session(session_id)          -> ()
-send_prompt(session_id, text)     -> ()    // emits acp:update:<id> events
+get_config()                      -> Config
+set_config(config)                -> ()
+start_session(agent_id)           -> SessionRecord
+send_prompt(text)                 -> ()       // emits acp:update events
 respond_permission(req_id, accept)-> ()
-move_card(issue_id, column)       -> ()
-run_blocking_analysis()           -> ()
+stop_session()                    -> ()
 ```
 
 ## Risks and open issues
 
-1. **Structured-output reliability across agents.** Different agents have
-   different propensities to add prose around fenced JSON, ignore the
-   format, or wrap in extra code fences. Mitigation: a tolerant parser
-   that strips markdown fences, finds the largest valid JSON object, and
-   falls back to "couldn't parse — re-run". Long-term: consider an
-   ACP-level "structured response" extension if one lands.
-2. **Per-agent quirks at launch.** Some `npx` agents are slow on first
-   run (cold install). Some binary releases mismatch `cmd` against actual
-   extracted layout. We need a clear timeout + error UI per agent; v1
-   surfaces stdout/stderr in the agents page on failure.
-3. **Authentication UX divergence.** Agent Auth is hands-off, but
+1. **Per-agent quirks at launch.** Some `npx` agents are slow on first
+   run (cold install). Some binary releases mismatch `cmd` against the
+   actual extracted layout. We need a clear timeout + error UI per
+   agent; v1 surfaces stdout/stderr in the agents page on failure.
+2. **Authentication UX divergence.** Agent Auth is hands-off, but
    Terminal Auth needs a real pty with the user staring at the screen.
-   Embedding a TTY view in the webview is non-trivial; v1 spawns Terminal
-   Auth in the user's default terminal app and waits for the agent to
-   exit before resuming.
-4. **Worktree disk usage.** Many open issues × full repo checkout per
-   worktree = real disk pressure on big monorepos. Default to **lazy
-   worktrees** (`git worktree add` only on session start, removed on
-   session close) — never for un-started issues.
-5. **Branch collision with brokk.** Brokk also creates worktrees in
-   `~/.brokk/worktrees/<repo>/`. We use a distinct branch prefix
-   (`foreman/...`) and reuse `getNextWorktreePath`-style numeric names;
-   brokk and foreman can coexist in the same repo without stepping on
-   each other, but a user mass-deleting via brokk's UI can orphan our
-   session records. v1 detects this on startup with `git worktree list
-   --porcelain` and marks orphaned sessions `failed`.
+   Embedding a TTY view in the webview is non-trivial; v1 spawns
+   Terminal Auth in the user's default terminal app and waits for the
+   agent to exit before resuming.
+3. **Structured-output reliability across agents** is a v2 concern only
+   (no enrichment in v1).
 
 ## Verification (end-to-end, once the wrapper and UI land)
 
@@ -534,35 +335,28 @@ run_blocking_analysis()           -> ()
    Vite dev server.
 2. Open the agents page; the registry loads (verify network tab shows
    the CDN URL); install `claude-acp` (npx) or a custom local binary.
-3. Configure GitHub PAT in settings; click Refresh on the kanban; verify
-   open issues appear in `Backlog`.
-4. Wait for auto-enrichment to flip cards to `Enriched`; click an issue;
-   verify the JSON enrichment is rendered and the original prompt /
-   response is in the audit trail.
-5. Click "Run blocking analysis"; verify edges appear and `Blocked by N`
-   badges render.
-6. From an `Enriched` issue, click "Start session" with a chosen agent;
-   verify a worktree is created at `~/.brokk/worktrees/<repo>/wt<N>` on
-   the `foreman/<key>` branch and the agent process starts; verify
-   `SessionPane` streams responses and permission prompts.
-7. Send a prompt; observe streaming. Cancel; observe clean shutdown of
-   the child process (`ps -p` shows it gone).
-8. Open the worktree separately (`git -C <path> status`); verify it is
-   real and on the right branch.
-9. Drag the card to `Done`; click "Close session"; verify worktree
-   removal and branch cleanup, and `sessions.status='closed'` in the DB.
-10. Tests: `cargo test` for the registry parser (already in tree), the
-    worktree shell-out (against a temp git repo), and the
-    enrichment-JSON tolerant parser (varied real agent outputs as
-    fixtures).
+3. Configure repo path in settings.
+4. From `/session`, pick an agent and click Start. Verify the agent
+   process appears in `ps` and Rust logs show `initialize` +
+   `session/new` succeeding.
+5. Send a prompt; observe streaming `SessionUpdate` events in the page.
+6. Trigger a tool-use turn (e.g. "list files in this repo"); verify the
+   permission modal appears and accepting forwards through ACP.
+7. Click Cancel mid-turn; observe clean cancellation.
+8. Click Stop; verify clean shutdown of the child process (`ps -p`
+   shows it gone).
+9. Repeat with an `npx`-distributed registry agent.
+10. Tests: `cargo test` for the registry parser, the migration runner,
+    and any added integration tests for the ACP client wrapper.
 
 ## Scope cut summary for v1 ship
 
-Keep: kanban, issue list, enrichment-on-import, blocking analysis, ACP
-sessions per issue with worktrees, registry browser + custom installs,
-Agent Auth + (out-of-app) Terminal Auth.
+Keep: agent picker (registry browser + custom installs), single
+session against a configured repo path, prompt + streaming updates,
+permission modal, Agent Auth + (out-of-app) Terminal Auth.
 
-Cut: in-app pty for Terminal Auth, GitHub Projects/Jira board sync,
-multi-repo, configurable kanban columns, mobile/web build, auto-resume of
-crashed sessions across restarts (we leave the session marked `failed`
-and the user re-runs).
+Cut from v1 (deferred to later milestones): worktree-per-session
+(next), GitHub/Jira issue providers, kanban UI, enrichment-on-import,
+blocking-graph analysis, in-app pty for Terminal Auth, multi-repo,
+configurable kanban columns, mobile/web build, auto-resume of crashed
+sessions across restarts, multiple concurrent sessions.

--- a/brokk-foreman/package.json
+++ b/brokk-foreman/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",
-    "@tauri-apps/plugin-shell": "^2.0.0",
-    "svelte-dnd-action": "^0.9.50"
+    "@tauri-apps/plugin-shell": "^2.0.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.0",

--- a/brokk-foreman/pnpm-lock.yaml
+++ b/brokk-foreman/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@tauri-apps/plugin-shell':
         specifier: ^2.0.0
         version: 2.3.5
-      svelte-dnd-action:
-        specifier: ^0.9.50
-        version: 0.9.69(svelte@5.55.5)
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
@@ -576,11 +573,6 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
-  svelte-dnd-action@0.9.69:
-    resolution: {integrity: sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw==}
-    peerDependencies:
-      svelte: '>=3.23.0 || ^5.0.0-next.0'
-
   svelte@5.55.5:
     resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
     engines: {node: '>=18'}
@@ -1047,10 +1039,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
-
-  svelte-dnd-action@0.9.69(svelte@5.55.5):
-    dependencies:
-      svelte: 5.55.5
 
   svelte@5.55.5:
     dependencies:

--- a/brokk-foreman/src-tauri/Cargo.toml
+++ b/brokk-foreman/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-description = "Cross-platform issue manager and ACP client for any Agent Client Protocol agent"
+description = "Cross-platform desktop ACP client for any Agent Client Protocol agent"
 
 [lib]
 name = "brokk_foreman_lib"
@@ -33,9 +33,8 @@ futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-# HTTP (registry CDN, GitHub via octocrab, Jira)
+# HTTP (registry CDN)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
-octocrab = { version = "0.50", default-features = false, features = ["rustls", "rustls-ring", "jwt-rust-crypto"] }
 
 # Storage
 rusqlite = { version = "0.36", features = ["bundled"] }

--- a/brokk-foreman/src-tauri/src/acp/agents.rs
+++ b/brokk-foreman/src-tauri/src/acp/agents.rs
@@ -1,0 +1,333 @@
+//! Persistence layer for the `agents` table — registry-imported and
+//! user-defined custom agents. `AgentRecord` is the typed row; `launch_spec`
+//! resolves the stored `Distribution` plus optional install path into the
+//! concrete `cmd + args + env` triple the launcher hands to
+//! `tokio::process::Command`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::acp::registry::{Distribution, Platform, RegistryAgent};
+
+/// One row of the `agents` table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRecord {
+    pub id: String,
+    pub source: AgentSource,
+    pub name: String,
+    pub version: Option<String>,
+    pub distribution: Distribution,
+    pub installed_path: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentSource {
+    Registry,
+    Custom,
+}
+
+impl AgentSource {
+    fn parse(s: &str) -> Result<Self, AgentsError> {
+        match s {
+            "registry" => Ok(Self::Registry),
+            "custom" => Ok(Self::Custom),
+            other => Err(AgentsError::UnknownSource(other.into())),
+        }
+    }
+}
+
+/// User-supplied custom agent spec — the v1 "add agent" form payload.
+/// Stored as a synthetic single-target binary `Distribution` keyed to the
+/// current host platform so the launcher path is identical for registry
+/// and custom agents.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomAgentSpec {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    pub cmd: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Error)]
+pub enum AgentsError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("agent json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("agent {0:?} not found")]
+    NotFound(String),
+    #[error("unknown agent source {0:?} in db")]
+    UnknownSource(String),
+    #[error("custom agent {0:?} cannot resolve a launch spec on this host")]
+    NoLaunchTarget(String),
+    #[error("agent {0:?} has no installed_path; install it via install_agent before launching")]
+    NotInstalled(String),
+}
+
+/// List every row in `agents`, ordered by name.
+pub fn list(conn: &Connection) -> Result<Vec<AgentRecord>, AgentsError> {
+    let mut stmt = conn.prepare(
+        "SELECT id, source, name, version, distribution, installed_path, enabled \
+         FROM agents ORDER BY name ASC",
+    )?;
+    let rows = stmt.query_map([], row_to_record)?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(AgentsError::Sqlite)
+        .and_then(|rs| rs.into_iter().collect())
+}
+
+/// Fetch a single agent row.
+pub fn get(conn: &Connection, id: &str) -> Result<AgentRecord, AgentsError> {
+    conn.query_row(
+        "SELECT id, source, name, version, distribution, installed_path, enabled \
+         FROM agents WHERE id = ?1",
+        params![id],
+        row_to_record,
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => AgentsError::NotFound(id.into()),
+        other => AgentsError::Sqlite(other),
+    })
+    .and_then(|r| r)
+}
+
+/// Insert a registry agent (no install yet — `installed_path` left `NULL`).
+pub fn upsert_registry(
+    conn: &Connection,
+    agent: &RegistryAgent,
+) -> Result<AgentRecord, AgentsError> {
+    let dist_json = serde_json::to_string(&agent.distribution)?;
+    conn.execute(
+        "INSERT INTO agents (id, source, name, version, distribution, installed_path, enabled) \
+         VALUES (?1, 'registry', ?2, ?3, ?4, NULL, 1) \
+         ON CONFLICT(id) DO UPDATE SET \
+            name = excluded.name, version = excluded.version, distribution = excluded.distribution",
+        params![agent.id, agent.name, agent.version, dist_json],
+    )?;
+    get(conn, &agent.id)
+}
+
+/// Insert a user-defined custom agent built from a `CustomAgentSpec`.
+pub fn upsert_custom(
+    conn: &Connection,
+    spec: &CustomAgentSpec,
+) -> Result<AgentRecord, AgentsError> {
+    let distribution = custom_spec_to_distribution(spec);
+    let dist_json = serde_json::to_string(&distribution)?;
+    conn.execute(
+        "INSERT INTO agents (id, source, name, version, distribution, installed_path, enabled) \
+         VALUES (?1, 'custom', ?2, ?3, ?4, NULL, 1) \
+         ON CONFLICT(id) DO UPDATE SET \
+            name = excluded.name, version = excluded.version, distribution = excluded.distribution",
+        params![spec.id, spec.name, spec.version, dist_json],
+    )?;
+    get(conn, &spec.id)
+}
+
+/// Record an extracted binary install path for an agent.
+pub fn set_installed_path(
+    conn: &Connection,
+    id: &str,
+    installed_path: &str,
+) -> Result<(), AgentsError> {
+    let n = conn.execute(
+        "UPDATE agents SET installed_path = ?1 WHERE id = ?2",
+        params![installed_path, id],
+    )?;
+    if n == 0 {
+        return Err(AgentsError::NotFound(id.into()));
+    }
+    Ok(())
+}
+
+/// Remove an agent row and clear any stored install path.
+pub fn delete(conn: &Connection, id: &str) -> Result<(), AgentsError> {
+    let n = conn.execute("DELETE FROM agents WHERE id = ?1", params![id])?;
+    if n == 0 {
+        return Err(AgentsError::NotFound(id.into()));
+    }
+    Ok(())
+}
+
+/// Concrete launch spec resolved from an `AgentRecord` for the running host.
+#[derive(Debug, Clone)]
+pub struct LaunchSpec {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub kind: LaunchKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchKind {
+    Binary,
+    Npx,
+    Uvx,
+}
+
+/// Resolve the agent's distribution into the concrete launch spec. For
+/// `binary` distributions we require `installed_path` to be set; the
+/// caller (install flow) is responsible for downloading and extracting
+/// the archive first.
+pub fn launch_spec(record: &AgentRecord) -> Result<LaunchSpec, AgentsError> {
+    let host = Platform::current();
+    let dist = &record.distribution;
+
+    if let (Some(p), Some(targets)) = (host, dist.binary.as_ref())
+        && let Some(target) = targets.get(&p)
+    {
+        // Custom agents ship a synthetic binary distribution whose `cmd` is
+        // the absolute path the user typed into the form — no install dir.
+        // Registry binary agents have `cmd` relative to the extracted
+        // archive root recorded in `installed_path`.
+        let program = match record.source {
+            AgentSource::Custom => PathBuf::from(&target.cmd),
+            AgentSource::Registry => {
+                let installed_path = record
+                    .installed_path
+                    .as_deref()
+                    .ok_or_else(|| AgentsError::NotInstalled(record.id.clone()))?;
+                PathBuf::from(installed_path).join(&target.cmd)
+            }
+        };
+        return Ok(LaunchSpec {
+            program,
+            args: target.args.clone(),
+            env: target.env.clone(),
+            kind: LaunchKind::Binary,
+        });
+    }
+
+    if let Some(npx) = dist.npx.as_ref() {
+        let mut args = vec!["--yes".to_string(), npx.package.clone()];
+        args.extend(npx.args.iter().cloned());
+        return Ok(LaunchSpec {
+            program: PathBuf::from("npx"),
+            args,
+            env: npx.env.clone(),
+            kind: LaunchKind::Npx,
+        });
+    }
+
+    if let Some(uvx) = dist.uvx.as_ref() {
+        let mut args = vec![uvx.package.clone()];
+        args.extend(uvx.args.iter().cloned());
+        return Ok(LaunchSpec {
+            program: PathBuf::from("uvx"),
+            args,
+            env: uvx.env.clone(),
+            kind: LaunchKind::Uvx,
+        });
+    }
+
+    Err(AgentsError::NoLaunchTarget(record.id.clone()))
+}
+
+fn custom_spec_to_distribution(spec: &CustomAgentSpec) -> Distribution {
+    use crate::acp::registry::BinaryTarget;
+    let host = Platform::current();
+    let mut binary = HashMap::new();
+    if let Some(host) = host {
+        binary.insert(
+            host,
+            BinaryTarget {
+                archive: String::new(),
+                cmd: spec.cmd.clone(),
+                args: spec.args.clone(),
+                env: spec.env.clone(),
+            },
+        );
+    }
+    Distribution {
+        binary: Some(binary),
+        npx: None,
+        uvx: None,
+    }
+}
+
+fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<Result<AgentRecord, AgentsError>> {
+    let id: String = row.get(0)?;
+    let source: String = row.get(1)?;
+    let name: String = row.get(2)?;
+    let version: Option<String> = row.get(3)?;
+    let distribution_json: String = row.get(4)?;
+    let installed_path: Option<String> = row.get(5)?;
+    let enabled: bool = row.get::<_, i64>(6)? != 0;
+
+    Ok((|| -> Result<AgentRecord, AgentsError> {
+        let source = AgentSource::parse(&source)?;
+        let distribution: Distribution = serde_json::from_str(&distribution_json)?;
+        Ok(AgentRecord {
+            id,
+            source,
+            name,
+            version,
+            distribution,
+            installed_path,
+            enabled,
+        })
+    })())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    fn sample_custom(id: &str) -> CustomAgentSpec {
+        CustomAgentSpec {
+            id: id.into(),
+            name: format!("custom {id}"),
+            version: Some("0.1".into()),
+            cmd: "/usr/local/bin/my-agent".into(),
+            args: vec!["--stdio".into()],
+            env: HashMap::from([("FOO".into(), "bar".into())]),
+        }
+    }
+
+    #[test]
+    fn custom_agent_round_trip() {
+        let conn = db::open_in_memory().unwrap();
+        let rec = upsert_custom(&conn, &sample_custom("local-agent")).unwrap();
+        assert_eq!(rec.source, AgentSource::Custom);
+        assert_eq!(rec.name, "custom local-agent");
+
+        let listed = list(&conn).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "local-agent");
+
+        delete(&conn, "local-agent").unwrap();
+        assert!(list(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn delete_unknown_errors() {
+        let conn = db::open_in_memory().unwrap();
+        let err = delete(&conn, "nope").unwrap_err();
+        assert!(matches!(err, AgentsError::NotFound(_)));
+    }
+
+    #[test]
+    fn custom_launch_spec_resolves_for_host() {
+        let conn = db::open_in_memory().unwrap();
+        let rec = upsert_custom(&conn, &sample_custom("c")).unwrap();
+        if Platform::current().is_none() {
+            // Skip on registry-unsupported targets (CI runners on exotic hosts).
+            return;
+        }
+        let spec = launch_spec(&rec).unwrap();
+        assert_eq!(spec.kind, LaunchKind::Binary);
+        assert_eq!(spec.args, vec!["--stdio"]);
+    }
+}

--- a/brokk-foreman/src-tauri/src/acp/auth.rs
+++ b/brokk-foreman/src-tauri/src/acp/auth.rs
@@ -1,0 +1,105 @@
+//! Authentication handling for ACP agents.
+//!
+//! v1 detects the two flavors of `AUTH_REQUIRED` responses from
+//! `session/new` and reports them back to the UI; the actual auth flow is
+//! deferred:
+//!
+//! - **Agent Auth** (`type: "agent"`): the agent owns its OAuth flow.
+//!   Foreman calls `authenticate` per the ACP spec and waits for the
+//!   agent to come back to a usable state.
+//! - **Terminal Auth** (`type: "terminal"`): foreman re-launches the
+//!   agent with the response's `args`/`env` *replacing* the defaults,
+//!   attached to a TTY. v1 spawns Terminal Auth in the user's default
+//!   terminal app via `tauri-plugin-shell` and waits for the child to
+//!   exit before resuming.
+//!
+//! This module currently exposes the typed helpers; concrete wiring lands
+//! once the basic session lifecycle is verified end-to-end.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AuthFlow {
+    /// The agent will handle its own OAuth flow once `authenticate` is sent.
+    Agent,
+    /// The agent must be re-launched attached to a TTY with the supplied
+    /// argv/env.
+    Terminal {
+        args: Vec<String>,
+        env: std::collections::HashMap<String, String>,
+    },
+    /// Anything else; the message is surfaced verbatim to the user.
+    Other { message: String },
+}
+
+/// Map an arbitrary JSON `AUTH_REQUIRED` payload from the agent into our
+/// typed enum. Unknown shapes fall through to `Other` so the user still
+/// gets some visibility while we add coverage.
+pub fn classify(payload: &serde_json::Value) -> AuthFlow {
+    match payload.get("type").and_then(|v| v.as_str()) {
+        Some("agent") => AuthFlow::Agent,
+        Some("terminal") => {
+            let args = payload
+                .get("args")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let env = payload
+                .get("env")
+                .and_then(|v| v.as_object())
+                .map(|m| {
+                    m.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                        .collect()
+                })
+                .unwrap_or_default();
+            AuthFlow::Terminal { args, env }
+        }
+        _ => AuthFlow::Other {
+            message: payload.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn classifies_agent_flow() {
+        assert!(matches!(
+            classify(&json!({"type": "agent"})),
+            AuthFlow::Agent
+        ));
+    }
+
+    #[test]
+    fn classifies_terminal_flow_with_args_and_env() {
+        let payload = json!({
+            "type": "terminal",
+            "args": ["login", "--device"],
+            "env": {"FOO": "bar"}
+        });
+        match classify(&payload) {
+            AuthFlow::Terminal { args, env } => {
+                assert_eq!(args, vec!["login", "--device"]);
+                assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+            }
+            other => panic!("expected Terminal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_kind_falls_through() {
+        assert!(matches!(
+            classify(&json!({"type": "unknown"})),
+            AuthFlow::Other { .. }
+        ));
+    }
+}

--- a/brokk-foreman/src-tauri/src/acp/client.rs
+++ b/brokk-foreman/src-tauri/src/acp/client.rs
@@ -1,0 +1,389 @@
+//! ACP session manager.
+//!
+//! Wraps a single live ACP session: spawns the agent process (via
+//! `launcher`), drives the `agent-client-protocol` connection on a tokio
+//! task, forwards inbound `SessionUpdate` notifications and
+//! `requestPermission` calls to the frontend as Tauri events, and exposes
+//! a typed surface (`start`, `prompt`, `cancel`, `stop`, `respond_permission`)
+//! to be called from `#[tauri::command]` handlers.
+//!
+//! Pattern mirrors the `yolo_one_shot_client.rs` example from the
+//! `agent-client-protocol` crate, with a long-lived `mpsc::Receiver` loop
+//! replacing the single-prompt body so the UI can drive multiple prompts.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use agent_client_protocol::schema::{
+    CancelNotification, ContentBlock, InitializeRequest, NewSessionRequest, PromptRequest,
+    ProtocolVersion, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    SelectedPermissionOutcome, SessionId, SessionNotification, TextContent,
+};
+use agent_client_protocol::{ByteStreams, Client, ConnectionTo};
+use tauri::{AppHandle, Emitter};
+use thiserror::Error;
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+use crate::acp::agents::{AgentRecord, launch_spec};
+use crate::acp::launcher::{self, SpawnedAgent};
+use crate::events::{
+    ACP_PERMISSION_CHANNEL, ACP_SESSION_STATUS_CHANNEL, ACP_STDERR_CHANNEL, ACP_UPDATE_CHANNEL,
+    AcpStderr, AcpUpdate, PermissionRequest, SessionStatus,
+};
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("a session is already running for agent {0:?}; stop it first")]
+    AlreadyRunning(String),
+    #[error("no active session")]
+    NoActiveSession,
+    #[error("session command channel is closed (driver task ended)")]
+    ChannelClosed,
+    #[error("launcher error: {0}")]
+    Launcher(#[from] launcher::LauncherError),
+    #[error("agent error: {0}")]
+    Agent(#[from] crate::acp::agents::AgentsError),
+    #[error("unknown permission request id {0:?}")]
+    UnknownPermission(String),
+}
+
+/// Per-process state managed by Tauri. Holds at most one live session at a
+/// time (v1 constraint).
+pub struct SessionManager {
+    inner: Mutex<Option<ActiveSession>>,
+    pending_permissions: Arc<Mutex<HashMap<String, oneshot::Sender<RequestPermissionResponse>>>>,
+}
+
+struct ActiveSession {
+    agent_id: String,
+    cmd_tx: mpsc::Sender<SessionCommand>,
+    /// Set once the driver task has handshaked and received a session id.
+    session_id: Arc<Mutex<Option<String>>>,
+    join: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Debug)]
+enum SessionCommand {
+    Prompt(String),
+    Cancel,
+    Stop,
+}
+
+impl Default for SessionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionManager {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(None),
+            pending_permissions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Start a session against `record` with `cwd = repo_path`.
+    pub async fn start(
+        &self,
+        record: AgentRecord,
+        repo_path: PathBuf,
+        app: AppHandle,
+    ) -> Result<(), ClientError> {
+        let mut slot = self.inner.lock().await;
+        if let Some(active) = slot.as_ref() {
+            return Err(ClientError::AlreadyRunning(active.agent_id.clone()));
+        }
+
+        let agent_id = record.id.clone();
+        let _ = app.emit(
+            ACP_SESSION_STATUS_CHANNEL,
+            SessionStatus::Starting {
+                agent_id: agent_id.clone(),
+            },
+        );
+
+        let spec = launch_spec(&record)?;
+        let spawned = launcher::spawn(&spec, &repo_path)?;
+
+        let (cmd_tx, cmd_rx) = mpsc::channel::<SessionCommand>(32);
+        let session_id_slot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+        let task = tokio::spawn(run_session(RunArgs {
+            spawned,
+            repo_path,
+            agent_id: agent_id.clone(),
+            app: app.clone(),
+            permissions: self.pending_permissions.clone(),
+            session_id_slot: session_id_slot.clone(),
+            cmd_rx,
+        }));
+
+        *slot = Some(ActiveSession {
+            agent_id,
+            cmd_tx,
+            session_id: session_id_slot,
+            join: task,
+        });
+        Ok(())
+    }
+
+    pub async fn send_prompt(&self, text: String) -> Result<(), ClientError> {
+        let slot = self.inner.lock().await;
+        let active = slot.as_ref().ok_or(ClientError::NoActiveSession)?;
+        active
+            .cmd_tx
+            .send(SessionCommand::Prompt(text))
+            .await
+            .map_err(|_| ClientError::ChannelClosed)
+    }
+
+    pub async fn cancel(&self) -> Result<(), ClientError> {
+        let slot = self.inner.lock().await;
+        let active = slot.as_ref().ok_or(ClientError::NoActiveSession)?;
+        active
+            .cmd_tx
+            .send(SessionCommand::Cancel)
+            .await
+            .map_err(|_| ClientError::ChannelClosed)
+    }
+
+    pub async fn stop(&self) -> Result<(), ClientError> {
+        let mut slot = self.inner.lock().await;
+        if let Some(active) = slot.take() {
+            let _ = active.cmd_tx.send(SessionCommand::Stop).await;
+            active.join.abort();
+            // Best-effort await — abort is enough to release the spawned
+            // child via kill_on_drop, and we don't want to block the
+            // caller indefinitely if the driver is wedged on a send.
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), async move {
+                let _ = active.join.await;
+            })
+            .await;
+        }
+        Ok(())
+    }
+
+    /// Surface the frontend's decision for an outstanding permission
+    /// prompt. `accept = true` selects the first available option,
+    /// `false` resolves with `Cancelled`. v1 keeps the UX binary; refining
+    /// "accept" into the agent's per-option ids is a v2 enhancement.
+    pub async fn respond_permission(
+        &self,
+        request_id: &str,
+        accept: bool,
+        selected_option_id: Option<String>,
+    ) -> Result<(), ClientError> {
+        let mut pending = self.pending_permissions.lock().await;
+        let tx = pending
+            .remove(request_id)
+            .ok_or_else(|| ClientError::UnknownPermission(request_id.into()))?;
+        let response = if accept {
+            let id = selected_option_id.unwrap_or_else(|| "allow".into());
+            RequestPermissionResponse::new(RequestPermissionOutcome::Selected(
+                SelectedPermissionOutcome::new(id),
+            ))
+        } else {
+            RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled)
+        };
+        let _ = tx.send(response);
+        Ok(())
+    }
+
+    pub async fn current_session_id(&self) -> Option<String> {
+        let slot = self.inner.lock().await;
+        let active = slot.as_ref()?;
+        active.session_id.lock().await.clone()
+    }
+}
+
+struct RunArgs {
+    spawned: SpawnedAgent,
+    repo_path: PathBuf,
+    agent_id: String,
+    app: AppHandle,
+    permissions: Arc<Mutex<HashMap<String, oneshot::Sender<RequestPermissionResponse>>>>,
+    session_id_slot: Arc<Mutex<Option<String>>>,
+    cmd_rx: mpsc::Receiver<SessionCommand>,
+}
+
+async fn run_session(args: RunArgs) {
+    let RunArgs {
+        spawned,
+        repo_path,
+        agent_id,
+        app,
+        permissions,
+        session_id_slot,
+        cmd_rx,
+    } = args;
+
+    let SpawnedAgent {
+        child: _child,
+        stdin,
+        stdout,
+        stderr,
+    } = spawned;
+
+    // Forward stderr as Tauri events so the agents page can show launch
+    // errors. The task ends when the child closes its stderr pipe.
+    let stderr_app = app.clone();
+    let stderr_agent_id = agent_id.clone();
+    tokio::spawn(async move {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        let mut lines = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let _ = stderr_app.emit(
+                ACP_STDERR_CHANNEL,
+                AcpStderr {
+                    agent_id: stderr_agent_id.clone(),
+                    line,
+                },
+            );
+        }
+    });
+
+    let transport = ByteStreams::new(stdin.compat_write(), stdout.compat());
+
+    let app_for_notif = app.clone();
+    let app_for_perm = app.clone();
+    let permissions_for_handler = permissions.clone();
+
+    let result = Client
+        .builder()
+        .on_receive_notification(
+            async move |notification: SessionNotification, _cx| {
+                let payload = AcpUpdate {
+                    session_id: notification.session_id.to_string(),
+                    update: serde_json::to_value(&notification.update).unwrap_or_default(),
+                };
+                if let Err(e) = app_for_notif.emit(ACP_UPDATE_CHANNEL, payload) {
+                    tracing::warn!("emit {ACP_UPDATE_CHANNEL} failed: {e}");
+                }
+                Ok(())
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .on_receive_request(
+            async move |req: RequestPermissionRequest, responder, _cx| {
+                let request_id = uuid::Uuid::new_v4().to_string();
+                let (tx, rx) = oneshot::channel::<RequestPermissionResponse>();
+                permissions_for_handler
+                    .lock()
+                    .await
+                    .insert(request_id.clone(), tx);
+
+                let payload = PermissionRequest {
+                    request_id: request_id.clone(),
+                    session_id: req.session_id.to_string(),
+                    tool_call: serde_json::to_value(&req.tool_call).unwrap_or_default(),
+                    options: serde_json::to_value(&req.options).unwrap_or_default(),
+                };
+                if let Err(e) = app_for_perm.emit(ACP_PERMISSION_CHANNEL, payload) {
+                    tracing::warn!("emit {ACP_PERMISSION_CHANNEL} failed: {e}");
+                    // Without a UI we cannot resolve the prompt; cancel
+                    // so the agent isn't stuck waiting.
+                    permissions_for_handler.lock().await.remove(&request_id);
+                    return responder.respond(RequestPermissionResponse::new(
+                        RequestPermissionOutcome::Cancelled,
+                    ));
+                }
+
+                match rx.await {
+                    Ok(response) => responder.respond(response),
+                    Err(_) => responder.respond(RequestPermissionResponse::new(
+                        RequestPermissionOutcome::Cancelled,
+                    )),
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .connect_with(transport, |connection: ConnectionTo<_>| async move {
+            drive_session(
+                connection,
+                repo_path,
+                agent_id,
+                app,
+                session_id_slot,
+                cmd_rx,
+            )
+            .await
+        })
+        .await;
+
+    if let Err(e) = result {
+        tracing::warn!("ACP session driver ended with error: {e}");
+    }
+}
+
+async fn drive_session(
+    connection: ConnectionTo<agent_client_protocol::Agent>,
+    repo_path: PathBuf,
+    agent_id: String,
+    app: AppHandle,
+    session_id_slot: Arc<Mutex<Option<String>>>,
+    mut cmd_rx: mpsc::Receiver<SessionCommand>,
+) -> agent_client_protocol::Result<()> {
+    tracing::info!(%agent_id, "ACP initialize");
+    let init_resp = connection
+        .send_request(InitializeRequest::new(ProtocolVersion::V1))
+        .block_task()
+        .await?;
+    tracing::info!(?init_resp.agent_info, "ACP initialize complete");
+
+    tracing::info!(repo_path = %repo_path.display(), "ACP session/new");
+    let new_sess = connection
+        .send_request(NewSessionRequest::new(repo_path))
+        .block_task()
+        .await?;
+    let session_id: SessionId = new_sess.session_id;
+    *session_id_slot.lock().await = Some(session_id.to_string());
+    let _ = app.emit(
+        ACP_SESSION_STATUS_CHANNEL,
+        SessionStatus::Ready {
+            agent_id: agent_id.clone(),
+            session_id: session_id.to_string(),
+        },
+    );
+
+    while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            SessionCommand::Prompt(text) => {
+                let req = PromptRequest::new(
+                    session_id.clone(),
+                    vec![ContentBlock::Text(TextContent::new(text))],
+                );
+                if let Err(e) = connection.send_request(req).block_task().await {
+                    tracing::warn!("prompt request failed: {e}");
+                    let _ = app.emit(
+                        ACP_SESSION_STATUS_CHANNEL,
+                        SessionStatus::Failed {
+                            agent_id: agent_id.clone(),
+                            error: format!("prompt failed: {e}"),
+                        },
+                    );
+                    break;
+                }
+            }
+            SessionCommand::Cancel => {
+                if let Err(e) =
+                    connection.send_notification(CancelNotification::new(session_id.clone()))
+                {
+                    tracing::warn!("cancel notification failed: {e}");
+                }
+            }
+            SessionCommand::Stop => break,
+        }
+    }
+
+    let _ = app.emit(
+        ACP_SESSION_STATUS_CHANNEL,
+        SessionStatus::Stopped {
+            agent_id,
+            reason: "session ended".into(),
+        },
+    );
+    Ok(())
+}

--- a/brokk-foreman/src-tauri/src/acp/installer.rs
+++ b/brokk-foreman/src-tauri/src/acp/installer.rs
@@ -1,0 +1,192 @@
+//! Install flow for registry-distributed agents.
+//!
+//! - `binary`: download the archive matching `Platform::current()` to
+//!   `<install_dir>/<id>/<version>.<ext>`, extract to
+//!   `<install_dir>/<id>/<version>/`, return that extracted path so the
+//!   caller can persist it via `agents::set_installed_path`.
+//! - `npx` / `uvx`: nothing to fetch ahead of time; we only verify the
+//!   launcher binary (`npx`/`uvx`) exists at install-button time so the
+//!   user gets fast feedback if it's missing.
+//!
+//! Archive formats supported: `.tar.gz`/`.tgz` and `.zip`. Installer-style
+//! formats (`.dmg`/`.pkg`/`.deb`/`.rpm`/`.msi`/`.appimage`) are rejected
+//! per the registry spec — those install system-wide, not under our
+//! sandboxed agents directory.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+use tokio::fs;
+
+use crate::acp::registry::{Distribution, Platform, RegistryAgent};
+
+#[derive(Debug, Error)]
+pub enum InstallError {
+    #[error("agent {0:?} has no binary target for the running host platform")]
+    NoBinaryForHost(String),
+    #[error("agent {0:?} declared neither binary nor npx nor uvx distribution")]
+    NoDistribution(String),
+    #[error("rejected installer-style archive {0:?} (use a portable tar.gz or zip)")]
+    UnsupportedArchive(String),
+    #[error("unrecognized archive extension for {0:?}; expected .tar.gz/.tgz or .zip")]
+    UnknownArchiveFormat(String),
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("zip extraction error: {0}")]
+    Zip(#[from] zip::result::ZipError),
+    #[error("npx is not on PATH; install Node.js >=18 to use npx-distributed agents")]
+    NpxMissing,
+    #[error("uvx is not on PATH; install uv (Astral) to use uvx-distributed agents")]
+    UvxMissing,
+    #[error("registry CDN returned {0}")]
+    Status(reqwest::StatusCode),
+}
+
+/// Concrete result of an install. The caller writes `installed_path` into
+/// the agents table (only meaningful for `Binary`).
+#[derive(Debug, Clone)]
+pub enum InstallOutcome {
+    Binary { installed_path: PathBuf },
+    Npx,
+    Uvx,
+}
+
+/// Install (or "verify availability of") an agent's preferred distribution
+/// for the host. Resolution order matches `agents::launch_spec`: binary,
+/// then npx, then uvx — install the first one we can satisfy.
+pub async fn install(
+    agent: &RegistryAgent,
+    install_root: &Path,
+) -> Result<InstallOutcome, InstallError> {
+    let dist = &agent.distribution;
+
+    if let Some(target) = host_binary_target(dist) {
+        let archive_url = target.archive.clone();
+        ensure_supported_archive(&archive_url)?;
+        let dest_dir = install_root
+            .join(&agent.id)
+            .join(version_or_unknown(&agent.version));
+        fs::create_dir_all(&dest_dir).await?;
+        let archive_bytes = download(&archive_url).await?;
+        extract(&archive_url, &archive_bytes, &dest_dir).await?;
+        return Ok(InstallOutcome::Binary {
+            installed_path: dest_dir,
+        });
+    }
+
+    if dist.npx.is_some() {
+        which::which("npx").map_err(|_| InstallError::NpxMissing)?;
+        return Ok(InstallOutcome::Npx);
+    }
+
+    if dist.uvx.is_some() {
+        which::which("uvx").map_err(|_| InstallError::UvxMissing)?;
+        return Ok(InstallOutcome::Uvx);
+    }
+
+    if dist.binary.is_some() {
+        Err(InstallError::NoBinaryForHost(agent.id.clone()))
+    } else {
+        Err(InstallError::NoDistribution(agent.id.clone()))
+    }
+}
+
+fn host_binary_target(dist: &Distribution) -> Option<&crate::acp::registry::BinaryTarget> {
+    let host = Platform::current()?;
+    dist.binary.as_ref()?.get(&host)
+}
+
+fn version_or_unknown(v: &str) -> &str {
+    if v.is_empty() { "unknown" } else { v }
+}
+
+fn ensure_supported_archive(url: &str) -> Result<(), InstallError> {
+    let lower = url.to_ascii_lowercase();
+    for bad in [".dmg", ".pkg", ".deb", ".rpm", ".msi", ".appimage"] {
+        if lower.ends_with(bad) {
+            return Err(InstallError::UnsupportedArchive(url.into()));
+        }
+    }
+    if lower.ends_with(".tar.gz") || lower.ends_with(".tgz") || lower.ends_with(".zip") {
+        Ok(())
+    } else {
+        Err(InstallError::UnknownArchiveFormat(url.into()))
+    }
+}
+
+async fn download(url: &str) -> Result<Vec<u8>, InstallError> {
+    let resp = reqwest::Client::builder()
+        .user_agent("brokk-foreman/0.1")
+        .build()?
+        .get(url)
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Err(InstallError::Status(resp.status()));
+    }
+    let bytes = resp.bytes().await?;
+    Ok(bytes.to_vec())
+}
+
+async fn extract(url: &str, bytes: &[u8], dest: &Path) -> Result<(), InstallError> {
+    let lower = url.to_ascii_lowercase();
+    let dest_owned = dest.to_path_buf();
+    let bytes_owned = bytes.to_vec();
+    let lower_owned = lower.clone();
+
+    // Archive extraction is sync (flate2/tar, zip) and CPU/disk heavy. Run
+    // it on the blocking pool so it doesn't stall the runtime.
+    tokio::task::spawn_blocking(move || -> Result<(), InstallError> {
+        if lower_owned.ends_with(".tar.gz") || lower_owned.ends_with(".tgz") {
+            let gz = flate2::read::GzDecoder::new(&bytes_owned[..]);
+            let mut archive = tar::Archive::new(gz);
+            archive.unpack(&dest_owned)?;
+            return Ok(());
+        }
+        if lower_owned.ends_with(".zip") {
+            let reader = std::io::Cursor::new(bytes_owned);
+            let mut zip = zip::ZipArchive::new(reader)?;
+            zip.extract(&dest_owned)?;
+            return Ok(());
+        }
+        Err(InstallError::UnknownArchiveFormat(lower_owned))
+    })
+    .await
+    .map_err(|e| InstallError::Io(std::io::Error::other(e)))??;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_installer_archives() {
+        assert!(matches!(
+            ensure_supported_archive("https://x/y.dmg"),
+            Err(InstallError::UnsupportedArchive(_))
+        ));
+        assert!(matches!(
+            ensure_supported_archive("https://x/y.msi"),
+            Err(InstallError::UnsupportedArchive(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_archive_formats() {
+        assert!(matches!(
+            ensure_supported_archive("https://x/y.rar"),
+            Err(InstallError::UnknownArchiveFormat(_))
+        ));
+    }
+
+    #[test]
+    fn accepts_tar_gz_and_zip() {
+        ensure_supported_archive("https://x/y.tar.gz").unwrap();
+        ensure_supported_archive("https://x/y.tgz").unwrap();
+        ensure_supported_archive("https://x/y.zip").unwrap();
+    }
+}

--- a/brokk-foreman/src-tauri/src/acp/launcher.rs
+++ b/brokk-foreman/src-tauri/src/acp/launcher.rs
@@ -1,0 +1,83 @@
+//! Spawn an ACP agent as a child process and hand back the typed stdio
+//! handles to the client wrapper.
+//!
+//! The spawn pattern (piped stdin/stdout/stderr, `kill_on_drop(true)`)
+//! mirrors `brokk-acp-rust/src/bifrost_client.rs`. The actual ACP wire
+//! framing is handled by `agent_client_protocol::ByteStreams` once the
+//! pipes are wrapped in `tokio_util::compat`.
+
+use std::path::Path;
+use std::process::Stdio;
+
+use thiserror::Error;
+use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
+
+use crate::acp::agents::LaunchSpec;
+
+#[derive(Debug, Error)]
+pub enum LauncherError {
+    #[error("failed to spawn agent process: {0}")]
+    Spawn(#[from] std::io::Error),
+    #[error("agent process did not expose stdin")]
+    NoStdin,
+    #[error("agent process did not expose stdout")]
+    NoStdout,
+    #[error("agent process did not expose stderr")]
+    NoStderr,
+    #[error("npx is not on PATH; install Node.js >=18 or pick a different agent")]
+    NpxMissing,
+    #[error("uvx is not on PATH; install uv (Astral) or pick a different agent")]
+    UvxMissing,
+}
+
+/// The spawned agent and its three stdio pipes. The caller owns `child`
+/// (drops it to kill the process via `kill_on_drop`) and the pipes.
+pub struct SpawnedAgent {
+    pub child: Child,
+    pub stdin: ChildStdin,
+    pub stdout: ChildStdout,
+    pub stderr: ChildStderr,
+}
+
+/// Spawn an agent according to `spec` with `cwd` as the working directory
+/// of the child process.
+pub fn spawn(spec: &LaunchSpec, cwd: &Path) -> Result<SpawnedAgent, LauncherError> {
+    use crate::acp::agents::LaunchKind;
+    use which::which;
+
+    match spec.kind {
+        LaunchKind::Npx => {
+            which("npx").map_err(|_| LauncherError::NpxMissing)?;
+        }
+        LaunchKind::Uvx => {
+            which("uvx").map_err(|_| LauncherError::UvxMissing)?;
+        }
+        LaunchKind::Binary => {}
+    }
+
+    tracing::info!(
+        program = %spec.program.display(),
+        args = ?spec.args,
+        cwd = %cwd.display(),
+        "spawning ACP agent"
+    );
+
+    let mut cmd = Command::new(&spec.program);
+    cmd.args(&spec.args)
+        .envs(&spec.env)
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = cmd.spawn()?;
+    let stdin = child.stdin.take().ok_or(LauncherError::NoStdin)?;
+    let stdout = child.stdout.take().ok_or(LauncherError::NoStdout)?;
+    let stderr = child.stderr.take().ok_or(LauncherError::NoStderr)?;
+    Ok(SpawnedAgent {
+        child,
+        stdin,
+        stdout,
+        stderr,
+    })
+}

--- a/brokk-foreman/src-tauri/src/acp/mod.rs
+++ b/brokk-foreman/src-tauri/src/acp/mod.rs
@@ -1,1 +1,6 @@
+pub mod agents;
+pub mod auth;
+pub mod client;
+pub mod installer;
+pub mod launcher;
 pub mod registry;

--- a/brokk-foreman/src-tauri/src/acp/registry.rs
+++ b/brokk-foreman/src-tauri/src/acp/registry.rs
@@ -4,9 +4,11 @@
 //! Schema mirror: `https://cdn.agentclientprotocol.com/registry/v1/latest/agent.schema.json`.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::fs;
 
 pub const REGISTRY_URL: &str =
     "https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json";
@@ -119,6 +121,14 @@ pub enum RegistryError {
     EmptyDistribution(String),
     #[error("failed to deserialize registry JSON: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("registry HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("registry IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("registry CDN returned {0}")]
+    Status(reqwest::StatusCode),
+    #[error("registry cache is empty and the CDN is unreachable")]
+    NoCacheAndOffline,
 }
 
 impl Registry {
@@ -143,6 +153,100 @@ impl Distribution {
         let binary_empty = self.binary.as_ref().is_none_or(HashMap::is_empty);
         binary_empty && self.npx.is_none() && self.uvx.is_none()
     }
+}
+
+/// Filesystem-backed registry cache. Stores the raw JSON body alongside the
+/// last ETag the CDN gave us so subsequent fetches can revalidate cheaply
+/// (HTTP 304 keeps `cdn.agentclientprotocol.com` traffic down for users
+/// who open the agents page repeatedly).
+pub struct RegistryCache {
+    dir: PathBuf,
+}
+
+impl RegistryCache {
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    fn json_path(&self) -> PathBuf {
+        self.dir.join("registry-cache.json")
+    }
+
+    fn etag_path(&self) -> PathBuf {
+        self.dir.join("registry-cache.etag")
+    }
+
+    async fn read_cached_etag(&self) -> Option<String> {
+        fs::read_to_string(self.etag_path()).await.ok()
+    }
+
+    async fn read_cached_body(&self) -> Option<String> {
+        fs::read_to_string(self.json_path()).await.ok()
+    }
+
+    async fn write_cache(&self, body: &str, etag: Option<&str>) -> std::io::Result<()> {
+        fs::create_dir_all(&self.dir).await?;
+        fs::write(self.json_path(), body).await?;
+        if let Some(tag) = etag {
+            fs::write(self.etag_path(), tag).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Fetch the registry from the CDN, honoring the cached `ETag` for 304s.
+///
+/// `force_refresh = true` bypasses the conditional `If-None-Match` header so
+/// the UI's "Refresh" button always re-downloads. On any network error the
+/// cached body is used as a fallback when present.
+pub async fn fetch(cache: &RegistryCache, force_refresh: bool) -> Result<Registry, RegistryError> {
+    let client = reqwest::Client::builder()
+        .user_agent("brokk-foreman/0.1")
+        .build()?;
+    let mut req = client.get(REGISTRY_URL);
+    let cached_etag = cache.read_cached_etag().await;
+    if !force_refresh && let Some(tag) = cached_etag.as_deref() {
+        req = req.header(reqwest::header::IF_NONE_MATCH, tag);
+    }
+
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("registry fetch failed: {e}; falling back to cache");
+            return load_from_cache(cache).await;
+        }
+    };
+
+    if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+        tracing::debug!("registry CDN returned 304; using cached body");
+        return load_from_cache(cache).await;
+    }
+    if !resp.status().is_success() {
+        return Err(RegistryError::Status(resp.status()));
+    }
+
+    let new_etag = resp
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let body = resp.text().await?;
+    let registry = Registry::parse(&body)?;
+    cache.write_cache(&body, new_etag.as_deref()).await?;
+    Ok(registry)
+}
+
+async fn load_from_cache(cache: &RegistryCache) -> Result<Registry, RegistryError> {
+    match cache.read_cached_body().await {
+        Some(body) => Registry::parse(&body),
+        None => Err(RegistryError::NoCacheAndOffline),
+    }
+}
+
+/// Path helpers exposed for callers that need the cache directory (e.g.
+/// install flow places extracted archives under a sibling directory).
+pub fn registry_cache_dir(data_dir: &Path) -> PathBuf {
+    data_dir.to_path_buf()
 }
 
 impl RegistryAgent {

--- a/brokk-foreman/src-tauri/src/commands.rs
+++ b/brokk-foreman/src-tauri/src/commands.rs
@@ -1,0 +1,148 @@
+//! Tauri commands surfaced to the Svelte frontend.
+//!
+//! Each handler returns `Result<T, String>` because Tauri serializes the
+//! error variant to the frontend as a plain string. Internal modules use
+//! typed `thiserror` errors; we map to strings here at the boundary.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use rusqlite::Connection;
+use tauri::{AppHandle, State};
+
+use crate::acp::agents::{self, AgentRecord, CustomAgentSpec};
+use crate::acp::client::SessionManager;
+use crate::acp::installer::{self, InstallOutcome};
+use crate::acp::registry::{Registry, RegistryAgent, RegistryCache};
+use crate::config::{self, Config};
+
+/// Connection handle shared across commands. The Mutex protects against
+/// concurrent invocations from independent frontend command calls.
+pub type DbState<'a> = State<'a, Mutex<Connection>>;
+
+fn err<E: std::fmt::Display>(e: E) -> String {
+    format!("{e}")
+}
+
+#[tauri::command]
+pub fn list_agents(db: DbState<'_>) -> Result<Vec<AgentRecord>, String> {
+    let conn = db.lock().map_err(|e| format!("db mutex poisoned: {e}"))?;
+    agents::list(&conn).map_err(err)
+}
+
+#[tauri::command]
+pub fn add_custom_agent(spec: CustomAgentSpec, db: DbState<'_>) -> Result<AgentRecord, String> {
+    let conn = db.lock().map_err(|e| format!("db mutex poisoned: {e}"))?;
+    agents::upsert_custom(&conn, &spec).map_err(err)
+}
+
+#[tauri::command]
+pub fn uninstall_agent(id: String, db: DbState<'_>) -> Result<(), String> {
+    let conn = db.lock().map_err(|e| format!("db mutex poisoned: {e}"))?;
+    agents::delete(&conn, &id).map_err(err)
+}
+
+#[tauri::command]
+pub async fn fetch_registry(force_refresh: bool) -> Result<Vec<RegistryAgent>, String> {
+    let data_dir = config::data_dir().ok_or_else(|| "no user data dir on this host".to_string())?;
+    let cache = RegistryCache::new(&data_dir);
+    let registry: Registry = crate::acp::registry::fetch(&cache, force_refresh)
+        .await
+        .map_err(err)?;
+    Ok(registry.agents)
+}
+
+#[tauri::command]
+pub async fn install_agent(
+    registry_id: String,
+    db: State<'_, Mutex<Connection>>,
+) -> Result<AgentRecord, String> {
+    // Load the matching registry entry from the cache (which must exist —
+    // the frontend always calls fetch_registry before install).
+    let data_dir = config::data_dir().ok_or_else(|| "no user data dir on this host".to_string())?;
+    let cache = RegistryCache::new(&data_dir);
+    let registry = crate::acp::registry::fetch(&cache, false)
+        .await
+        .map_err(err)?;
+    let agent = registry
+        .agents
+        .into_iter()
+        .find(|a| a.id == registry_id)
+        .ok_or_else(|| format!("agent {registry_id:?} not found in registry"))?;
+
+    let install_root = config::agents_install_dir()
+        .ok_or_else(|| "no agents install dir on this host".to_string())?;
+    let outcome = installer::install(&agent, &install_root)
+        .await
+        .map_err(err)?;
+
+    let conn = db.lock().map_err(|e| format!("db mutex poisoned: {e}"))?;
+    let record = agents::upsert_registry(&conn, &agent).map_err(err)?;
+    if let InstallOutcome::Binary { installed_path } = outcome {
+        agents::set_installed_path(&conn, &record.id, &installed_path.to_string_lossy())
+            .map_err(err)?;
+    }
+    agents::get(&conn, &record.id).map_err(err)
+}
+
+#[tauri::command]
+pub fn get_config(db: DbState<'_>) -> Result<Config, String> {
+    let conn = db.lock().map_err(|e| format!("db mutex poisoned: {e}"))?;
+    Config::load(&conn).map_err(err)
+}
+
+#[tauri::command]
+pub fn set_config(config: Config, db: DbState<'_>) -> Result<(), String> {
+    let conn = db.lock().map_err(|e| format!("db mutex poisoned: {e}"))?;
+    config.save(&conn).map_err(err)
+}
+
+#[tauri::command]
+pub async fn start_session(
+    agent_id: String,
+    db: State<'_, Mutex<Connection>>,
+    session: State<'_, SessionManager>,
+    app: AppHandle,
+) -> Result<(), String> {
+    // Resolve record + repo path under the DB lock, drop it, then hand off
+    // to the async session manager — we don't hold a std::sync::Mutex
+    // across await points.
+    let (record, repo_path) = {
+        let conn = db.lock().map_err(|e| format!("db mutex poisoned: {e}"))?;
+        let record = agents::get(&conn, &agent_id).map_err(err)?;
+        let cfg = Config::load(&conn).map_err(err)?;
+        let repo_path = cfg
+            .repo_path
+            .ok_or_else(|| "no repo_path configured; set one in Settings first".to_string())?;
+        (record, PathBuf::from(repo_path))
+    };
+    session.start(record, repo_path, app).await.map_err(err)
+}
+
+#[tauri::command]
+pub async fn send_prompt(text: String, session: State<'_, SessionManager>) -> Result<(), String> {
+    session.send_prompt(text).await.map_err(err)
+}
+
+#[tauri::command]
+pub async fn cancel_session(session: State<'_, SessionManager>) -> Result<(), String> {
+    session.cancel().await.map_err(err)
+}
+
+#[tauri::command]
+pub async fn stop_session(session: State<'_, SessionManager>) -> Result<(), String> {
+    session.stop().await.map_err(err)
+}
+
+#[tauri::command]
+pub async fn respond_permission(
+    request_id: String,
+    accept: bool,
+    option_id: Option<String>,
+    session: State<'_, SessionManager>,
+) -> Result<(), String> {
+    session
+        .respond_permission(&request_id, accept, option_id)
+        .await
+        .map_err(err)
+}

--- a/brokk-foreman/src-tauri/src/config.rs
+++ b/brokk-foreman/src-tauri/src/config.rs
@@ -1,18 +1,110 @@
-//! Foreman configuration on disk. Layout decisions and concrete loader land
-//! in a follow-up — for now this module exists so the rest of the tree can
-//! reference `crate::config` without breaking.
-
-#![allow(dead_code)]
+//! Foreman configuration: data-dir resolution plus a thin `config_kv`-backed
+//! `Config` (repo path + default agent id). Values are persisted in the
+//! `config_kv` SQLite table so the same connection state used by the rest of
+//! the app owns them — no separate TOML on disk in v1.
 
 use std::path::PathBuf;
 
 use directories::ProjectDirs;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
 
 /// Resolve the per-user data directory for foreman, e.g.
 /// `~/Library/Application Support/ai.brokk.foreman/` on macOS.
 ///
-/// We return `None` if the platform's user dirs cannot be resolved (very
-/// unusual; happens on bare CI containers without `$HOME`).
+/// Returns `None` on bare CI containers without `$HOME`.
 pub fn data_dir() -> Option<PathBuf> {
     ProjectDirs::from("ai", "brokk", "foreman").map(|p| p.data_dir().to_path_buf())
+}
+
+/// Directory under `data_dir()` where installed agent binaries are extracted.
+/// Returns `None` for the same reason `data_dir` does.
+pub fn agents_install_dir() -> Option<PathBuf> {
+    data_dir().map(|d| d.join("agents"))
+}
+
+const KEY_REPO_PATH: &str = "repo_path";
+const KEY_DEFAULT_AGENT_ID: &str = "default_agent_id";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Config {
+    pub repo_path: Option<String>,
+    pub default_agent_id: Option<String>,
+}
+
+impl Config {
+    pub fn load(conn: &Connection) -> rusqlite::Result<Self> {
+        Ok(Self {
+            repo_path: get_kv(conn, KEY_REPO_PATH)?,
+            default_agent_id: get_kv(conn, KEY_DEFAULT_AGENT_ID)?,
+        })
+    }
+
+    pub fn save(&self, conn: &Connection) -> rusqlite::Result<()> {
+        set_kv(conn, KEY_REPO_PATH, self.repo_path.as_deref())?;
+        set_kv(conn, KEY_DEFAULT_AGENT_ID, self.default_agent_id.as_deref())?;
+        Ok(())
+    }
+}
+
+fn get_kv(conn: &Connection, key: &str) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM config_kv WHERE key = ?1",
+        params![key],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+}
+
+fn set_kv(conn: &Connection, key: &str, value: Option<&str>) -> rusqlite::Result<()> {
+    match value {
+        Some(v) => {
+            conn.execute(
+                "INSERT INTO config_kv (key, value) VALUES (?1, ?2) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![key, v],
+            )?;
+        }
+        None => {
+            conn.execute("DELETE FROM config_kv WHERE key = ?1", params![key])?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    #[test]
+    fn round_trips_through_config_kv() {
+        let conn = db::open_in_memory().unwrap();
+        let cfg = Config {
+            repo_path: Some("/tmp/repo".into()),
+            default_agent_id: Some("registry:claude-acp".into()),
+        };
+        cfg.save(&conn).unwrap();
+        let loaded = Config::load(&conn).unwrap();
+        assert_eq!(loaded.repo_path.as_deref(), Some("/tmp/repo"));
+        assert_eq!(
+            loaded.default_agent_id.as_deref(),
+            Some("registry:claude-acp")
+        );
+    }
+
+    #[test]
+    fn clearing_keys_removes_rows() {
+        let conn = db::open_in_memory().unwrap();
+        Config {
+            repo_path: Some("/tmp/repo".into()),
+            default_agent_id: None,
+        }
+        .save(&conn)
+        .unwrap();
+        Config::default().save(&conn).unwrap();
+        let loaded = Config::load(&conn).unwrap();
+        assert!(loaded.repo_path.is_none());
+        assert!(loaded.default_agent_id.is_none());
+    }
 }

--- a/brokk-foreman/src-tauri/src/db/mod.rs
+++ b/brokk-foreman/src-tauri/src/db/mod.rs
@@ -103,16 +103,28 @@ mod tests {
             .unwrap()
             .collect::<rusqlite::Result<_>>()
             .unwrap();
-        for expected in [
-            "agents",
-            "blocking_edges",
-            "config_kv",
-            "issues",
-            "sessions",
-        ] {
+        for expected in ["agents", "config_kv"] {
             assert!(
                 names.iter().any(|n| n == expected),
                 "missing table {expected}; got {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_drops_deferred_tables() {
+        let conn = open_in_memory().unwrap();
+        let names: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        for deferred in ["issues", "blocking_edges", "sessions"] {
+            assert!(
+                !names.iter().any(|n| n == deferred),
+                "v1 schema must not include deferred table {deferred}; got {names:?}"
             );
         }
     }
@@ -138,32 +150,12 @@ mod tests {
     }
 
     #[test]
-    fn fk_cascade_actually_fires() {
+    fn foreign_keys_pragma_is_on() {
         let conn = open_in_memory().unwrap();
-        conn.execute(
-            "INSERT INTO issues(id, provider, external_key, title, imported_at, updated_at) \
-             VALUES ('github:42', 'github', '42', 'a', 0, 0)",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO issues(id, provider, external_key, title, imported_at, updated_at) \
-             VALUES ('github:43', 'github', '43', 'b', 0, 0)",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO blocking_edges(blocker_id, blocked_id, computed_at) \
-             VALUES ('github:42', 'github:43', 0)",
-            [],
-        )
-        .unwrap();
-        conn.execute("DELETE FROM issues WHERE id = 'github:42'", [])
+        let on: i64 = conn
+            .query_row("PRAGMA foreign_keys", [], |r| r.get(0))
             .unwrap();
-        let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM blocking_edges", [], |r| r.get(0))
-            .unwrap();
-        assert_eq!(count, 0);
+        assert_eq!(on, 1, "foreign_keys pragma must be enabled per connection");
     }
 
     #[test]

--- a/brokk-foreman/src-tauri/src/db/schema.sql
+++ b/brokk-foreman/src-tauri/src/db/schema.sql
@@ -1,7 +1,8 @@
--- Baseline schema for brokk-foreman. Applied on first launch.
--- ON DELETE CASCADE below is silently ignored unless every connection runs
--- `PRAGMA foreign_keys = ON;` first; SQLite's default is OFF. The migration
--- runner that consumes this file must enable it on each connection it opens.
+-- Baseline schema for brokk-foreman v1. Applied on first launch.
+-- The migration runner enables `PRAGMA foreign_keys = ON;` on every
+-- connection (SQLite's default is OFF). v1 has no FK relationships among
+-- the two tables below, but the pragma is kept on for forward compat
+-- when worktree/session/issue tables land in later milestones.
 PRAGMA foreign_keys = ON;
 
 CREATE TABLE IF NOT EXISTS agents (
@@ -12,46 +13,6 @@ CREATE TABLE IF NOT EXISTS agents (
   distribution    TEXT NOT NULL,        -- JSON serialized Distribution
   installed_path  TEXT,
   enabled         INTEGER NOT NULL DEFAULT 1
-);
-
-CREATE TABLE IF NOT EXISTS issues (
-  id              TEXT PRIMARY KEY,
-  provider        TEXT NOT NULL,        -- 'github' | 'jira'
-  external_key    TEXT NOT NULL,
-  title           TEXT NOT NULL,
-  body            TEXT,
-  url             TEXT,
-  state           TEXT,
-  kanban_column   TEXT NOT NULL DEFAULT 'backlog',
-  enrichment      TEXT,                 -- JSON
-  enriched_at     INTEGER,
-  imported_at     INTEGER NOT NULL,
-  updated_at      INTEGER NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS blocking_edges (
-  blocker_id      TEXT NOT NULL,
-  blocked_id      TEXT NOT NULL,
-  confidence      REAL,
-  rationale       TEXT,
-  computed_at     INTEGER NOT NULL,
-  PRIMARY KEY (blocker_id, blocked_id),
-  FOREIGN KEY (blocker_id) REFERENCES issues(id) ON DELETE CASCADE,
-  FOREIGN KEY (blocked_id) REFERENCES issues(id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS sessions (
-  id              TEXT PRIMARY KEY,
-  issue_id        TEXT NOT NULL UNIQUE,
-  agent_id        TEXT NOT NULL,
-  worktree_path   TEXT NOT NULL,
-  branch          TEXT NOT NULL,
-  acp_session_id  TEXT,
-  status          TEXT NOT NULL,
-  created_at      INTEGER NOT NULL,
-  closed_at       INTEGER,
-  FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE,
-  FOREIGN KEY (agent_id) REFERENCES agents(id)
 );
 
 CREATE TABLE IF NOT EXISTS config_kv (

--- a/brokk-foreman/src-tauri/src/events.rs
+++ b/brokk-foreman/src-tauri/src/events.rs
@@ -1,0 +1,72 @@
+//! Payload types for Tauri events emitted from the Rust backend to the
+//! Svelte frontend. The channel names are stable wire identifiers.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Channel: every ACP `SessionUpdate` notification received from the active
+/// agent. v1 has at most one live session so we don't suffix the channel
+/// with a session id — the frontend mirrors the same constraint.
+pub const ACP_UPDATE_CHANNEL: &str = "acp:update";
+
+/// Channel: lifecycle transitions of the active session.
+pub const ACP_SESSION_STATUS_CHANNEL: &str = "acp:session_status";
+
+/// Channel: incoming `requestPermission` from the agent. The frontend
+/// surfaces a modal and calls `respond_permission(req_id, accept)` back.
+pub const ACP_PERMISSION_CHANNEL: &str = "acp:permission";
+
+/// Channel: stderr lines from the spawned agent process (best-effort tail
+/// for the agents page on failure).
+pub const ACP_STDERR_CHANNEL: &str = "acp:stderr";
+
+/// One forwarded `SessionUpdate`. We pass the raw schema notification as
+/// JSON so the frontend can render new update variants without a Rust
+/// release.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpUpdate {
+    pub session_id: String,
+    pub update: Value,
+}
+
+/// One forwarded `requestPermission`. The frontend keys its modal by
+/// `request_id` and posts the user's choice back via the
+/// `respond_permission` command.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionRequest {
+    pub request_id: String,
+    pub session_id: String,
+    pub tool_call: Value,
+    pub options: Value,
+}
+
+/// Lifecycle states the frontend cares about for the session pane.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum SessionStatus {
+    Starting {
+        agent_id: String,
+    },
+    Ready {
+        agent_id: String,
+        session_id: String,
+    },
+    AuthRequired {
+        agent_id: String,
+        auth_kind: String,
+    },
+    Stopped {
+        agent_id: String,
+        reason: String,
+    },
+    Failed {
+        agent_id: String,
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpStderr {
+    pub agent_id: String,
+    pub line: String,
+}

--- a/brokk-foreman/src-tauri/src/issues/mod.rs
+++ b/brokk-foreman/src-tauri/src/issues/mod.rs
@@ -1,4 +1,0 @@
-//! Issue providers (GitHub, Jira). Concrete implementations land in a
-//! follow-up; this stub keeps the module tree wired up.
-
-#![allow(dead_code)]

--- a/brokk-foreman/src-tauri/src/lib.rs
+++ b/brokk-foreman/src-tauri/src/lib.rs
@@ -1,13 +1,14 @@
 pub mod acp;
+pub mod commands;
 pub mod config;
 pub mod db;
-pub mod issues;
-pub mod llm;
-pub mod worktree;
+pub mod events;
 
 use std::sync::Mutex;
 
 use tauri::Manager;
+
+use crate::acp::client::SessionManager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -20,6 +21,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .manage(SessionManager::new())
         .setup(|app| {
             let db_path = config::data_dir()
                 .ok_or("could not resolve user data dir for foreman")?
@@ -29,6 +31,20 @@ pub fn run() {
             app.manage(Mutex::new(conn));
             Ok(())
         })
+        .invoke_handler(tauri::generate_handler![
+            commands::list_agents,
+            commands::add_custom_agent,
+            commands::uninstall_agent,
+            commands::fetch_registry,
+            commands::install_agent,
+            commands::get_config,
+            commands::set_config,
+            commands::start_session,
+            commands::send_prompt,
+            commands::cancel_session,
+            commands::stop_session,
+            commands::respond_permission,
+        ])
         .run(tauri::generate_context!())
         .unwrap_or_else(|e| {
             tracing::error!(error = ?e, "foreman failed to start");

--- a/brokk-foreman/src-tauri/src/llm/mod.rs
+++ b/brokk-foreman/src-tauri/src/llm/mod.rs
@@ -1,5 +1,0 @@
-//! LLM-driven steps that all run *through* a configured ACP agent rather
-//! than calling any provider directly: enrichment on import, blocking-graph
-//! analysis. Implementation lands in a follow-up.
-
-#![allow(dead_code)]

--- a/brokk-foreman/src-tauri/src/worktree.rs
+++ b/brokk-foreman/src-tauri/src/worktree.rs
@@ -1,4 +1,0 @@
-//! Git worktree manager — shells out to `git worktree`. Concrete
-//! implementation in a follow-up.
-
-#![allow(dead_code)]

--- a/brokk-foreman/src/App.svelte
+++ b/brokk-foreman/src/App.svelte
@@ -1,28 +1,94 @@
 <script lang="ts">
-  // Placeholder root component. The kanban, issue view, and agent picker
-  // land in subsequent commits.
-  let placeholder = "Brokk Foreman is alive.";
+  import Settings from "./routes/Settings.svelte";
+  import Agents from "./routes/Agents.svelte";
+  import Session from "./routes/Session.svelte";
+
+  type Tab = "session" | "agents" | "settings";
+
+  // Hash-routing keeps the chosen tab across reloads without pulling in
+  // a router dep. v1 has 3 routes; a switch on a state variable is plenty.
+  function tabFromHash(hash: string): Tab {
+    const trimmed = hash.replace(/^#/, "");
+    if (trimmed === "agents" || trimmed === "settings" || trimmed === "session") {
+      return trimmed;
+    }
+    return "session";
+  }
+
+  let tab: Tab = $state(tabFromHash(window.location.hash));
+
+  function go(next: Tab) {
+    tab = next;
+    window.location.hash = next;
+  }
+
+  window.addEventListener("hashchange", () => {
+    tab = tabFromHash(window.location.hash);
+  });
 </script>
 
-<main>
-  <h1>Brokk Foreman</h1>
-  <p>{placeholder}</p>
-  <p class="muted">
-    Cross-platform issue manager and ACP client. Skeleton commit — kanban,
-    issue view, and agent picker arrive next.
-  </p>
-</main>
+<div class="app">
+  <nav>
+    <span class="brand">brokk-foreman</span>
+    <button class:active={tab === "session"} onclick={() => go("session")}>
+      Session
+    </button>
+    <button class:active={tab === "agents"} onclick={() => go("agents")}>
+      Agents
+    </button>
+    <button class:active={tab === "settings"} onclick={() => go("settings")}>
+      Settings
+    </button>
+  </nav>
+
+  <main>
+    {#if tab === "session"}
+      <Session />
+    {:else if tab === "agents"}
+      <Agents />
+    {:else}
+      <Settings />
+    {/if}
+  </main>
+</div>
 
 <style>
+  .app {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+  nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.7rem 1.2rem;
+    border-bottom: 1px solid #2b313a;
+    background: #14181f;
+  }
+  .brand {
+    font-weight: 700;
+    margin-right: 1rem;
+    color: var(--accent);
+  }
+  nav button {
+    background: transparent;
+    color: inherit;
+    border: 1px solid transparent;
+    padding: 0.35rem 0.8rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+  }
+  nav button.active {
+    border-color: #2b313a;
+    background: #1c2027;
+  }
+  nav button:hover {
+    border-color: var(--accent);
+  }
   main {
-    max-width: 720px;
-    margin: 4rem auto;
-    padding: 2rem;
-  }
-  h1 {
-    margin-top: 0;
-  }
-  .muted {
-    color: var(--muted);
+    padding: 1.5rem 2rem;
+    flex: 1;
   }
 </style>

--- a/brokk-foreman/src/lib/api.ts
+++ b/brokk-foreman/src/lib/api.ts
@@ -1,0 +1,91 @@
+import { invoke } from "@tauri-apps/api/core";
+
+// Mirrors the Rust types in src-tauri/src/acp/agents.rs and config.rs.
+// Kept loose (Record-shaped distributions) because the registry schema is
+// driven by the upstream CDN; tight typing would force a frontend release
+// for every new ACP distribution kind.
+
+export type AgentSource = "registry" | "custom";
+
+export interface BinaryTarget {
+  archive: string;
+  cmd: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export type Platform =
+  | "darwin-aarch64"
+  | "darwin-x86_64"
+  | "linux-aarch64"
+  | "linux-x86_64"
+  | "windows-aarch64"
+  | "windows-x86_64";
+
+export interface Distribution {
+  binary?: Partial<Record<Platform, BinaryTarget>>;
+  npx?: { package: string; args?: string[]; env?: Record<string, string> };
+  uvx?: { package: string; args?: string[]; env?: Record<string, string> };
+}
+
+export interface AgentRecord {
+  id: string;
+  source: AgentSource;
+  name: string;
+  version?: string | null;
+  distribution: Distribution;
+  installed_path?: string | null;
+  enabled: boolean;
+}
+
+export interface RegistryAgent {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  repository?: string;
+  website?: string;
+  authors?: string[];
+  license?: string;
+  icon?: string;
+  distribution: Distribution;
+}
+
+export interface CustomAgentSpec {
+  id: string;
+  name: string;
+  version?: string;
+  cmd: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface Config {
+  repo_path?: string | null;
+  default_agent_id?: string | null;
+}
+
+export const api = {
+  listAgents: (): Promise<AgentRecord[]> => invoke("list_agents"),
+  addCustomAgent: (spec: CustomAgentSpec): Promise<AgentRecord> =>
+    invoke("add_custom_agent", { spec }),
+  uninstallAgent: (id: string): Promise<void> =>
+    invoke("uninstall_agent", { id }),
+  fetchRegistry: (forceRefresh: boolean): Promise<RegistryAgent[]> =>
+    invoke("fetch_registry", { forceRefresh }),
+  installAgent: (registryId: string): Promise<AgentRecord> =>
+    invoke("install_agent", { registryId }),
+  getConfig: (): Promise<Config> => invoke("get_config"),
+  setConfig: (config: Config): Promise<void> => invoke("set_config", { config }),
+  startSession: (agentId: string): Promise<void> =>
+    invoke("start_session", { agentId }),
+  sendPrompt: (text: string): Promise<void> => invoke("send_prompt", { text }),
+  cancelSession: (): Promise<void> => invoke("cancel_session"),
+  stopSession: (): Promise<void> => invoke("stop_session"),
+  respondPermission: (
+    requestId: string,
+    accept: boolean,
+    optionId?: string,
+  ): Promise<void> =>
+    invoke("respond_permission", { requestId, accept, optionId }),
+};

--- a/brokk-foreman/src/lib/events.ts
+++ b/brokk-foreman/src/lib/events.ts
@@ -1,0 +1,59 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+// Channel names mirror src-tauri/src/events.rs.
+export const ACP_UPDATE_CHANNEL = "acp:update";
+export const ACP_SESSION_STATUS_CHANNEL = "acp:session_status";
+export const ACP_PERMISSION_CHANNEL = "acp:permission";
+export const ACP_STDERR_CHANNEL = "acp:stderr";
+
+export interface AcpUpdate {
+  session_id: string;
+  update: unknown; // Raw SessionUpdate JSON from the agent.
+}
+
+export interface PermissionRequest {
+  request_id: string;
+  session_id: string;
+  tool_call: unknown;
+  options: unknown;
+}
+
+export type SessionStatus =
+  | { kind: "starting"; agent_id: string }
+  | { kind: "ready"; agent_id: string; session_id: string }
+  | { kind: "auth_required"; agent_id: string; auth_kind: string }
+  | { kind: "stopped"; agent_id: string; reason: string }
+  | { kind: "failed"; agent_id: string; error: string };
+
+export interface AcpStderr {
+  agent_id: string;
+  line: string;
+}
+
+export function onAcpUpdate(
+  handler: (payload: AcpUpdate) => void,
+): Promise<UnlistenFn> {
+  return listen<AcpUpdate>(ACP_UPDATE_CHANNEL, (event) => handler(event.payload));
+}
+
+export function onSessionStatus(
+  handler: (payload: SessionStatus) => void,
+): Promise<UnlistenFn> {
+  return listen<SessionStatus>(ACP_SESSION_STATUS_CHANNEL, (event) =>
+    handler(event.payload),
+  );
+}
+
+export function onPermissionRequest(
+  handler: (payload: PermissionRequest) => void,
+): Promise<UnlistenFn> {
+  return listen<PermissionRequest>(ACP_PERMISSION_CHANNEL, (event) =>
+    handler(event.payload),
+  );
+}
+
+export function onStderr(
+  handler: (payload: AcpStderr) => void,
+): Promise<UnlistenFn> {
+  return listen<AcpStderr>(ACP_STDERR_CHANNEL, (event) => handler(event.payload));
+}

--- a/brokk-foreman/src/lib/stores/agents.svelte.ts
+++ b/brokk-foreman/src/lib/stores/agents.svelte.ts
@@ -1,0 +1,42 @@
+// Svelte 5 runes-based reactive state for the agents list. Re-loaded
+// after install/uninstall/add-custom; the rest of the UI reads via
+// `agentsStore.list`.
+
+import { api, type AgentRecord } from "../api";
+
+interface AgentsState {
+  list: AgentRecord[];
+  loading: boolean;
+  error: string | null;
+}
+
+function createAgentsStore() {
+  let state = $state<AgentsState>({ list: [], loading: false, error: null });
+
+  async function refresh() {
+    state.loading = true;
+    state.error = null;
+    try {
+      state.list = await api.listAgents();
+    } catch (e) {
+      state.error = `${e}`;
+    } finally {
+      state.loading = false;
+    }
+  }
+
+  return {
+    get list() {
+      return state.list;
+    },
+    get loading() {
+      return state.loading;
+    },
+    get error() {
+      return state.error;
+    },
+    refresh,
+  };
+}
+
+export const agentsStore = createAgentsStore();

--- a/brokk-foreman/src/lib/stores/session.svelte.ts
+++ b/brokk-foreman/src/lib/stores/session.svelte.ts
@@ -1,0 +1,62 @@
+// Svelte 5 runes-backed state for the live ACP session pane.
+// Streams from Tauri events; the Session route subscribes once on mount.
+
+import type {
+  AcpStderr,
+  AcpUpdate,
+  PermissionRequest,
+  SessionStatus,
+} from "../events";
+
+interface SessionState {
+  status: SessionStatus | null;
+  updates: AcpUpdate[];
+  pendingPermission: PermissionRequest | null;
+  stderrTail: string[];
+}
+
+function createSessionStore() {
+  let state = $state<SessionState>({
+    status: null,
+    updates: [],
+    pendingPermission: null,
+    stderrTail: [],
+  });
+
+  return {
+    get status() {
+      return state.status;
+    },
+    get updates() {
+      return state.updates;
+    },
+    get pendingPermission() {
+      return state.pendingPermission;
+    },
+    get stderrTail() {
+      return state.stderrTail;
+    },
+    pushUpdate(u: AcpUpdate) {
+      state.updates = [...state.updates, u];
+    },
+    setStatus(s: SessionStatus) {
+      state.status = s;
+      // Starting a fresh session clears prior updates.
+      if (s.kind === "starting") {
+        state.updates = [];
+        state.pendingPermission = null;
+        state.stderrTail = [];
+      }
+    },
+    setPermission(p: PermissionRequest | null) {
+      state.pendingPermission = p;
+    },
+    pushStderr(s: AcpStderr) {
+      // Keep only the last 100 lines so the UI doesn't drown.
+      const tail = [...state.stderrTail, s.line];
+      state.stderrTail = tail.slice(-100);
+    },
+  };
+}
+
+export const sessionStore = createSessionStore();

--- a/brokk-foreman/src/routes/Agents.svelte
+++ b/brokk-foreman/src/routes/Agents.svelte
@@ -1,0 +1,316 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { api, type CustomAgentSpec, type RegistryAgent } from "../lib/api";
+  import { agentsStore } from "../lib/stores/agents.svelte";
+
+  let registry: RegistryAgent[] = $state([]);
+  let registryLoading = $state(false);
+  let registryError: string | null = $state(null);
+  let installingId: string | null = $state(null);
+
+  let showCustomForm = $state(false);
+  let customForm = $state<CustomAgentSpec>({
+    id: "",
+    name: "",
+    version: "",
+    cmd: "",
+    args: [],
+    env: {},
+  });
+  let argsText = $state("");
+  let envText = $state("");
+  let customError: string | null = $state(null);
+
+  onMount(async () => {
+    await Promise.all([agentsStore.refresh(), refreshRegistry(false)]);
+  });
+
+  async function refreshRegistry(force: boolean) {
+    registryLoading = true;
+    registryError = null;
+    try {
+      registry = await api.fetchRegistry(force);
+    } catch (e) {
+      registryError = `${e}`;
+    } finally {
+      registryLoading = false;
+    }
+  }
+
+  async function install(id: string) {
+    installingId = id;
+    try {
+      await api.installAgent(id);
+      await agentsStore.refresh();
+    } catch (e) {
+      registryError = `${e}`;
+    } finally {
+      installingId = null;
+    }
+  }
+
+  async function uninstall(id: string) {
+    try {
+      await api.uninstallAgent(id);
+      await agentsStore.refresh();
+    } catch (e) {
+      registryError = `${e}`;
+    }
+  }
+
+  async function submitCustom(event: SubmitEvent) {
+    event.preventDefault();
+    customError = null;
+    try {
+      const args = argsText
+        .split(/\s+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      const env: Record<string, string> = {};
+      for (const line of envText.split(/\n+/)) {
+        const trimmed = line.trim();
+        if (trimmed === "") continue;
+        const eq = trimmed.indexOf("=");
+        if (eq === -1) {
+          customError = `Env line missing '=': ${trimmed}`;
+          return;
+        }
+        env[trimmed.slice(0, eq)] = trimmed.slice(eq + 1);
+      }
+      const spec: CustomAgentSpec = {
+        id: customForm.id.trim(),
+        name: customForm.name.trim(),
+        version: customForm.version?.trim() || undefined,
+        cmd: customForm.cmd.trim(),
+        args,
+        env,
+      };
+      if (!spec.id || !spec.name || !spec.cmd) {
+        customError = "id, name, and cmd are required";
+        return;
+      }
+      await api.addCustomAgent(spec);
+      showCustomForm = false;
+      customForm = { id: "", name: "", version: "", cmd: "", args: [], env: {} };
+      argsText = "";
+      envText = "";
+      await agentsStore.refresh();
+    } catch (e) {
+      customError = `${e}`;
+    }
+  }
+
+  function isInstalled(registryId: string): boolean {
+    return agentsStore.list.some(
+      (a) => a.id === registryId && a.source === "registry",
+    );
+  }
+</script>
+
+<section class="agents">
+  <header>
+    <h2>Agents</h2>
+    <div class="header-actions">
+      <button type="button" onclick={() => refreshRegistry(true)} disabled={registryLoading}>
+        Refresh registry
+      </button>
+      <button type="button" onclick={() => (showCustomForm = !showCustomForm)}>
+        {showCustomForm ? "Cancel" : "Add custom agent"}
+      </button>
+    </div>
+  </header>
+
+  {#if showCustomForm}
+    <form class="custom-form" onsubmit={submitCustom}>
+      <h3>Custom agent</h3>
+      <label>
+        <span>ID</span>
+        <input bind:value={customForm.id} placeholder="my-local-agent" />
+      </label>
+      <label>
+        <span>Name</span>
+        <input bind:value={customForm.name} placeholder="My Agent" />
+      </label>
+      <label>
+        <span>Version (optional)</span>
+        <input bind:value={customForm.version} placeholder="0.1" />
+      </label>
+      <label>
+        <span>Command</span>
+        <input bind:value={customForm.cmd} placeholder="/usr/local/bin/my-agent" />
+      </label>
+      <label>
+        <span>Args (space-separated)</span>
+        <input bind:value={argsText} placeholder="--stdio" />
+      </label>
+      <label>
+        <span>Env (KEY=VALUE per line)</span>
+        <textarea rows="3" bind:value={envText}></textarea>
+      </label>
+      <div class="actions">
+        <button type="submit">Save</button>
+        {#if customError}<span class="err">{customError}</span>{/if}
+      </div>
+    </form>
+  {/if}
+
+  <h3>Installed</h3>
+  {#if agentsStore.loading}
+    <p class="muted">Loading…</p>
+  {:else if agentsStore.list.length === 0}
+    <p class="muted">No agents yet. Install one from the registry below or add a custom one.</p>
+  {:else}
+    <table>
+      <thead>
+        <tr><th>Name</th><th>ID</th><th>Source</th><th>Version</th><th></th></tr>
+      </thead>
+      <tbody>
+        {#each agentsStore.list as agent (agent.id)}
+          <tr>
+            <td>{agent.name}</td>
+            <td><code>{agent.id}</code></td>
+            <td>{agent.source}</td>
+            <td>{agent.version ?? ""}</td>
+            <td>
+              <button type="button" onclick={() => uninstall(agent.id)}>Uninstall</button>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+
+  <h3>Registry</h3>
+  {#if registryLoading}
+    <p class="muted">Loading registry…</p>
+  {:else if registryError}
+    <p class="err">{registryError}</p>
+  {:else}
+    <table>
+      <thead>
+        <tr><th>Name</th><th>ID</th><th>Version</th><th>Description</th><th></th></tr>
+      </thead>
+      <tbody>
+        {#each registry as agent (agent.id)}
+          <tr>
+            <td>{agent.name}</td>
+            <td><code>{agent.id}</code></td>
+            <td>{agent.version}</td>
+            <td class="desc">{agent.description}</td>
+            <td>
+              {#if isInstalled(agent.id)}
+                <span class="muted">Installed</span>
+              {:else}
+                <button type="button" onclick={() => install(agent.id)} disabled={installingId === agent.id}>
+                  {installingId === agent.id ? "Installing…" : "Install"}
+                </button>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</section>
+
+<style>
+  .agents {
+    max-width: 980px;
+  }
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .header-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+  h2,
+  h3 {
+    margin-top: 1.5rem;
+  }
+  h2:first-child {
+    margin-top: 0;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 0.5rem;
+    font-size: 0.92rem;
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid #2b313a;
+    vertical-align: top;
+  }
+  th {
+    color: var(--muted);
+    font-weight: 600;
+  }
+  td.desc {
+    color: var(--muted);
+    max-width: 360px;
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  button {
+    background: #1c2027;
+    color: inherit;
+    border: 1px solid #2b313a;
+    padding: 0.3rem 0.7rem;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  button:hover {
+    border-color: var(--accent);
+  }
+  button[disabled] {
+    opacity: 0.6;
+    cursor: progress;
+  }
+  .custom-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    background: #14181f;
+    padding: 1rem;
+    border: 1px solid #2b313a;
+    border-radius: 6px;
+    margin-top: 1rem;
+  }
+  .custom-form h3 {
+    margin: 0;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.9rem;
+  }
+  input,
+  textarea {
+    padding: 0.4rem 0.5rem;
+    background: #1c2027;
+    border: 1px solid #2b313a;
+    color: inherit;
+    border-radius: 4px;
+    font: inherit;
+  }
+  .actions {
+    display: flex;
+    gap: 0.7rem;
+    align-items: center;
+  }
+  .err {
+    color: #f85149;
+  }
+  .muted {
+    color: var(--muted);
+  }
+</style>

--- a/brokk-foreman/src/routes/Session.svelte
+++ b/brokk-foreman/src/routes/Session.svelte
@@ -1,0 +1,340 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import type { UnlistenFn } from "@tauri-apps/api/event";
+  import { api } from "../lib/api";
+  import { agentsStore } from "../lib/stores/agents.svelte";
+  import { sessionStore } from "../lib/stores/session.svelte";
+  import {
+    onAcpUpdate,
+    onPermissionRequest,
+    onSessionStatus,
+    onStderr,
+  } from "../lib/events";
+
+  let selectedAgentId = $state("");
+  let prompt = $state("");
+  let sending = $state(false);
+  let actionError: string | null = $state(null);
+
+  let unlisteners: UnlistenFn[] = [];
+
+  // Bind event listeners + load agents + preselect the configured default.
+  onMount(async () => {
+    unlisteners.push(
+      await onAcpUpdate((u) => sessionStore.pushUpdate(u)),
+      await onSessionStatus((s) => sessionStore.setStatus(s)),
+      await onPermissionRequest((p) => sessionStore.setPermission(p)),
+      await onStderr((s) => sessionStore.pushStderr(s)),
+    );
+    await agentsStore.refresh();
+    try {
+      const cfg = await api.getConfig();
+      if (cfg.default_agent_id) {
+        selectedAgentId = cfg.default_agent_id;
+      } else if (agentsStore.list.length > 0) {
+        selectedAgentId = agentsStore.list[0]!.id;
+      }
+    } catch {
+      // Settings not configured yet — leave selection blank.
+    }
+  });
+
+  onDestroy(() => {
+    for (const un of unlisteners) un();
+  });
+
+  async function start() {
+    actionError = null;
+    if (!selectedAgentId) {
+      actionError = "Pick an agent first.";
+      return;
+    }
+    try {
+      await api.startSession(selectedAgentId);
+    } catch (e) {
+      actionError = `${e}`;
+    }
+  }
+
+  async function stop() {
+    actionError = null;
+    try {
+      await api.stopSession();
+    } catch (e) {
+      actionError = `${e}`;
+    }
+  }
+
+  async function cancel() {
+    actionError = null;
+    try {
+      await api.cancelSession();
+    } catch (e) {
+      actionError = `${e}`;
+    }
+  }
+
+  async function send() {
+    if (prompt.trim() === "") return;
+    sending = true;
+    actionError = null;
+    try {
+      await api.sendPrompt(prompt);
+      prompt = "";
+    } catch (e) {
+      actionError = `${e}`;
+    } finally {
+      sending = false;
+    }
+  }
+
+  async function respondPermission(accept: boolean) {
+    const pending = sessionStore.pendingPermission;
+    if (!pending) return;
+    try {
+      // For v1 we forward "accept" by picking the first option id when
+      // available; cancel sends `accept = false`.
+      const opts = pending.options as Array<{ option_id?: string }> | undefined;
+      const firstOption =
+        Array.isArray(opts) && opts.length > 0 ? opts[0]?.option_id : undefined;
+      await api.respondPermission(pending.request_id, accept, firstOption);
+    } catch (e) {
+      actionError = `${e}`;
+    } finally {
+      sessionStore.setPermission(null);
+    }
+  }
+
+  let statusLabel = $derived.by(() => {
+    const s = sessionStore.status;
+    if (!s) return "No session";
+    switch (s.kind) {
+      case "starting":
+        return `Starting ${s.agent_id}…`;
+      case "ready":
+        return `Ready (${s.agent_id} / ${s.session_id})`;
+      case "auth_required":
+        return `Auth required (${s.auth_kind})`;
+      case "stopped":
+        return `Stopped: ${s.reason}`;
+      case "failed":
+        return `Failed: ${s.error}`;
+    }
+  });
+
+  let isRunning = $derived(
+    sessionStore.status?.kind === "ready" ||
+      sessionStore.status?.kind === "starting",
+  );
+</script>
+
+<section class="session">
+  <header>
+    <h2>Session</h2>
+    <span class="status">{statusLabel}</span>
+  </header>
+
+  <div class="controls">
+    <label>
+      <span>Agent</span>
+      <select bind:value={selectedAgentId} disabled={isRunning}>
+        <option value="">(pick an agent)</option>
+        {#each agentsStore.list as agent (agent.id)}
+          <option value={agent.id}>{agent.name} ({agent.id})</option>
+        {/each}
+      </select>
+    </label>
+    {#if !isRunning}
+      <button type="button" onclick={start}>Start</button>
+    {:else}
+      <button type="button" onclick={cancel}>Cancel turn</button>
+      <button type="button" onclick={stop}>Stop session</button>
+    {/if}
+  </div>
+
+  {#if actionError}<p class="err">{actionError}</p>{/if}
+
+  <div class="prompt-row">
+    <textarea
+      bind:value={prompt}
+      placeholder="Ask the agent…"
+      rows="3"
+      disabled={!isRunning || sending}
+    ></textarea>
+    <button
+      type="button"
+      onclick={send}
+      disabled={!isRunning || sending || prompt.trim() === ""}
+    >
+      {sending ? "Sending…" : "Send"}
+    </button>
+  </div>
+
+  <h3>Session updates</h3>
+  {#if sessionStore.updates.length === 0}
+    <p class="muted">Streaming updates from the agent appear here.</p>
+  {:else}
+    <ol class="updates">
+      {#each sessionStore.updates as u, i (i)}
+        <li><pre>{JSON.stringify(u.update, null, 2)}</pre></li>
+      {/each}
+    </ol>
+  {/if}
+
+  {#if sessionStore.stderrTail.length > 0}
+    <details>
+      <summary>Agent stderr (last {sessionStore.stderrTail.length} lines)</summary>
+      <pre class="stderr">{sessionStore.stderrTail.join("\n")}</pre>
+    </details>
+  {/if}
+
+  {#if sessionStore.pendingPermission}
+    <div class="modal-backdrop">
+      <div class="modal">
+        <h3>Permission requested</h3>
+        <pre>{JSON.stringify(sessionStore.pendingPermission.tool_call, null, 2)}</pre>
+        <p class="muted">
+          Allow this tool call? "Allow" forwards the first option in the
+          agent's permission menu; "Deny" cancels the request.
+        </p>
+        <div class="modal-actions">
+          <button type="button" onclick={() => respondPermission(false)}>Deny</button>
+          <button type="button" onclick={() => respondPermission(true)}>Allow</button>
+        </div>
+      </div>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .session {
+    max-width: 980px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  h2 {
+    margin: 0;
+  }
+  .status {
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  .controls {
+    display: flex;
+    align-items: end;
+    gap: 0.7rem;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.9rem;
+    flex: 1;
+  }
+  select,
+  textarea {
+    padding: 0.4rem 0.6rem;
+    background: #1c2027;
+    border: 1px solid #2b313a;
+    color: inherit;
+    border-radius: 4px;
+    font: inherit;
+  }
+  textarea {
+    resize: vertical;
+  }
+  button {
+    background: var(--accent);
+    color: white;
+    border: none;
+    padding: 0.5rem 0.9rem;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  button[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .prompt-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: stretch;
+  }
+  .prompt-row textarea {
+    flex: 1;
+  }
+  .updates {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    max-height: 50vh;
+    overflow-y: auto;
+    border: 1px solid #2b313a;
+    border-radius: 4px;
+  }
+  .updates li {
+    border-bottom: 1px solid #2b313a;
+  }
+  .updates li:last-child {
+    border-bottom: none;
+  }
+  pre {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+    margin: 0;
+    padding: 0.5rem 0.7rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .stderr {
+    background: #14181f;
+    padding: 0.5rem 0.7rem;
+    border-radius: 4px;
+    color: var(--muted);
+  }
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+  }
+  .modal {
+    background: #14181f;
+    border: 1px solid #2b313a;
+    border-radius: 6px;
+    padding: 1.2rem;
+    max-width: 560px;
+    width: 92%;
+  }
+  .modal h3 {
+    margin-top: 0;
+  }
+  .modal pre {
+    background: #0e1116;
+    border-radius: 4px;
+    padding: 0.5rem;
+    max-height: 240px;
+    overflow: auto;
+  }
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.8rem;
+  }
+  .err {
+    color: #f85149;
+  }
+  .muted {
+    color: var(--muted);
+  }
+</style>

--- a/brokk-foreman/src/routes/Settings.svelte
+++ b/brokk-foreman/src/routes/Settings.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { api, type Config } from "../lib/api";
+  import { agentsStore } from "../lib/stores/agents.svelte";
+
+  let repoPath = $state("");
+  let defaultAgentId = $state("");
+  let loading = $state(false);
+  let saving = $state(false);
+  let error: string | null = $state(null);
+  let saved = $state(false);
+
+  onMount(async () => {
+    loading = true;
+    try {
+      const [cfg] = await Promise.all([api.getConfig(), agentsStore.refresh()]);
+      repoPath = cfg.repo_path ?? "";
+      defaultAgentId = cfg.default_agent_id ?? "";
+    } catch (e) {
+      error = `${e}`;
+    } finally {
+      loading = false;
+    }
+  });
+
+  async function save() {
+    saving = true;
+    error = null;
+    saved = false;
+    try {
+      const config: Config = {
+        repo_path: repoPath.trim() === "" ? null : repoPath.trim(),
+        default_agent_id:
+          defaultAgentId.trim() === "" ? null : defaultAgentId.trim(),
+      };
+      await api.setConfig(config);
+      saved = true;
+    } catch (e) {
+      error = `${e}`;
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<section class="settings">
+  <h2>Settings</h2>
+
+  {#if loading}
+    <p class="muted">Loading…</p>
+  {:else}
+    <form onsubmit={(e) => { e.preventDefault(); save(); }}>
+      <label>
+        <span>Repository path</span>
+        <input
+          type="text"
+          bind:value={repoPath}
+          placeholder="/Users/you/code/your-repo"
+          autocomplete="off"
+        />
+        <span class="hint">
+          Absolute path to the repo the ACP session will run against. v1
+          runs in this directory directly (no worktree).
+        </span>
+      </label>
+
+      <label>
+        <span>Default agent</span>
+        <select bind:value={defaultAgentId}>
+          <option value="">(none)</option>
+          {#each agentsStore.list as agent (agent.id)}
+            <option value={agent.id}>{agent.name} ({agent.id})</option>
+          {/each}
+        </select>
+        <span class="hint">
+          Pre-selected on the Session page. Add agents on the Agents tab.
+        </span>
+      </label>
+
+      <div class="actions">
+        <button type="submit" disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+        {#if saved}<span class="ok">Saved.</span>{/if}
+        {#if error}<span class="err">{error}</span>{/if}
+      </div>
+    </form>
+  {/if}
+</section>
+
+<style>
+  .settings {
+    max-width: 640px;
+  }
+  h2 {
+    margin-top: 0;
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.95rem;
+  }
+  label > span:first-child {
+    font-weight: 600;
+  }
+  input,
+  select {
+    padding: 0.5rem 0.6rem;
+    background: #1c2027;
+    border: 1px solid #2b313a;
+    color: inherit;
+    border-radius: 4px;
+    font-size: 0.95rem;
+  }
+  .hint {
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  button {
+    background: var(--accent);
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  button[disabled] {
+    opacity: 0.6;
+    cursor: progress;
+  }
+  .ok {
+    color: #2ea043;
+  }
+  .err {
+    color: #f85149;
+  }
+</style>


### PR DESCRIPTION
## Summary

Restart `brokk-foreman` at the minimum-viable scope: an open ACP-protocol desktop client that lets the user pick **any** registry-listed or custom ACP agent and run one session at a time against a configured repo root.

Worktrees, GitHub/Jira issue providers, kanban UI, enrichment, and blocking-graph analysis are **deferred** until the ACP-client core is shipping and useful. The next milestone after v1 is worktree-per-session.

## Why

The previous `PLANS.md` (569 lines) bundled three independent surfaces — issue REST APIs, kanban UX, and ACP — before any single one was usable end-to-end. Restarting at "pure ACP client" decouples the project from any one vendor's stack and aligns with the ACP industry direction (Zed + JetBrains shipped registry support in early 2026; brokk-foreman becomes a third client of the same registry).

## What changed

**Scaffold cleanup**
- Drop unused stubs: `worktree.rs`, `issues/`, `llm/`.
- Drop `svelte-dnd-action` dep (kanban only).
- Drop `octocrab` dep (GitHub issues only).
- Simplify DB schema to `agents` + `config_kv`. New test `schema_drops_deferred_tables` locks the contract.

**New Rust modules**
- `acp/agents.rs` — CRUD over the `agents` table; `LaunchSpec` resolves a stored `Distribution` (+ optional `installed_path`) into the concrete `program/args/env` triple for spawn.
- `acp/launcher.rs` — `tokio::process::Command` with `stdin/stdout/stderr` piped, `kill_on_drop(true)`. Verifies `which("npx"/"uvx")` for those distribution kinds.
- `acp/installer.rs` — HTTP download + `.tar.gz`/`.zip` extraction on the blocking pool. Rejects installer-style archives (`.dmg/.pkg/.deb/.rpm/.msi/.appimage`) per the registry spec.
- `acp/client.rs` — `SessionManager` (one live session at a time, v1 constraint). Drives `Client.builder()...connect_with(...)` from the `agent-client-protocol` crate; an `mpsc::Receiver` loop converts UI commands (Prompt/Cancel/Stop) into `connection.send_request` calls. Inbound `RequestPermissionRequest` is round-tripped via a `oneshot::Sender` registry indexed by a fresh UUID — the frontend modal resolves it.
- `acp/auth.rs` — typed classification of `AUTH_REQUIRED` payloads (Agent / Terminal / Other).
- `acp/registry.rs` — extended with `RegistryCache` (ETag + `If-None-Match`, cached body at `~/.brokk/foreman/registry-cache.json`, offline fallback).
- `commands.rs` + `events.rs` + `lib.rs` — 12 Tauri commands wired (`list_agents`, `fetch_registry`, `install_agent`, `add_custom_agent`, `uninstall_agent`, `get_config`, `set_config`, `start_session`, `send_prompt`, `cancel_session`, `stop_session`, `respond_permission`) and 4 typed event channels (`acp:update`, `acp:session_status`, `acp:permission`, `acp:stderr`).
- `config.rs` — extended with typed `Config { repo_path, default_agent_id }` round-tripping through `config_kv`.

**Svelte frontend**
- Hash-routed `App.svelte` shell (3 routes; no router dep).
- `routes/Settings.svelte` — repo path + default agent.
- `routes/Agents.svelte` — registry browser, install/uninstall, add-custom form.
- `routes/Session.svelte` — agent picker + streaming `SessionUpdate` list + Cancel/Stop + permission modal.
- `lib/api.ts`, `lib/events.ts`, `lib/stores/*.svelte.ts` — typed `invoke()` wrappers, event subscribers, runes-backed stores.

## Reference

The ACP client wiring mirrors the upstream crate's `examples/yolo_one_shot_client.rs`:
```rust
Client.builder()
    .on_receive_notification(...)   // forwards SessionUpdate -> Tauri events
    .on_receive_request(...)        // permission round-trip via oneshot
    .connect_with(transport, |cx: ConnectionTo<Agent>| async move {
        let _ = cx.send_request(InitializeRequest::new(ProtocolVersion::V1)).block_task().await?;
        let new_sess = cx.send_request(NewSessionRequest::new(repo_path)).block_task().await?;
        while let Some(cmd) = cmd_rx.recv().await { ... }
        Ok(())
    })
    .await
```

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (0 warnings)
- [x] `cargo test` — 31 tests pass (18 lib + 13 registry parser; new tests cover the simplified schema, custom-agent round-trip, archive-extension validation, and auth-payload classification)
- [x] `pnpm check` — 107 files, 0 errors, 0 warnings
- [x] `pnpm build` — 122 modules, 52 KB JS bundle
- [ ] **End-to-end manual** (next): `cargo tauri dev` → Agents tab → install an `npx` agent (e.g. `claude-acp`) → Settings → repo path → Session → Start → send a prompt → observe streaming updates and accept a permission modal → Stop → verify clean child shutdown via `ps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
