### PR TITLE
Fix #3197: dir-prefix globs in searchFileContents

### DIFF
--- a/app/src/test/java/ai/brokk/tools/SearchToolsTest.java
+++ b/app/src/test/java/ai/brokk/tools/SearchToolsTest.java
@@ -1360,6 +1360,55 @@ public class SearchToolsTest {
         assertTrue(result.contains("dir/file.txt"), "Should find file in subdirectory using literal subpath");
     }
 
+    // Regression: #3197 — dir-prefix globs should match top-level files in that directory,
+    // not only files nested under at least one intermediate segment.
+    @Test
+    void testSearchFileContents_DirPrefixDoubleStarStar_MatchesTopLevel() throws Exception {
+        Path dir = projectRoot.resolve("brokk-code");
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("top.txt"), "MATCH");
+        Files.writeString(Files.createDirectories(dir.resolve("sub")).resolve("nested.txt"), "MATCH");
+        mockProjectFiles.add(new ProjectFile(projectRoot, "brokk-code/top.txt"));
+        mockProjectFiles.add(new ProjectFile(projectRoot, "brokk-code/sub/nested.txt"));
+
+        String result = searchTools.searchFileContents(List.of("MATCH"), "brokk-code/**/*", false, false, 0, 200);
+        assertTrue(
+                result.contains("brokk-code/top.txt"),
+                "dir/**/* must match top-level file (was empty before #3197 fix)");
+        assertTrue(result.contains("brokk-code/sub/nested.txt"), "dir/**/* must still match nested file");
+    }
+
+    @Test
+    void testSearchFileContents_DirPrefixDoubleStar_MatchesAllDepths() throws Exception {
+        Path dir = projectRoot.resolve("brokk-code");
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("top.txt"), "MATCH");
+        Files.writeString(Files.createDirectories(dir.resolve("sub")).resolve("nested.txt"), "MATCH");
+        mockProjectFiles.add(new ProjectFile(projectRoot, "brokk-code/top.txt"));
+        mockProjectFiles.add(new ProjectFile(projectRoot, "brokk-code/sub/nested.txt"));
+
+        String result = searchTools.searchFileContents(List.of("MATCH"), "brokk-code/**", false, false, 0, 200);
+        assertTrue(result.contains("brokk-code/top.txt"));
+        assertTrue(result.contains("brokk-code/sub/nested.txt"));
+    }
+
+    @Test
+    void testSearchFileContents_InfixGlob_MatchesByBasename() throws Exception {
+        Files.writeString(projectRoot.resolve("mcp.py"), "MATCH");
+        Path sub = projectRoot.resolve("server");
+        Files.createDirectories(sub);
+        Files.writeString(sub.resolve("mcp_server.py"), "MATCH");
+        Files.writeString(sub.resolve("unrelated.py"), "MATCH");
+        mockProjectFiles.add(new ProjectFile(projectRoot, "mcp.py"));
+        mockProjectFiles.add(new ProjectFile(projectRoot, "server/mcp_server.py"));
+        mockProjectFiles.add(new ProjectFile(projectRoot, "server/unrelated.py"));
+
+        String result = searchTools.searchFileContents(List.of("MATCH"), "**/*mcp*", false, false, 0, 200);
+        assertTrue(result.contains("mcp.py"), "**/*mcp* must match root-level mcp.py");
+        assertTrue(result.contains("server/mcp_server.py"), "**/*mcp* must match nested mcp_server.py");
+        assertFalse(result.contains("server/unrelated.py"), "**/*mcp* must not match files without 'mcp' in name");
+    }
+
     @Test
     void testSearchFileContents_MultiplePatternsSameLine_Deduped() throws Exception {
         Path txt = projectRoot.resolve("multi_pattern_dedupe.txt");

--- a/brokk-shared/src/main/java/ai/brokk/util/AlmostGrep.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/AlmostGrep.java
@@ -8,9 +8,6 @@ import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.concurrent.LoggingFuture;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -86,16 +83,15 @@ public final class AlmostGrep {
     public record FileContentSearchResult(String output, int matches) {}
 
     public static List<ProjectFile> findProjectTextFilesByGlob(Set<ProjectFile> allFiles, String globPattern) {
-        PathMatcher matcher = compileGlobPathMatcher(globPattern);
+        // Use FilenamePatternMatcher's glob-to-regex so directory-prefix patterns like
+        // "dir/**/*" also match top-level files in "dir/" (Java's strict glob: PathMatcher
+        // requires at least one intermediate segment after **/, which surprises LLM clients).
+        var regex = FilenamePatternMatcher.globToRegex(toUnixPath(globPattern));
         return allFiles.stream()
                 .filter(ProjectFile::isText)
-                .filter(file -> matcher.matches(Path.of(toUnixPath(file.toString()))))
+                .filter(file -> regex.matcher(toUnixPath(file.toString())).matches())
                 .sorted()
                 .toList();
-    }
-
-    private static PathMatcher compileGlobPathMatcher(String pattern) {
-        return FileSystems.getDefault().getPathMatcher("glob:" + toUnixPath(pattern));
     }
 
     public static FindFilesContainingResult findFilesContainingPatterns(


### PR DESCRIPTION
## Summary
- `searchFileContents` rejected common LLM-friendly glob patterns. Java's strict `glob:` `PathMatcher` requires an intermediate segment after `**/`, so `brokk-code/**/*` never matched `brokk-code/foo.txt`, and case sensitivity varied between Windows and *nix.
- Switched `AlmostGrep.findProjectTextFilesByGlob` to `FilenamePatternMatcher.globToRegex` — the same translator already used by `findFilenames` since #3554. It maps `**/` to `.*/?` (optional trailing slash), so directory-prefix patterns match every depth, and behavior is now identical across OSes.
- Removed the now-unused `compileGlobPathMatcher` helper and three `java.nio.file` imports (`FileSystems`, `Path`, `PathMatcher`).
- Both `app/` and `brokk-core/` `SearchTools` call sites route through this one method, so the single edit fixes both.

Fixes #3197.

## Test plan
- [x] `./gradlew :app:test --tests "ai.brokk.tools.SearchToolsTest.testSearchFileContents_*"` — all 21 tests pass, including 3 new regression tests:
  - `testSearchFileContents_DirPrefixDoubleStarStar_MatchesTopLevel` — `brokk-code/**/*` finds `brokk-code/top.txt` (the canonical #3197 failure)
  - `testSearchFileContents_DirPrefixDoubleStar_MatchesAllDepths` — `brokk-code/**` finds files at all depths
  - `testSearchFileContents_InfixGlob_MatchesByBasename` — `**/*mcp*` matches `mcp.py` and `server/mcp_server.py`, excludes `server/unrelated.py`
- [x] `./gradlew :brokk-shared:test :brokk-core:test :app:spotlessCheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)