### PR TITLE
feat(brokk-acp-rust): per-session reasoning_effort knob for ChatGPT Codex (#3542)

### DIFF
--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -19,7 +19,7 @@ use agent_client_protocol::{
 };
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::llm_client::{ChatMessage, LlmBackend};
+use crate::llm_client::{ChatMessage, LlmBackend, ModelMetadata};
 use crate::multi_backend::MultiBackend;
 use crate::session::{
     ConversationTurn, PermissionMode, SessionMode, SessionSnapshot, SessionStore,
@@ -34,6 +34,14 @@ const BEHAVIOR_CONFIG_ID: &str = "behavior_mode";
 /// Mirrors the Java executor's wire id so cross-implementation clients
 /// (Zed, brokk-code) can drive model selection through one canonical name.
 const MODEL_CONFIG_ID: &str = "model_selection";
+/// Per-session reasoning-effort knob, scoped to the Codex/ChatGPT backend.
+/// Empty string in the wire payload clears the user's pick (back to the
+/// model's `default_reasoning_level`).
+const REASONING_EFFORT_CONFIG_ID: &str = "reasoning_effort";
+/// Sentinel value the client sends to clear the user's pick. We accept
+/// either an empty string or this token so editor implementations that
+/// strip-trim selection ids still work.
+const REASONING_EFFORT_DEFAULT_VALUE: &str = "(default)";
 
 /// Available session modes exposed to ACP clients.
 fn available_modes() -> Vec<AcpSessionMode> {
@@ -116,22 +124,94 @@ fn model_config_option(current: &str, available_models: &[String]) -> Option<Ses
     )
 }
 
+/// Build the reasoning-effort `SessionConfigOption` for the active model.
+/// Returns `None` when the model exposes no presets (e.g. an Ollama model
+/// or a Codex slug whose `supported_reasoning_levels` is empty) -- the
+/// dropdown is omitted entirely in that case rather than shown empty.
+///
+/// Layout: an explicit "(default)" entry at the head represents "no user
+/// pick, server uses `default_reasoning_level`". The user's stored pick
+/// (`current`) selects whichever option matches; when no pick exists, the
+/// default entry is selected so the picker reflects actual intent.
+fn reasoning_effort_config_option(
+    current: Option<&str>,
+    catalog: &[ModelMetadata],
+    current_model: &str,
+) -> Option<SessionConfigOption> {
+    let model = catalog.iter().find(|m| m.id == current_model)?;
+    if model.supported_reasoning_levels.is_empty() {
+        return None;
+    }
+    let default_label = match &model.default_reasoning_level {
+        Some(d) => format!("Default ({d})"),
+        None => "Default".to_string(),
+    };
+    let mut options = vec![
+        SessionConfigSelectOption::new(REASONING_EFFORT_DEFAULT_VALUE, default_label)
+            .description("Use the model's default reasoning effort."),
+    ];
+    options.extend(model.supported_reasoning_levels.iter().map(|preset| {
+        let opt = SessionConfigSelectOption::new(preset.effort.clone(), preset.effort.clone());
+        if preset.description.is_empty() {
+            opt
+        } else {
+            opt.description(preset.description.clone())
+        }
+    }));
+    // Coerce out-of-catalog picks (e.g. stale from before a slug bump)
+    // to the default sentinel so the picker always renders against an
+    // entry it advertises.
+    let current_value = match current {
+        Some(eff)
+            if model
+                .supported_reasoning_levels
+                .iter()
+                .any(|p| p.effort == eff) =>
+        {
+            eff.to_string()
+        }
+        _ => REASONING_EFFORT_DEFAULT_VALUE.to_string(),
+    };
+    Some(
+        SessionConfigOption::select(
+            REASONING_EFFORT_CONFIG_ID,
+            "Reasoning effort",
+            current_value,
+            options,
+        )
+        .description(
+            "Controls how much chain-of-thought the model spends on each turn. \
+             Higher levels are deeper but slower and cost more against your plan's quota.",
+        )
+        .category(SessionConfigOptionCategory::Model),
+    )
+}
+
 /// All configOption selectors we expose, in display order. The model
 /// selector is appended only when the LLM catalog is known; clients that
 /// drive model selection through the meta extension still see the current
-/// model via `meta.brokk.modelId`.
+/// model via `meta.brokk.modelId`. The reasoning-effort selector is appended
+/// only when the active model publishes presets (Codex/ChatGPT models do,
+/// Ollama models don't).
 fn all_config_options(
     behavior: SessionMode,
     permission: PermissionMode,
     current_model: &str,
-    available_models: &[String],
+    available_models: &[ModelMetadata],
+    current_reasoning_effort: Option<&str>,
 ) -> Vec<SessionConfigOption> {
+    let model_ids: Vec<String> = available_models.iter().map(|m| m.id.clone()).collect();
     let mut opts = vec![
         behavior_config_option(behavior),
         permission_config_option(permission),
     ];
-    if let Some(model_opt) = model_config_option(current_model, available_models) {
+    if let Some(model_opt) = model_config_option(current_model, &model_ids) {
         opts.push(model_opt);
+    }
+    if let Some(re_opt) =
+        reasoning_effort_config_option(current_reasoning_effort, available_models, current_model)
+    {
+        opts.push(re_opt);
     }
     opts
 }
@@ -177,7 +257,7 @@ fn spawn_throttled_refresh(
             // next try_lock observes "in flight". Drop is implicit at
             // the end of the spawned future.
             let _refresh_guard = guard;
-            match llm.list_models().await {
+            match llm.list_model_metadata().await {
                 Ok(models) => {
                     tracing::debug!(
                         count = models.len(),
@@ -247,7 +327,7 @@ pub async fn run_agent(
                 tracing::info!("ACP initialize");
 
                 // Try to discover models at startup and cache them for session/new.
-                let models = match llm_init.list_models().await {
+                let models = match llm_init.list_model_metadata().await {
                     Ok(m) => m,
                     Err(e) => {
                         tracing::warn!("model discovery failed during init: {e}");
@@ -255,7 +335,7 @@ pub async fn run_agent(
                     }
                 };
                 if let Some(first) = models.first() {
-                    sessions_init.set_default_model(first.clone()).await;
+                    sessions_init.set_default_model(first.id.clone()).await;
                 }
                 sessions_init.set_available_models(models).await;
 
@@ -296,16 +376,19 @@ pub async fn run_agent(
                     sessions_new.clone(),
                 );
 
-                // Use the cached list populated at init; fall back to the session's own model.
-                let mut models = sessions_new.available_models().await;
-                if models.is_empty() && !session.model.is_empty() {
-                    models = vec![session.model.clone()];
+                // Use the cached catalog populated at init; fall back to a
+                // single-entry catalog from the session's own model so the
+                // dropdown still renders something on a fresh discovery miss.
+                let mut catalog = sessions_new.available_model_metadata().await;
+                if catalog.is_empty() && !session.model.is_empty() {
+                    catalog = vec![ModelMetadata::id_only(&session.model)];
                 }
+                let model_ids: Vec<String> = catalog.iter().map(|m| m.id.clone()).collect();
 
                 let meta_value = serde_json::json!({
                     "brokk": {
                         "modelId": session.model,
-                        "availableModels": models,
+                        "availableModels": model_ids,
                     }
                 });
                 let meta_map = match meta_value {
@@ -319,7 +402,8 @@ pub async fn run_agent(
                         session.mode,
                         session.permission_mode,
                         &session.model,
-                        &models,
+                        &catalog,
+                        session.selected_reasoning_effort.as_deref(),
                     ))
                     .meta(meta_map);
 
@@ -361,7 +445,7 @@ pub async fn run_agent(
                     }
                 }
 
-                let models = sessions_load.available_models().await;
+                let catalog = sessions_load.available_model_metadata().await;
                 send_available_commands_update(&cx, &session_id);
 
                 responder.respond(
@@ -371,7 +455,8 @@ pub async fn run_agent(
                             session.mode,
                             session.permission_mode,
                             &session.model,
-                            &models,
+                            &catalog,
+                            session.selected_reasoning_effort.as_deref(),
                         )),
                 )
             },
@@ -389,7 +474,7 @@ pub async fn run_agent(
                 match sessions_resume.get_session(&session_id, &cwd).await {
                     Some(session) => {
                         sessions_resume.update_cwd(&session_id, cwd).await;
-                        let models = sessions_resume.available_models().await;
+                        let catalog = sessions_resume.available_model_metadata().await;
                         send_available_commands_update(&cx, &session_id);
                         responder.respond(
                             ResumeSessionResponse::new()
@@ -398,7 +483,8 @@ pub async fn run_agent(
                                     session.mode,
                                     session.permission_mode,
                                     &session.model,
-                                    &models,
+                                    &catalog,
+                                    session.selected_reasoning_effort.as_deref(),
                                 )),
                         )
                     }
@@ -527,6 +613,7 @@ pub async fn run_agent(
                 let session_id_for_loop = session_id.clone();
                 let prompt_text_for_turn = prompt_text;
                 let model_for_loop = snap.model;
+                let reasoning_effort_for_loop = snap.reasoning_effort;
 
                 cx.spawn(async move {
                     use futures::FutureExt;
@@ -534,11 +621,21 @@ pub async fn run_agent(
 
                     let cx_text = cx_for_loop.clone();
                     let sid_text = session_id_for_loop.clone();
+                    let cx_thought = cx_for_loop.clone();
+                    let sid_thought = session_id_for_loop.clone();
 
                     // Text tokens stream to the client in real time via this shared sink.
                     let text_sink: crate::tool_loop::TextSink = std::sync::Arc::new(
                         std::sync::Mutex::new(move |token: &str| {
                             send_message(&cx_text, &sid_text, token);
+                        }),
+                    );
+                    // Reasoning deltas stream into the dedicated ACP
+                    // thought channel so the client can render them as
+                    // a collapsible block separate from the final answer.
+                    let thought_sink: crate::tool_loop::TextSink = std::sync::Arc::new(
+                        std::sync::Mutex::new(move |token: &str| {
+                            send_thought(&cx_thought, &sid_thought, token);
                         }),
                     );
 
@@ -555,10 +652,12 @@ pub async fn run_agent(
                         &llm_for_loop,
                         &registry,
                         &model_for_loop,
+                        reasoning_effort_for_loop.as_deref(),
                         messages,
                         max_turns,
                         cancel,
                         text_sink,
+                        thought_sink,
                         spawned_cx,
                         session_id_for_loop.clone(),
                         sessions_for_loop.clone(),
@@ -781,7 +880,82 @@ pub async fn run_agent(
                                 ),
                             );
                         }
-                        if !sessions_perm.set_model(&session_id, value.clone()).await {
+                        let (ok, cleared_effort) =
+                            sessions_perm.set_model(&session_id, value.clone()).await;
+                        if !ok {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::invalid_params().data(
+                                    serde_json::json!({
+                                        "reason": format!("unknown session '{session_id}'"),
+                                    }),
+                                ),
+                            );
+                        }
+                        // Auto-fallback notice: when the previous
+                        // reasoning_effort pick isn't in the new model's
+                        // supported set, the store drops it. Surface a
+                        // one-line system note so the silent change
+                        // isn't mysterious next time the user wonders
+                        // why thoughts shortened.
+                        if let Some(prev) = cleared_effort {
+                            send_message(
+                                &cx,
+                                &session_id,
+                                &format!(
+                                    "Reasoning effort reset: `{prev}` is not supported by `{value}`. \
+                                     Using model default until you pick a level."
+                                ),
+                            );
+                        }
+                    }
+                    REASONING_EFFORT_CONFIG_ID => {
+                        // Empty string or the "(default)" sentinel both
+                        // mean "clear my pick, use the model default".
+                        let effort = if value.is_empty() || value == REASONING_EFFORT_DEFAULT_VALUE
+                        {
+                            None
+                        } else {
+                            Some(value.clone())
+                        };
+                        // Validate against the active model's published
+                        // levels when one is known. An unknown catalog
+                        // (e.g. discovery never finished) accepts any
+                        // string so a manually-configured backend still
+                        // works.
+                        if let Some(eff) = &effort {
+                            let fallback_cwd = std::env::current_dir().unwrap_or_default();
+                            let active_model = sessions_perm
+                                .get_session(&session_id, &fallback_cwd)
+                                .await
+                                .map(|s| s.model);
+                            let catalog = sessions_perm.available_model_metadata().await;
+                            if let Some(model_id) = active_model
+                                && let Some(meta) =
+                                    catalog.iter().find(|m| m.id == model_id)
+                                && !meta.supported_reasoning_levels.is_empty()
+                                && !meta
+                                    .supported_reasoning_levels
+                                    .iter()
+                                    .any(|p| &p.effort == eff)
+                            {
+                                let supported: Vec<String> = meta
+                                    .supported_reasoning_levels
+                                    .iter()
+                                    .map(|p| p.effort.clone())
+                                    .collect();
+                                return responder.respond_with_error(
+                                    agent_client_protocol::Error::invalid_params().data(
+                                        serde_json::json!({
+                                            "reason": format!(
+                                                "reasoning effort '{eff}' is not supported by model '{model_id}'"
+                                            ),
+                                            "supported": supported,
+                                        }),
+                                    ),
+                                );
+                            }
+                        }
+                        if !sessions_perm.set_reasoning_effort(&session_id, effort).await {
                             return responder.respond_with_error(
                                 agent_client_protocol::Error::invalid_params().data(
                                     serde_json::json!({
@@ -800,6 +974,7 @@ pub async fn run_agent(
                                         BEHAVIOR_CONFIG_ID,
                                         PERMISSION_CONFIG_ID,
                                         MODEL_CONFIG_ID,
+                                        REASONING_EFFORT_CONFIG_ID,
                                     ],
                                 }),
                             ),
@@ -820,12 +995,13 @@ pub async fn run_agent(
                         })),
                     );
                 };
-                let models = sessions_perm.available_models().await;
+                let catalog = sessions_perm.available_model_metadata().await;
                 let updated_options = all_config_options(
                     session.mode,
                     session.permission_mode,
                     &session.model,
-                    &models,
+                    &catalog,
+                    session.selected_reasoning_effort.as_deref(),
                 );
 
                 let notification = SessionNotification::new(
@@ -889,6 +1065,20 @@ fn send_user_message(cx: &ConnectionTo<Client>, session_id: &str, text: &str) {
     let notification = SessionNotification::new(session_id.to_string(), update);
     if let Err(e) = cx.send_notification(notification) {
         tracing::warn!("failed to send user session update: {e}");
+    }
+}
+
+/// Send an agent_thought_chunk session update to the client. Mirrors
+/// `send_message` but routes through ACP 0.12's `AgentThoughtChunk`
+/// variant so the client renders reasoning text as a distinct,
+/// typically-collapsible block instead of interleaving it with the
+/// final answer.
+fn send_thought(cx: &ConnectionTo<Client>, session_id: &str, text: &str) {
+    let chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(text)));
+    let update = SessionUpdate::AgentThoughtChunk(chunk);
+    let notification = SessionNotification::new(session_id.to_string(), update);
+    if let Err(e) = cx.send_notification(notification) {
+        tracing::warn!("failed to send thought session update: {e}");
     }
 }
 
@@ -1311,6 +1501,7 @@ mod tests {
                 agent_response: "ok".repeat(8),
                 ..Default::default()
             }],
+            reasoning_effort: None,
         };
         let report = render_context_report(&snap, PermissionMode::AcceptEdits, &["gpt-99".into()]);
 
@@ -1333,6 +1524,7 @@ mod tests {
             mode: SessionMode::Lutz,
             model: String::new(),
             history: vec![],
+            reasoning_effort: None,
         };
         let report = render_context_report(&snap, PermissionMode::Default, &[]);
         assert!(report.contains("Model: `(none)`"));
@@ -1355,6 +1547,7 @@ mod tests {
                 agent_response: "a language".into(),
                 ..Default::default()
             }],
+            reasoning_effort: None,
         };
         let msgs = build_prompt_messages(&snap, "follow up");
         // system + user(history) + assistant(history) + user(new)
@@ -1397,6 +1590,7 @@ mod tests {
                     },
                 ],
             }],
+            reasoning_effort: None,
         };
         let msgs = build_prompt_messages(&snap, "now fix them");
 
@@ -1443,6 +1637,7 @@ mod tests {
             mode: SessionMode::Lutz,
             model: "m".into(),
             history: vec![],
+            reasoning_effort: None,
         };
         let msgs = build_prompt_messages(&snap, "hi");
         assert_eq!(msgs.len(), 2);
@@ -1476,6 +1671,7 @@ mod tests {
                     result: "no matches".into(),
                 }],
             }],
+            reasoning_effort: None,
         };
         let msgs = build_prompt_messages(&snap, "next");
 

--- a/brokk-acp-rust/src/codex_client.rs
+++ b/brokk-acp-rust/src/codex_client.rs
@@ -35,7 +35,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::codex_auth::{AuthDotJson, is_stale, read_auth_dot_json, refresh_if_stale, urlencode};
 use crate::llm_client::{
-    ChatMessage, FunctionCall, LlmBackend, LlmResponse, ToolCall, ToolDefinition,
+    ChatMessage, FunctionCall, LlmBackend, LlmResponse, ModelMetadata, ReasoningLevelPreset,
+    ToolCall, ToolDefinition,
 };
 
 // Codex CLI's `chatgpt_base_url` default is
@@ -215,30 +216,39 @@ impl CodexClient {
         ChatGptCredentials::from_auth(&auth)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn stream_chat_impl(
         &self,
         model: String,
         messages: Vec<ChatMessage>,
         tools: Option<Vec<ToolDefinition>>,
+        reasoning_effort: Option<String>,
         on_token: Box<dyn FnMut(&str) + Send>,
+        on_thought: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
     ) -> Result<LlmResponse> {
         let creds = self.load_credentials().await?;
-        let body = build_responses_request(&model, &messages, tools.as_deref());
+        let body = build_responses_request(
+            &model,
+            &messages,
+            tools.as_deref(),
+            reasoning_effort.as_deref(),
+        );
         match self
-            .send_responses_request(&creds, &body, on_token, cancel.clone())
+            .send_responses_request(&creds, &body, on_token, on_thought, cancel.clone())
             .await
         {
             Ok(resp) => Ok(resp),
             Err(e) if is_unauthorized(&e) => {
                 tracing::info!("ChatGPT backend returned 401; refreshing tokens and retrying once");
                 let creds = self.force_refresh().await?;
-                // Caller's on_token sink is consumed by the first attempt;
-                // build a no-op sink for the retry so the trait stays
-                // FnMut-only. Streaming text from the retry still flows
-                // back via `LlmResponse::Text`.
-                let noop: Box<dyn FnMut(&str) + Send> = Box::new(|_| {});
-                self.send_responses_request(&creds, &body, noop, cancel)
+                // Caller's on_token/on_thought sinks are consumed by the first
+                // attempt; build no-op sinks for the retry so the trait stays
+                // FnMut-only. Streaming text from the retry still flows back
+                // via `LlmResponse::Text`.
+                let noop_token: Box<dyn FnMut(&str) + Send> = Box::new(|_| {});
+                let noop_thought: Box<dyn FnMut(&str) + Send> = Box::new(|_| {});
+                self.send_responses_request(&creds, &body, noop_token, noop_thought, cancel)
                     .await
             }
             Err(e) => Err(e),
@@ -250,6 +260,7 @@ impl CodexClient {
         creds: &ChatGptCredentials,
         body: &ResponsesRequest,
         on_token: Box<dyn FnMut(&str) + Send>,
+        on_thought: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
     ) -> Result<LlmResponse> {
         let req = self
@@ -275,10 +286,10 @@ impl CodexClient {
             .bytes_stream()
             .map(|r| r.map(|b| b.to_vec()).map_err(anyhow::Error::from));
 
-        drive_responses_sse_stream(stream, on_token, cancel, IDLE_CHUNK_TIMEOUT).await
+        drive_responses_sse_stream(stream, on_token, on_thought, cancel, IDLE_CHUNK_TIMEOUT).await
     }
 
-    /// Discover usable model slugs by hitting `chatgpt.com/backend-api/codex/models`.
+    /// Discover usable models by hitting `chatgpt.com/backend-api/codex/models`.
     /// We deliberately don't ship a hardcoded picker any more: the
     /// model lineup moves faster than our release cadence, and shipping
     /// stale slugs (e.g. `gpt-5-pro` after that family is retired)
@@ -287,27 +298,27 @@ impl CodexClient {
     /// (`FALLBACK_CHATGPT_MODEL`) so ACP `initialize` still advertises
     /// *something*; the user can override via `--default-model` or the
     /// `/config` model picker.
-    async fn list_models_impl(&self) -> Result<Vec<String>> {
+    async fn list_model_metadata_impl(&self) -> Result<Vec<ModelMetadata>> {
         let creds = match self.load_credentials().await {
             Ok(c) => c,
             Err(e) => {
                 tracing::warn!("skipping ChatGPT model discovery (credentials not ready): {e:#}");
-                return Ok(vec![FALLBACK_CHATGPT_MODEL.to_string()]);
+                return Ok(vec![ModelMetadata::id_only(FALLBACK_CHATGPT_MODEL)]);
             }
         };
         match fetch_chatgpt_models(&self.http, &creds).await {
-            Ok(slugs) if !slugs.is_empty() => Ok(slugs),
+            Ok(models) if !models.is_empty() => Ok(models),
             Ok(_) => {
                 tracing::warn!(
                     "ChatGPT /models endpoint returned no slugs; falling back to {FALLBACK_CHATGPT_MODEL}"
                 );
-                Ok(vec![FALLBACK_CHATGPT_MODEL.to_string()])
+                Ok(vec![ModelMetadata::id_only(FALLBACK_CHATGPT_MODEL)])
             }
             Err(e) => {
                 tracing::warn!(
                     "ChatGPT model discovery failed ({CHATGPT_MODELS_URL}): {e:#}; falling back to {FALLBACK_CHATGPT_MODEL}"
                 );
-                Ok(vec![FALLBACK_CHATGPT_MODEL.to_string()])
+                Ok(vec![ModelMetadata::id_only(FALLBACK_CHATGPT_MODEL)])
             }
         }
     }
@@ -327,7 +338,7 @@ impl CodexClient {
 async fn fetch_chatgpt_models(
     http: &reqwest::Client,
     creds: &ChatGptCredentials,
-) -> Result<Vec<String>> {
+) -> Result<Vec<ModelMetadata>> {
     let url = format!(
         "{CHATGPT_MODELS_URL}?client_version={}",
         urlencode(CODEX_COMPAT_CLIENT_VERSION)
@@ -394,7 +405,18 @@ async fn fetch_chatgpt_models(
         models.len(),
         models.iter().map(|m| m.slug.as_str()).collect::<Vec<_>>()
     );
-    Ok(models.into_iter().map(|m| m.slug).collect())
+    Ok(models
+        .into_iter()
+        .map(|m| ModelMetadata {
+            id: m.slug,
+            default_reasoning_level: m.default_reasoning_level,
+            supported_reasoning_levels: m
+                .supported_reasoning_levels
+                .into_iter()
+                .map(ReasoningLevelPreset::from)
+                .collect(),
+        })
+        .collect())
 }
 
 /// Render up to `limit` bytes of `body` as a debug-safe string. Used
@@ -430,11 +452,50 @@ struct ChatGptModelEntry {
     /// picker. Default to 0 if absent so missing-field models sort last.
     #[serde(default)]
     priority: i32,
+    /// Effort preset the server applies when the client doesn't specify
+    /// one. Used as the picker's initial value and as the fallback when
+    /// the user switches to a model that doesn't advertise their current
+    /// pick.
+    #[serde(default)]
+    default_reasoning_level: Option<String>,
+    /// Distinct reasoning-effort presets the model accepts. Each entry
+    /// carries the wire `effort` token (low/medium/high/xhigh) and a
+    /// server-written description we surface in the ACP picker so users
+    /// know what each level actually means.
+    #[serde(default)]
+    supported_reasoning_levels: Vec<ChatGptReasoningLevel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatGptReasoningLevel {
+    effort: String,
+    #[serde(default)]
+    description: String,
+}
+
+impl From<ChatGptReasoningLevel> for ReasoningLevelPreset {
+    fn from(value: ChatGptReasoningLevel) -> Self {
+        Self {
+            effort: value.effort,
+            description: value.description,
+        }
+    }
 }
 
 impl LlmBackend for CodexClient {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>>> {
-        Box::pin(self.list_models_impl())
+        Box::pin(async move {
+            Ok(self
+                .list_model_metadata_impl()
+                .await?
+                .into_iter()
+                .map(|m| m.id)
+                .collect())
+        })
+    }
+
+    fn list_model_metadata(&self) -> BoxFuture<'_, Result<Vec<ModelMetadata>>> {
+        Box::pin(self.list_model_metadata_impl())
     }
 
     fn stream_chat(
@@ -442,11 +503,22 @@ impl LlmBackend for CodexClient {
         model: &str,
         messages: Vec<ChatMessage>,
         tools: Option<Vec<ToolDefinition>>,
+        reasoning_effort: Option<&str>,
         on_token: Box<dyn FnMut(&str) + Send>,
+        on_thought: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
     ) -> BoxFuture<'_, Result<LlmResponse>> {
         let model = model.to_string();
-        Box::pin(self.stream_chat_impl(model, messages, tools, on_token, cancel))
+        let reasoning_effort = reasoning_effort.map(str::to_string);
+        Box::pin(self.stream_chat_impl(
+            model,
+            messages,
+            tools,
+            reasoning_effort,
+            on_token,
+            on_thought,
+            cancel,
+        ))
     }
 }
 
@@ -539,6 +611,18 @@ pub(crate) struct ResponsesRequest {
     /// session/turn persistence and we don't want a side-channel copy
     /// living on OpenAI's storage tied to the user's subscription.
     pub(crate) store: bool,
+    /// Optional per-request reasoning-effort override. The agent layer
+    /// resolves "no pick" to the active model's `default_reasoning_level`
+    /// upstream so the omitted-vs-explicit distinction here directly
+    /// reflects user intent: omit (None) = let the server pick; present =
+    /// honor the level the user asked for in the picker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) reasoning: Option<ReasoningConfig>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ReasoningConfig {
+    pub(crate) effort: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -587,6 +671,7 @@ pub(crate) fn build_responses_request(
     model: &str,
     messages: &[ChatMessage],
     tools: Option<&[ToolDefinition]>,
+    reasoning_effort: Option<&str>,
 ) -> ResponsesRequest {
     let mut instructions_parts: Vec<String> = Vec::new();
     let mut input: Vec<ResponsesInputItem> = Vec::new();
@@ -674,6 +759,10 @@ pub(crate) fn build_responses_request(
         Some(instructions_parts.join("\n\n"))
     };
 
+    let reasoning = reasoning_effort.map(|effort| ReasoningConfig {
+        effort: effort.to_string(),
+    });
+
     ResponsesRequest {
         model: model.to_string(),
         instructions,
@@ -683,6 +772,7 @@ pub(crate) fn build_responses_request(
         parallel_tool_calls: true,
         stream: true,
         store: false,
+        reasoning,
     }
 }
 
@@ -691,9 +781,10 @@ pub(crate) fn build_responses_request(
 // ---------------------------------------------------------------------------
 
 /// Subset of `ResponsesStreamEvent` from codex-rs we actually consume.
-/// Unknown event types (`response.reasoning_summary_text.delta`,
-/// `response.metadata`, etc.) deserialize successfully but contribute
-/// nothing -- we surface only text deltas and final-shape items.
+/// Text deltas surface via `on_token`; reasoning deltas (`response.reasoning_text.delta`,
+/// `response.reasoning_summary_text.delta`) route to `on_thought`; other unknown event
+/// types (`response.metadata`, rate-limit snapshots, etc.) deserialize successfully but
+/// contribute nothing beyond resetting the idle timer.
 #[derive(Debug, Deserialize)]
 struct StreamEvent {
     #[serde(rename = "type")]
@@ -771,6 +862,7 @@ enum OutputItemContent {
 async fn drive_responses_sse_stream<S>(
     mut stream: S,
     mut on_token: Box<dyn FnMut(&str) + Send>,
+    mut on_thought: Box<dyn FnMut(&str) + Send>,
     cancel: CancellationToken,
     idle: Duration,
 ) -> Result<LlmResponse>
@@ -919,10 +1011,28 @@ where
                             completed = true;
                             break;
                         }
-                        // Reasoning summaries, metadata, rate-limit
-                        // snapshots, etc. -- we don't surface them but
-                        // count them as activity so the idle timer
-                        // doesn't fire mid-think.
+                        // Chain-of-thought deltas: route to the
+                        // dedicated `on_thought` sink (the agent layer
+                        // wraps it as an ACP `AgentThoughtChunk` so
+                        // clients can render reasoning text in a
+                        // collapsible block rather than interleaved
+                        // with the final answer). Both event names
+                        // exist because Codex publishes raw reasoning
+                        // text on the high-effort path and condensed
+                        // summaries elsewhere; both belong in the
+                        // same channel for the client.
+                        "response.reasoning_text.delta"
+                        | "response.reasoning_summary_text.delta" => {
+                            if let Some(delta) = event.delta {
+                                made_progress = true;
+                                on_thought(&delta);
+                            }
+                        }
+                        // Other unmodeled events (metadata, rate-limit
+                        // snapshots, output_item.added etc.) -- we
+                        // don't surface them but count them as
+                        // activity so the idle timer doesn't fire
+                        // mid-think.
                         _ => {
                             made_progress = true;
                         }
@@ -969,6 +1079,12 @@ mod tests {
         Box::new(move |t: &str| buf.lock().unwrap().push_str(t))
     }
 
+    /// Throwaway thought sink for SSE tests that don't care about
+    /// reasoning text. Kept inline so each test reads top-to-bottom.
+    fn noop_sink() -> Box<dyn FnMut(&str) + Send> {
+        Box::new(|_| {})
+    }
+
     #[test]
     fn build_request_collapses_system_messages_into_instructions() {
         let messages = vec![
@@ -976,7 +1092,7 @@ mod tests {
             ChatMessage::system("also be brief"),
             ChatMessage::user("hi"),
         ];
-        let req = build_responses_request("gpt-5-codex", &messages, None);
+        let req = build_responses_request("gpt-5-codex", &messages, None, None);
         assert_eq!(
             req.instructions.as_deref(),
             Some("be helpful\n\nalso be brief")
@@ -1013,7 +1129,7 @@ mod tests {
             }]),
             ChatMessage::tool_result("fc_abc", "search", "no results"),
         ];
-        let req = build_responses_request("gpt-5-codex", &messages, None);
+        let req = build_responses_request("gpt-5-codex", &messages, None, None);
         assert_eq!(req.input.len(), 3);
         match &req.input[1] {
             ResponsesInputItem::FunctionCall {
@@ -1046,7 +1162,7 @@ mod tests {
                 parameters: json!({"type": "object", "properties": {}}),
             },
         }];
-        let req = build_responses_request("gpt-5", &[ChatMessage::user("hi")], Some(&tools));
+        let req = build_responses_request("gpt-5", &[ChatMessage::user("hi")], Some(&tools), None);
         let serialized = serde_json::to_value(&req).unwrap();
         let tools = serialized.get("tools").unwrap().as_array().unwrap();
         assert_eq!(tools.len(), 1);
@@ -1079,12 +1195,42 @@ mod tests {
             tool_call_id: None,
             name: None,
         }];
-        let req = build_responses_request("gpt-5", &messages, None);
+        let req = build_responses_request("gpt-5", &messages, None, None);
         assert_eq!(req.input.len(), 1);
         assert!(matches!(
             req.input[0],
             ResponsesInputItem::FunctionCall { .. }
         ));
+    }
+
+    #[test]
+    fn build_request_emits_reasoning_when_effort_is_set() {
+        // The Responses API takes `reasoning: { "effort": "..." }`. The
+        // agent layer is responsible for resolving "user has no pick"
+        // to either the model's `default_reasoning_level` or None
+        // before reaching here, so an explicit Some(_) here is direct
+        // user intent and must appear on the wire.
+        let req =
+            build_responses_request("gpt-5.5", &[ChatMessage::user("hi")], None, Some("xhigh"));
+        let serialized = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            serialized.get("reasoning"),
+            Some(&serde_json::json!({"effort": "xhigh"}))
+        );
+    }
+
+    #[test]
+    fn build_request_omits_reasoning_when_effort_is_none() {
+        // No pick = let the server use its own default. The field is
+        // skip_serializing_if=Option::is_none so it must not appear at
+        // all (vs. being present with a null/empty value, which the
+        // server would reject as an invalid effort).
+        let req = build_responses_request("gpt-5.5", &[ChatMessage::user("hi")], None, None);
+        let serialized = serde_json::to_value(&req).unwrap();
+        assert!(
+            serialized.get("reasoning").is_none(),
+            "reasoning field must be omitted entirely when effort is None"
+        );
     }
 
     #[tokio::test]
@@ -1100,9 +1246,10 @@ mod tests {
         let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
         let cb = sink_collecting(collected.clone());
         let cancel = CancellationToken::new();
-        let resp = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
-            .await
-            .expect("stream completes");
+        let resp =
+            drive_responses_sse_stream(stream, cb, noop_sink(), cancel, Duration::from_secs(5))
+                .await
+                .expect("stream completes");
         match resp {
             LlmResponse::ToolCalls { text, calls } => {
                 assert_eq!(text, "hello");
@@ -1128,9 +1275,10 @@ mod tests {
         let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
         let cb = sink_collecting(collected.clone());
         let cancel = CancellationToken::new();
-        let resp = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
-            .await
-            .expect("stream completes");
+        let resp =
+            drive_responses_sse_stream(stream, cb, noop_sink(), cancel, Duration::from_secs(5))
+                .await
+                .expect("stream completes");
         match resp {
             LlmResponse::Text(text) => assert_eq!(text, "ok"),
             other => panic!("expected Text, got {other:?}"),
@@ -1155,9 +1303,10 @@ mod tests {
         let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
         let cb = sink_collecting(collected.clone());
         let cancel = CancellationToken::new();
-        let resp = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
-            .await
-            .expect("stream completes");
+        let resp =
+            drive_responses_sse_stream(stream, cb, noop_sink(), cancel, Duration::from_secs(5))
+                .await
+                .expect("stream completes");
         match resp {
             LlmResponse::Text(text) => assert_eq!(text, "hello"),
             other => panic!("expected Text, got {other:?}"),
@@ -1172,9 +1321,10 @@ mod tests {
         let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
         let cb = sink_collecting(collected.clone());
         let cancel = CancellationToken::new();
-        let err = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
-            .await
-            .expect_err("response.failed must surface as Err");
+        let err =
+            drive_responses_sse_stream(stream, cb, noop_sink(), cancel, Duration::from_secs(5))
+                .await
+                .expect_err("response.failed must surface as Err");
         let msg = format!("{err:#}");
         assert!(msg.contains("rate_limit_exceeded"), "got: {msg}");
         assert!(msg.contains("slow down"), "got: {msg}");
@@ -1182,11 +1332,15 @@ mod tests {
 
     #[tokio::test]
     async fn sse_parser_ignores_unknown_event_types() {
-        // New event types (reasoning summaries, rate-limit metadata,
-        // etc.) must not poison the stream -- they should keep the
-        // idle timer alive but contribute nothing to the result.
+        // Unmodeled event types (rate-limit metadata, new shapes we
+        // haven't taught the parser about) must not poison the stream
+        // -- they should keep the idle timer alive but contribute
+        // nothing to the result. (Reasoning deltas USED to fall in
+        // this bucket and now route to on_thought -- see
+        // `sse_parser_routes_reasoning_deltas_to_on_thought` for that
+        // coverage.)
         let raw = concat!(
-            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"thinking\"}\n\n",
+            "data: {\"type\":\"response.audio.delta\",\"delta\":\"<binary>\"}\n\n",
             "data: {\"type\":\"response.metadata\",\"metadata\":{}}\n\n",
             "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
             "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
@@ -1195,13 +1349,50 @@ mod tests {
         let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
         let cb = sink_collecting(collected.clone());
         let cancel = CancellationToken::new();
-        let resp = drive_responses_sse_stream(stream, cb, cancel, Duration::from_secs(5))
-            .await
-            .expect("stream completes");
+        let resp =
+            drive_responses_sse_stream(stream, cb, noop_sink(), cancel, Duration::from_secs(5))
+                .await
+                .expect("stream completes");
         match resp {
             LlmResponse::Text(text) => assert_eq!(text, "hi"),
             other => panic!("expected Text, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn sse_parser_routes_reasoning_deltas_to_on_thought() {
+        // Reasoning text and reasoning summary deltas go to the
+        // dedicated on_thought sink. They must NOT contaminate the
+        // primary text (which the assistant message is built from)
+        // because the ACP client renders them as a separate block.
+        let raw = concat!(
+            "data: {\"type\":\"response.reasoning_text.delta\",\"delta\":\"weigh \"}\n\n",
+            "data: {\"type\":\"response.reasoning_text.delta\",\"delta\":\"options\"}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\" => pick A\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"answer is A\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+        );
+        let stream = futures::stream::iter(vec![Ok(raw.as_bytes().to_vec())]);
+        let text = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let thought = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let token_sink = sink_collecting(text.clone());
+        let thought_sink = sink_collecting(thought.clone());
+        let cancel = CancellationToken::new();
+        let resp = drive_responses_sse_stream(
+            stream,
+            token_sink,
+            thought_sink,
+            cancel,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("stream completes");
+        match resp {
+            LlmResponse::Text(t) => assert_eq!(t, "answer is A"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+        assert_eq!(text.lock().unwrap().as_str(), "answer is A");
+        assert_eq!(thought.lock().unwrap().as_str(), "weigh options => pick A");
     }
 
     #[test]
@@ -1265,7 +1456,7 @@ mod tests {
     #[test]
     fn parses_models_response_with_unknown_fields() {
         // The real payload carries dozens of fields we don't model
-        // (reasoning levels, instructions templates, etc.). Make sure
+        // (instructions templates, truncation policy, etc.). Make sure
         // they don't break our deserializer.
         let raw = r#"{
             "models": [
@@ -1293,5 +1484,50 @@ mod tests {
         let parsed: ChatGptModelsResponse = serde_json::from_str(raw).unwrap();
         assert_eq!(parsed.models.len(), 1);
         assert_eq!(parsed.models[0].slug, "gpt-future");
+    }
+
+    #[test]
+    fn parses_models_response_with_reasoning_levels() {
+        // The real /models payload carries `default_reasoning_level`
+        // and `supported_reasoning_levels[]`; both surface in the
+        // ACP picker. Mirror a slimmed but representative entry.
+        let raw = r#"{
+            "models": [
+                {
+                    "slug": "gpt-5.2",
+                    "priority": 50,
+                    "visibility": "list",
+                    "default_reasoning_level": "medium",
+                    "supported_reasoning_levels": [
+                        {"effort": "low",    "description": "Balances speed with some reasoning"},
+                        {"effort": "medium", "description": "Solid balance of depth and latency"},
+                        {"effort": "high",   "description": "Maximize reasoning depth"},
+                        {"effort": "xhigh",  "description": "Extra high reasoning for complex problems"}
+                    ]
+                },
+                {
+                    "slug": "gpt-mini",
+                    "priority": 10,
+                    "visibility": "list"
+                }
+            ]
+        }"#;
+        let parsed: ChatGptModelsResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.models.len(), 2);
+        let gpt52 = &parsed.models[0];
+        assert_eq!(gpt52.slug, "gpt-5.2");
+        assert_eq!(gpt52.default_reasoning_level.as_deref(), Some("medium"));
+        assert_eq!(gpt52.supported_reasoning_levels.len(), 4);
+        assert_eq!(gpt52.supported_reasoning_levels[3].effort, "xhigh");
+        assert_eq!(
+            gpt52.supported_reasoning_levels[3].description,
+            "Extra high reasoning for complex problems"
+        );
+        // Models without the reasoning fields deserialize with serde
+        // defaults -- None + empty vec -- so the picker simply omits
+        // the effort selector for them rather than crashing.
+        let gpt_mini = &parsed.models[1];
+        assert!(gpt_mini.default_reasoning_level.is_none());
+        assert!(gpt_mini.supported_reasoning_levels.is_empty());
     }
 }

--- a/brokk-acp-rust/src/llm_client.rs
+++ b/brokk-acp-rust/src/llm_client.rs
@@ -134,18 +134,75 @@ impl ChatMessage {
 }
 
 // ---------------------------------------------------------------------------
+// Model metadata
+// ---------------------------------------------------------------------------
+
+/// One reasoning-effort preset advertised by the server for a given model.
+/// Mirrors the `supported_reasoning_levels[]` entries returned by the
+/// ChatGPT `/models` endpoint. Backends without per-effort presets (Ollama,
+/// OpenAI `/v1/models`) simply leave the per-model vec empty.
+#[derive(Debug, Clone)]
+pub struct ReasoningLevelPreset {
+    pub effort: String,
+    pub description: String,
+}
+
+/// Richer model descriptor surfaced through `LlmBackend::list_model_metadata`.
+/// The `id` is the wire identifier the backend expects in `stream_chat`;
+/// the optional reasoning fields are populated only for backends whose
+/// catalog publishes them (today: `CodexClient`).
+#[derive(Debug, Clone)]
+pub struct ModelMetadata {
+    pub id: String,
+    pub default_reasoning_level: Option<String>,
+    pub supported_reasoning_levels: Vec<ReasoningLevelPreset>,
+}
+
+impl ModelMetadata {
+    /// Lift a bare model id to a metadata record with no reasoning data.
+    /// Used by backends that don't publish reasoning presets, and by the
+    /// default impl of `list_model_metadata` so existing `list_models`
+    /// impls don't have to be rewritten.
+    pub fn id_only(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            default_reasoning_level: None,
+            supported_reasoning_levels: Vec::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // LLM backend trait
 // ---------------------------------------------------------------------------
 
 pub trait LlmBackend: Send + Sync {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>>>;
 
+    /// Same catalog as `list_models`, but carrying any per-model
+    /// reasoning-effort presets the backend's discovery endpoint
+    /// publishes. The default impl lifts each id to `ModelMetadata::id_only`,
+    /// so backends that don't expose reasoning data don't need to override.
+    fn list_model_metadata(&self) -> BoxFuture<'_, Result<Vec<ModelMetadata>>> {
+        let fut = self.list_models();
+        Box::pin(async move { Ok(fut.await?.into_iter().map(ModelMetadata::id_only).collect()) })
+    }
+
+    /// Stream a chat completion. `reasoning_effort` is honored only by
+    /// backends that route to a reasoning-capable endpoint (today,
+    /// `CodexClient` via the ChatGPT Responses API); other backends
+    /// ignore it. `on_thought` receives chain-of-thought / reasoning
+    /// text deltas separate from the assistant text on `on_token`;
+    /// backends that don't surface reasoning never invoke it.
+    #[allow(clippy::too_many_arguments)]
     fn stream_chat(
         &self,
         model: &str,
         messages: Vec<ChatMessage>,
         tools: Option<Vec<ToolDefinition>>,
+        reasoning_effort: Option<&str>,
         on_token: Box<dyn FnMut(&str) + Send>,
+        on_thought: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
     ) -> BoxFuture<'_, Result<LlmResponse>>;
 }
@@ -313,7 +370,13 @@ impl LlmBackend for OpenAiClient {
         model: &str,
         messages: Vec<ChatMessage>,
         tools: Option<Vec<ToolDefinition>>,
+        // Chat Completions doesn't take a reasoning_effort dimension on
+        // non-reasoning models, and the reasoning-capable o1/o3 family
+        // routes its own dedicated parameter -- not in scope here.
+        _reasoning_effort: Option<&str>,
         on_token: Box<dyn FnMut(&str) + Send>,
+        // No chain-of-thought stream on the Chat Completions SSE schema.
+        _on_thought: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
     ) -> BoxFuture<'_, Result<LlmResponse>> {
         let model = model.to_string();

--- a/brokk-acp-rust/src/multi_backend.rs
+++ b/brokk-acp-rust/src/multi_backend.rs
@@ -14,6 +14,7 @@
 //! `/config` model picker would get a "no backend for model" error even
 //! though the picker also offers `ollama::llama3:latest`.
 
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
@@ -24,7 +25,7 @@ use crate::discovery::{
     DiscoveredModel, ModelSource, OLLAMA_DEFAULT_URL, discover_all, discovery_http_client,
     split_wire_id,
 };
-use crate::llm_client::{ChatMessage, LlmBackend, LlmResponse, ToolDefinition};
+use crate::llm_client::{ChatMessage, LlmBackend, LlmResponse, ModelMetadata, ToolDefinition};
 
 /// LLM backend that routes by `<source>::<id>` prefix. Either inner
 /// backend may be absent (e.g. no `auth.json`, or no Ollama on the
@@ -133,24 +134,63 @@ impl MultiBackend {
 
 impl LlmBackend for MultiBackend {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>>> {
+        // Thin adapter over `list_model_metadata` so the bare-id and
+        // metadata paths can't drift -- e.g. forgetting to pick up a
+        // freshly-installed Codex backend on only one of the two.
         Box::pin(async move {
-            let http = discovery_http_client();
-            // Codex lookup is delegated to the configured backend's own
-            // `list_models` so we keep auth-mode handling, fallback slugs,
-            // and Cloudflare cookie state where they already live.
-            // Snapshotting under the read lock and dropping the guard
-            // before the discovery future means a concurrent
-            // `install_codex` call still observes a consistent state.
+            Ok(self
+                .list_model_metadata()
+                .await?
+                .into_iter()
+                .map(|m| m.id)
+                .collect())
+        })
+    }
+
+    fn list_model_metadata(&self) -> BoxFuture<'_, Result<Vec<ModelMetadata>>> {
+        Box::pin(async move {
+            // Snapshot the Codex backend once and pull its enriched
+            // catalog (slugs + per-model reasoning presets). Holding
+            // only an `Arc` clone here means a concurrent
+            // `install_codex` doesn't perturb this discovery pass.
             let codex = self.codex_snapshot();
-            let codex_lookup = || async move {
-                match codex {
-                    Some(c) => c.list_models().await,
-                    None => Ok(Vec::new()),
-                }
+            let codex_metadata: Vec<ModelMetadata> = match &codex {
+                Some(c) => c.list_model_metadata().await.unwrap_or_default(),
+                None => Vec::new(),
             };
+            // Index by bare slug so we can re-attach reasoning data
+            // to the wire-prefixed records returned by discover_all.
+            let codex_by_id: HashMap<String, ModelMetadata> = codex_metadata
+                .iter()
+                .map(|m| (m.id.clone(), m.clone()))
+                .collect();
+            // Hand discover_all the bare slugs we already have so we
+            // don't hit `/models` twice during a single list call.
+            let codex_ids: Vec<String> = codex_metadata.iter().map(|m| m.id.clone()).collect();
+            let codex_lookup = || async move { Ok::<_, anyhow::Error>(codex_ids) };
+            let http = discovery_http_client();
             let discovered: Vec<DiscoveredModel> =
                 discover_all(&http, OLLAMA_DEFAULT_URL, codex_lookup).await;
-            Ok(discovered.into_iter().map(|m| m.wire_id()).collect())
+            Ok(discovered
+                .into_iter()
+                .map(|m| {
+                    let wire = m.wire_id();
+                    match m.source {
+                        ModelSource::Codex => codex_by_id
+                            .get(&m.id)
+                            .map(|meta| ModelMetadata {
+                                id: wire.clone(),
+                                default_reasoning_level: meta.default_reasoning_level.clone(),
+                                supported_reasoning_levels: meta.supported_reasoning_levels.clone(),
+                            })
+                            .unwrap_or_else(|| ModelMetadata::id_only(wire)),
+                        // Ollama doesn't publish reasoning presets;
+                        // ids surface with empty metadata so the picker
+                        // simply omits the effort selector for them.
+                        ModelSource::Ollama => ModelMetadata::id_only(wire),
+                    }
+                })
+                .collect())
         })
     }
 
@@ -159,14 +199,25 @@ impl LlmBackend for MultiBackend {
         model: &str,
         messages: Vec<ChatMessage>,
         tools: Option<Vec<ToolDefinition>>,
+        reasoning_effort: Option<&str>,
         on_token: Box<dyn FnMut(&str) + Send>,
+        on_thought: Box<dyn FnMut(&str) + Send>,
         cancel: CancellationToken,
     ) -> BoxFuture<'_, Result<LlmResponse>> {
         let resolution = self.resolve(model);
+        let reasoning_effort = reasoning_effort.map(str::to_string);
         Box::pin(async move {
             let (backend, bare) = resolution?;
             backend
-                .stream_chat(&bare, messages, tools, on_token, cancel)
+                .stream_chat(
+                    &bare,
+                    messages,
+                    tools,
+                    reasoning_effort.as_deref(),
+                    on_token,
+                    on_thought,
+                    cancel,
+                )
                 .await
         })
     }
@@ -178,13 +229,16 @@ mod tests {
     use futures::future::FutureExt;
     use std::sync::Mutex;
 
-    /// Test double that records the model id it was called with. Lets us
-    /// assert that `MultiBackend` strips the `<source>::` prefix before
-    /// delegating, so the inner client receives the bare id Ollama or
-    /// the Responses API actually expects.
+    /// Test double that records the model id and reasoning effort it was
+    /// called with. Lets us assert that `MultiBackend` strips the
+    /// `<source>::` prefix before delegating, so the inner client
+    /// receives the bare id Ollama or the Responses API actually expects,
+    /// and that the per-session reasoning_effort threads all the way
+    /// through the dispatcher unchanged.
     struct RecordingBackend {
         name: &'static str,
         last_model: Arc<Mutex<Option<String>>>,
+        last_reasoning_effort: Arc<Mutex<Option<String>>>,
     }
 
     impl LlmBackend for RecordingBackend {
@@ -198,22 +252,39 @@ mod tests {
             model: &str,
             _messages: Vec<ChatMessage>,
             _tools: Option<Vec<ToolDefinition>>,
+            reasoning_effort: Option<&str>,
             _on_token: Box<dyn FnMut(&str) + Send>,
+            _on_thought: Box<dyn FnMut(&str) + Send>,
             _cancel: CancellationToken,
         ) -> BoxFuture<'_, Result<LlmResponse>> {
             *self.last_model.lock().unwrap() = Some(model.to_string());
+            *self.last_reasoning_effort.lock().unwrap() = reasoning_effort.map(str::to_string);
             let response = LlmResponse::Text(format!("hello from {}", self.name));
             async move { Ok(response) }.boxed()
         }
     }
 
-    fn recording(name: &'static str) -> (Arc<dyn LlmBackend>, Arc<Mutex<Option<String>>>) {
-        let last = Arc::new(Mutex::new(None));
+    /// Captured per-call state for assertions.
+    struct RecordingHandles {
+        last_model: Arc<Mutex<Option<String>>>,
+        last_reasoning_effort: Arc<Mutex<Option<String>>>,
+    }
+
+    fn recording(name: &'static str) -> (Arc<dyn LlmBackend>, RecordingHandles) {
+        let last_model = Arc::new(Mutex::new(None));
+        let last_reasoning_effort = Arc::new(Mutex::new(None));
         let backend = Arc::new(RecordingBackend {
             name,
-            last_model: last.clone(),
+            last_model: last_model.clone(),
+            last_reasoning_effort: last_reasoning_effort.clone(),
         });
-        (backend, last)
+        (
+            backend,
+            RecordingHandles {
+                last_model,
+                last_reasoning_effort,
+            },
+        )
     }
 
     /// Wire ids tagged `codex::` route to the Codex backend with the bare
@@ -221,8 +292,8 @@ mod tests {
     /// model string it received so we can assert the prefix was stripped.
     #[tokio::test]
     async fn stream_chat_routes_by_wire_prefix() {
-        let (codex_backend, codex_last) = recording("codex");
-        let (ollama_backend, ollama_last) = recording("ollama");
+        let (codex_backend, codex_handles) = recording("codex");
+        let (ollama_backend, ollama_handles) = recording("ollama");
         let multi = MultiBackend::new(Some(codex_backend), Some(ollama_backend));
 
         let _ = multi
@@ -230,19 +301,26 @@ mod tests {
                 "codex::gpt-5-codex",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
             .await
             .expect("codex route");
-        assert_eq!(codex_last.lock().unwrap().as_deref(), Some("gpt-5-codex"));
-        assert!(ollama_last.lock().unwrap().is_none());
+        assert_eq!(
+            codex_handles.last_model.lock().unwrap().as_deref(),
+            Some("gpt-5-codex")
+        );
+        assert!(ollama_handles.last_model.lock().unwrap().is_none());
 
         let _ = multi
             .stream_chat(
                 "ollama::llama3:latest",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
@@ -250,7 +328,7 @@ mod tests {
             .expect("ollama route");
         // The Ollama tag suffix must survive prefix stripping.
         assert_eq!(
-            ollama_last.lock().unwrap().as_deref(),
+            ollama_handles.last_model.lock().unwrap().as_deref(),
             Some("llama3:latest")
         );
     }
@@ -260,8 +338,8 @@ mod tests {
     /// capable choice and the more likely user intent for a bare id.
     #[tokio::test]
     async fn bare_id_routes_to_codex_fallback_when_both_configured() {
-        let (codex_backend, codex_last) = recording("codex");
-        let (ollama_backend, ollama_last) = recording("ollama");
+        let (codex_backend, codex_handles) = recording("codex");
+        let (ollama_backend, ollama_handles) = recording("ollama");
         let multi = MultiBackend::new(Some(codex_backend), Some(ollama_backend));
 
         let _ = multi
@@ -269,13 +347,18 @@ mod tests {
                 "gpt-5-codex",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
             .await
             .expect("bare id falls back to codex");
-        assert_eq!(codex_last.lock().unwrap().as_deref(), Some("gpt-5-codex"));
-        assert!(ollama_last.lock().unwrap().is_none());
+        assert_eq!(
+            codex_handles.last_model.lock().unwrap().as_deref(),
+            Some("gpt-5-codex")
+        );
+        assert!(ollama_handles.last_model.lock().unwrap().is_none());
     }
 
     /// Bare id with only Ollama configured: falls through to Ollama
@@ -283,7 +366,7 @@ mod tests {
     /// raw model ids into `/config`.
     #[tokio::test]
     async fn bare_id_routes_to_ollama_when_codex_absent() {
-        let (ollama_backend, ollama_last) = recording("ollama");
+        let (ollama_backend, ollama_handles) = recording("ollama");
         let multi = MultiBackend::new(None, Some(ollama_backend));
 
         let _ = multi
@@ -291,12 +374,17 @@ mod tests {
                 "llama3",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
             .await
             .expect("bare id falls back to ollama");
-        assert_eq!(ollama_last.lock().unwrap().as_deref(), Some("llama3"));
+        assert_eq!(
+            ollama_handles.last_model.lock().unwrap().as_deref(),
+            Some("llama3")
+        );
     }
 
     /// Wire id requesting an absent backend errors loudly instead of
@@ -306,7 +394,7 @@ mod tests {
     #[tokio::test]
     async fn wire_id_for_absent_backend_returns_error() {
         // Only Ollama is configured; a `codex::` wire id must error.
-        let (ollama_backend, _ollama_last) = recording("ollama");
+        let (ollama_backend, _ollama_handles) = recording("ollama");
         let multi = MultiBackend::new(None, Some(ollama_backend));
 
         let err = multi
@@ -314,6 +402,8 @@ mod tests {
                 "codex::gpt-5",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
@@ -335,6 +425,8 @@ mod tests {
                 "anything",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
@@ -364,6 +456,8 @@ mod tests {
                 "codex::gpt-5-codex",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
@@ -373,7 +467,7 @@ mod tests {
 
         // User runs `/codex-login` successfully -- the handler installs
         // a freshly-built Codex backend.
-        let (codex_backend, codex_last) = recording("codex");
+        let (codex_backend, codex_handles) = recording("codex");
         multi.install_codex(codex_backend);
 
         // Now the same request routes through Codex with the prefix
@@ -384,12 +478,17 @@ mod tests {
                 "codex::gpt-5-codex",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
             .await
             .expect("codex route must succeed after install");
-        assert_eq!(codex_last.lock().unwrap().as_deref(), Some("gpt-5-codex"));
+        assert_eq!(
+            codex_handles.last_model.lock().unwrap().as_deref(),
+            Some("gpt-5-codex")
+        );
     }
 
     /// Bare ids must also start routing to Codex once it's installed.
@@ -401,7 +500,7 @@ mod tests {
     async fn bare_id_falls_back_to_codex_after_install() {
         let multi = MultiBackend::new(None, None);
 
-        let (codex_backend, codex_last) = recording("codex");
+        let (codex_backend, codex_handles) = recording("codex");
         multi.install_codex(codex_backend);
 
         let _ = multi
@@ -409,12 +508,17 @@ mod tests {
                 "gpt-5-codex",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
             .await
             .expect("bare id must route to newly-installed codex");
-        assert_eq!(codex_last.lock().unwrap().as_deref(), Some("gpt-5-codex"));
+        assert_eq!(
+            codex_handles.last_model.lock().unwrap().as_deref(),
+            Some("gpt-5-codex")
+        );
     }
 
     /// `list_models` must consult the currently-installed Codex backend,
@@ -425,7 +529,7 @@ mod tests {
     #[tokio::test]
     async fn list_models_reflects_installed_codex() {
         let multi = MultiBackend::new(None, None);
-        let (codex_backend, _codex_last) = recording("codex");
+        let (codex_backend, _codex_handles) = recording("codex");
         multi.install_codex(codex_backend);
 
         // RecordingBackend::list_models returns ["codex-stub"].
@@ -451,7 +555,7 @@ mod tests {
     #[tokio::test]
     async fn codex_uninstall_unroutes_codex_requests() {
         let multi = MultiBackend::new(None, None);
-        let (codex_backend, _codex_last) = recording("codex");
+        let (codex_backend, _codex_handles) = recording("codex");
         multi.install_codex(codex_backend);
 
         // Sanity check: routable while installed.
@@ -460,6 +564,8 @@ mod tests {
                 "codex::gpt-5-codex",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
@@ -474,6 +580,8 @@ mod tests {
                 "codex::gpt-5-codex",
                 vec![],
                 None,
+                None,
+                Box::new(|_| {}),
                 Box::new(|_| {}),
                 CancellationToken::new(),
             )
@@ -482,6 +590,39 @@ mod tests {
         assert!(
             format!("{err:#}").contains("codex"),
             "error must mention codex backend"
+        );
+    }
+
+    /// `reasoning_effort` threads through the dispatcher unchanged --
+    /// it must arrive at the resolved inner backend, not get swallowed
+    /// or coerced. (This protects the Codex picker's per-session
+    /// selection from being silently lost on its way through
+    /// `MultiBackend`.)
+    #[tokio::test]
+    async fn stream_chat_forwards_reasoning_effort() {
+        let (codex_backend, codex_handles) = recording("codex");
+        let multi = MultiBackend::new(Some(codex_backend), None);
+
+        let _ = multi
+            .stream_chat(
+                "codex::gpt-5.2",
+                vec![],
+                None,
+                Some("xhigh"),
+                Box::new(|_| {}),
+                Box::new(|_| {}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("codex route");
+        assert_eq!(
+            codex_handles
+                .last_reasoning_effort
+                .lock()
+                .unwrap()
+                .as_deref(),
+            Some("xhigh"),
+            "reasoning_effort must arrive at the inner backend unchanged"
         );
     }
 }

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
+use crate::llm_client::ModelMetadata;
 use crate::tools::ToolRegistry;
 
 // ---------------------------------------------------------------------------
@@ -216,6 +217,12 @@ pub struct Session {
     /// Tool names the user has chosen "Always allow" for this session.
     /// In-memory only (matches `claude-agent-acp` behavior).
     pub always_allow_tools: HashSet<String>,
+    /// User's explicit pick from the reasoning-effort dropdown, if any.
+    /// `None` means "use the active model's `default_reasoning_level`";
+    /// `Some(_)` means "honor this exact level, fail if unsupported".
+    /// In-memory only -- the issue scope explicitly excludes
+    /// workspace-level persistence for this knob.
+    pub selected_reasoning_effort: Option<String>,
 }
 
 impl Session {
@@ -248,6 +255,7 @@ impl Session {
             manifest,
             permission_mode,
             always_allow_tools: HashSet::new(),
+            selected_reasoning_effort: None,
         }
     }
 
@@ -288,6 +296,11 @@ impl Session {
             manifest,
             permission_mode: PermissionMode::Default,
             always_allow_tools: HashSet::new(),
+            // Reset reasoning effort on load -- it's a transient
+            // per-session preference (per issue scope), so a
+            // reloaded zip starts at "use model default" until the
+            // user picks again.
+            selected_reasoning_effort: None,
         })
     }
 }
@@ -326,6 +339,11 @@ pub struct SessionSnapshot {
     pub mode: SessionMode,
     pub model: String,
     pub history: Vec<ConversationTurn>,
+    /// Reasoning-effort level to send on this turn, already resolved
+    /// against the user's pick and the active model's
+    /// `default_reasoning_level`. `None` means the model exposes no
+    /// effort presets, so the backend will simply omit the field.
+    pub reasoning_effort: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1009,9 +1027,15 @@ fn list_manifests_from_disk(cwd: &Path) -> Vec<SessionManifest> {
 pub struct SessionStore {
     sessions: Arc<RwLock<HashMap<String, Session>>>,
     default_model: Arc<RwLock<String>>,
-    /// Last-known list of models, populated by `set_available_models` from the LLM endpoint.
-    /// Used to fulfil `session/new` without re-fetching on every call.
-    available_models: Arc<RwLock<Vec<String>>>,
+    /// Last-known catalog of models, populated by `set_available_models`
+    /// from the LLM endpoint. Used to fulfil `session/new` without
+    /// re-fetching on every call, and to look up per-model reasoning
+    /// presets when the agent needs to resolve "no user pick" to the
+    /// model's `default_reasoning_level`. Stored as full
+    /// `ModelMetadata` records so the picker and the reasoning resolver
+    /// share one source of truth -- string ids alone would force a
+    /// parallel cache to avoid drift.
+    available_models: Arc<RwLock<Vec<ModelMetadata>>>,
     cancel_tokens: Arc<RwLock<HashMap<String, CancellationToken>>>,
     /// One ToolRegistry per session, kept warm across turns so any bifrost
     /// subprocess survives. Populated lazily on first prompt.
@@ -1136,11 +1160,28 @@ impl SessionStore {
         registry
     }
 
-    pub async fn set_available_models(&self, models: Vec<String>) {
+    pub async fn set_available_models(&self, models: Vec<ModelMetadata>) {
         *self.available_models.write().await = models;
     }
 
+    /// Bare ids only, in display order. Existing callers (the picker
+    /// builder, the model-validation arm of `set_model`) just want the
+    /// catalog of ids; metadata-aware callers reach for
+    /// `available_model_metadata` instead.
     pub async fn available_models(&self) -> Vec<String> {
+        self.available_models
+            .read()
+            .await
+            .iter()
+            .map(|m| m.id.clone())
+            .collect()
+    }
+
+    /// Full catalog snapshot, including per-model reasoning presets.
+    /// Used by the agent to render the reasoning-effort picker and to
+    /// resolve "user has no pick" to the model's
+    /// `default_reasoning_level` before issuing a request.
+    pub async fn available_model_metadata(&self) -> Vec<ModelMetadata> {
         self.available_models.read().await.clone()
     }
 
@@ -1273,18 +1314,42 @@ impl SessionStore {
         if !self.load_into_memory_if_cold(id, fallback_cwd).await {
             return None;
         }
-        let snap = {
+        // Build the snapshot under the sessions read lock, then resolve
+        // reasoning effort under the available_models lock outside it.
+        // Holding both at once is unnecessary and would invite a lock
+        // ordering hazard with set_model (which writes sessions then
+        // reads available_models on auto-fallback).
+        let (snap_base, selected_effort) = {
             let sessions = self.sessions.read().await;
             let s = sessions.get(id)?;
-            SessionSnapshot {
-                cwd: s.cwd.clone(),
-                mode: s.mode,
-                model: s.model.clone(),
-                history: s.history.clone(),
-            }
+            (
+                (s.cwd.clone(), s.mode, s.model.clone(), s.history.clone()),
+                s.selected_reasoning_effort.clone(),
+            )
+        };
+        let (cwd, mode, model, history) = snap_base;
+        // Resolve "user has no pick" to the model's
+        // default_reasoning_level so the backend gets a concrete
+        // intent. Models that publish no presets resolve to None and
+        // the backend omits the field entirely.
+        let reasoning_effort = match selected_effort {
+            Some(eff) => Some(eff),
+            None => self
+                .available_models
+                .read()
+                .await
+                .iter()
+                .find(|m| m.id == model)
+                .and_then(|m| m.default_reasoning_level.clone()),
         };
         self.touch(id);
-        Some(snap)
+        Some(SessionSnapshot {
+            cwd,
+            mode,
+            model,
+            history,
+            reasoning_effort,
+        })
     }
 
     pub async fn update_cwd(&self, id: &str, cwd: PathBuf) {
@@ -1391,16 +1456,59 @@ impl SessionStore {
     /// Update the per-session LLM model. Returns false if the session is
     /// unknown. Persists the new model into the session manifest so it
     /// survives a reload, mirroring `set_mode`.
-    pub async fn set_model(&self, id: &str, model: String) -> bool {
-        let snapshot = {
+    ///
+    /// When the previously-selected reasoning effort isn't in the new
+    /// model's supported set, the selection is auto-cleared so the next
+    /// turn falls back to the new model's `default_reasoning_level`.
+    /// Returns the cleared value (if any) so the caller can notify the
+    /// user, since silently dropping the pick would look like a bug
+    /// next time they wonder why thoughts shortened.
+    pub async fn set_model(&self, id: &str, model: String) -> (bool, Option<String>) {
+        // Pull the supported-effort set for the new model BEFORE
+        // acquiring the sessions write lock -- the available_models
+        // store and the sessions store are separate locks, and reading
+        // available_models while holding sessions in write would
+        // invert the lock order taken by `snapshot()`.
+        let supported_effort: Option<Vec<String>> = {
+            let catalog = self.available_models.read().await;
+            catalog.iter().find(|m| m.id == model).map(|m| {
+                m.supported_reasoning_levels
+                    .iter()
+                    .map(|p| p.effort.clone())
+                    .collect()
+            })
+        };
+
+        let (snapshot, cleared_effort) = {
             let mut sessions = self.sessions.write().await;
             match sessions.get_mut(id) {
                 Some(session) => {
                     session.model = model.clone();
-                    session.manifest.model = if model.is_empty() { None } else { Some(model) };
-                    Some((session.cwd.clone(), session.manifest.clone()))
+                    session.manifest.model = if model.is_empty() {
+                        None
+                    } else {
+                        Some(model.clone())
+                    };
+                    // Auto-fallback: if the user had a pick but the new
+                    // model doesn't advertise it, drop the pick. The
+                    // next snapshot resolves to the new model's default.
+                    let cleared = match (&session.selected_reasoning_effort, &supported_effort) {
+                        (Some(eff), Some(supported)) if !supported.iter().any(|s| s == eff) => {
+                            session.selected_reasoning_effort.take()
+                        }
+                        // No catalog metadata for the new model (e.g.
+                        // Ollama, or model discovery hasn't run yet):
+                        // leave the pick as-is. We don't have evidence
+                        // the pick is invalid; let the server be the
+                        // arbiter rather than dropping silently.
+                        _ => None,
+                    };
+                    (
+                        Some((session.cwd.clone(), session.manifest.clone())),
+                        cleared,
+                    )
                 }
-                None => None,
+                None => (None, None),
             }
         };
         match snapshot {
@@ -1410,6 +1518,21 @@ impl SessionStore {
                     rewrite_manifest_in_zip(&zip_path, &manifest)
                 })
                 .await;
+                (true, cleared_effort)
+            }
+            None => (false, None),
+        }
+    }
+
+    /// Record the user's reasoning-effort pick for this session.
+    /// `None` clears it (back to "use model default"). Returns false
+    /// if the session is unknown. In-memory only -- not persisted to
+    /// the manifest, by issue scope.
+    pub async fn set_reasoning_effort(&self, id: &str, effort: Option<String>) -> bool {
+        let mut sessions = self.sessions.write().await;
+        match sessions.get_mut(id) {
+            Some(session) => {
+                session.selected_reasoning_effort = effort;
                 true
             }
             None => false,
@@ -1913,7 +2036,12 @@ mod tests {
         let session = store.create_session(cwd).await;
         let id = session.id.clone();
 
-        assert!(store.set_model(&id, "next-model".to_string()).await);
+        let (ok, cleared) = store.set_model(&id, "next-model".to_string()).await;
+        assert!(ok);
+        assert!(
+            cleared.is_none(),
+            "no reasoning effort was selected, nothing to clear"
+        );
         let sessions = store.sessions.read().await;
         let s = sessions.get(&id).expect("session still in memory");
         assert_eq!(s.model, "next-model");
@@ -1923,11 +2051,11 @@ mod tests {
     #[tokio::test]
     async fn set_model_returns_false_for_unknown_session() {
         let store = SessionStore::new("initial-model".to_string());
-        assert!(
-            !store
-                .set_model("no-such-session", "next-model".into())
-                .await
-        );
+        let (ok, cleared) = store
+            .set_model("no-such-session", "next-model".into())
+            .await;
+        assert!(!ok);
+        assert!(cleared.is_none());
     }
 
     /// `SessionMode::parse` round-trips every variant via its wire id, with
@@ -2165,13 +2293,156 @@ mod tests {
         let store = SessionStore::new("m".to_string());
         assert!(store.available_models().await.is_empty());
 
-        let models = vec!["a".to_string(), "b".to_string()];
-        store.set_available_models(models.clone()).await;
-        assert_eq!(store.available_models().await, models);
+        let models = vec![ModelMetadata::id_only("a"), ModelMetadata::id_only("b")];
+        store.set_available_models(models).await;
+        assert_eq!(
+            store.available_models().await,
+            vec!["a".to_string(), "b".to_string()]
+        );
 
         // Setting an empty list is allowed (model discovery cleared).
         store.set_available_models(vec![]).await;
         assert!(store.available_models().await.is_empty());
+    }
+
+    /// When the user picks a reasoning effort that the new model
+    /// doesn't advertise, `set_model` clears the pick and surfaces the
+    /// cleared value so the caller can notify the user. Auto-fallback
+    /// to the new model's default happens at the next `snapshot()`.
+    #[tokio::test]
+    async fn set_model_clears_reasoning_effort_when_unsupported() {
+        use crate::llm_client::ReasoningLevelPreset;
+
+        let store = SessionStore::new("gpt-big".to_string());
+        store
+            .set_available_models(vec![
+                ModelMetadata {
+                    id: "gpt-big".to_string(),
+                    default_reasoning_level: Some("medium".to_string()),
+                    supported_reasoning_levels: vec![
+                        ReasoningLevelPreset {
+                            effort: "low".to_string(),
+                            description: "".to_string(),
+                        },
+                        ReasoningLevelPreset {
+                            effort: "medium".to_string(),
+                            description: "".to_string(),
+                        },
+                        ReasoningLevelPreset {
+                            effort: "high".to_string(),
+                            description: "".to_string(),
+                        },
+                        ReasoningLevelPreset {
+                            effort: "xhigh".to_string(),
+                            description: "".to_string(),
+                        },
+                    ],
+                },
+                ModelMetadata {
+                    id: "gpt-mini".to_string(),
+                    default_reasoning_level: Some("medium".to_string()),
+                    supported_reasoning_levels: vec![
+                        ReasoningLevelPreset {
+                            effort: "low".to_string(),
+                            description: "".to_string(),
+                        },
+                        ReasoningLevelPreset {
+                            effort: "medium".to_string(),
+                            description: "".to_string(),
+                        },
+                        ReasoningLevelPreset {
+                            effort: "high".to_string(),
+                            description: "".to_string(),
+                        },
+                    ],
+                },
+            ])
+            .await;
+        let cwd = std::env::temp_dir().join(format!(
+            "brokk-acp-rust-set-model-clears-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let session = store.create_session(cwd.clone()).await;
+        let id = session.id.clone();
+        assert!(
+            store
+                .set_reasoning_effort(&id, Some("xhigh".to_string()))
+                .await
+        );
+
+        // Switch to gpt-mini, which doesn't advertise xhigh.
+        let (ok, cleared) = store.set_model(&id, "gpt-mini".to_string()).await;
+        assert!(ok);
+        assert_eq!(cleared.as_deref(), Some("xhigh"));
+
+        // The snapshot now resolves to gpt-mini's default.
+        let snap = store
+            .snapshot(&id, &cwd)
+            .await
+            .expect("session still loadable");
+        assert_eq!(snap.reasoning_effort.as_deref(), Some("medium"));
+
+        let _ = std::fs::remove_dir_all(&cwd);
+    }
+
+    /// Picking a level that *is* still supported by the new model
+    /// must NOT be cleared -- this protects the user's intent across
+    /// a slug bump within the same family (e.g. gpt-5.4 -> gpt-5.5).
+    #[tokio::test]
+    async fn set_model_preserves_reasoning_effort_when_supported() {
+        use crate::llm_client::ReasoningLevelPreset;
+
+        let supported = vec![
+            ReasoningLevelPreset {
+                effort: "low".to_string(),
+                description: "".to_string(),
+            },
+            ReasoningLevelPreset {
+                effort: "medium".to_string(),
+                description: "".to_string(),
+            },
+            ReasoningLevelPreset {
+                effort: "high".to_string(),
+                description: "".to_string(),
+            },
+        ];
+        let store = SessionStore::new("gpt-a".to_string());
+        store
+            .set_available_models(vec![
+                ModelMetadata {
+                    id: "gpt-a".to_string(),
+                    default_reasoning_level: Some("medium".to_string()),
+                    supported_reasoning_levels: supported.clone(),
+                },
+                ModelMetadata {
+                    id: "gpt-b".to_string(),
+                    default_reasoning_level: Some("medium".to_string()),
+                    supported_reasoning_levels: supported,
+                },
+            ])
+            .await;
+        let cwd = std::env::temp_dir().join(format!(
+            "brokk-acp-rust-set-model-preserves-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let session = store.create_session(cwd.clone()).await;
+        let id = session.id.clone();
+        assert!(
+            store
+                .set_reasoning_effort(&id, Some("high".to_string()))
+                .await
+        );
+
+        let (ok, cleared) = store.set_model(&id, "gpt-b".to_string()).await;
+        assert!(ok);
+        assert!(cleared.is_none(), "high is still supported by gpt-b");
+        let snap = store
+            .snapshot(&id, &cwd)
+            .await
+            .expect("session still loadable");
+        assert_eq!(snap.reasoning_effort.as_deref(), Some("high"));
+
+        let _ = std::fs::remove_dir_all(&cwd);
     }
 
     /// `list_sessions_from_disk` ignores non-zip files in the sessions

--- a/brokk-acp-rust/src/tool_loop.rs
+++ b/brokk-acp-rust/src/tool_loop.rs
@@ -157,10 +157,12 @@ pub(crate) async fn run(
     llm: &Arc<dyn LlmBackend>,
     registry: &ToolRegistry,
     model: &str,
+    reasoning_effort: Option<&str>,
     mut messages: Vec<ChatMessage>,
     max_turns: usize,
     cancel: CancellationToken,
     on_text: TextSink,
+    on_thought: TextSink,
     spawned_cx: SpawnedCx<'_>,
     session_id: String,
     sessions: SessionStore,
@@ -185,9 +187,18 @@ pub(crate) async fn run(
         };
 
         // Forward tokens straight through to the caller; no buffering.
-        let sink = on_text.clone();
+        let text_clone = on_text.clone();
         let on_token: Box<dyn FnMut(&str) + Send> = Box::new(move |token: &str| {
-            if let Ok(mut cb) = sink.lock() {
+            if let Ok(mut cb) = text_clone.lock() {
+                cb(token);
+            }
+        });
+        // Reasoning deltas route to a parallel sink so the agent layer
+        // can emit them as ACP AgentThoughtChunk events; backends that
+        // don't surface reasoning simply never invoke this closure.
+        let thought_clone = on_thought.clone();
+        let on_thought_cb: Box<dyn FnMut(&str) + Send> = Box::new(move |token: &str| {
+            if let Ok(mut cb) = thought_clone.lock() {
                 cb(token);
             }
         });
@@ -202,7 +213,9 @@ pub(crate) async fn run(
                 model,
                 messages.clone(),
                 turn_tools,
+                reasoning_effort,
                 on_token,
+                on_thought_cb,
                 cancel.clone(),
             )
             .await;


### PR DESCRIPTION
## Summary

Implements [#3542](https://github.com/BrokkAi/brokk/issues/3542): surfaces the ChatGPT Responses API `reasoning.effort` dimension as a **per-session ACP picker** for the Codex/`--use-codex` backend, parallel to the existing model selector. On a ChatGPT subscription, `gpt-5.5 @ xhigh` and `gpt-5.5 @ low` are functionally different models (latency, quota, depth) — until now brokk-acp-rust collapsed that to a single dimension because every prompt ran at the model's `default_reasoning_level`.

## What changed

**Protocol/types** ([llm_client.rs](https://github.com/BrokkAi/brokk/blob/claude/agitated-dubinsky-226bee/brokk-acp-rust/src/llm_client.rs))
- New `ModelMetadata` and `ReasoningLevelPreset` types.
- New `LlmBackend::list_model_metadata` with a default impl that lifts each id to `ModelMetadata::id_only` — so Ollama / OpenAI backends don't need to change.
- `LlmBackend::stream_chat` gains `reasoning_effort: Option<&str>` and a second `on_thought: Box<dyn FnMut(&str) + Send>` callback. OpenAI Chat Completions ignores both (scope is Codex-only per the issue).

**ChatGPT backend** ([codex_client.rs](https://github.com/BrokkAi/brokk/blob/claude/agitated-dubinsky-226bee/brokk-acp-rust/src/codex_client.rs))
- `ChatGptModelEntry` now parses `default_reasoning_level` and `supported_reasoning_levels[]` (with `#[serde(default)]` for back-compat).
- `ResponsesRequest` gains `reasoning: Option<ReasoningConfig>` — omitted on the wire when `None`, populated with `{ "effort": "..." }` otherwise.
- SSE handler routes `response.reasoning_text.delta` and `response.reasoning_summary_text.delta` to the new `on_thought` callback instead of bucketing them under the `_` "ignore but reset idle timer" arm.

**Routing** ([multi_backend.rs](https://github.com/BrokkAi/brokk/blob/claude/agitated-dubinsky-226bee/brokk-acp-rust/src/multi_backend.rs))
- `list_model_metadata` snapshots Codex once and joins its enriched catalog (slugs + reasoning presets) to the wire-prefixed records from `discover_all`. `list_models` becomes a thin adapter so the two paths can't drift.
- `MultiBackend::stream_chat` forwards `reasoning_effort` and `on_thought` to the resolved backend verbatim. New test verifies forwarding.

**Session state** ([session.rs](https://github.com/BrokkAi/brokk/blob/claude/agitated-dubinsky-226bee/brokk-acp-rust/src/session.rs))
- `Session.selected_reasoning_effort: Option<String>` — **in-memory only**, no manifest persistence (per issue scope: "A workspace-level `/config` persistence story… is out of scope").
- `SessionSnapshot.reasoning_effort` carries the *resolved* effort (user pick OR model's `default_reasoning_level`) so the agent layer can pass it straight to `stream_chat`.
- `set_model` now returns `(bool, Option<String>)`: when the prior pick isn't in the new model's supported set, it's auto-cleared and the dropped value is surfaced so the caller can notify the user. The catalog cache is now `Vec<ModelMetadata>` (single source of truth).

**ACP/agent** ([agent.rs](https://github.com/BrokkAi/brokk/blob/claude/agitated-dubinsky-226bee/brokk-acp-rust/src/agent.rs), [tool_loop.rs](https://github.com/BrokkAi/brokk/blob/claude/agitated-dubinsky-226bee/brokk-acp-rust/src/tool_loop.rs))
- New `REASONING_EFFORT_CONFIG_ID` selector wired through the existing `session/set_config_option` + `ConfigOptionUpdate` flow. Each preset surfaces with its server-supplied description; an explicit "(default)" entry represents "use model default". The picker is omitted entirely for models that don't advertise presets (e.g. Ollama).
- The model setter arm now consumes the tuple and emits a one-line system note when the auto-fallback fires (`"Reasoning effort reset: \`xhigh\` is not supported by \`gpt-5.4-mini\`…"`).
- Reasoning deltas are surfaced as ACP **`SessionUpdate::AgentThoughtChunk`** (already in ACP 0.12's schema), so clients can render reasoning text as a distinct collapsible block separate from the final answer.

## Why this matters for the sub story

`gpt-5.5 @ xhigh` and `gpt-5.5 @ low` are functionally different models for the user — different latency, different cost against the plan's quota, different output quality. Today picking the slug alone collapses that to one dimension. After this change the user picks both, in one flow, with server-written descriptions so they know what each level actually means.

## Why this is scoped to Codex (not LlmBackend broadly)

Per the issue: Chat Completions doesn't accept a `reasoning_effort` dimension for non-reasoning models, and the reasoning-capable ones (o1, o3) take their own dedicated parameter. The `LlmBackend` trait change here is **plumbing** (one extra `Option<&str>` and one no-op callback both impls accept and forward), not behavior — only `CodexClient` acts on the value. This avoids forcing every backend to grow a per-call config struct for one knob.

## Acceptance criteria (from #3542)

- [x] After `/codex-login`, the picker lists the levels supported by the current model with their server-supplied descriptions.
- [x] Selecting a level applies to subsequent prompts in the session.
- [x] Reasoning text from `xhigh`-effort responses is observable in the transcript (separate `AgentThoughtChunk` block, not interleaved).
- [x] Switching slugs with a different `default_reasoning_level` updates the picker (and auto-falls-back when the prior pick isn't supported).

## Test plan

Local checks all green on this branch:
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — **170/170**, including 6 new tests:
  - `parses_models_response_with_reasoning_levels`
  - `build_request_emits_reasoning_when_effort_is_set` / `..._omits_reasoning_when_effort_is_none`
  - `sse_parser_routes_reasoning_deltas_to_on_thought`
  - `stream_chat_forwards_reasoning_effort`
  - `set_model_clears_reasoning_effort_when_unsupported` / `..._preserves_reasoning_effort_when_supported`

Manual ACP verification still TODO before merge:
- [ ] After `/codex-login`, the IDE picker exposes "Reasoning effort" with the levels & descriptions from `/models`.
- [ ] Selecting `xhigh` on a model that supports it routes a turn that emits at least one `AgentThoughtChunk` block before the final answer.
- [ ] Switching to a slug without `xhigh` shows the system-note auto-fallback line and the picker updates accordingly.

## Notes for reviewers

- The `Session` field is intentionally in-memory only — workspace-level persistence is OUT of scope per the issue. A reloaded session zip resets to "use model default" until the user picks again.
- `MultiBackend::list_model_metadata` does a single Codex fetch and hands its `id` list to `discover_all` for the merge with Ollama, so we don't double-hit `/models` per discovery pass.
- ACP `AgentThoughtChunk` is already in the 0.12 schema (`agent-client-protocol-schema-0.12.0/src/client.rs:90`), so no protocol bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
