### PR TITLE
Consolidate usage analysis worker pools

### DIFF
--- a/app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java
+++ b/app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java
@@ -11,13 +11,11 @@ import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.analyzer.TypeHierarchyProvider;
 import ai.brokk.analyzer.usages.FuzzyResult;
+import ai.brokk.analyzer.usages.UsageAnalysisExecutors;
 import ai.brokk.analyzer.usages.UsageAnalyzer;
 import ai.brokk.analyzer.usages.UsageHit;
 import ai.brokk.analyzer.usages.UsagePrompt;
-import ai.brokk.concurrent.ExecutorsUtil;
-import ai.brokk.concurrent.LoggingExecutorService;
 import ai.brokk.project.IProject;
-import ai.brokk.util.ConcurrencyUtil;
 import ai.brokk.util.FileUtil;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -50,9 +48,6 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class LlmUsageAnalyzer implements UsageAnalyzer {
     private static final Logger logger = LogManager.getLogger(LlmUsageAnalyzer.class);
-    private static final int FUZZY_SCAN_PARALLELISM = ConcurrencyUtil.computeAdaptiveIoConcurrencyCap();
-    private static final LoggingExecutorService FUZZY_SCAN_EXECUTOR =
-            ExecutorsUtil.newVirtualThreadExecutor("fuzzy-usage-scan-", FUZZY_SCAN_PARALLELISM);
 
     private final IProject project;
     private final IAnalyzer analyzer;
@@ -188,7 +183,7 @@ public final class LlmUsageAnalyzer implements UsageAnalyzer {
                 })
                 .toList();
 
-        var futures = FUZZY_SCAN_EXECUTOR.invokeAll(tasks);
+        var futures = UsageAnalysisExecutors.ioExecutor().invokeAll(tasks);
         for (var future : futures) {
             try {
                 future.get();

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/java/JdtUsageAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/java/JdtUsageAnalyzer.java
@@ -4,9 +4,8 @@ import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.CodeUnitType;
 import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.analyzer.usages.UsageAnalysisExecutors;
 import ai.brokk.analyzer.usages.UsageHit;
-import ai.brokk.concurrent.ExecutorsUtil;
-import ai.brokk.concurrent.LoggingExecutorService;
 import ai.brokk.project.ICoreProject;
 import com.google.common.collect.Lists;
 import java.nio.file.Files;
@@ -156,43 +155,40 @@ public class JdtUsageAnalyzer {
         List<List<ProjectFile>> batches = Lists.partition(javaFiles, 50);
 
         Set<UsageHit> allHits = new HashSet<>();
-        int threads = Runtime.getRuntime().availableProcessors();
-        try (LoggingExecutorService executor = ExecutorsUtil.newFixedThreadExecutor("jdt-usage-analyzer-", threads)) {
-            List<Callable<Set<UsageHit>>> tasks = batches.stream()
-                    .map(batch -> (Callable<Set<UsageHit>>) () -> {
-                        ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
-                        parser.setResolveBindings(true);
-                        parser.setBindingsRecovery(true);
-                        parser.setKind(ASTParser.K_COMPILATION_UNIT);
-                        parser.setCompilerOptions(options);
-                        parser.setEnvironment(classpath, sourceRoots, null, true);
+        List<Callable<Set<UsageHit>>> tasks = batches.stream()
+                .map(batch -> (Callable<Set<UsageHit>>) () -> {
+                    ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+                    parser.setResolveBindings(true);
+                    parser.setBindingsRecovery(true);
+                    parser.setKind(ASTParser.K_COMPILATION_UNIT);
+                    parser.setCompilerOptions(options);
+                    parser.setEnvironment(classpath, sourceRoots, null, true);
 
-                        String[] sourcePaths = batch.stream()
-                                .map(pf -> pf.absPath().toString())
-                                .toArray(String[]::new);
+                    String[] sourcePaths =
+                            batch.stream().map(pf -> pf.absPath().toString()).toArray(String[]::new);
 
-                        UsageCollector collector = new UsageCollector(target, new HashSet<>(batch));
-                        try {
-                            parser.createASTs(sourcePaths, null, new String[0], collector, null);
-                        } catch (AssertionError | Exception t) {
-                            log.error("JDT analysis failed for a batch in {}", target.fqName(), t);
-                            throw new RuntimeException("Failed to analyze JDT batch for " + target.fqName(), t);
-                        }
-                        return collector.getHits();
-                    })
-                    .toList();
+                    UsageCollector collector = new UsageCollector(target, new HashSet<>(batch));
+                    try {
+                        parser.createASTs(sourcePaths, null, new String[0], collector, null);
+                    } catch (AssertionError | Exception t) {
+                        log.error("JDT analysis failed for a batch in {}", target.fqName(), t);
+                        throw new RuntimeException("Failed to analyze JDT batch for " + target.fqName(), t);
+                    }
+                    return collector.getHits();
+                })
+                .toList();
 
-            try {
-                List<Future<Set<UsageHit>>> futures = executor.invokeAll(tasks);
-                for (var future : futures) {
-                    allHits.addAll(future.get());
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException("JDT usage analysis interrupted", e);
-            } catch (Exception e) {
-                throw new RuntimeException("JDT usage analysis failed", e);
+        try {
+            List<Future<Set<UsageHit>>> futures =
+                    UsageAnalysisExecutors.cpuExecutor().invokeAll(tasks);
+            for (var future : futures) {
+                allHits.addAll(future.get());
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("JDT usage analysis interrupted", e);
+        } catch (Exception e) {
+            throw new RuntimeException("JDT usage analysis failed", e);
         }
 
         return Collections.unmodifiableSet(allHits);

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/RegexUsageAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/RegexUsageAnalyzer.java
@@ -11,7 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -70,56 +72,71 @@ public final class RegexUsageAnalyzer implements UsageAnalyzer {
         return new FuzzyResult.Ambiguous(target.shortName(), matchingCodeUnits, Map.of(target, hits));
     }
 
-    private Set<UsageHit> extractUsageHits(Set<ProjectFile> candidateFiles, Set<String> searchPatterns) {
+    private Set<UsageHit> extractUsageHits(Set<ProjectFile> candidateFiles, Set<String> searchPatterns)
+            throws InterruptedException {
         var hits = new ConcurrentHashMap<UsageHit, Boolean>();
         final var patterns = searchPatterns.stream().map(Pattern::compile).toList();
 
-        candidateFiles.parallelStream().forEach(file -> {
-            try {
-                if (!file.isText()) return;
-                var contentOpt = file.read();
-                if (contentOpt.isEmpty()) return;
-                var content = contentOpt.get();
-                if (content.isEmpty()) return;
+        var tasks = candidateFiles.stream()
+                .<Callable<Void>>map(file -> () -> {
+                    try {
+                        if (!file.isText()) return null;
+                        var contentOpt = file.read();
+                        if (contentOpt.isEmpty()) return null;
+                        var content = contentOpt.get();
+                        if (content.isEmpty()) return null;
 
-                String[] lines = null;
-                int[] lineStarts = null;
+                        String[] lines = null;
+                        int[] lineStarts = null;
 
-                for (var pattern : patterns) {
-                    var matcher = pattern.matcher(content);
-                    while (matcher.find()) {
-                        int start = matcher.start();
-                        int end = matcher.end();
-                        int startByte = ASTTraversalUtils.charPositionToUtf8ByteOffset(content, start);
-                        int endByte = ASTTraversalUtils.charPositionToUtf8ByteOffset(content, end);
+                        for (var pattern : patterns) {
+                            var matcher = pattern.matcher(content);
+                            while (matcher.find()) {
+                                int start = matcher.start();
+                                int end = matcher.end();
+                                int startByte = ASTTraversalUtils.charPositionToUtf8ByteOffset(content, start);
+                                int endByte = ASTTraversalUtils.charPositionToUtf8ByteOffset(content, end);
 
-                        if (!analyzer.isAccessExpression(file, startByte, endByte)) continue;
+                                if (!analyzer.isAccessExpression(file, startByte, endByte)) continue;
 
-                        if (lines == null) {
-                            lines = content.split("\\R", -1);
-                            lineStarts = FileUtil.computeLineStarts(content);
+                                if (lines == null) {
+                                    lines = content.split("\\R", -1);
+                                    lineStarts = FileUtil.computeLineStarts(content);
+                                }
+                                int[] starts = Objects.requireNonNull(lineStarts);
+
+                                int lineIdx = FileUtil.findLineIndexForOffset(starts, start);
+                                int startLine = Math.max(0, lineIdx - 3);
+                                int endLine = Math.min(lines.length - 1, lineIdx + 3);
+                                String[] snippetLines = lines;
+                                var snippet = IntStream.rangeClosed(startLine, endLine)
+                                        .mapToObj(i -> snippetLines[i])
+                                        .collect(Collectors.joining("\n"));
+
+                                var range = new IAnalyzer.Range(startByte, endByte, lineIdx, lineIdx, lineIdx);
+                                var enclosingCodeUnit = analyzer.enclosingCodeUnit(file, range);
+
+                                enclosingCodeUnit.ifPresent(codeUnit -> hits.put(
+                                        new UsageHit(file, lineIdx + 1, start, end, codeUnit, 1.0, snippet), true));
+                            }
                         }
-                        int[] starts = Objects.requireNonNull(lineStarts);
-
-                        int lineIdx = FileUtil.findLineIndexForOffset(starts, start);
-                        int startLine = Math.max(0, lineIdx - 3);
-                        int endLine = Math.min(lines.length - 1, lineIdx + 3);
-                        String[] snippetLines = lines;
-                        var snippet = IntStream.rangeClosed(startLine, endLine)
-                                .mapToObj(i -> snippetLines[i])
-                                .collect(Collectors.joining("\n"));
-
-                        var range = new IAnalyzer.Range(startByte, endByte, lineIdx, lineIdx, lineIdx);
-                        var enclosingCodeUnit = analyzer.enclosingCodeUnit(file, range);
-
-                        enclosingCodeUnit.ifPresent(codeUnit ->
-                                hits.put(new UsageHit(file, lineIdx + 1, start, end, codeUnit, 1.0, snippet), true));
+                    } catch (Exception e) {
+                        logger.warn("Failed to extract usage hits from {}: {}", file, e.toString());
                     }
+                    return null;
+                })
+                .toList();
+        var futures = UsageAnalysisExecutors.ioExecutor().invokeAll(tasks);
+        for (var future : futures) {
+            try {
+                future.get();
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof RuntimeException re) {
+                    throw re;
                 }
-            } catch (Exception e) {
-                logger.warn("Failed to extract usage hits from {}: {}", file, e.toString());
+                throw new RuntimeException("Regex usage scan failed", e.getCause());
             }
-        });
+        }
         return Set.copyOf(hits.keySet());
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/TextSearchCandidateProvider.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/TextSearchCandidateProvider.java
@@ -6,7 +6,9 @@ import ai.brokk.analyzer.Language;
 import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -33,18 +35,32 @@ public final class TextSearchCandidateProvider implements CandidateFileProvider 
         }
 
         var matches = new ConcurrentHashMap<ProjectFile, Boolean>();
-        filesToSearch.parallelStream().forEach(file -> {
+        var tasks = filesToSearch.stream()
+                .<Callable<Void>>map(file -> () -> {
+                    try {
+                        if (!file.isText()) return null;
+                        var contentOpt = file.read();
+                        if (contentOpt.isEmpty()) return null;
+                        if (contentOpt.get().contains(identifier)) {
+                            matches.put(file, true);
+                        }
+                    } catch (Exception e) {
+                        logger.warn("TextSearchCandidateProvider failed for {}: {}", file, e.toString());
+                    }
+                    return null;
+                })
+                .toList();
+        var futures = UsageAnalysisExecutors.ioExecutor().invokeAll(tasks);
+        for (var future : futures) {
             try {
-                if (!file.isText()) return;
-                var contentOpt = file.read();
-                if (contentOpt.isEmpty()) return;
-                if (contentOpt.get().contains(identifier)) {
-                    matches.put(file, true);
+                future.get();
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof RuntimeException re) {
+                    throw re;
                 }
-            } catch (Exception e) {
-                logger.warn("TextSearchCandidateProvider failed for {}: {}", file, e.toString());
+                throw new RuntimeException("Text search candidate scan failed", e.getCause());
             }
-        });
+        }
         return Set.copyOf(matches.keySet());
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageAnalysisExecutors.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageAnalysisExecutors.java
@@ -1,0 +1,24 @@
+package ai.brokk.analyzer.usages;
+
+import ai.brokk.concurrent.ExecutorsUtil;
+import ai.brokk.concurrent.LoggingExecutorService;
+import ai.brokk.util.ConcurrencyUtil;
+
+public final class UsageAnalysisExecutors {
+    private static final int USAGE_ANALYSIS_PARALLELISM = Runtime.getRuntime().availableProcessors();
+    private static final int USAGE_ANALYSIS_IO_PARALLELISM = ConcurrencyUtil.computeAdaptiveIoConcurrencyCap();
+    private static final LoggingExecutorService CPU_EXECUTOR =
+            ExecutorsUtil.newFixedThreadExecutor("usage-analysis-cpu-", USAGE_ANALYSIS_PARALLELISM);
+    private static final LoggingExecutorService IO_EXECUTOR =
+            ExecutorsUtil.newVirtualThreadExecutor("usage-analysis-io-", USAGE_ANALYSIS_IO_PARALLELISM);
+
+    private UsageAnalysisExecutors() {}
+
+    public static LoggingExecutorService cpuExecutor() {
+        return CPU_EXECUTOR;
+    }
+
+    public static LoggingExecutorService ioExecutor() {
+        return IO_EXECUTOR;
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageAnalysisExecutors.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageAnalysisExecutors.java
@@ -7,18 +7,19 @@ import ai.brokk.util.ConcurrencyUtil;
 public final class UsageAnalysisExecutors {
     private static final int USAGE_ANALYSIS_PARALLELISM = Runtime.getRuntime().availableProcessors();
     private static final int USAGE_ANALYSIS_IO_PARALLELISM = ConcurrencyUtil.computeAdaptiveIoConcurrencyCap();
-    private static final LoggingExecutorService CPU_EXECUTOR =
-            ExecutorsUtil.newFixedThreadExecutor("usage-analysis-cpu-", USAGE_ANALYSIS_PARALLELISM);
-    private static final LoggingExecutorService IO_EXECUTOR =
-            ExecutorsUtil.newVirtualThreadExecutor("usage-analysis-io-", USAGE_ANALYSIS_IO_PARALLELISM);
+    private static final UsageAnalysisExecutorPool POOL = new UsageAnalysisExecutorPool(
+            ExecutorsUtil.newFixedThreadExecutor("usage-analysis-cpu-", USAGE_ANALYSIS_PARALLELISM),
+            ExecutorsUtil.newVirtualThreadExecutor("usage-analysis-io-", USAGE_ANALYSIS_IO_PARALLELISM));
 
     private UsageAnalysisExecutors() {}
 
     public static LoggingExecutorService cpuExecutor() {
-        return CPU_EXECUTOR;
+        return POOL.cpuExecutor();
     }
 
     public static LoggingExecutorService ioExecutor() {
-        return IO_EXECUTOR;
+        return POOL.ioExecutor();
     }
+
+    public record UsageAnalysisExecutorPool(LoggingExecutorService cpuExecutor, LoggingExecutorService ioExecutor) {}
 }


### PR DESCRIPTION
### Description
Consolidates usage-analysis worker pools so CodeQualityTools and usage scan paths reuse shared bounded executors instead of creating per-query pools or maintaining separate fuzzy-scan pools.

**Key Changes**:
- Adds a shared usage-analysis executor bundle with separate CPU and bounded virtual-thread I/O executors.
- Routes JDT usage analysis, regex/text usage scans, and app-layer fuzzy usage scans through the shared executors.

**Touch Points**:
- app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/java/JdtUsageAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/usages/RegexUsageAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/usages/TextSearchCandidateProvider.java
- brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageAnalysisExecutors.java