### PR TITLE
brokk-acp-rust: map Default permission mode to WorkspaceWrite sandbox

### DIFF
--- a/brokk-acp-rust/src/tools/sandbox.rs
+++ b/brokk-acp-rust/src/tools/sandbox.rs
@@ -57,14 +57,21 @@ pub enum SandboxPolicy {
 impl SandboxPolicy {
     /// Map a session's `PermissionMode` to a sandbox tier.
     ///
-    /// `Default` resolves to `ReadOnly` because in default mode shell calls
-    /// still hit the per-call permission prompt; the sandbox bounds what
-    /// "Allow" actually grants. `BypassPermissions` is the explicit opt-out.
+    /// `Default` resolves to `WorkspaceWrite` so the per-call permission
+    /// prompt is the meaningful gate -- when the user clicks "Allow" the
+    /// shell call can actually write under cwd, mirroring what `writeFile`
+    /// (which bypasses the sandbox entirely) already does in this mode.
+    /// Previously `Default` mapped to `ReadOnly`, which silently turned the
+    /// "Allow" prompt into a no-op for shell writes and contradicted the
+    /// README contract ("Prompts the user for approval before every mutating
+    /// tool call"). `ReadOnly` mode still maps to `ReadOnly` for "no writes
+    /// at all", and `BypassPermissions` is the explicit opt-out from
+    /// sandboxing entirely.
     pub fn from_permission_mode(mode: PermissionMode) -> Self {
         match mode {
             PermissionMode::BypassPermissions => Self::None,
             PermissionMode::ReadOnly => Self::ReadOnly,
-            PermissionMode::Default => Self::ReadOnly,
+            PermissionMode::Default => Self::WorkspaceWrite,
             PermissionMode::AcceptEdits => Self::WorkspaceWrite,
         }
     }
@@ -162,9 +169,18 @@ fn wrap_platform(
     command: &str,
 ) -> std::io::Result<WrappedCommand> {
     let policy_content = build_seatbelt_policy(policy, cwd);
+    let has_write_rule = policy_content.contains("file-write*");
     let path = std::env::temp_dir().join(format!("brokk-seatbelt-{}.sb", uuid::Uuid::new_v4()));
     write_policy_file_secure(&path, &policy_content)
         .map_err(|e| sandbox_io_error(format!("write seatbelt profile: {e}")))?;
+    tracing::debug!(
+        target: "brokk_acp_rust::tools::sandbox",
+        policy = ?policy,
+        cwd = %cwd.display(),
+        profile_path = %path.display(),
+        has_workspace_write_rule = has_write_rule,
+        "materialized seatbelt profile",
+    );
     let temp = TempPolicyFile::new(path.clone());
 
     let argv = vec![
@@ -196,6 +212,15 @@ fn wrap_platform(
     }
 
     let argv = build_bwrap_argv(policy, cwd, command);
+    let has_workspace_bind = argv.windows(2).any(|w| w[0] == "--bind");
+    tracing::debug!(
+        target: "brokk_acp_rust::tools::sandbox",
+        policy = ?policy,
+        cwd = %cwd.display(),
+        has_workspace_bind = has_workspace_bind,
+        argv_len = argv.len(),
+        "prepared bwrap invocation",
+    );
     Ok(WrappedCommand {
         argv,
         sandboxed: true,
@@ -781,11 +806,36 @@ mod tests {
         );
         assert_eq!(
             SandboxPolicy::from_permission_mode(PermissionMode::Default),
-            SandboxPolicy::ReadOnly
+            SandboxPolicy::WorkspaceWrite
         );
         assert_eq!(
             SandboxPolicy::from_permission_mode(PermissionMode::AcceptEdits),
             SandboxPolicy::WorkspaceWrite
+        );
+    }
+
+    /// Regression for the bug where Default mode produced a seatbelt profile
+    /// with no `file-write*` rule, so clicking "Allow" on the per-call
+    /// permission prompt could not actually let shell writes through.
+    /// `writeFile` (which bypasses the sandbox entirely) succeeded in the
+    /// same mode, making the user experience appear arbitrary.
+    #[test]
+    fn default_mode_seatbelt_profile_grants_workspace_writes() {
+        let policy = SandboxPolicy::from_permission_mode(PermissionMode::Default);
+        let scheme = build_seatbelt_policy(policy, Path::new("/tmp"));
+        assert!(
+            scheme.contains("file-write*"),
+            "Default mode must emit a file-write* rule so an approved shell call can write under cwd; got:\n{scheme}"
+        );
+    }
+
+    #[test]
+    fn read_only_mode_seatbelt_profile_still_blocks_writes() {
+        let policy = SandboxPolicy::from_permission_mode(PermissionMode::ReadOnly);
+        let scheme = build_seatbelt_policy(policy, Path::new("/tmp"));
+        assert!(
+            !scheme.contains("file-write*"),
+            "ReadOnly mode must never emit a file-write* rule; got:\n{scheme}"
         );
     }
 

--- a/brokk-acp-rust/src/tools/shell.rs
+++ b/brokk-acp-rust/src/tools/shell.rs
@@ -336,6 +336,14 @@ pub async fn run_shell_command(
             };
         }
     };
+    tracing::debug!(
+        target: "brokk_acp_rust::tools::shell",
+        policy = ?policy,
+        cwd = %cwd.display(),
+        sandboxed = wrapped.sandboxed,
+        argv0 = %wrapped.argv[0],
+        "runShellCommand: wrapped command ready",
+    );
 
     // The user requested a sandbox tier (ReadOnly / WorkspaceWrite) but the
     // platform tooling was missing. We still execute -- matching Java's


### PR DESCRIPTION
## Summary

In Default permission mode, `runShellCommand` writes were silently blocked at the seatbelt/bwrap layer even after the user clicked Allow on the per-call permission prompt, while `writeFile` (which bypasses the sandbox) succeeded on the same paths. This PR aligns the Rust ACP server's sandbox mapping with the README contract.

## Root cause

`SandboxPolicy::from_permission_mode` mapped `PermissionMode::Default -> SandboxPolicy::ReadOnly`. In ReadOnly mode, `build_seatbelt_policy` returns the base profile with no `file-write*` rule, so the kernel rejected every shell write regardless of the user-approval outcome. The README ligne 93 promises:

> **Default**: Prompts the user for approval before every mutating tool call.

That promise was functionally broken for shell mutations — the prompt fired, but Allow couldn't release the write.

## Fix

One-line change in `from_permission_mode`:

```diff
-PermissionMode::Default => Self::ReadOnly,
+PermissionMode::Default => Self::WorkspaceWrite,
```

The per-call permission prompt for `runShellCommand` remains in place (`requires_per_call_prompt` is unchanged); it is now the meaningful gate. Other modes are unchanged: ReadOnly still blocks all writes, AcceptEdits still auto-allows edits while prompting for shell, BypassPermissions still skips sandboxing.

## Observability added

Three `tracing::debug!` breadcrumbs make future sandbox diagnostics tractable without re-instrumenting:

- `brokk_acp_rust::tools::sandbox` on macOS — logs the materialized profile_path plus a pre-computed `has_workspace_write_rule` boolean (the smoking gun for any future "writes are silently denied" report).
- `brokk_acp_rust::tools::sandbox` on Linux — logs whether the bwrap argv contains a workspace `--bind`.
- `brokk_acp_rust::tools::shell` — logs policy + cwd + sandboxed for every `runShellCommand`.

Enable with `RUST_LOG=brokk_acp_rust::tools=debug`.

## Tests

Two regression tests added:

- `default_mode_seatbelt_profile_grants_workspace_writes` — asserts the Default-mode profile contains a `file-write*` rule.
- `read_only_mode_seatbelt_profile_still_blocks_writes` — asserts ReadOnly continues to block writes.

Existing `from_permission_mode_maps_to_expected_tiers` updated to pin the new mapping. The gate-decision tests in `tool_loop.rs` are orthogonal (they test the user-approval gate, not the sandbox tier) and are unchanged.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --bins`: 185/185 pass.

## Security note for reviewers

In Default mode, an erroneously approved `runShellCommand` can now actually write to disk (within cwd). Previously such a click had no effect because the kernel killed the write. The new posture matches `writeFile`'s existing behavior in Default mode (where it has always honored Allow) and matches what AcceptEdits already does for shell. seatbelt/bwrap continues to confine writes to cwd; network egress and process exec are unchanged.

If you'd prefer the inverse symmetry (route `writeFile` through the sandbox so it also gets blocked in Default), say so and I'll spin that off — but it would require a README rewrite to clarify that Default's "prompt" cannot actually grant writes.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bins` — 185/185 pass (was 183 before regression tests)
- [ ] Manual: launch the server in Default mode from Zed or IntelliJ Brokk, have an agent `sed -i '' 's/foo/foo/' src/tools/shell.rs`, click Allow on the prompt; confirm the write lands and `RUST_LOG=brokk_acp_rust::tools=debug` shows `policy=WorkspaceWrite has_workspace_write_rule=true`.
