### PR TITLE
Fix repeated analyzer declaration scans in test filtering

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TestFileHeuristics.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TestFileHeuristics.java
@@ -21,15 +21,16 @@ public final class TestFileHeuristics {
             + ".*");
 
     public static boolean isTestFile(ProjectFile file, @Nullable IAnalyzer analyzer) {
-        if (analyzer != null && !analyzer.isEmpty()) {
-            IAnalyzer effectiveAnalyzer = analyzer;
-            if (analyzer instanceof MultiAnalyzer multi) {
+        if (analyzer != null) {
+            var effectiveAnalyzer = analyzer;
+            if (effectiveAnalyzer instanceof MultiAnalyzer multi) {
                 var lang = Languages.fromExtension(file.extension());
                 effectiveAnalyzer = multi.getDelegates().get(lang);
             }
 
             if (effectiveAnalyzer != null
-                    && effectiveAnalyzer.as(TestDetectionProvider.class).isPresent()) {
+                    && effectiveAnalyzer.as(TestDetectionProvider.class).isPresent()
+                    && !effectiveAnalyzer.isEmpty()) {
                 return effectiveAnalyzer.containsTests(file);
             }
         }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1356,6 +1356,11 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     }
 
     @Override
+    public boolean isEmpty() {
+        return this.state.codeUnitState.isEmpty();
+    }
+
+    @Override
     public Set<CodeUnit> searchDefinitions(String pattern, boolean autoQuote) {
         // Validate pattern
         if (pattern.isEmpty()) {

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/tests/JavaTestDetectionTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/tests/JavaTestDetectionTest.java
@@ -1,14 +1,17 @@
 package ai.brokk.analyzer.tests;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.JavaAnalyzer;
 import ai.brokk.analyzer.Languages;
+import ai.brokk.analyzer.MultiAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.analyzer.TestDetectionProvider;
 import ai.brokk.analyzer.TestFileHeuristics;
 import ai.brokk.testutil.InlineTestProjectCreator;
+import ai.brokk.testutil.TestAnalyzer;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -163,6 +166,56 @@ public class JavaTestDetectionTest {
             assertTrue(
                     TestFileHeuristics.isTestFile(sqlFile, multiAnalyzer),
                     "SQL file should fall back to filename heuristics because SQL delegate lacks TestDetectionProvider capability");
+        }
+    }
+
+    @Test
+    void multiAnalyzerTestDetectionDoesNotMaterializeUnrelatedDelegateDeclarations() throws Exception {
+        try (var project = InlineTestProjectCreator.code("class Subject {}", "src/Subject.java")
+                .addFileContents("SELECT 1;", "db/QueryTest.sql")
+                .build()) {
+            var javaFile = new ProjectFile(project.getRoot(), "src/Subject.java");
+            var sqlFile = new ProjectFile(project.getRoot(), "db/QueryTest.sql");
+            var javaAnalyzer = new CountingTestAnalyzer(javaFile);
+            var sqlAnalyzer = new ThrowingDeclarationAnalyzer();
+            var multiAnalyzer = new MultiAnalyzer(Map.of(Languages.JAVA, javaAnalyzer, Languages.SQL, sqlAnalyzer));
+
+            assertTrue(TestFileHeuristics.isTestFile(javaFile, multiAnalyzer));
+            assertEquals(1, javaAnalyzer.getAllDeclarationsCalls);
+            assertEquals(0, sqlAnalyzer.getAllDeclarationsCalls);
+
+            assertTrue(TestFileHeuristics.isTestFile(sqlFile, multiAnalyzer));
+            assertEquals(1, javaAnalyzer.getAllDeclarationsCalls);
+            assertEquals(0, sqlAnalyzer.getAllDeclarationsCalls);
+        }
+    }
+
+    private static final class CountingTestAnalyzer extends TestAnalyzer {
+        private int getAllDeclarationsCalls;
+
+        private CountingTestAnalyzer(ProjectFile declarationFile) {
+            addDeclaration(CodeUnit.cls(declarationFile, "", "Subject"));
+            setContainsTests(declarationFile, true);
+        }
+
+        @Override
+        public List<CodeUnit> getAllDeclarations() {
+            getAllDeclarationsCalls++;
+            return super.getAllDeclarations();
+        }
+    }
+
+    private static final class ThrowingDeclarationAnalyzer extends TestAnalyzer {
+        private int getAllDeclarationsCalls;
+
+        private ThrowingDeclarationAnalyzer() {
+            setSupportsTestDetection(false);
+        }
+
+        @Override
+        public List<CodeUnit> getAllDeclarations() {
+            getAllDeclarationsCalls++;
+            throw new AssertionError("Unrelated delegate declarations should not be materialized");
         }
     }
 

--- a/brokk-shared/src/testFixtures/java/ai/brokk/testutil/TestAnalyzer.java
+++ b/brokk-shared/src/testFixtures/java/ai/brokk/testutil/TestAnalyzer.java
@@ -1,7 +1,7 @@
 package ai.brokk.testutil;
 
 import ai.brokk.analyzer.*;
-import ai.brokk.project.IProject;
+import ai.brokk.project.ICoreProject;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,10 +30,10 @@ public class TestAnalyzer
     private final Map<CodeUnit, List<Range>> rangesByCodeUnit = new HashMap<>();
     private final Map<ProjectFile, List<ImportInfo>> importInfoByFile = new HashMap<>();
     private final Map<CodeUnit, Set<String>> relevantImportsByCodeUnit = new LinkedHashMap<>();
-    private @Nullable IProject testProject;
+    private @Nullable ICoreProject testProject;
 
     public TestAnalyzer(
-            List<CodeUnit> allClasses, Map<String, List<CodeUnit>> methodsMap, @Nullable IProject testProject) {
+            List<CodeUnit> allClasses, Map<String, List<CodeUnit>> methodsMap, @Nullable ICoreProject testProject) {
         this.allClasses = allClasses;
         this.methodsMap = methodsMap;
         this.testProject = testProject;
@@ -85,7 +85,7 @@ public class TestAnalyzer
     }
 
     @Override
-    public IProject getProject() {
+    public ICoreProject getProject() {
         if (testProject == null) {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
### Description
Fixes usage snapshot construction spending excessive CPU and allocations while filtering test files on large repositories. The test-file heuristic now selects a MultiAnalyzer language delegate before checking whether semantic test detection can run, and TreeSitterAnalyzer exposes a cheap isEmpty() implementation.

**Key Changes**:
- Avoid calling MultiAnalyzer.isEmpty() for every candidate file before delegate routing, preventing unrelated analyzers from materializing full declaration lists during test filtering.
- Add a direct TreeSitterAnalyzer.isEmpty() check against codeUnitState and cover the MultiAnalyzer routing behavior with a regression test.
- Move TestAnalyzer into brokk-shared test fixtures so analyzer tests can share the existing mock.

**Touch Points**:
- brokk-shared/src/main/java/ai/brokk/analyzer/TestFileHeuristics.java
- brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
- brokk-shared/src/test/java/ai/brokk/analyzer/tests/JavaTestDetectionTest.java
- brokk-shared/src/testFixtures/java/ai/brokk/testutil/TestAnalyzer.java

Fixes #3577