### PR TITLE
Avoid JS/TS route-group signature warnings

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CSharpAnalyzer.java
@@ -272,6 +272,11 @@ public final class CSharpAnalyzer extends TreeSitterAnalyzer {
     }
 
     @Override
+    protected boolean warnOnSignatureInFqNameLookup() {
+        return true;
+    }
+
+    @Override
     public List<ExceptionHandlingSmell> findExceptionHandlingSmells(ProjectFile file, ExceptionSmellWeights weights) {
         checkStale("findExceptionHandlingSmells");
         ExceptionSmellWeights resolvedWeights = weights != null ? weights : ExceptionSmellWeights.defaults();

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CppAnalyzer.java
@@ -243,6 +243,11 @@ public class CppAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisPro
     }
 
     @Override
+    protected boolean warnOnSignatureInFqNameLookup() {
+        return true;
+    }
+
+    @Override
     public int computeCognitiveComplexity(CodeUnit cu) {
         return computeCognitiveComplexity(cu, CognitiveComplexityAnalysis::compute);
     }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JavaAnalyzer.java
@@ -599,6 +599,11 @@ public class JavaAnalyzer extends TreeSitterAnalyzer
     }
 
     @Override
+    protected boolean warnOnSignatureInFqNameLookup() {
+        return true;
+    }
+
+    @Override
     protected Optional<String> extractSimpleName(TSNode decl, SourceContent sourceContent) {
         // Special handling for Java lambdas: synthesize a bytecode-style anonymous name
         if (nodeType(LAMBDA_EXPRESSION).equals(decl.getType())) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/ScalaAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/ScalaAnalyzer.java
@@ -71,6 +71,11 @@ public class ScalaAnalyzer extends TreeSitterAnalyzer implements JvmBasedAnalyze
     }
 
     @Override
+    protected boolean warnOnSignatureInFqNameLookup() {
+        return true;
+    }
+
+    @Override
     public int computeCognitiveComplexity(CodeUnit cu) {
         return computeCognitiveComplexity(cu, CognitiveComplexityAnalysis::compute);
     }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1281,7 +1281,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         checkStale("getDefinitions");
         String normalizedFqName = normalizeFullName(fqName);
 
-        if (normalizedFqName.contains("(")) {
+        if (warnOnSignatureInFqNameLookup() && normalizedFqName.contains("(")) {
             log.warn(
                     "getDefinitions called with signature in fqName '{}'; filter by CodeUnit.signature() after lookup instead",
                     fqName);
@@ -1640,6 +1640,14 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     protected String normalizeFullName(String fqName) {
         // Should be overridden by the subclasses
         return fqName;
+    }
+
+    /**
+     * Whether this language should warn when callers pass a signature-shaped fqName to {@link #getDefinitions(String)}.
+     * Many languages use filesystem-derived fqNames where parentheses can be valid path segments, so this is opt-in.
+     */
+    protected boolean warnOnSignatureInFqNameLookup() {
+        return false;
     }
 
     /**

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/SignatureFqNameWarningPolicyTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/SignatureFqNameWarningPolicyTest.java
@@ -1,0 +1,55 @@
+package ai.brokk.analyzer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.testutil.InlineTestProjectCreator;
+import org.junit.jupiter.api.Test;
+
+final class SignatureFqNameWarningPolicyTest {
+
+    @Test
+    void dynamicAnalyzersDoNotWarnOnParenthesizedFqNames() {
+        try (var project = InlineTestProjectCreator.code(
+                        "export const uiConfig = {};", "app/(dashboard)/hooks/uiConfig.ts")
+                .addFileContents("export const value = 1;", "app/(dashboard)/hooks/value.js")
+                .build()) {
+            var typescriptAnalyzer = new TypescriptAnalyzer(project);
+            var javascriptAnalyzer = new JavascriptAnalyzer(project);
+
+            assertFalse(typescriptAnalyzer.warnOnSignatureInFqNameLookup());
+            assertFalse(javascriptAnalyzer.warnOnSignatureInFqNameLookup());
+        }
+    }
+
+    @Test
+    void routeGroupFqNameStillLooksUpInTypescript() {
+        try (var project = InlineTestProjectCreator.code(
+                        "export const uiConfig = {};", "app/(dashboard)/hooks/uiConfig.ts")
+                .build()) {
+            var analyzer = new TypescriptAnalyzer(project);
+
+            var definitions = analyzer.getDefinitions("app.(dashboard).hooks.uiConfig.ts.uiConfig");
+
+            assertEquals(1, definitions.size());
+            assertEquals(
+                    "app.(dashboard).hooks.uiConfig.ts.uiConfig",
+                    definitions.getFirst().fqName());
+        }
+    }
+
+    @Test
+    void overloadAwareAnalyzersWarnOnSignatureFqNames() {
+        try (var project = InlineTestProjectCreator.code("class C { void m(int i) {} }", "C.java")
+                .addFileContents("void f(int i) {}", "f.cpp")
+                .addFileContents("class C { void M(int i) {} }", "C.cs")
+                .addFileContents("class C { def m(i: Int): Unit = () }", "C.scala")
+                .build()) {
+            assertTrue(new JavaAnalyzer(project).warnOnSignatureInFqNameLookup());
+            assertTrue(new CppAnalyzer(project).warnOnSignatureInFqNameLookup());
+            assertTrue(new CSharpAnalyzer(project).warnOnSignatureInFqNameLookup());
+            assertTrue(new ScalaAnalyzer(project).warnOnSignatureInFqNameLookup());
+        }
+    }
+}


### PR DESCRIPTION
### Description

Fixes #3569 by making the `getDefinitions` warning for signature-shaped fqName lookups opt-in by language. This keeps the warning for overload-aware analyzers while avoiding noisy false positives from JS/TS filesystem-derived route-group segments such as `app.(dashboard)`.

**Key Changes**:
- Added a `TreeSitterAnalyzer` policy hook that defaults signature-in-fqName warnings off, with Java, C++, C#, and Scala opting in.
- Added regression coverage for JS/TS route-group fqNames and overload-aware analyzer warning policy.

**Touch Points**:
- `TreeSitterAnalyzer.java`
- `JavaAnalyzer.java`
- `CppAnalyzer.java`
- `CSharpAnalyzer.java`
- `ScalaAnalyzer.java`
- `SignatureFqNameWarningPolicyTest.java`

Validation:
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.SignatureFqNameWarningPolicyTest`
- `./gradlew fix tidy`
- `./gradlew analyze`