### PR TITLE
Expose headless model token budgets

### DIFF
--- a/app/src/main/java/ai/brokk/AbstractService.java
+++ b/app/src/main/java/ai/brokk/AbstractService.java
@@ -139,6 +139,8 @@ public abstract class AbstractService implements ExceptionReporter.ReportingServ
         }
     }
 
+    public record ModelTokenBudget(int maxInputTokens, int maxOutputTokens, boolean tokensEstimated) {}
+
     public record PriceBand(
             long minTokensInclusive,
             long maxTokensInclusive, // Long.MAX_VALUE means "no upper limit"
@@ -466,6 +468,49 @@ public abstract class AbstractService implements ExceptionReporter.ReportingServ
         var value = info.get("max_input_tokens");
         assert value instanceof Integer;
         return (Integer) value;
+    }
+
+    public Optional<ModelTokenBudget> getModelTokenBudget(String modelName) {
+        var explicitInfo = getExplicitModelInfo(modelName);
+        if (explicitInfo.isPresent()) {
+            return parseModelTokenBudget(explicitInfo.get(), MainProject.isCustomProvider());
+        }
+
+        if (MainProject.isCustomProvider()) {
+            return parseModelTokenBudget(CUSTOM_MODEL_DEFAULTS, true);
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<Map<String, Object>> getExplicitModelInfo(String modelName) {
+        var info = modelInfoMap.get(modelName);
+        if (info != null) {
+            return Optional.of(info);
+        }
+
+        return modelInfoMap.values().stream()
+                .filter(m -> modelName.equals(m.get("model_location")))
+                .findFirst();
+    }
+
+    private static Optional<ModelTokenBudget> parseModelTokenBudget(Map<String, Object> info, boolean tokensEstimated) {
+        var maxInputTokens = positiveInt(info.get("max_input_tokens"));
+        var maxOutputTokens = positiveInt(info.get("max_output_tokens"));
+        if (maxInputTokens.isEmpty() || maxOutputTokens.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new ModelTokenBudget(maxInputTokens.get(), maxOutputTokens.get(), tokensEstimated));
+    }
+
+    private static Optional<Integer> positiveInt(@Nullable Object value) {
+        if (value instanceof Number number) {
+            var intValue = number.intValue();
+            if (intValue > 0) {
+                return Optional.of(intValue);
+            }
+        }
+        return Optional.empty();
     }
 
     /**

--- a/app/src/main/java/ai/brokk/executor/routers/ModelsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/ModelsRouter.java
@@ -1,13 +1,18 @@
 package ai.brokk.executor.routers;
 
+import ai.brokk.AbstractService.ModelTokenBudget;
 import ai.brokk.ContextManager;
 import ai.brokk.executor.http.SimpleHttpServer;
 import ai.brokk.executor.jobs.ErrorPayload;
 import com.sun.net.httpserver.HttpExchange;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -29,6 +34,17 @@ public final class ModelsRouter implements SimpleHttpServer.CheckedHttpHandler {
             return;
         }
         try {
+            var path = exchange.getRequestURI().getPath();
+            if (path.startsWith("/v1/models/") && path.endsWith("/budget")) {
+                handleBudgetLookup(exchange, path);
+                return;
+            }
+            if (!path.equals("/v1/models")) {
+                SimpleHttpServer.sendJsonResponse(
+                        exchange, 404, ErrorPayload.of(ErrorPayload.Code.NOT_FOUND, "Model endpoint not found"));
+                return;
+            }
+
             var service = contextManager.getService();
             var availableModels = service.getAvailableModels();
             var models = availableModels.entrySet().stream()
@@ -40,6 +56,7 @@ public final class ModelsRouter implements SimpleHttpServer.CheckedHttpHandler {
                         model.put("location", entry.getValue());
                         model.put("supportsReasoningEffort", service.supportsReasoningEffort(name));
                         model.put("supportsReasoningDisable", service.supportsReasoningDisable(name));
+                        addBudgetFields(model, service.getModelTokenBudget(name).orElse(null));
                         return model;
                     })
                     .toList();
@@ -50,5 +67,41 @@ public final class ModelsRouter implements SimpleHttpServer.CheckedHttpHandler {
             SimpleHttpServer.sendJsonResponse(
                     exchange, 500, ErrorPayload.internalError("Failed to retrieve models", e));
         }
+    }
+
+    private void handleBudgetLookup(HttpExchange exchange, String path) throws Exception {
+        var encodedName = path.substring("/v1/models/".length(), path.length() - "/budget".length());
+        if (encodedName.isBlank()) {
+            RouterUtil.sendValidationError(exchange, "model name is required");
+            return;
+        }
+
+        var modelName = URLDecoder.decode(encodedName, StandardCharsets.UTF_8);
+        var service = contextManager.getService();
+        var budget = service.getAvailableModels().containsKey(modelName)
+                ? service.getModelTokenBudget(modelName)
+                : Optional.<ModelTokenBudget>empty();
+        if (budget.isEmpty()) {
+            SimpleHttpServer.sendJsonResponse(
+                    exchange,
+                    404,
+                    ErrorPayload.of(ErrorPayload.Code.NOT_FOUND, "Token budget not found for model: " + modelName));
+            return;
+        }
+
+        var response = new HashMap<String, Object>();
+        response.put("model", modelName);
+        addBudgetFields(response, budget.get());
+        SimpleHttpServer.sendJsonResponse(exchange, response);
+    }
+
+    private static void addBudgetFields(Map<String, Object> model, @Nullable ModelTokenBudget budget) {
+        model.put("budgetAvailable", budget != null);
+        model.put("tokensEstimated", budget != null && budget.tokensEstimated());
+        if (budget == null) {
+            return;
+        }
+        model.put("maxInputTokens", budget.maxInputTokens());
+        model.put("maxOutputTokens", budget.maxOutputTokens());
     }
 }

--- a/app/src/test/java/ai/brokk/executor/routers/ModelsRouterTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/ModelsRouterTest.java
@@ -1,26 +1,22 @@
 package ai.brokk.executor.routers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.brokk.AbstractService;
 import ai.brokk.ContextManager;
 import ai.brokk.executor.jobs.ErrorPayload;
 import ai.brokk.project.MainProject;
+import ai.brokk.testutil.TestService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.net.httpserver.Headers;
-import com.sun.net.httpserver.HttpContext;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpPrincipal;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -29,12 +25,20 @@ class ModelsRouterTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private ModelsRouter modelsRouter;
+    private TestService service;
 
     @BeforeEach
     void setUp(@TempDir Path tempDir) throws Exception {
         var project = new MainProject(tempDir);
-        var contextManager = new ContextManager(project);
+        var serviceProvider = TestService.testProvider(project);
+        var contextManager = new ContextManager(project, serviceProvider);
+        service = serviceProvider.testService();
         modelsRouter = new ModelsRouter(contextManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MainProject.setHeadlessProxySettingOverride(null);
     }
 
     @Test
@@ -49,6 +53,100 @@ class ModelsRouterTest {
     }
 
     @Test
+    void handleGetModels_includesTokenBudgetsWhenKnown() throws Exception {
+        service.setAvailableModels(Map.of("model-a", TestService.modelInfo(true, false)));
+
+        var exchange = TestHttpExchange.request("GET", "/v1/models");
+        modelsRouter.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        Map<String, List<Map<String, Object>>> body =
+                MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+        var model = body.get("models").getFirst();
+        assertEquals("model-a", model.get("name"));
+        assertEquals(8192, model.get("maxInputTokens"));
+        assertEquals(2048, model.get("maxOutputTokens"));
+        assertEquals(Boolean.TRUE, model.get("budgetAvailable"));
+        assertEquals(Boolean.FALSE, model.get("tokensEstimated"));
+    }
+
+    @Test
+    void handleGetModels_marksCustomProviderBudgetsEstimated() throws Exception {
+        MainProject.setHeadlessProxySettingOverride(MainProject.LlmProxySetting.CUSTOM);
+        service.setAvailableModels(Map.of("custom-model", TestService.modelInfo(true, false)));
+
+        var exchange = TestHttpExchange.request("GET", "/v1/models");
+        modelsRouter.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        Map<String, List<Map<String, Object>>> body =
+                MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+        var model = body.get("models").getFirst();
+        assertEquals("custom-model", model.get("name"));
+        assertEquals(Boolean.TRUE, model.get("budgetAvailable"));
+        assertEquals(Boolean.TRUE, model.get("tokensEstimated"));
+    }
+
+    @Test
+    void handleGetModels_marksBudgetUnavailableWhenMetadataIsMissing() throws Exception {
+        service.setAvailableModels(Map.of(
+                "model-a",
+                Map.of("supported_openai_params", List.of("temperature"), "supports_reasoning_disable", false)));
+
+        var exchange = TestHttpExchange.request("GET", "/v1/models");
+        modelsRouter.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        Map<String, List<Map<String, Object>>> body =
+                MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+        var model = body.get("models").getFirst();
+        assertEquals(Boolean.FALSE, model.get("budgetAvailable"));
+        assertEquals(Boolean.FALSE, model.get("tokensEstimated"));
+        assertFalse(model.containsKey("maxInputTokens"));
+        assertFalse(model.containsKey("maxOutputTokens"));
+    }
+
+    @Test
+    void handleGetModelBudget_returnsBudgetForExactModelName() throws Exception {
+        service.setAvailableModels(Map.of("provider/model a", TestService.modelInfo(false, false)));
+
+        var modelName = URLEncoder.encode("provider/model a", StandardCharsets.UTF_8);
+        var exchange = TestHttpExchange.request("GET", "/v1/models/" + modelName + "/budget");
+        modelsRouter.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        Map<String, Object> body = MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+        assertEquals("provider/model a", body.get("model"));
+        assertEquals(8192, body.get("maxInputTokens"));
+        assertEquals(2048, body.get("maxOutputTokens"));
+        assertEquals(Boolean.TRUE, body.get("budgetAvailable"));
+        assertEquals(Boolean.FALSE, body.get("tokensEstimated"));
+    }
+
+    @Test
+    void handleGetModelBudget_returnsNotFoundWhenBudgetIsUnknown() throws Exception {
+        var exchange = TestHttpExchange.request("GET", "/v1/models/unknown/budget");
+        modelsRouter.handle(exchange);
+
+        assertEquals(404, exchange.responseCode());
+        var payload = MAPPER.readValue(exchange.responseBodyBytes(), ErrorPayload.class);
+        assertEquals(ErrorPayload.Code.NOT_FOUND, payload.code());
+    }
+
+    @Test
+    void handleGetModelBudget_returnsNotFoundWhenModelIsUnavailable() throws Exception {
+        service.setAvailableModels(Map.of(AbstractService.UNAVAILABLE, TestService.modelInfo(false, false)));
+
+        var modelName = URLEncoder.encode(AbstractService.UNAVAILABLE, StandardCharsets.UTF_8);
+        var exchange = TestHttpExchange.request("GET", "/v1/models/" + modelName + "/budget");
+        modelsRouter.handle(exchange);
+
+        assertEquals(404, exchange.responseCode());
+        var payload = MAPPER.readValue(exchange.responseBodyBytes(), ErrorPayload.class);
+        assertEquals(ErrorPayload.Code.NOT_FOUND, payload.code());
+    }
+
+    @Test
     void handlePostModels_returnsMethodNotAllowed() throws Exception {
         var exchange = TestHttpExchange.request("POST", "/v1/models");
         modelsRouter.handle(exchange);
@@ -56,109 +154,5 @@ class ModelsRouterTest {
         assertEquals(405, exchange.responseCode());
         var payload = MAPPER.readValue(exchange.responseBodyBytes(), ErrorPayload.class);
         assertEquals(ErrorPayload.Code.METHOD_NOT_ALLOWED, payload.code());
-    }
-
-    private static final class TestHttpExchange extends HttpExchange {
-        private final Headers requestHeaders = new Headers();
-        private final Headers responseHeaders = new Headers();
-        private final ByteArrayOutputStream responseBody = new ByteArrayOutputStream();
-        private String method = "GET";
-        private URI uri = URI.create("/");
-        private byte[] requestBodyBytes = new byte[0];
-        private int responseCode = -1;
-
-        static TestHttpExchange request(String method, String path) {
-            var ex = new TestHttpExchange();
-            ex.method = method;
-            ex.uri = URI.create(path);
-            return ex;
-        }
-
-        int responseCode() {
-            return responseCode;
-        }
-
-        byte[] responseBodyBytes() {
-            return responseBody.toByteArray();
-        }
-
-        @Override
-        public Headers getRequestHeaders() {
-            return requestHeaders;
-        }
-
-        @Override
-        public Headers getResponseHeaders() {
-            return responseHeaders;
-        }
-
-        @Override
-        public URI getRequestURI() {
-            return uri;
-        }
-
-        @Override
-        public String getRequestMethod() {
-            return method;
-        }
-
-        @Override
-        public HttpContext getHttpContext() {
-            return null;
-        }
-
-        @Override
-        public void close() {}
-
-        @Override
-        public InputStream getRequestBody() {
-            return new ByteArrayInputStream(requestBodyBytes);
-        }
-
-        @Override
-        public OutputStream getResponseBody() {
-            return responseBody;
-        }
-
-        @Override
-        public void sendResponseHeaders(int rCode, long responseLength) {
-            this.responseCode = rCode;
-        }
-
-        @Override
-        public int getResponseCode() {
-            return responseCode;
-        }
-
-        @Override
-        public InetSocketAddress getRemoteAddress() {
-            return null;
-        }
-
-        @Override
-        public InetSocketAddress getLocalAddress() {
-            return null;
-        }
-
-        @Override
-        public String getProtocol() {
-            return "HTTP/1.1";
-        }
-
-        @Override
-        public Object getAttribute(String name) {
-            return null;
-        }
-
-        @Override
-        public void setAttribute(String name, Object value) {}
-
-        @Override
-        public void setStreams(InputStream i, OutputStream o) {}
-
-        @Override
-        public HttpPrincipal getPrincipal() {
-            return null;
-        }
     }
 }

--- a/app/src/test/java/ai/brokk/testutil/TestService.java
+++ b/app/src/test/java/ai/brokk/testutil/TestService.java
@@ -105,20 +105,34 @@ public class TestService extends AbstractService {
         // No-op for test service
     }
 
+    public static TestServiceProvider testProvider(IProject project) {
+        return new TestServiceProvider(project);
+    }
+
     // Backward-compatible provider entry point used by other tests
     public static Service.Provider provider(MainProject project) {
-        return new Service.Provider() {
-            private TestService svc = new TestService(project);
+        return testProvider(project);
+    }
 
-            @Override
-            public AbstractService get() {
-                return svc;
-            }
+    public static class TestServiceProvider implements Service.Provider {
+        private TestService svc;
 
-            @Override
-            public void reinit(IProject p) {
-                svc = new TestService(p);
-            }
-        };
+        private TestServiceProvider(IProject project) {
+            this.svc = new TestService(project);
+        }
+
+        @Override
+        public AbstractService get() {
+            return svc;
+        }
+
+        @Override
+        public void reinit(IProject project) {
+            svc = new TestService(project);
+        }
+
+        public TestService testService() {
+            return svc;
+        }
     }
 }


### PR DESCRIPTION
### Description
Expose token budget metadata through the headless executor model APIs so callers can retrieve max input/output limits for exact model names without relying on context endpoint defaults or client-side model tables.

**Key Changes**:
- Adds a model token budget lookup to `AbstractService` with explicit availability and estimated-budget signaling for custom providers.
- Extends `/v1/models` entries and adds `/v1/models/{modelName}/budget`, while gating direct lookup through the same available-model filters as the model list.
- Adds focused router coverage for known, missing, custom-provider estimated, exact lookup, and unavailable model budget behavior.

**Touch Points**:
- `app/src/main/java/ai/brokk/AbstractService.java`
- `app/src/main/java/ai/brokk/executor/routers/ModelsRouter.java`
- `app/src/test/java/ai/brokk/executor/routers/ModelsRouterTest.java`

Verification:
- `./gradlew :app:test --tests ai.brokk.executor.routers.ModelsRouterTest`
- `./gradlew fix tidy`
- `./gradlew analyze`