### PR TITLE
brokk-acp-rust: honor AGENTS.md / CLAUDE.md project instructions

### DIFF
--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "tiny_http",
  "tokio",
  "tokio-util",

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -61,3 +61,7 @@ tokio = { version = "1", features = ["test-util"] }
 # extraction, mirroring what `brokk-code/brokk_code/rust_acp_install.py`
 # already does for the production install path.
 sha2 = "0.10"
+# Used by `agents_md` tests to build throwaway project trees (`.git`
+# marker + AGENTS.md/CLAUDE.md fixtures) without polluting the working
+# directory.
+tempfile = "3"

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -1090,7 +1090,9 @@ fn send_thought(cx: &ConnectionTo<Client>, session_id: &str, text: &str) {
 fn build_prompt_messages(snap: &SessionSnapshot, new_prompt: &str) -> Vec<ChatMessage> {
     let mut messages = Vec::with_capacity(snap.history.len() * 2 + 2);
     messages.push(ChatMessage::system(build_system_prompt(
-        &snap.mode, &snap.cwd,
+        &snap.mode,
+        &snap.cwd,
+        &snap.project_instructions,
     )));
     for turn in &snap.history {
         messages.push(ChatMessage::user(turn.user_prompt.clone()));
@@ -1152,12 +1154,22 @@ fn build_prompt_messages(snap: &SessionSnapshot, new_prompt: &str) -> Vec<ChatMe
     messages
 }
 
-fn build_system_prompt(mode: &SessionMode, cwd: &Path) -> String {
+fn build_system_prompt(mode: &SessionMode, cwd: &Path, project_instructions: &str) -> String {
     let cwd_context = format!(
         "The user's working directory is: {}\n\
          All file paths should be interpreted relative to this directory.\n\n",
         cwd.display()
     );
+
+    // Position project instructions between cwd context and the mode role
+    // so the assembled prompt reads: "you are in X / the project says Y /
+    // your role is Z" -- matching the AGENTS.md spec intent that project
+    // rules override generic defaults.
+    let project_block = if project_instructions.is_empty() {
+        String::new()
+    } else {
+        format!("Project instructions (AGENTS.md):\n{project_instructions}\n\n")
+    };
 
     let mode_prompt = match mode {
         SessionMode::Lutz => {
@@ -1179,7 +1191,7 @@ fn build_system_prompt(mode: &SessionMode, cwd: &Path) -> String {
         }
     };
 
-    format!("{cwd_context}{mode_prompt}")
+    format!("{cwd_context}{project_block}{mode_prompt}")
 }
 
 /// Returns true when `prompt_text` invokes the slash command `name`,
@@ -1473,7 +1485,7 @@ mod tests {
             (SessionMode::Ask, "Answer questions about code"),
             (SessionMode::Plan, "focused on planning"),
         ] {
-            let prompt = build_system_prompt(&mode, cwd);
+            let prompt = build_system_prompt(&mode, cwd, "");
             assert!(
                 prompt.contains("/tmp/some-cwd") || prompt.contains("\\tmp\\some-cwd"),
                 "system prompt for {mode:?} must embed the cwd, got: {prompt}"
@@ -1502,6 +1514,7 @@ mod tests {
                 ..Default::default()
             }],
             reasoning_effort: None,
+            project_instructions: String::new(),
         };
         let report = render_context_report(&snap, PermissionMode::AcceptEdits, &["gpt-99".into()]);
 
@@ -1525,6 +1538,7 @@ mod tests {
             model: String::new(),
             history: vec![],
             reasoning_effort: None,
+            project_instructions: String::new(),
         };
         let report = render_context_report(&snap, PermissionMode::Default, &[]);
         assert!(report.contains("Model: `(none)`"));
@@ -1548,6 +1562,7 @@ mod tests {
                 ..Default::default()
             }],
             reasoning_effort: None,
+            project_instructions: String::new(),
         };
         let msgs = build_prompt_messages(&snap, "follow up");
         // system + user(history) + assistant(history) + user(new)
@@ -1591,6 +1606,7 @@ mod tests {
                 ],
             }],
             reasoning_effort: None,
+            project_instructions: String::new(),
         };
         let msgs = build_prompt_messages(&snap, "now fix them");
 
@@ -1638,6 +1654,7 @@ mod tests {
             model: "m".into(),
             history: vec![],
             reasoning_effort: None,
+            project_instructions: String::new(),
         };
         let msgs = build_prompt_messages(&snap, "hi");
         assert_eq!(msgs.len(), 2);
@@ -1672,6 +1689,7 @@ mod tests {
                 }],
             }],
             reasoning_effort: None,
+            project_instructions: String::new(),
         };
         let msgs = build_prompt_messages(&snap, "next");
 

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -1084,16 +1084,22 @@ fn send_thought(cx: &ConnectionTo<Client>, session_id: &str, text: &str) {
 
 /// Build a system prompt based on the current session mode and working directory.
 /// Build the `Vec<ChatMessage>` to send to the LLM for a fresh prompt:
-/// system prompt, then replayed history (with tool exchanges, #3409),
-/// then the new user prompt. Pure -- exposed for unit testing the
+/// system prompt, optional project instruction context, then replayed
+/// history (with tool exchanges, #3409), then the new user prompt.
+/// Pure -- exposed for unit testing the
 /// replay shape without spinning up an LLM.
 fn build_prompt_messages(snap: &SessionSnapshot, new_prompt: &str) -> Vec<ChatMessage> {
-    let mut messages = Vec::with_capacity(snap.history.len() * 2 + 2);
+    let mut messages = Vec::with_capacity(snap.history.len() * 2 + 3);
     messages.push(ChatMessage::system(build_system_prompt(
-        &snap.mode,
-        &snap.cwd,
-        &snap.project_instructions,
+        &snap.mode, &snap.cwd,
     )));
+    if !snap.project_instructions.is_empty() {
+        messages.push(ChatMessage::user(format!(
+            "# AGENTS.md instructions for {}\n\n<INSTRUCTIONS>\n{}\n</INSTRUCTIONS>",
+            snap.cwd.display(),
+            snap.project_instructions
+        )));
+    }
     for turn in &snap.history {
         messages.push(ChatMessage::user(turn.user_prompt.clone()));
 
@@ -1154,22 +1160,12 @@ fn build_prompt_messages(snap: &SessionSnapshot, new_prompt: &str) -> Vec<ChatMe
     messages
 }
 
-fn build_system_prompt(mode: &SessionMode, cwd: &Path, project_instructions: &str) -> String {
+fn build_system_prompt(mode: &SessionMode, cwd: &Path) -> String {
     let cwd_context = format!(
         "The user's working directory is: {}\n\
          All file paths should be interpreted relative to this directory.\n\n",
         cwd.display()
     );
-
-    // Position project instructions between cwd context and the mode role
-    // so the assembled prompt reads: "you are in X / the project says Y /
-    // your role is Z" -- matching the AGENTS.md spec intent that project
-    // rules override generic defaults.
-    let project_block = if project_instructions.is_empty() {
-        String::new()
-    } else {
-        format!("Project instructions (AGENTS.md):\n{project_instructions}\n\n")
-    };
 
     let mode_prompt = match mode {
         SessionMode::Lutz => {
@@ -1191,7 +1187,7 @@ fn build_system_prompt(mode: &SessionMode, cwd: &Path, project_instructions: &st
         }
     };
 
-    format!("{cwd_context}{project_block}{mode_prompt}")
+    format!("{cwd_context}{mode_prompt}")
 }
 
 /// Returns true when `prompt_text` invokes the slash command `name`,
@@ -1485,7 +1481,7 @@ mod tests {
             (SessionMode::Ask, "Answer questions about code"),
             (SessionMode::Plan, "focused on planning"),
         ] {
-            let prompt = build_system_prompt(&mode, cwd, "");
+            let prompt = build_system_prompt(&mode, cwd);
             assert!(
                 prompt.contains("/tmp/some-cwd") || prompt.contains("\\tmp\\some-cwd"),
                 "system prompt for {mode:?} must embed the cwd, got: {prompt}"
@@ -1661,6 +1657,38 @@ mod tests {
         assert_eq!(msgs[0].role, "system");
         assert_eq!(msgs[1].role, "user");
         assert_eq!(msgs[1].content.as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn build_prompt_messages_puts_project_instructions_in_user_context() {
+        use crate::session::SessionSnapshot;
+        let snap = SessionSnapshot {
+            cwd: std::path::PathBuf::from("/tmp/cwd"),
+            mode: SessionMode::Code,
+            model: "m".into(),
+            history: vec![],
+            reasoning_effort: None,
+            project_instructions: "Use the local style.".into(),
+        };
+
+        let msgs = build_prompt_messages(&snap, "hi");
+
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0].role, "system");
+        assert!(
+            !msgs[0]
+                .content
+                .as_deref()
+                .expect("system prompt")
+                .contains("Use the local style."),
+            "project-controlled AGENTS.md content must not be system instructions"
+        );
+        assert_eq!(msgs[1].role, "user");
+        let project_context = msgs[1].content.as_deref().expect("project context");
+        assert!(project_context.starts_with("# AGENTS.md instructions for "));
+        assert!(project_context.contains("<INSTRUCTIONS>\nUse the local style.\n</INSTRUCTIONS>"));
+        assert_eq!(msgs[2].role, "user");
+        assert_eq!(msgs[2].content.as_deref(), Some("hi"));
     }
 
     /// A turn that ended without final assistant text (e.g. tool_loop hit

--- a/brokk-acp-rust/src/agents_md.rs
+++ b/brokk-acp-rust/src/agents_md.rs
@@ -1,4 +1,4 @@
-//! AGENTS.md / CLAUDE.md discovery for the ACP system prompt.
+//! AGENTS.md / CLAUDE.md discovery for the ACP prompt context.
 //!
 //! Honors the [agents.md](https://agents.md/) open convention plus the
 //! global-config proposal at <https://github.com/agentsmd/agents.md/issues/91>.
@@ -40,15 +40,16 @@ pub fn discover(cwd: &Path) -> String {
 }
 
 fn discover_inner(cwd: &Path, global: Option<(PathBuf, String)>) -> String {
+    let cwd = normalize_path(cwd);
     let mut slots: Vec<(PathBuf, String)> = Vec::new();
 
     if let Some(slot) = global {
         slots.push(slot);
     }
 
-    let git_root = find_git_root(cwd);
-    let dir_chain = build_dir_chain(cwd, git_root.as_deref());
-    let display_base = git_root.as_deref().unwrap_or(cwd);
+    let git_root = find_git_root(&cwd);
+    let dir_chain = build_dir_chain(&cwd, git_root.as_deref());
+    let display_base = git_root.as_deref().unwrap_or(&cwd);
     for dir in dir_chain {
         if let Some((path, content)) = read_preferred(&dir) {
             slots.push((path, content));
@@ -149,6 +150,10 @@ fn find_git_root(start: &Path) -> Option<PathBuf> {
     None
 }
 
+fn normalize_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
 fn read_preferred(dir: &Path) -> Option<(PathBuf, String)> {
     if let Some(hit) = read_if_exists(&dir.join(PRIMARY)) {
         return Some(hit);
@@ -157,6 +162,19 @@ fn read_preferred(dir: &Path) -> Option<(PathBuf, String)> {
 }
 
 fn read_if_exists(path: &Path) -> Option<(PathBuf, String)> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => return None,
+        Err(e) if e.kind() == ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                "AGENTS.md candidate metadata is unreadable: {e}"
+            );
+            return None;
+        }
+    }
+
     match std::fs::read_to_string(path) {
         Ok(content) => Some((path.to_path_buf(), content)),
         Err(e) if e.kind() == ErrorKind::NotFound => None,
@@ -280,6 +298,27 @@ mod tests {
         assert!(out.contains("CLAUDE.md"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn ignores_special_agents_file_and_reads_fallback() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        let fifo = tmp.path().join(PRIMARY);
+        let c_path = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+        assert_eq!(rc, 0);
+        write(&tmp.path().join(FALLBACK), "fallback rule");
+
+        let out = discover_inner(tmp.path(), None);
+
+        assert!(out.contains("fallback rule"));
+        assert!(out.contains(FALLBACK));
+        assert!(!out.contains(PRIMARY));
+    }
+
     #[test]
     fn prefers_agents_when_both_present_in_same_dir() {
         let tmp = TempDir::new().unwrap();
@@ -309,6 +348,29 @@ mod tests {
         assert!(
             root_pos < leaf_pos,
             "expected root before leaf (general -> specific); got:\n{out}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonicalizes_symlinked_cwd_before_git_root_walk() {
+        use std::os::unix::fs::symlink;
+
+        let repo = TempDir::new().unwrap();
+        touch_git(repo.path());
+        write(&repo.path().join(PRIMARY), "root rule");
+        let real_subdir = repo.path().join("a").join("b");
+        fs::create_dir_all(&real_subdir).unwrap();
+
+        let links = TempDir::new().unwrap();
+        let linked_cwd = links.path().join("linked-cwd");
+        symlink(&real_subdir, &linked_cwd).unwrap();
+
+        let out = discover_inner(&linked_cwd, None);
+
+        assert!(
+            out.contains("root rule"),
+            "symlinked cwd should discover the real repo root; got:\n{out}"
         );
     }
 

--- a/brokk-acp-rust/src/agents_md.rs
+++ b/brokk-acp-rust/src/agents_md.rs
@@ -1,0 +1,409 @@
+//! AGENTS.md / CLAUDE.md discovery for the ACP system prompt.
+//!
+//! Honors the [agents.md](https://agents.md/) open convention plus the
+//! global-config proposal at <https://github.com/agentsmd/agents.md/issues/91>.
+//! At every slot (global + each directory from git root down to cwd) we
+//! prefer `AGENTS.md`; if it is absent we fall back to `CLAUDE.md` at the
+//! same slot. Results are concatenated general -> specific so deeper
+//! directories naturally override.
+//!
+//! Walk-up is bounded by the discovered git root so a cwd without an
+//! ancestor `.git` cannot accidentally pick up a stray AGENTS.md from
+//! `~`, `/tmp`, or `/`.
+//!
+//! Pure module; no LLM/session deps. Re-runs are cheap and idempotent --
+//! callers may invoke `discover` again whenever a session's cwd changes.
+
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+pub const MAX_TOTAL_BYTES: usize = 64 * 1024;
+const PRIMARY: &str = "AGENTS.md";
+const FALLBACK: &str = "CLAUDE.md";
+
+/// Discover and concatenate project instructions for the given working
+/// directory. Returns an empty string when nothing is found.
+///
+/// Order (general -> specific):
+///   1. global AGENTS.md (XDG / APPDATA)
+///   2. global CLAUDE.md (`~/.claude/CLAUDE.md`)  -- only if (1) is absent
+///   3. AGENTS.md at the git root (else CLAUDE.md there)
+///   4. AGENTS.md at each intermediate directory down to `cwd`
+///   5. AGENTS.md at `cwd` itself
+///
+/// The total byte size is capped at [`MAX_TOTAL_BYTES`]; further reads
+/// stop and the offending file is truncated on a UTF-8 char boundary
+/// with a `tracing::warn!`.
+pub fn discover(cwd: &Path) -> String {
+    let global = read_global_default();
+    discover_inner(cwd, global)
+}
+
+fn discover_inner(cwd: &Path, global: Option<(PathBuf, String)>) -> String {
+    let mut slots: Vec<(PathBuf, String)> = Vec::new();
+
+    if let Some(slot) = global {
+        slots.push(slot);
+    }
+
+    let git_root = find_git_root(cwd);
+    let dir_chain = build_dir_chain(cwd, git_root.as_deref());
+    let display_base = git_root.as_deref().unwrap_or(cwd);
+    for dir in dir_chain {
+        if let Some((path, content)) = read_preferred(&dir) {
+            slots.push((path, content));
+        }
+    }
+
+    if slots.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::new();
+    let mut remaining = MAX_TOTAL_BYTES;
+    let found_paths: Vec<&Path> = slots.iter().map(|(p, _)| p.as_path()).collect();
+    tracing::info!(found = ?found_paths, "AGENTS.md discovery");
+
+    for (path, content) in &slots {
+        if remaining == 0 {
+            tracing::warn!(
+                path = %path.display(),
+                "AGENTS.md discovery cap reached ({} bytes); skipping remaining files",
+                MAX_TOTAL_BYTES
+            );
+            break;
+        }
+
+        let display = render_display_path(path, display_base);
+        let header = format!("\n--- {} ---\n", display);
+        let header_bytes = header.len();
+        if header_bytes > remaining {
+            tracing::warn!(
+                path = %path.display(),
+                "AGENTS.md discovery cap reached while emitting header; skipping"
+            );
+            break;
+        }
+        out.push_str(&header);
+        remaining -= header_bytes;
+
+        let (chunk, truncated) = clip_at_char_boundary(content, remaining);
+        out.push_str(chunk);
+        remaining = remaining.saturating_sub(chunk.len());
+        if truncated {
+            tracing::warn!(
+                path = %path.display(),
+                "AGENTS.md content truncated at {}-byte cap",
+                MAX_TOTAL_BYTES
+            );
+            out.push_str("\n[...truncated]\n");
+            remaining = 0;
+        } else if !chunk.ends_with('\n') {
+            // Make sure successive headers don't run onto a non-newline-
+            // terminated file's last line.
+            if remaining > 0 {
+                out.push('\n');
+                remaining -= 1;
+            }
+        }
+    }
+    out
+}
+
+/// Returns the chain of directories from the git root down to `cwd`
+/// (inclusive of both ends, deduplicated when `cwd == git_root`).
+/// If no git root is provided, the chain is just `[cwd]`.
+fn build_dir_chain(cwd: &Path, git_root: Option<&Path>) -> Vec<PathBuf> {
+    let Some(root) = git_root else {
+        return vec![cwd.to_path_buf()];
+    };
+    if root == cwd {
+        return vec![cwd.to_path_buf()];
+    }
+    let Ok(rel) = cwd.strip_prefix(root) else {
+        // `cwd` is not under `root` (symlinks, exotic paths). Fall back
+        // to a single-slot chain so we don't fabricate ancestors.
+        return vec![cwd.to_path_buf()];
+    };
+    let mut chain = vec![root.to_path_buf()];
+    let mut acc = root.to_path_buf();
+    for part in rel.iter() {
+        acc.push(part);
+        chain.push(acc.clone());
+    }
+    chain
+}
+
+/// Walk up from `start` looking for an entry named `.git` (either a
+/// directory in a normal repo or a file in a worktree/submodule).
+/// Returns the first ancestor that contains `.git`, or `None` if none
+/// is found before the filesystem root.
+fn find_git_root(start: &Path) -> Option<PathBuf> {
+    let mut cur = Some(start);
+    while let Some(p) = cur {
+        if p.join(".git").exists() {
+            return Some(p.to_path_buf());
+        }
+        cur = p.parent();
+    }
+    None
+}
+
+fn read_preferred(dir: &Path) -> Option<(PathBuf, String)> {
+    if let Some(hit) = read_if_exists(&dir.join(PRIMARY)) {
+        return Some(hit);
+    }
+    read_if_exists(&dir.join(FALLBACK))
+}
+
+fn read_if_exists(path: &Path) -> Option<(PathBuf, String)> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => Some((path.to_path_buf(), content)),
+        Err(e) if e.kind() == ErrorKind::NotFound => None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                "AGENTS.md candidate exists but is unreadable: {e}"
+            );
+            None
+        }
+    }
+}
+
+/// Global slot: try `AGENTS.md` at the XDG/APPDATA location first, fall
+/// back to `~/.claude/CLAUDE.md` (the Claude Code convention path).
+fn read_global_default() -> Option<(PathBuf, String)> {
+    if let Some(p) = global_agents_path()
+        && let Some(hit) = read_if_exists(&p)
+    {
+        return Some(hit);
+    }
+    if let Some(p) = global_claude_path()
+        && let Some(hit) = read_if_exists(&p)
+    {
+        return Some(hit);
+    }
+    None
+}
+
+#[cfg(unix)]
+fn global_agents_path() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        return Some(PathBuf::from(xdg).join("agents").join(PRIMARY));
+    }
+    dirs::home_dir().map(|h| h.join(".config").join("agents").join(PRIMARY))
+}
+
+#[cfg(windows)]
+fn global_agents_path() -> Option<PathBuf> {
+    std::env::var("APPDATA")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|s| PathBuf::from(s).join("agents").join(PRIMARY))
+}
+
+fn global_claude_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claude").join(FALLBACK))
+}
+
+fn render_display_path(path: &Path, base: &Path) -> String {
+    if let Ok(rel) = path.strip_prefix(base) {
+        if rel.as_os_str().is_empty() {
+            return path.display().to_string();
+        }
+        return rel.display().to_string();
+    }
+    path.display().to_string()
+}
+
+/// Returns `(slice, was_truncated)`. When `s.len() <= max_bytes` the
+/// whole string is returned and `was_truncated` is false. Otherwise the
+/// slice is cut at the largest UTF-8 char boundary `<= max_bytes`.
+fn clip_at_char_boundary(s: &str, max_bytes: usize) -> (&str, bool) {
+    if s.len() <= max_bytes {
+        return (s, false);
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    (&s[..end], true)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    fn touch_git(root: &Path) {
+        fs::create_dir_all(root.join(".git")).unwrap();
+    }
+
+    #[test]
+    fn returns_empty_when_no_files_present() {
+        let tmp = TempDir::new().unwrap();
+        let out = discover_inner(tmp.path(), None);
+        assert!(out.is_empty(), "expected empty discovery, got: {out:?}");
+    }
+
+    #[test]
+    fn reads_agents_md_at_cwd() {
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        write(&tmp.path().join(PRIMARY), "rule from agents");
+        let out = discover_inner(tmp.path(), None);
+        assert!(out.contains("rule from agents"));
+        assert!(out.contains("AGENTS.md"));
+    }
+
+    #[test]
+    fn falls_back_to_claude_md_when_agents_missing() {
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        write(&tmp.path().join(FALLBACK), "rule from claude");
+        let out = discover_inner(tmp.path(), None);
+        assert!(out.contains("rule from claude"));
+        assert!(out.contains("CLAUDE.md"));
+    }
+
+    #[test]
+    fn prefers_agents_when_both_present_in_same_dir() {
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        write(&tmp.path().join(PRIMARY), "from agents");
+        write(&tmp.path().join(FALLBACK), "from claude");
+        let out = discover_inner(tmp.path(), None);
+        assert!(out.contains("from agents"));
+        assert!(
+            !out.contains("from claude"),
+            "CLAUDE.md should be ignored when AGENTS.md exists at same dir, got: {out}"
+        );
+    }
+
+    #[test]
+    fn walks_up_from_subdir_to_git_root() {
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        write(&tmp.path().join(PRIMARY), "root rule");
+        let sub = tmp.path().join("a").join("b");
+        fs::create_dir_all(&sub).unwrap();
+        write(&sub.join(PRIMARY), "leaf rule");
+
+        let out = discover_inner(&sub, None);
+        let root_pos = out.find("root rule").expect("root rule missing");
+        let leaf_pos = out.find("leaf rule").expect("leaf rule missing");
+        assert!(
+            root_pos < leaf_pos,
+            "expected root before leaf (general -> specific); got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn mixed_agents_at_root_and_claude_in_subdir() {
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        write(&tmp.path().join(PRIMARY), "root agents");
+        let sub = tmp.path().join("pkg");
+        fs::create_dir_all(&sub).unwrap();
+        write(&sub.join(FALLBACK), "pkg claude");
+
+        let out = discover_inner(&sub, None);
+        assert!(out.contains("root agents"));
+        assert!(out.contains("pkg claude"));
+    }
+
+    #[test]
+    fn no_git_ancestor_uses_cwd_only_no_parent_walk() {
+        let tmp = TempDir::new().unwrap();
+        // Sibling AGENTS.md outside the cwd subdir; if we wrongly walked
+        // up to the fs root we'd pick it up.
+        write(&tmp.path().join(PRIMARY), "should not appear");
+        let cwd = tmp.path().join("isolated");
+        fs::create_dir_all(&cwd).unwrap();
+        write(&cwd.join(PRIMARY), "only this");
+
+        let out = discover_inner(&cwd, None);
+        assert!(out.contains("only this"));
+        assert!(
+            !out.contains("should not appear"),
+            "walk-up must stop at cwd when no .git ancestor; got: {out}"
+        );
+    }
+
+    #[test]
+    fn global_slot_is_prepended() {
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        write(&tmp.path().join(PRIMARY), "project rule");
+        let fake_global = PathBuf::from("/fake/global/AGENTS.md");
+        let global = Some((fake_global, "global rule".to_string()));
+
+        let out = discover_inner(tmp.path(), global);
+        let g_pos = out.find("global rule").expect("global rule missing");
+        let p_pos = out.find("project rule").expect("project rule missing");
+        assert!(
+            g_pos < p_pos,
+            "global should appear before project; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn cwd_equals_git_root_does_not_double_emit() {
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        write(&tmp.path().join(PRIMARY), "single rule");
+        let out = discover_inner(tmp.path(), None);
+        assert_eq!(out.matches("single rule").count(), 1);
+    }
+
+    #[test]
+    fn oversized_content_is_truncated_at_cap() {
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        let big = "x".repeat(MAX_TOTAL_BYTES + 4096);
+        write(&tmp.path().join(PRIMARY), &big);
+
+        let out = discover_inner(tmp.path(), None);
+        assert!(out.contains("[...truncated]"));
+        assert!(
+            out.len() <= MAX_TOTAL_BYTES + 64,
+            "output exceeds cap with slack: {} bytes",
+            out.len()
+        );
+    }
+
+    #[test]
+    fn truncation_preserves_utf8_char_boundary() {
+        // Pick a char that crosses the cap boundary.
+        let mut s = String::with_capacity(MAX_TOTAL_BYTES + 16);
+        // Fill almost to cap...
+        for _ in 0..(MAX_TOTAL_BYTES - 1) {
+            s.push('a');
+        }
+        // ...then a 4-byte char that would straddle the cap.
+        s.push('\u{1F600}');
+        s.push_str("trailing");
+
+        let tmp = TempDir::new().unwrap();
+        touch_git(tmp.path());
+        write(&tmp.path().join(PRIMARY), &s);
+
+        let out = discover_inner(tmp.path(), None);
+        // Should not panic and the emitted UTF-8 must be valid.
+        assert!(out.is_char_boundary(out.len()));
+    }
+}

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use clap::Parser;
 
 mod agent;
+mod agents_md;
 mod bifrost_client;
 mod codex_auth;
 mod codex_client;

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -223,6 +223,13 @@ pub struct Session {
     /// In-memory only -- the issue scope explicitly excludes
     /// workspace-level persistence for this knob.
     pub selected_reasoning_effort: Option<String>,
+    /// Concatenated AGENTS.md / CLAUDE.md content discovered under `cwd`
+    /// (and the user's global config slot) at session creation or on the
+    /// most recent `update_cwd`. Empty string means none found. Not
+    /// persisted -- re-discovered on load so the prompt sees the current
+    /// file on disk rather than a stale snapshot from when the session
+    /// was first created.
+    pub project_instructions: String,
 }
 
 impl Session {
@@ -246,6 +253,7 @@ impl Session {
                 Some(model.clone())
             },
         };
+        let project_instructions = crate::agents_md::discover(&cwd);
         Self {
             id,
             cwd,
@@ -256,6 +264,7 @@ impl Session {
             permission_mode,
             always_allow_tools: HashSet::new(),
             selected_reasoning_effort: None,
+            project_instructions,
         }
     }
 
@@ -287,6 +296,7 @@ impl Session {
                 loaded: manifest.id,
             });
         }
+        let project_instructions = crate::agents_md::discover(&cwd);
         Ok(Self {
             id,
             cwd,
@@ -301,6 +311,7 @@ impl Session {
             // reloaded zip starts at "use model default" until the
             // user picks again.
             selected_reasoning_effort: None,
+            project_instructions,
         })
     }
 }
@@ -344,6 +355,9 @@ pub struct SessionSnapshot {
     /// `default_reasoning_level`. `None` means the model exposes no
     /// effort presets, so the backend will simply omit the field.
     pub reasoning_effort: Option<String>,
+    /// AGENTS.md / CLAUDE.md content discovered for this session,
+    /// concatenated general -> specific. Empty when nothing is found.
+    pub project_instructions: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -1319,12 +1333,13 @@ impl SessionStore {
         // Holding both at once is unnecessary and would invite a lock
         // ordering hazard with set_model (which writes sessions then
         // reads available_models on auto-fallback).
-        let (snap_base, selected_effort) = {
+        let (snap_base, selected_effort, project_instructions) = {
             let sessions = self.sessions.read().await;
             let s = sessions.get(id)?;
             (
                 (s.cwd.clone(), s.mode, s.model.clone(), s.history.clone()),
                 s.selected_reasoning_effort.clone(),
+                s.project_instructions.clone(),
             )
         };
         let (cwd, mode, model, history) = snap_base;
@@ -1349,12 +1364,19 @@ impl SessionStore {
             model,
             history,
             reasoning_effort,
+            project_instructions,
         })
     }
 
     pub async fn update_cwd(&self, id: &str, cwd: PathBuf) {
+        // Re-discover AGENTS.md/CLAUDE.md against the new cwd before
+        // taking the write lock: file I/O off the lock keeps prompt
+        // turns and other session mutations unblocked. The discovery
+        // result is then swapped in atomically alongside the cwd.
+        let project_instructions = crate::agents_md::discover(&cwd);
         if let Some(session) = self.sessions.write().await.get_mut(id) {
             session.cwd = cwd;
+            session.project_instructions = project_instructions;
         }
     }
 


### PR DESCRIPTION
## Summary

Adds AGENTS.md (with CLAUDE.md fallback) discovery to `brokk-acp-rust`'s system prompt. Sessions now honor the open [agents.md](https://agents.md/) convention plus the proposed global-config location from [agentsmd/agents.md#91](https://github.com/agentsmd/agents.md/issues/91), so a brokk session in any repo with project instructions picks them up automatically.

Before: `build_system_prompt` was fully static (cwd context + mode boilerplate). Every other AGENTS.md-aware tool (Codex CLI, Cursor, droid, Amp) honored project conventions; brokk-acp did not.

## What changed

- **New `brokk-acp-rust/src/agents_md.rs`**: pure module with `discover(cwd) -> String`, plus helpers for git-root detection, XDG/APPDATA resolution, per-directory AGENTS-preferred-over-CLAUDE reads, and UTF-8-safe truncation at the 64 KB cap. 11 unit tests.
- **`session.rs`**: new `Session::project_instructions: String` field (in-memory only), populated in `Session::new`, `Session::from_persisted`, and re-run in `SessionStore::update_cwd`. Threaded through `SessionSnapshot`.
- **`agent.rs`**: `build_system_prompt(mode, cwd, project_instructions)` injects the discovered content between the cwd context and the mode role text, with a no-op guard when empty so prompts are byte-identical to today for projects without AGENTS.md/CLAUDE.md.
- **`main.rs`** / **`Cargo.toml`**: module wiring + `tempfile` dev-dependency for the new tests.

## Discovery order (general → specific)

1. Global: `$XDG_CONFIG_HOME/agents/AGENTS.md` (Unix) or `%APPDATA%\agents\AGENTS.md` (Windows); falls back to `~/.claude/CLAUDE.md` when the global AGENTS.md is absent.
2. Each directory from the discovered git root down to `cwd` (inclusive). Walk-up is bounded by `.git` so a cwd without an ancestor repo cannot pick up unrelated AGENTS.md from `~`, `/tmp`, or `/`.

At every slot AGENTS.md is preferred over CLAUDE.md (no double-counting when a repo keeps both during a migration).

## Notes for reviewers

- **Not persisted in the session zip** — re-discovered on session/load so the prompt always reflects the file on disk, not a snapshot from session creation. No changes to the zip schema.
- **Cap = 64 KB total** with `tracing::warn!` on overflow; the offending file is sliced at a UTF-8 char boundary to keep the emitted string valid.
- **No "closest-wins per edited file"** — the spec's per-file precedence would require hooking the filesystem tools and per-turn replay state. Out of scope for v1.
- **No new ACP config option** — opt-out is "don't have an AGENTS.md/CLAUDE.md."

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 194 tests pass, including 11 new `agents_md::tests` covering: empty discovery, AGENTS-only, CLAUDE-only, AGENTS preferred when both present, walk-up from subdir, mixed AGENTS/CLAUDE across levels, no-git-ancestor bound, global slot prepended, no double-emit when cwd == git_root, oversize truncation, UTF-8 char-boundary safety.
- [ ] Manual smoke: drop an AGENTS.md in a repo and confirm a brokk-acp session honors its rules; rename to CLAUDE.md and confirm the fallback path; drop one at `~/.config/agents/AGENTS.md` and confirm the global rule applies across sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
