### PR TITLE
brokk-acp-rust: discover sandbox PATH and expand env allowlist (#3543)

### DIFF
--- a/brokk-acp-rust/src/tools/sandbox.rs
+++ b/brokk-acp-rust/src/tools/sandbox.rs
@@ -545,7 +545,22 @@ pub fn discover_sandbox_path() -> String {
         push((*abs).to_string());
     }
 
-    entries.join(":")
+    // Use the platform's native PATH separator (`:` on Unix, `;` on Windows).
+    // The sandbox itself is Unix-only, but `discover_sandbox_path` is called
+    // unconditionally from `shell.rs::run_shell_command`, so on Windows CI
+    // the function must still produce a syntactically valid PATH string.
+    // `join_paths` returns Err only when an entry already contains the
+    // separator; we fall back to a hand-joined string in that case rather
+    // than panicking, since the offending entry would have been silently
+    // dropped from the result anyway.
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    match std::env::join_paths(&entries) {
+        Ok(joined) => joined.to_string_lossy().into_owned(),
+        Err(e) => {
+            tracing::warn!(error = %e, "join_paths failed; falling back to naive join");
+            entries.join(sep)
+        }
+    }
 }
 
 /// A `~`-relative tool dir is safe iff: it exists as a directory, is owned
@@ -1040,17 +1055,30 @@ mod tests {
         }
     }
 
+    /// Acquire `SANDBOX_ENV_LOCK` even if a prior test panicked while
+    /// holding it. The lock protects against parallel env-var mutation,
+    /// not shared in-memory state, so a panic in one test never corrupts
+    /// anything observable here — unpoisoning is the right call.
+    fn sandbox_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        SANDBOX_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[test]
     fn discover_sandbox_path_includes_static_fallback() {
         // With no override, the result must always contain the static
         // fallback dirs so the existing behavior is a strict subset of
         // the new behavior.
-        let _g = SANDBOX_ENV_LOCK.lock().unwrap();
+        let _g = sandbox_env_lock();
         let _clear = SandboxEnvGuard::unset(BROKK_ACP_PATH_ENV);
         let path = discover_sandbox_path();
+        let entries: Vec<String> = std::env::split_paths(&path)
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
         for fallback in ["/usr/local/bin", "/usr/bin", "/bin"] {
             assert!(
-                path.split(':').any(|p| p == fallback),
+                entries.iter().any(|p| p == fallback),
                 "fallback '{fallback}' missing from discovered PATH '{path}'"
             );
         }
@@ -1059,22 +1087,26 @@ mod tests {
     #[test]
     fn discover_sandbox_path_de_duplicates_entries() {
         // No entry should appear twice even when the parent PATH overlaps
-        // with our static fallback or with home tool dirs.
-        let _g = SANDBOX_ENV_LOCK.lock().unwrap();
+        // with our static fallback or with home tool dirs. Use
+        // `split_paths` (not `split(':')`) so this works on Windows CI,
+        // where the platform separator is `;` and Unix-style `:` splitting
+        // breaks `D:\a\...` paths into spurious `D` fragments.
+        let _g = sandbox_env_lock();
         let _clear = SandboxEnvGuard::unset(BROKK_ACP_PATH_ENV);
         let path = discover_sandbox_path();
         let mut seen = std::collections::HashSet::new();
-        for entry in path.split(':') {
+        for entry in std::env::split_paths(&path) {
+            let s = entry.to_string_lossy().into_owned();
             assert!(
-                seen.insert(entry),
-                "PATH entry '{entry}' is duplicated: '{path}'"
+                seen.insert(s.clone()),
+                "PATH entry '{s}' is duplicated: '{path}'"
             );
         }
     }
 
     #[test]
     fn discover_sandbox_path_brokk_acp_path_override_returns_verbatim() {
-        let _g = SANDBOX_ENV_LOCK.lock().unwrap();
+        let _g = sandbox_env_lock();
         let _set = SandboxEnvGuard::set(BROKK_ACP_PATH_ENV, "/custom/bin:/another/bin");
         let path = discover_sandbox_path();
         assert_eq!(path, "/custom/bin:/another/bin");
@@ -1085,11 +1117,14 @@ mod tests {
         // A whitespace-only or empty BROKK_ACP_PATH must not short-circuit
         // discovery -- otherwise an `export BROKK_ACP_PATH=` in a parent
         // shell wipes the user's PATH inside the sandbox.
-        let _g = SANDBOX_ENV_LOCK.lock().unwrap();
+        let _g = sandbox_env_lock();
         let _set = SandboxEnvGuard::set(BROKK_ACP_PATH_ENV, "   ");
         let path = discover_sandbox_path();
+        let entries: Vec<String> = std::env::split_paths(&path)
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
         assert!(
-            path.split(':').any(|p| p == "/usr/bin"),
+            entries.iter().any(|p| p == "/usr/bin"),
             "empty override must fall through to discovery, got '{path}'"
         );
     }

--- a/brokk-acp-rust/src/tools/sandbox.rs
+++ b/brokk-acp-rust/src/tools/sandbox.rs
@@ -397,7 +397,7 @@ pub fn cleanup_stale_policy_files() {
 /// (`Environment.java:521-529`), which binds the parent roots and so leaves
 /// `~/.cargo/credentials.toml`, `~/.gradle/gradle.properties`, and
 /// `~/.m2/settings.xml` exposed to the sandboxed command alongside the cache.
-#[cfg_attr(not(any(target_os = "linux", test)), allow(dead_code))]
+#[cfg(any(target_os = "linux", all(test, unix)))]
 const HOME_CACHE_SUBDIRS: &[&str] = &[
     ".cargo/registry",
     ".cargo/git",
@@ -451,16 +451,19 @@ pub const ENV_WHITELIST: &[&str] = &[
 /// Operator-supplied override that fully replaces the discovered PATH inside
 /// the sandbox. Lets sophisticated users opt into custom toolchain layouts
 /// without us having to enumerate every package manager.
+#[cfg(unix)]
 pub const BROKK_ACP_PATH_ENV: &str = "BROKK_ACP_PATH";
 
 /// Static fallback PATH segments, appended last. Mirrors the historic
 /// hardcoded value so commands that resolve only through `/usr/bin` etc.
 /// keep working when discovery turns up nothing.
+#[cfg(unix)]
 const STATIC_PATH_FALLBACK: &[&str] = &["/usr/local/bin", "/usr/bin", "/bin"];
 
 /// Well-known toolchain-manager dirs that live under `$HOME`. Each is checked
 /// individually for existence, ownership, and mode bits before being added
 /// to PATH. Order is preference order (first match wins for `command -v`).
+#[cfg(unix)]
 const HOME_TOOL_DIRS: &[&str] = &[
     ".cargo/bin",
     ".local/bin",
@@ -474,6 +477,7 @@ const HOME_TOOL_DIRS: &[&str] = &[
 /// Well-known toolchain-manager dirs at fixed absolute paths. Not owned by
 /// the user (typically by the brew admin user or root), so they're checked
 /// only for existence and "not world-writable".
+#[cfg(unix)]
 const SYSTEM_TOOL_DIRS: &[&str] = &["/opt/homebrew/bin", "/opt/homebrew/sbin"];
 
 /// Build the PATH used inside the sandbox.
@@ -487,6 +491,13 @@ const SYSTEM_TOOL_DIRS: &[&str] = &["/opt/homebrew/bin", "/opt/homebrew/sbin"];
 /// `BROKK_ACP_PATH` short-circuits the whole pipeline: if set to a non-empty
 /// value the override is returned verbatim, leaving safety enforcement to the
 /// operator. Used by ops who run brokk-acp under bespoke toolchain layouts.
+///
+/// Unix-only: the sandbox itself (`sandbox-exec`, `bwrap`) is unimplemented
+/// on Windows, and the path layout we discover here (`~/.cargo/bin`,
+/// `/opt/homebrew/bin`, `/usr/local/bin`, ...) is meaningless under Win32.
+/// On Windows the caller in `shell.rs` falls through to the parent process'
+/// own PATH, which is the desired no-op-when-no-sandbox behavior.
+#[cfg(unix)]
 pub fn discover_sandbox_path() -> String {
     if let Ok(override_val) = std::env::var(BROKK_ACP_PATH_ENV)
         && !override_val.trim().is_empty()
@@ -545,22 +556,7 @@ pub fn discover_sandbox_path() -> String {
         push((*abs).to_string());
     }
 
-    // Use the platform's native PATH separator (`:` on Unix, `;` on Windows).
-    // The sandbox itself is Unix-only, but `discover_sandbox_path` is called
-    // unconditionally from `shell.rs::run_shell_command`, so on Windows CI
-    // the function must still produce a syntactically valid PATH string.
-    // `join_paths` returns Err only when an entry already contains the
-    // separator; we fall back to a hand-joined string in that case rather
-    // than panicking, since the offending entry would have been silently
-    // dropped from the result anyway.
-    let sep = if cfg!(windows) { ";" } else { ":" };
-    match std::env::join_paths(&entries) {
-        Ok(joined) => joined.to_string_lossy().into_owned(),
-        Err(e) => {
-            tracing::warn!(error = %e, "join_paths failed; falling back to naive join");
-            entries.join(sep)
-        }
-    }
+    entries.join(":")
 }
 
 /// A `~`-relative tool dir is safe iff: it exists as a directory, is owned
@@ -624,26 +620,7 @@ fn is_safe_parent_path_entry(path: &Path) -> bool {
     is_safe_system_dir(path)
 }
 
-/// Non-Unix platforms (Windows) don't have a sandbox here today; the function
-/// is only called via cfg-gated callers, but we provide a portable fallback
-/// for tests and future platforms. Existence is the only enforceable check
-/// without Unix mode bits.
-#[cfg(not(unix))]
-fn is_safe_home_dir(path: &Path) -> bool {
-    path.is_dir()
-}
-
-#[cfg(not(unix))]
-fn is_safe_system_dir(path: &Path) -> bool {
-    path.is_dir()
-}
-
-#[cfg(not(unix))]
-fn is_safe_parent_path_entry(path: &Path) -> bool {
-    path.is_dir()
-}
-
-#[cfg_attr(not(any(target_os = "linux", test)), allow(dead_code))]
+#[cfg(any(target_os = "linux", all(test, unix)))]
 fn build_bwrap_argv(policy: SandboxPolicy, cwd: &Path, command: &str) -> Vec<String> {
     let mut a: Vec<String> = Vec::with_capacity(48);
     a.push("bwrap".into());
@@ -906,6 +883,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn bwrap_argv_read_only_has_no_workspace_bind() {
         let argv = build_bwrap_argv(SandboxPolicy::ReadOnly, Path::new("/workspace"), "echo hi");
@@ -923,6 +901,7 @@ mod tests {
         assert_eq!(&argv[dash_idx + 1..], &["sh", "-c", "echo hi"]);
     }
 
+    #[cfg(unix)]
     #[test]
     fn bwrap_argv_workspace_write_binds_root_rw() {
         let argv = build_bwrap_argv(
@@ -937,6 +916,7 @@ mod tests {
         assert!(argv.contains(&"--tmpfs".to_string()));
     }
 
+    #[cfg(unix)]
     #[test]
     fn bwrap_argv_clearenv_with_path_and_term() {
         let argv = build_bwrap_argv(SandboxPolicy::ReadOnly, Path::new("/workspace"), "echo hi");
@@ -976,6 +956,7 @@ mod tests {
         assert!(has_term, "TERM must be set to dumb via --setenv");
     }
 
+    #[cfg(unix)]
     #[test]
     fn bwrap_argv_no_credential_root_binds() {
         // Stricter than Java: we must NOT bind ~/.cargo or ~/.gradle as
@@ -1004,7 +985,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // PATH discovery
+    // PATH discovery (Unix-only: discover_sandbox_path and the
+    // is_safe_* helpers are cfg(unix); these tests follow suit.)
     // -----------------------------------------------------------------
 
     /// Serializes tests that mutate process-wide env vars touched by
@@ -1012,16 +994,19 @@ mod tests {
     /// `#[test]` cases in parallel inside one binary, so any test that
     /// `set_var` here must hold this lock to avoid racing readers from
     /// sibling tests.
+    #[cfg(unix)]
     static SANDBOX_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// Restores a single env var on Drop. Pair with `SANDBOX_ENV_LOCK` so
     /// the drop ordering is deterministic and we don't leak state into
     /// the next test.
+    #[cfg(unix)]
     struct SandboxEnvGuard {
         var: &'static str,
         prior: Option<std::ffi::OsString>,
     }
 
+    #[cfg(unix)]
     impl SandboxEnvGuard {
         fn set(var: &'static str, value: &str) -> Self {
             let prior = std::env::var_os(var);
@@ -1043,6 +1028,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     impl Drop for SandboxEnvGuard {
         fn drop(&mut self) {
             // SAFETY: same as set()/unset().
@@ -1059,12 +1045,14 @@ mod tests {
     /// holding it. The lock protects against parallel env-var mutation,
     /// not shared in-memory state, so a panic in one test never corrupts
     /// anything observable here — unpoisoning is the right call.
+    #[cfg(unix)]
     fn sandbox_env_lock() -> std::sync::MutexGuard<'static, ()> {
         SANDBOX_ENV_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
+    #[cfg(unix)]
     #[test]
     fn discover_sandbox_path_includes_static_fallback() {
         // With no override, the result must always contain the static
@@ -1084,6 +1072,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn discover_sandbox_path_de_duplicates_entries() {
         // No entry should appear twice even when the parent PATH overlaps
@@ -1104,6 +1093,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn discover_sandbox_path_brokk_acp_path_override_returns_verbatim() {
         let _g = sandbox_env_lock();
@@ -1112,6 +1102,7 @@ mod tests {
         assert_eq!(path, "/custom/bin:/another/bin");
     }
 
+    #[cfg(unix)]
     #[test]
     fn discover_sandbox_path_empty_override_falls_through_to_discovery() {
         // A whitespace-only or empty BROKK_ACP_PATH must not short-circuit
@@ -1195,6 +1186,7 @@ mod tests {
         let _ = std::fs::remove_dir(&tmp);
     }
 
+    #[cfg(unix)]
     #[test]
     fn is_safe_helpers_reject_nonexistent_path() {
         let path = Path::new("/this/definitely/does/not/exist/brokk-zzz");

--- a/brokk-acp-rust/src/tools/sandbox.rs
+++ b/brokk-acp-rust/src/tools/sandbox.rs
@@ -513,11 +513,16 @@ pub fn discover_sandbox_path() -> String {
         }
     };
 
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    if let Some(ref h) = home {
+    // Canonicalize $HOME once so `is_safe_home_dir` can require each
+    // candidate's canonical path to stay inside it (rejects symlinks
+    // under $HOME that escape to elsewhere on disk, per #3543).
+    let canonical_home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .and_then(|h| h.canonicalize().ok());
+    if let Some(ref h_canon) = canonical_home {
         for rel in HOME_TOOL_DIRS {
-            let path = h.join(rel);
-            if !is_safe_home_dir(&path) {
+            let path = h_canon.join(rel);
+            if !is_safe_home_dir(&path, h_canon) {
                 continue;
             }
             if let Some(s) = path.to_str() {
@@ -559,15 +564,44 @@ pub fn discover_sandbox_path() -> String {
     entries.join(":")
 }
 
-/// A `~`-relative tool dir is safe iff: it exists as a directory, is owned
-/// by the current uid, and has no group/world write bits set. The ownership
-/// check is the tightest of the three — anything not owned by the user has
-/// presumably been planted by another principal and is denied even if its
-/// mode bits look fine.
+/// A `~`-relative tool dir is safe iff: its canonical path remains under
+/// `canonical_home`, exists as a directory, is owned by the current uid,
+/// and has no group/world write bits set.
+///
+/// The canonicalize-and-contain check rejects symlinks under `$HOME` whose
+/// targets land elsewhere on disk — even when the target is owned by the
+/// current user and has tight mode bits, e.g. `~/.cargo/bin -> /tmp/bin`.
+/// #3543's acceptance criterion explicitly calls this case out: "PATH
+/// discovery skips ... symlinks pointing outside the user's home". Without
+/// this check, an attacker who could plant a symlink in $HOME (e.g. via a
+/// careless tarball extraction) could redirect tool resolution to a path
+/// they control.
+///
+/// The ownership check on top of that catches the case where the target
+/// *is* under $HOME but somehow ended up owned by another principal.
 #[cfg(unix)]
-fn is_safe_home_dir(path: &Path) -> bool {
+fn is_safe_home_dir(path: &Path, canonical_home: &Path) -> bool {
     use std::os::unix::fs::MetadataExt;
-    let Ok(meta) = std::fs::metadata(path) else {
+
+    // Resolve symlinks fully and require the result to stay under
+    // canonical $HOME. canonicalize() returns Err for non-existent paths,
+    // which is the right answer here too: a missing dir is just not on
+    // PATH, no warning needed.
+    let canonical = match path.canonicalize() {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    if !canonical.starts_with(canonical_home) {
+        tracing::warn!(
+            path = %path.display(),
+            canonical = %canonical.display(),
+            home = %canonical_home.display(),
+            "skipping home tool dir whose canonical path escapes $HOME (symlink redirect)"
+        );
+        return false;
+    }
+
+    let Ok(meta) = std::fs::metadata(&canonical) else {
         return false;
     };
     if !meta.is_dir() {
@@ -577,7 +611,7 @@ fn is_safe_home_dir(path: &Path) -> bool {
     let current_uid = unsafe { libc::getuid() };
     if meta.uid() != current_uid {
         tracing::warn!(
-            path = %path.display(),
+            path = %canonical.display(),
             owner_uid = meta.uid(),
             current_uid,
             "skipping home tool dir not owned by current user"
@@ -586,7 +620,7 @@ fn is_safe_home_dir(path: &Path) -> bool {
     }
     if meta.mode() & 0o022 != 0 {
         tracing::warn!(
-            path = %path.display(),
+            path = %canonical.display(),
             mode = format!("{:o}", meta.mode() & 0o777),
             "skipping home tool dir with group/world write bits set"
         );
@@ -1154,43 +1188,126 @@ mod tests {
         let _ = std::fs::remove_dir(&tmp);
     }
 
+    /// A scratch "fake home" rooted in `temp_dir()`, returned canonicalized
+    /// so `is_safe_home_dir` containment checks compare apples to apples on
+    /// hosts where `/tmp` -> `/private/tmp` (macOS) or similar. The Drop
+    /// guard removes the tree even if the test asserts midway.
+    #[cfg(unix)]
+    struct FakeHome {
+        canonical: PathBuf,
+        // Kept for drop-time cleanup.
+        original: PathBuf,
+    }
+
+    #[cfg(unix)]
+    impl FakeHome {
+        fn new(tag: &str) -> Self {
+            let original = std::env::temp_dir().join(format!(
+                "brokk-fakehome-{tag}-{}-{:?}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or_default()
+            ));
+            std::fs::create_dir(&original).expect("create fake home");
+            let canonical = original.canonicalize().expect("canonicalize fake home");
+            Self {
+                canonical,
+                original,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for FakeHome {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.original);
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn is_safe_home_dir_rejects_group_writable() {
         use std::os::unix::fs::PermissionsExt;
-        let tmp = std::env::temp_dir().join(format!(
-            "brokk-sandbox-test-gw-{}-{:?}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or_default()
-        ));
-        std::fs::create_dir(&tmp).expect("create tmp dir");
+        let home = FakeHome::new("gw");
+        let bin = home.canonical.join("bin");
+        std::fs::create_dir(&bin).expect("create bin");
         // Group-writable but not world-writable: passes is_safe_system_dir
         // (which only rejects 0o002) but fails is_safe_home_dir (which
         // rejects 0o022).
-        let mut perms = std::fs::metadata(&tmp).unwrap().permissions();
+        let mut perms = std::fs::metadata(&bin).unwrap().permissions();
         perms.set_mode(0o775);
-        std::fs::set_permissions(&tmp, perms).unwrap();
+        std::fs::set_permissions(&bin, perms).unwrap();
 
         assert!(
-            is_safe_system_dir(&tmp),
+            is_safe_system_dir(&bin),
             "0o775 dir is fine as a system dir (only world bit matters)"
         );
         assert!(
-            !is_safe_home_dir(&tmp),
+            !is_safe_home_dir(&bin, &home.canonical),
             "group-writable dir must be rejected by is_safe_home_dir"
         );
+    }
 
-        let _ = std::fs::remove_dir(&tmp);
+    /// #3543 acceptance: a symlink under `$HOME` whose target lives outside
+    /// `$HOME` is rejected, even when the target is owned by the current
+    /// user and has tight mode bits. Without `canonicalize() + starts_with`
+    /// in is_safe_home_dir, `metadata()` would silently follow the link
+    /// and accept the off-home target.
+    #[cfg(unix)]
+    #[test]
+    fn is_safe_home_dir_rejects_symlink_pointing_outside_home() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = FakeHome::new("symesc-home");
+        let outside = FakeHome::new("symesc-outside");
+        // Outside dir is squeaky-clean so the only thing rejecting it is
+        // the containment check.
+        let mut perms = std::fs::metadata(&outside.canonical).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&outside.canonical, perms).unwrap();
+
+        let link = home.canonical.join("escaped_bin");
+        std::os::unix::fs::symlink(&outside.canonical, &link).expect("create symlink");
+
+        assert!(
+            !is_safe_home_dir(&link, &home.canonical),
+            "symlink under home pointing to {} (outside home {}) must be rejected",
+            outside.canonical.display(),
+            home.canonical.display(),
+        );
+    }
+
+    /// Companion to the symlink-escape test: a symlink under `$HOME` whose
+    /// target is itself inside `$HOME` is fine. Prevents the containment
+    /// check from regressing into "no symlinks at all", which would break
+    /// legit setups like `~/.cargo/bin -> ~/.rustup/toolchains/stable/bin`.
+    #[cfg(unix)]
+    #[test]
+    fn is_safe_home_dir_accepts_symlink_pointing_inside_home() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = FakeHome::new("symok");
+        let inner_target = home.canonical.join("actual_bin");
+        std::fs::create_dir(&inner_target).expect("create inner target");
+        let mut perms = std::fs::metadata(&inner_target).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&inner_target, perms).unwrap();
+
+        let link = home.canonical.join("cargo_bin");
+        std::os::unix::fs::symlink(&inner_target, &link).expect("create symlink");
+
+        assert!(
+            is_safe_home_dir(&link, &home.canonical),
+            "symlink under home whose target is inside home must be accepted"
+        );
     }
 
     #[cfg(unix)]
     #[test]
     fn is_safe_helpers_reject_nonexistent_path() {
         let path = Path::new("/this/definitely/does/not/exist/brokk-zzz");
-        assert!(!is_safe_home_dir(path));
+        let dummy_home = Path::new("/");
+        assert!(!is_safe_home_dir(path, dummy_home));
         assert!(!is_safe_system_dir(path));
         assert!(!is_safe_parent_path_entry(path));
     }

--- a/brokk-acp-rust/src/tools/sandbox.rs
+++ b/brokk-acp-rust/src/tools/sandbox.rs
@@ -417,7 +417,216 @@ const HOME_CACHE_SUBDIRS: &[&str] = &[
 /// than Java, which inherits the parent process env wholesale (see
 /// `Environment.java:647-661`). LD_PRELOAD, DYLD_*, and any `*_TOKEN` /
 /// `*_KEY` / `*_SECRET` parent secrets are not listed and therefore stripped.
-pub const ENV_WHITELIST: &[&str] = &["HOME", "USER", "LOGNAME", "LANG", "LC_ALL"];
+///
+/// The toolchain-manager entries (CARGO_HOME, RUSTUP_HOME, NVM_DIR, ...) are
+/// pure path pointers into the user's home directory; they do not carry
+/// credentials. Without them, commands like `cargo` and `rustup` can still
+/// fail even when `~/.cargo/bin` is on PATH (e.g. `RUSTUP_HOME` redirected to
+/// a non-default location).
+pub const ENV_WHITELIST: &[&str] = &[
+    // Core identity / locale
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    // Terminal width hints (ripgrep, fd, ls --color, less, ...)
+    "COLUMNS",
+    "LINES",
+    // Toolchain-manager pointers (paths into $HOME; not credentials)
+    "CARGO_HOME",
+    "RUSTUP_HOME",
+    "NVM_DIR",
+    "FNM_DIR",
+    "ASDF_DIR",
+    "ASDF_DATA_DIR",
+    "MISE_DATA_DIR",
+    "MISE_CONFIG_DIR",
+    "PYENV_ROOT",
+    "BUN_INSTALL",
+    "DENO_INSTALL",
+];
+
+/// Operator-supplied override that fully replaces the discovered PATH inside
+/// the sandbox. Lets sophisticated users opt into custom toolchain layouts
+/// without us having to enumerate every package manager.
+pub const BROKK_ACP_PATH_ENV: &str = "BROKK_ACP_PATH";
+
+/// Static fallback PATH segments, appended last. Mirrors the historic
+/// hardcoded value so commands that resolve only through `/usr/bin` etc.
+/// keep working when discovery turns up nothing.
+const STATIC_PATH_FALLBACK: &[&str] = &["/usr/local/bin", "/usr/bin", "/bin"];
+
+/// Well-known toolchain-manager dirs that live under `$HOME`. Each is checked
+/// individually for existence, ownership, and mode bits before being added
+/// to PATH. Order is preference order (first match wins for `command -v`).
+const HOME_TOOL_DIRS: &[&str] = &[
+    ".cargo/bin",
+    ".local/bin",
+    ".local/share/mise/shims",
+    ".asdf/shims",
+    ".pyenv/shims",
+    ".bun/bin",
+    ".deno/bin",
+];
+
+/// Well-known toolchain-manager dirs at fixed absolute paths. Not owned by
+/// the user (typically by the brew admin user or root), so they're checked
+/// only for existence and "not world-writable".
+const SYSTEM_TOOL_DIRS: &[&str] = &["/opt/homebrew/bin", "/opt/homebrew/sbin"];
+
+/// Build the PATH used inside the sandbox.
+///
+/// Order: home tool dirs that pass `is_safe_home_dir`, then well-known system
+/// tool dirs that pass `is_safe_system_dir`, then parent `$PATH` entries that
+/// pass `is_safe_parent_path_entry`, then `STATIC_PATH_FALLBACK`. Duplicates
+/// are dropped in first-seen order so the preference layering above is
+/// preserved.
+///
+/// `BROKK_ACP_PATH` short-circuits the whole pipeline: if set to a non-empty
+/// value the override is returned verbatim, leaving safety enforcement to the
+/// operator. Used by ops who run brokk-acp under bespoke toolchain layouts.
+pub fn discover_sandbox_path() -> String {
+    if let Ok(override_val) = std::env::var(BROKK_ACP_PATH_ENV)
+        && !override_val.trim().is_empty()
+    {
+        return override_val;
+    }
+
+    let mut entries: Vec<String> = Vec::with_capacity(16);
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut push = |dir: String| {
+        if seen.insert(dir.clone()) {
+            entries.push(dir);
+        }
+    };
+
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    if let Some(ref h) = home {
+        for rel in HOME_TOOL_DIRS {
+            let path = h.join(rel);
+            if !is_safe_home_dir(&path) {
+                continue;
+            }
+            if let Some(s) = path.to_str() {
+                push(s.to_string());
+            }
+        }
+    }
+
+    for abs in SYSTEM_TOOL_DIRS {
+        let path = PathBuf::from(abs);
+        if is_safe_system_dir(&path)
+            && let Some(s) = path.to_str()
+        {
+            push(s.to_string());
+        }
+    }
+
+    if let Some(parent_path) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&parent_path) {
+            if !is_safe_parent_path_entry(&dir) {
+                if dir.exists() {
+                    tracing::warn!(
+                        path = %dir.display(),
+                        "skipping unsafe parent PATH entry (world-writable or non-directory)"
+                    );
+                }
+                continue;
+            }
+            if let Some(s) = dir.to_str() {
+                push(s.to_string());
+            }
+        }
+    }
+
+    for abs in STATIC_PATH_FALLBACK {
+        push((*abs).to_string());
+    }
+
+    entries.join(":")
+}
+
+/// A `~`-relative tool dir is safe iff: it exists as a directory, is owned
+/// by the current uid, and has no group/world write bits set. The ownership
+/// check is the tightest of the three — anything not owned by the user has
+/// presumably been planted by another principal and is denied even if its
+/// mode bits look fine.
+#[cfg(unix)]
+fn is_safe_home_dir(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_dir() {
+        return false;
+    }
+    // SAFETY: getuid() is async-signal-safe and always succeeds.
+    let current_uid = unsafe { libc::getuid() };
+    if meta.uid() != current_uid {
+        tracing::warn!(
+            path = %path.display(),
+            owner_uid = meta.uid(),
+            current_uid,
+            "skipping home tool dir not owned by current user"
+        );
+        return false;
+    }
+    if meta.mode() & 0o022 != 0 {
+        tracing::warn!(
+            path = %path.display(),
+            mode = format!("{:o}", meta.mode() & 0o777),
+            "skipping home tool dir with group/world write bits set"
+        );
+        return false;
+    }
+    true
+}
+
+/// A fixed system tool dir (e.g. `/opt/homebrew/bin`) is safe iff: it exists
+/// as a directory and isn't world-writable. We don't require ownership-by-user
+/// because Homebrew is typically owned by the admin user, not the LLM-driving
+/// user; the deny boundary here is "any user can write to it" (mode bit 0o002).
+#[cfg(unix)]
+fn is_safe_system_dir(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_dir() {
+        return false;
+    }
+    meta.mode() & 0o002 == 0
+}
+
+/// Parent-`$PATH` entries get the lightest filter: exists + not world-writable.
+/// Anything more restrictive (e.g. ownership) is too noisy in practice — devs
+/// commonly inherit dirs from package managers, distros, and CI images that
+/// they don't personally own but trust to host binaries.
+#[cfg(unix)]
+fn is_safe_parent_path_entry(path: &Path) -> bool {
+    is_safe_system_dir(path)
+}
+
+/// Non-Unix platforms (Windows) don't have a sandbox here today; the function
+/// is only called via cfg-gated callers, but we provide a portable fallback
+/// for tests and future platforms. Existence is the only enforceable check
+/// without Unix mode bits.
+#[cfg(not(unix))]
+fn is_safe_home_dir(path: &Path) -> bool {
+    path.is_dir()
+}
+
+#[cfg(not(unix))]
+fn is_safe_system_dir(path: &Path) -> bool {
+    path.is_dir()
+}
+
+#[cfg(not(unix))]
+fn is_safe_parent_path_entry(path: &Path) -> bool {
+    path.is_dir()
+}
 
 #[cfg_attr(not(any(target_os = "linux", test)), allow(dead_code))]
 fn build_bwrap_argv(policy: SandboxPolicy, cwd: &Path, command: &str) -> Vec<String> {
@@ -462,13 +671,11 @@ fn build_bwrap_argv(policy: SandboxPolicy, cwd: &Path, command: &str) -> Vec<Str
 
     // Strip the parent process environment (PATH manipulation, LD_PRELOAD,
     // OPENAI_API_KEY/GITHUB_TOKEN/AWS_*, ...). Replace with a small whitelist
-    // plus a sanitized PATH and TERM=dumb.
+    // plus a sanitized PATH and TERM=dumb. PATH is discovered (not hardcoded)
+    // so toolchains under ~/.cargo/bin, /opt/homebrew/bin, mise/asdf shims,
+    // etc. are reachable inside the sandbox without per-host config.
     a.push("--clearenv".into());
-    a.extend([
-        "--setenv".into(),
-        "PATH".into(),
-        "/usr/local/bin:/usr/bin:/bin".into(),
-    ]);
+    a.extend(["--setenv".into(), "PATH".into(), discover_sandbox_path()]);
     a.extend(["--setenv".into(), "TERM".into(), "dumb".into()]);
     for key in ENV_WHITELIST {
         if let Some(value) = std::env::var_os(key)
@@ -726,14 +933,31 @@ mod tests {
             clearenv_idx < setenv_idx,
             "--clearenv must precede --setenv"
         );
-        // PATH and TERM must be set explicitly.
-        let has_path = argv.windows(3).any(|w| {
-            w[0] == "--setenv" && w[1] == "PATH" && w[2] == "/usr/local/bin:/usr/bin:/bin"
-        });
+        // PATH must be set via --setenv to a non-empty discovered value that
+        // still contains the static fallback dirs at the tail. We assert
+        // structurally (substring match) rather than against a fixed string
+        // because discover_sandbox_path() reflects the host's installed
+        // toolchains and varies per machine.
+        let path_value = argv
+            .windows(3)
+            .find_map(|w| {
+                if w[0] == "--setenv" && w[1] == "PATH" {
+                    Some(w[2].clone())
+                } else {
+                    None
+                }
+            })
+            .expect("PATH must be sanitized via --setenv");
+        assert!(!path_value.is_empty(), "discovered PATH must not be empty");
+        for fallback in ["/usr/local/bin", "/usr/bin", "/bin"] {
+            assert!(
+                path_value.split(':').any(|p| p == fallback),
+                "discovered PATH must keep static fallback '{fallback}', got '{path_value}'"
+            );
+        }
         let has_term = argv
             .windows(3)
             .any(|w| w[0] == "--setenv" && w[1] == "TERM" && w[2] == "dumb");
-        assert!(has_path, "PATH must be sanitized via --setenv");
         assert!(has_term, "TERM must be set to dumb via --setenv");
     }
 
@@ -760,6 +984,220 @@ mod tests {
                 !bound,
                 "credential-bearing root '{}' must not be bound",
                 forbidden
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // PATH discovery
+    // -----------------------------------------------------------------
+
+    /// Serializes tests that mutate process-wide env vars touched by
+    /// `discover_sandbox_path` (BROKK_ACP_PATH, PATH). `cargo test` runs
+    /// `#[test]` cases in parallel inside one binary, so any test that
+    /// `set_var` here must hold this lock to avoid racing readers from
+    /// sibling tests.
+    static SANDBOX_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Restores a single env var on Drop. Pair with `SANDBOX_ENV_LOCK` so
+    /// the drop ordering is deterministic and we don't leak state into
+    /// the next test.
+    struct SandboxEnvGuard {
+        var: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl SandboxEnvGuard {
+        fn set(var: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(var);
+            // SAFETY: caller holds SANDBOX_ENV_LOCK; the crate's other
+            // env-mutating tests use their own locks for non-overlapping
+            // vars (BROKK_ACP_RLIMIT_*).
+            unsafe {
+                std::env::set_var(var, value);
+            }
+            Self { var, prior }
+        }
+        fn unset(var: &'static str) -> Self {
+            let prior = std::env::var_os(var);
+            // SAFETY: same as set().
+            unsafe {
+                std::env::remove_var(var);
+            }
+            Self { var, prior }
+        }
+    }
+
+    impl Drop for SandboxEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: same as set()/unset().
+            unsafe {
+                match self.prior.take() {
+                    Some(v) => std::env::set_var(self.var, v),
+                    None => std::env::remove_var(self.var),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn discover_sandbox_path_includes_static_fallback() {
+        // With no override, the result must always contain the static
+        // fallback dirs so the existing behavior is a strict subset of
+        // the new behavior.
+        let _g = SANDBOX_ENV_LOCK.lock().unwrap();
+        let _clear = SandboxEnvGuard::unset(BROKK_ACP_PATH_ENV);
+        let path = discover_sandbox_path();
+        for fallback in ["/usr/local/bin", "/usr/bin", "/bin"] {
+            assert!(
+                path.split(':').any(|p| p == fallback),
+                "fallback '{fallback}' missing from discovered PATH '{path}'"
+            );
+        }
+    }
+
+    #[test]
+    fn discover_sandbox_path_de_duplicates_entries() {
+        // No entry should appear twice even when the parent PATH overlaps
+        // with our static fallback or with home tool dirs.
+        let _g = SANDBOX_ENV_LOCK.lock().unwrap();
+        let _clear = SandboxEnvGuard::unset(BROKK_ACP_PATH_ENV);
+        let path = discover_sandbox_path();
+        let mut seen = std::collections::HashSet::new();
+        for entry in path.split(':') {
+            assert!(
+                seen.insert(entry),
+                "PATH entry '{entry}' is duplicated: '{path}'"
+            );
+        }
+    }
+
+    #[test]
+    fn discover_sandbox_path_brokk_acp_path_override_returns_verbatim() {
+        let _g = SANDBOX_ENV_LOCK.lock().unwrap();
+        let _set = SandboxEnvGuard::set(BROKK_ACP_PATH_ENV, "/custom/bin:/another/bin");
+        let path = discover_sandbox_path();
+        assert_eq!(path, "/custom/bin:/another/bin");
+    }
+
+    #[test]
+    fn discover_sandbox_path_empty_override_falls_through_to_discovery() {
+        // A whitespace-only or empty BROKK_ACP_PATH must not short-circuit
+        // discovery -- otherwise an `export BROKK_ACP_PATH=` in a parent
+        // shell wipes the user's PATH inside the sandbox.
+        let _g = SANDBOX_ENV_LOCK.lock().unwrap();
+        let _set = SandboxEnvGuard::set(BROKK_ACP_PATH_ENV, "   ");
+        let path = discover_sandbox_path();
+        assert!(
+            path.split(':').any(|p| p == "/usr/bin"),
+            "empty override must fall through to discovery, got '{path}'"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn is_safe_system_dir_rejects_world_writable() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = std::env::temp_dir().join(format!(
+            "brokk-sandbox-test-ww-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default()
+        ));
+        std::fs::create_dir(&tmp).expect("create tmp dir");
+        let mut perms = std::fs::metadata(&tmp).unwrap().permissions();
+        perms.set_mode(0o777);
+        std::fs::set_permissions(&tmp, perms).unwrap();
+
+        assert!(
+            !is_safe_system_dir(&tmp),
+            "world-writable dir must be rejected"
+        );
+
+        // Tighten back to 0o755 and confirm acceptance.
+        let mut perms = std::fs::metadata(&tmp).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&tmp, perms).unwrap();
+        assert!(
+            is_safe_system_dir(&tmp),
+            "0o755 dir must be accepted by is_safe_system_dir"
+        );
+
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn is_safe_home_dir_rejects_group_writable() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = std::env::temp_dir().join(format!(
+            "brokk-sandbox-test-gw-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default()
+        ));
+        std::fs::create_dir(&tmp).expect("create tmp dir");
+        // Group-writable but not world-writable: passes is_safe_system_dir
+        // (which only rejects 0o002) but fails is_safe_home_dir (which
+        // rejects 0o022).
+        let mut perms = std::fs::metadata(&tmp).unwrap().permissions();
+        perms.set_mode(0o775);
+        std::fs::set_permissions(&tmp, perms).unwrap();
+
+        assert!(
+            is_safe_system_dir(&tmp),
+            "0o775 dir is fine as a system dir (only world bit matters)"
+        );
+        assert!(
+            !is_safe_home_dir(&tmp),
+            "group-writable dir must be rejected by is_safe_home_dir"
+        );
+
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[test]
+    fn is_safe_helpers_reject_nonexistent_path() {
+        let path = Path::new("/this/definitely/does/not/exist/brokk-zzz");
+        assert!(!is_safe_home_dir(path));
+        assert!(!is_safe_system_dir(path));
+        assert!(!is_safe_parent_path_entry(path));
+    }
+
+    #[test]
+    fn env_whitelist_excludes_credential_names() {
+        // Defense-in-depth: the test fails if anyone adds a name matching
+        // a credential-shaped pattern to the allowlist.
+        for key in ENV_WHITELIST {
+            let upper = key.to_ascii_uppercase();
+            for forbidden in ["TOKEN", "SECRET", "PASSWORD", "API_KEY", "AWS_", "OPENAI_"] {
+                assert!(
+                    !upper.contains(forbidden),
+                    "ENV_WHITELIST entry '{key}' looks credential-shaped (matches '{forbidden}')"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn env_whitelist_includes_expected_toolchain_pointers() {
+        for required in [
+            "CARGO_HOME",
+            "RUSTUP_HOME",
+            "NVM_DIR",
+            "ASDF_DIR",
+            "MISE_DATA_DIR",
+            "PYENV_ROOT",
+            "BUN_INSTALL",
+            "DENO_INSTALL",
+        ] {
+            assert!(
+                ENV_WHITELIST.contains(&required),
+                "ENV_WHITELIST missing expected toolchain pointer '{required}'"
             );
         }
     }

--- a/brokk-acp-rust/src/tools/shell.rs
+++ b/brokk-acp-rust/src/tools/shell.rs
@@ -16,6 +16,12 @@ const SANDBOX_BYPASS_WARNING: &str = "[WARNING] OS sandbox unavailable on this p
 /// tool is installed somewhere we didn't auto-discover. Helps the LLM and
 /// the user disambiguate "tool missing" from "PATH layout problem" without
 /// either side having to grep the source.
+///
+/// Unix-only: 127 is POSIX-specific ("command not found" from `sh`), the
+/// sandbox PATH discovery is Unix-only, and `BROKK_ACP_PATH` only has an
+/// effect on Unix. On Windows the same exit code can mean unrelated things
+/// from `cmd.exe`/PowerShell-launched children, so we don't surface this.
+#[cfg(unix)]
 const EXIT_127_HINT: &str = "\n\nHint: exit 127 typically means \"command not found\". \
 The brokk-acp sandbox builds PATH from your parent environment plus well-known toolchain \
 dirs (~/.cargo/bin, ~/.local/bin, ~/.local/share/mise/shims, ~/.asdf/shims, ~/.pyenv/shims, \
@@ -342,18 +348,28 @@ pub async fn run_shell_command(
     // so secrets in the parent process (OPENAI_API_KEY, AWS_*, GH tokens,
     // LD_PRELOAD/DYLD_*) cannot leak into LLM-driven shell calls. On Linux
     // the same scrubbing is applied via bwrap's `--clearenv`/`--setenv`.
-    // PATH is discovered (not hardcoded) so toolchains under ~/.cargo/bin,
-    // /opt/homebrew/bin, mise/asdf shims, etc. are reachable from
-    // LLM-driven shell calls. On Linux this PATH only governs how bwrap
-    // itself resolves `sh`; the inner child's PATH is set via
-    // bwrap's --setenv (sandbox.rs). On macOS Seatbelt does not alter env
-    // so this is the PATH the child actually sees.
-    let discovered_path = sandbox::discover_sandbox_path();
+    // On Unix the sandbox PATH is discovered (not hardcoded) so toolchains
+    // under ~/.cargo/bin, /opt/homebrew/bin, mise/asdf shims, etc. are
+    // reachable from LLM-driven shell calls. On Linux this PATH only
+    // governs how bwrap itself resolves `sh`; the inner child's PATH is
+    // set via bwrap's --setenv (sandbox.rs). On macOS Seatbelt does not
+    // alter env so this is the PATH the child actually sees.
+    //
+    // On Windows there is no sandbox (`wrap_platform` is a passthrough),
+    // and the home-tool-dir / Homebrew layout makes no sense, so we
+    // fall back to the historic hardcoded Unix-style PATH the platform
+    // already had. The point is to keep Windows on its prior path of
+    // behavior; deciding what `runShellCommand` *should* do on Windows
+    // is a separate concern from this issue.
+    #[cfg(unix)]
+    let sandbox_path = sandbox::discover_sandbox_path();
+    #[cfg(not(unix))]
+    let sandbox_path: String = String::from("/usr/local/bin:/usr/bin:/bin");
     let mut cmd = Command::new(&wrapped.argv[0]);
     cmd.args(&wrapped.argv[1..])
         .current_dir(cwd)
         .env_clear()
-        .env("PATH", &discovered_path)
+        .env("PATH", &sandbox_path)
         .env("TERM", "dumb")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -421,6 +437,7 @@ pub async fn run_shell_command(
             let exit_code = output.status.code().unwrap_or(-1);
             if !output.status.success() {
                 combined.push_str(&format!("\n\nExit code: {exit_code}"));
+                #[cfg(unix)]
                 if exit_code == 127 {
                     combined.push_str(EXIT_127_HINT);
                 }

--- a/brokk-acp-rust/src/tools/shell.rs
+++ b/brokk-acp-rust/src/tools/shell.rs
@@ -9,6 +9,20 @@ const MAX_OUTPUT_BYTES: usize = 100_000; // 100KB
 const SANDBOX_BYPASS_WARNING: &str = "[WARNING] OS sandbox unavailable on this platform; the command above ran without one. \
      Install bubblewrap (`apt install bubblewrap`) on Linux to enable kernel-enforced isolation.\n";
 
+/// Hint appended when the shell exits 127 (POSIX "command not found"). The
+/// sandbox uses a curated PATH that excludes anything outside the parent's
+/// safe PATH entries + the well-known toolchain dirs (see
+/// `sandbox::discover_sandbox_path`), so an exit-127 here often means the
+/// tool is installed somewhere we didn't auto-discover. Helps the LLM and
+/// the user disambiguate "tool missing" from "PATH layout problem" without
+/// either side having to grep the source.
+const EXIT_127_HINT: &str = "\n\nHint: exit 127 typically means \"command not found\". \
+The brokk-acp sandbox builds PATH from your parent environment plus well-known toolchain \
+dirs (~/.cargo/bin, ~/.local/bin, ~/.local/share/mise/shims, ~/.asdf/shims, ~/.pyenv/shims, \
+~/.bun/bin, ~/.deno/bin, /opt/homebrew/bin, /opt/homebrew/sbin, /usr/local/bin, /usr/bin, /bin). \
+If your tool's install dir is none of these, export BROKK_ACP_PATH=\"<dirs>\" in the parent \
+shell before launching brokk-acp to replace the discovered PATH.";
+
 /// Per-process rlimit caps applied to every `runShellCommand` child on Unix.
 ///
 /// These are a parallel safety net to the OS sandbox: the sandbox bounds
@@ -328,11 +342,18 @@ pub async fn run_shell_command(
     // so secrets in the parent process (OPENAI_API_KEY, AWS_*, GH tokens,
     // LD_PRELOAD/DYLD_*) cannot leak into LLM-driven shell calls. On Linux
     // the same scrubbing is applied via bwrap's `--clearenv`/`--setenv`.
+    // PATH is discovered (not hardcoded) so toolchains under ~/.cargo/bin,
+    // /opt/homebrew/bin, mise/asdf shims, etc. are reachable from
+    // LLM-driven shell calls. On Linux this PATH only governs how bwrap
+    // itself resolves `sh`; the inner child's PATH is set via
+    // bwrap's --setenv (sandbox.rs). On macOS Seatbelt does not alter env
+    // so this is the PATH the child actually sees.
+    let discovered_path = sandbox::discover_sandbox_path();
     let mut cmd = Command::new(&wrapped.argv[0]);
     cmd.args(&wrapped.argv[1..])
         .current_dir(cwd)
         .env_clear()
-        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+        .env("PATH", &discovered_path)
         .env("TERM", "dumb")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -400,6 +421,9 @@ pub async fn run_shell_command(
             let exit_code = output.status.code().unwrap_or(-1);
             if !output.status.success() {
                 combined.push_str(&format!("\n\nExit code: {exit_code}"));
+                if exit_code == 127 {
+                    combined.push_str(EXIT_127_HINT);
+                }
             }
 
             if bypass_warning {
@@ -618,6 +642,53 @@ mod tests {
         assert!(
             matches!(result.status, ToolStatus::Success),
             "unlimited FSIZE should allow an 8 KiB write; got non-success with output: {}",
+            result.output
+        );
+    }
+
+    /// `exit 127` ("command not found") triggers the BROKK_ACP_PATH hint so
+    /// the LLM and the user can tell sandbox-PATH problems from genuine
+    /// missing tools. Runs with `SandboxPolicy::None` so we don't depend on
+    /// bwrap/sandbox-exec being available in CI.
+    #[tokio::test]
+    async fn shell_exit_127_appends_brokk_acp_path_hint() {
+        let _guard = ENV_LOCK.lock().await;
+        let dir = std::env::temp_dir();
+        let result = run_shell_command(
+            &dir,
+            "nonexistent_brokk_acp_command_xyz_qqq_42",
+            30,
+            SandboxPolicy::None,
+        )
+        .await;
+        assert!(
+            result.output.contains("Hint: exit 127"),
+            "exit-127 output must contain the diagnostic hint; got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("BROKK_ACP_PATH"),
+            "hint must mention the BROKK_ACP_PATH escape hatch; got: {}",
+            result.output
+        );
+    }
+
+    /// Successful commands must NOT carry the exit-127 hint -- it would
+    /// just be noise. Pairs with `shell_exit_127_appends_brokk_acp_path_hint`
+    /// to lock in the gate condition.
+    #[tokio::test]
+    async fn shell_exit_zero_omits_hint() {
+        let _guard = ENV_LOCK.lock().await;
+        let dir = std::env::temp_dir();
+        let result = run_shell_command(&dir, "echo hello-brokk", 30, SandboxPolicy::None).await;
+        assert!(
+            matches!(result.status, ToolStatus::Success),
+            "echo must succeed; got: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("Hint: exit 127"),
+            "successful command must not contain exit-127 hint; got: {}",
             result.output
         );
     }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded sandbox `PATH=/usr/local/bin:/usr/bin:/bin` with `discover_sandbox_path()`, which merges well-known toolchain dirs (`~/.cargo/bin`, mise/asdf/pyenv shims, `~/.bun/bin`, `~/.deno/bin`, `/opt/homebrew/{bin,sbin}`), parent `$PATH` entries that pass a safety filter, and the historic static fallback — deduped in preference order.
- Expands `ENV_WHITELIST` with toolchain-manager pointers (`CARGO_HOME`, `RUSTUP_HOME`, `NVM_DIR`, `FNM_DIR`, `ASDF_*`, `MISE_*`, `PYENV_ROOT`, `BUN_INSTALL`, `DENO_INSTALL`) plus locale/terminal hints (`LC_CTYPE`, `COLUMNS`, `LINES`). No credential-shaped names admitted.
- Wires the discovered PATH into both sides that matter: `Command::env("PATH", ...)` in `shell.rs` (effective on macOS Seatbelt and the no-bwrap fallback) and `--setenv PATH` for bwrap in `sandbox.rs` (effective inside the Linux sandbox).
- Adds an exit-127 diagnostic hint to `runShellCommand` output so `command not found` doesn't look identical to `tool is genuinely missing`.
- Adds a `BROKK_ACP_PATH` escape hatch: set on the parent process, it fully replaces the discovered PATH inside the sandbox without us having to enumerate every package manager.

Closes #3543.

## Why

The sandbox stripped the parent environment and pinned PATH to three directories. On a stock developer Mac with rustup + Homebrew + mise, that meant LLM-issued `cargo test`, `npm --version`, `python3 --version`, etc. all failed with `command not found` despite working fine outside the sandbox. The strip-and-allowlist posture is still correct; the allowlist just needed to match what real developer machines look like in 2026.

## Implementation notes

- Three safety tiers, applied per candidate dir:
  - Home-relative dirs (`HOME_TOOL_DIRS`): must exist, be owned by the current uid, and have no group/world write bits. `metadata()` follows symlinks, so an attacker-planted `~/.cargo/bin -> /tmp/evil` is rejected because the target's uid won't match.
  - Fixed system dirs (`SYSTEM_TOOL_DIRS` like `/opt/homebrew/bin`): must exist and not be world-writable. Ownership is not required because Homebrew dirs are typically owned by the admin user, not the LLM-driving user.
  - Parent `$PATH` entries: same as system dirs — anything more restrictive (e.g. ownership) is too noisy in practice and drops dirs from package managers and distro images that devs legitimately rely on.
- `BROKK_ACP_PATH` is read with a non-empty check; an empty or whitespace-only value falls through to discovery so a stray `export BROKK_ACP_PATH=` in a parent shell doesn't wipe the user's PATH.
- The historic test that asserted PATH equals the literal `"/usr/local/bin:/usr/bin:/bin"` migrated to a structural assertion (each fallback dir is still in the discovered PATH). Resilient to per-machine variation while still gating against accidental removal of the fallback dirs.
- The exit-127 hint mentions only the toolchain dirs we auto-discover and the `BROKK_ACP_PATH` escape hatch — no leaking of internal paths or environment.

## Out of scope

- Bringing parity with Java's `Environment.java` env handling — that path inherits the parent env wholesale, which is exactly what this sandbox is stricter than.
- Filesystem sandbox changes (bind mounts, RO/RW rules). Untouched.
- Per-tool PATH overrides or persisted user preferences. The CLI `--default-model`-style flag pattern wasn't needed here; the env var is the operator-facing knob.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 174 passed, 0 failed (11 new: PATH discovery, override semantics, safety helpers, ENV_WHITELIST shape, exit-127 hint)
- [ ] Manual: `cargo --version`, `npm --version`, `python3 --version` inside an LLM-issued `runShellCommand` on a host with rustup + Homebrew + mise installed.
- [ ] Manual: confirm `*_API_KEY`, `AWS_*`, `GH_TOKEN`, `OPENAI_*` parent env is **not** observable inside the sandbox even when set in the parent process (the existing strip-and-allowlist guarantee is preserved).
- [ ] Manual: set `BROKK_ACP_PATH=/custom/bin:/another/bin` in the parent shell and confirm the sandbox PATH matches verbatim.
