### PR TITLE
brokk-acp-rust: tests for tool-gate audit and always-allow reset (#3188)

### DIFF
--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -2237,6 +2237,65 @@ mod tests {
         let _ = std::fs::remove_dir_all(&cwd);
     }
 
+    /// SECURITY: a non-empty `always_allow_tools` set must NOT survive a
+    /// `session/load` round-trip. `get_session_loads_from_disk_when_cold`
+    /// already asserts an empty set reloads empty, but that proves nothing
+    /// about reset -- empty in, empty out is the trivial case. This test
+    /// populates the set, evicts the in-memory session, reloads from the
+    /// on-disk zip, and asserts the prior approvals were dropped.
+    ///
+    /// If a future change persists `always_allow_tools` into the manifest
+    /// (intentionally or by accident), this test fails. Issue #3188
+    /// explicitly defers persisted-across-reload approval as out of scope:
+    /// a stolen or tampered zip must never carry carte-blanche permissions
+    /// into the next session.
+    #[tokio::test]
+    async fn always_allow_set_does_not_survive_session_reload() {
+        let store = SessionStore::new("m".to_string());
+        let cwd = std::env::temp_dir().join(format!(
+            "brokk-acp-rust-always-allow-reload-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let created = store.create_session(cwd.clone()).await;
+        let id = created.id.clone();
+
+        // Populate the in-memory set with two distinct tool names so the
+        // assertion below distinguishes "empty by reset" from "empty by
+        // happenstance" (e.g. a typo'd tool name silently dropped).
+        store.add_always_allow(&id, "writeFile").await;
+        store.add_always_allow(&id, "get_summaries").await;
+        assert!(store.is_always_allowed(&id, "writeFile").await);
+        assert!(store.is_always_allowed(&id, "get_summaries").await);
+
+        // Evict from memory; the on-disk zip is unaffected. This mirrors
+        // the process-restart path: a fresh `SessionStore` would do the
+        // same lazy load via `get_session`.
+        store.sessions.write().await.remove(&id);
+        store.registries.write().await.remove(&id);
+
+        let reloaded = store
+            .get_session(&id, &cwd)
+            .await
+            .expect("session must reload from disk");
+        assert_eq!(reloaded.id, id);
+        assert!(
+            reloaded.always_allow_tools.is_empty(),
+            "always_allow_tools must be reset on reload (security guarantee); \
+             got {:?}",
+            reloaded.always_allow_tools
+        );
+        assert!(
+            !store.is_always_allowed(&id, "writeFile").await,
+            "writeFile must re-prompt after a reload"
+        );
+        assert!(
+            !store.is_always_allowed(&id, "get_summaries").await,
+            "get_summaries must re-prompt after a reload"
+        );
+
+        let _ = std::fs::remove_dir_all(&cwd);
+    }
+
     /// Permission-mode setters/getters round-trip, default to `Default`,
     /// and report `false` for unknown sessions instead of silently
     /// inserting an entry.

--- a/brokk-acp-rust/src/tool_loop.rs
+++ b/brokk-acp-rust/src/tool_loop.rs
@@ -839,4 +839,129 @@ mod tests {
             );
         }
     }
+
+    /// Anti-bypass audit: every tool advertised to the LLM must route
+    /// through `pure_gate_decision`, and that decision must NEVER be
+    /// `Allow` for a mutating kind in `Default` mode without an
+    /// explicit "Always allow" record.
+    ///
+    /// `tool_definitions()` is the registry's contract with the LLM --
+    /// any tool name returned there is callable. The single call site
+    /// of `ToolRegistry::execute` (in `execute_tool` above) consults
+    /// the gate first, so as long as every advertised tool produces a
+    /// well-defined gate decision, no new tool can be smuggled past
+    /// user consent by simply being added to the registry.
+    ///
+    /// Fails if a future tool is added with a `ToolKind` that would
+    /// auto-allow mutating work in `Default` mode (the gate's pure
+    /// decision matrix is the actual classifier; the assertions below
+    /// pin its invariants per kind). Also fails if `tool_definitions()`
+    /// returns the empty set, which would make the audit vacuous.
+    #[tokio::test]
+    async fn every_advertised_tool_routes_through_the_gate() {
+        use crate::tools::ToolRegistry;
+        use agent_client_protocol::schema::ToolKind;
+
+        // Bifrost intentionally disabled: we want a deterministic,
+        // offline set of tools driven by the built-in dispatch arms.
+        // Tests covering the bifrost handshake live separately under
+        // `bifrost_client::tests` and cross-check the `TOOLS` table
+        // against the running subprocess's advertised tools.
+        let registry = ToolRegistry::new(std::env::temp_dir(), None).await;
+        let advertised: Vec<String> = registry
+            .tool_definitions()
+            .into_iter()
+            .map(|d| d.function.name)
+            .collect();
+        assert!(
+            !advertised.is_empty(),
+            "registry must advertise at least one built-in tool; \
+             otherwise this gate audit is vacuous and a future regression \
+             that drops tool_definitions() would pass silently"
+        );
+
+        for name in &advertised {
+            let kind = ToolRegistry::tool_kind(name);
+            let is_info = matches!(
+                kind,
+                ToolKind::Read | ToolKind::Search | ToolKind::Think | ToolKind::Fetch
+            );
+            let is_edit = matches!(kind, ToolKind::Edit);
+
+            // Bypass: explicit user opt-out -- always allow.
+            assert_eq!(
+                decide(PermissionMode::BypassPermissions, kind, name, false),
+                PureGateDecision::Allow,
+                "{name} ({kind:?}): BypassPermissions must allow without consulting always-allow"
+            );
+
+            // ReadOnly: info-kinds only; everything else must be rejected
+            // even if a prior session had it in always-allow (regression
+            // covered by `read_only_rejects_mutating_kinds_even_when_always_allowed`).
+            let ro = decide(PermissionMode::ReadOnly, kind, name, false);
+            if is_info {
+                assert_eq!(
+                    ro,
+                    PureGateDecision::Allow,
+                    "{name} ({kind:?}): ReadOnly must auto-allow info kinds"
+                );
+            } else {
+                assert!(
+                    matches!(ro, PureGateDecision::Reject(_)),
+                    "{name} ({kind:?}): ReadOnly must reject non-info kinds, got {ro:?}"
+                );
+            }
+
+            // Default: info kinds auto-allow; mutating tools must prompt
+            // when there is no prior "Always allow" record. This is the
+            // core anti-bypass invariant -- a brand-new mutating tool
+            // cannot reach `Allow` without user consent.
+            let def = decide(PermissionMode::Default, kind, name, false);
+            if is_info {
+                assert_eq!(
+                    def,
+                    PureGateDecision::Allow,
+                    "{name} ({kind:?}): Default must auto-allow info kinds"
+                );
+            } else {
+                assert_eq!(
+                    def,
+                    PureGateDecision::Prompt,
+                    "{name} ({kind:?}): Default must prompt for mutating kinds; \
+                     reaching Allow without consent would be a gate bypass"
+                );
+            }
+
+            // AcceptEdits: like Default, but Edit gets a free pass.
+            let ae = decide(PermissionMode::AcceptEdits, kind, name, false);
+            if is_info || is_edit {
+                assert_eq!(
+                    ae,
+                    PureGateDecision::Allow,
+                    "{name} ({kind:?}): AcceptEdits must auto-allow info/edit kinds"
+                );
+            } else {
+                assert_eq!(
+                    ae,
+                    PureGateDecision::Prompt,
+                    "{name} ({kind:?}): AcceptEdits must prompt for non-info, non-edit kinds"
+                );
+            }
+        }
+
+        // Anti-sticky-shell: pin the runShellCommand carve-out against
+        // the registry's actual advertised list rather than a string
+        // literal, so a rename surfaces here. Even with always_allow=true
+        // the gate must prompt every call until #3390 lands an OS sandbox.
+        assert!(
+            advertised.iter().any(|n| n == "runShellCommand"),
+            "runShellCommand must be advertised; otherwise the anti-sticky-shell check is a no-op"
+        );
+        let shell_kind = ToolRegistry::tool_kind("runShellCommand");
+        assert_eq!(
+            decide(PermissionMode::Default, shell_kind, "runShellCommand", true),
+            PureGateDecision::Prompt,
+            "runShellCommand must re-prompt every call even when always-allowed (#3390)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes the remaining work on #3188 (route all tool calls through client approval). Two anti-regression tests, no production code changes — the audit found every advertised tool already flows through `consult_gate`.

### Changes

- **`brokk-acp-rust/src/session.rs`** — new test `always_allow_set_does_not_survive_session_reload`. Populates the in-memory `always_allow_tools` set, evicts the session, reloads from disk, and asserts the approvals are dropped. The pre-existing cold-load test only covered the trivial empty-in / empty-out case; this one fails if a future change persists `always_allow_tools` into the manifest.

- **`brokk-acp-rust/src/tool_loop.rs`** — new test `every_advertised_tool_routes_through_the_gate`. Iterates over `ToolRegistry::tool_definitions()` (the source of truth for what the LLM can call) and asserts `pure_gate_decision` produces a well-defined outcome for each name across every `PermissionMode`. Pins the matrix so a brand-new tool with a mutating `ToolKind` cannot reach `Allow` in Default mode without user consent, and re-pins the `runShellCommand` carve-out against the registry's actual list.

### Audit findings

Every tool advertised by `ToolRegistry::tool_definitions()` already routes through `consult_gate`:

- The only call site of `ToolRegistry::execute(...)` is `tool_loop::execute_tool` (`tool_loop.rs:619`), which is invoked exclusively at `tool_loop.rs:389` — immediately after `consult_gate` returns `Allow`.
- `ToolRegistry::execute` is `pub(crate)` with a SECURITY comment requiring gate consultation first.
- `grep -rn "registry\.execute\|ToolRegistry::execute"` returns no other call sites under `brokk-acp-rust/src/`.
- Bifrost-loaded tools fall through `ToolRegistry::execute`'s `_ =>` arm to `execute_bifrost`, so they too pass the gate.
- `runShellCommand` is gated by the additional `requires_per_call_prompt` carve-out (every call re-prompts, even when always-allowed) until OS sandboxing lands in #3390.

No tool needed routing fixes.

### Persisted-across-reload approval

The issue notes: "Decide whether persisted-across-reload is in scope here or a separate ticket." The current behavior (intentional reset on reload, mirroring `claude-agent-acp`) is the right security posture — a stolen or tampered session zip must never carry carte-blanche tool approvals into the next process. The new test pins this guarantee against future regressions.

If persisted approval becomes desirable later (e.g. keyed against a per-machine secret), it should ship as a separate, opt-in feature.

Closes #3188.

## Test plan

- [x] `cargo fmt --check` (manifest `brokk-acp-rust/Cargo.toml`)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bin brokk-acp` — 206 tests pass (was 204 on baseline; +2 = the new tests)
- [x] Sanity check: deliberately introducing a fake `ToolMeta { name: "evil", kind: ToolKind::Read }` for a mutating tool would still pass — that's a separate kind-correctness concern, not a gate-bypass one. The audit invariant is *every advertised tool is classified by the gate*, which holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
