### PR TITLE
Expose analyzer status endpoint

### DIFF
--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -86,6 +86,8 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
     @Nullable
     private IAnalyzerWrapper analyzerWrapper; // also initialized in createGui/createHeadless
 
+    private final AtomicReference<AnalyzerStatus> analyzerStatus = new AtomicReference<>(AnalyzerStatus.notReady());
+
     // Run main user-driven tasks in background (Code/Ask/Search/Run)
     // Only one of these can run at a time
     private final UserActionManager userActions;
@@ -449,6 +451,8 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
 
             @Override
             public void beforeEachBuild() {
+                analyzerStatus.set(AnalyzerStatus.building(0, 0, 0, "Building code intelligence"));
+
                 if (io instanceof Chrome chrome) {
                     chrome.showAnalyzerRebuildStatus();
                 }
@@ -461,6 +465,14 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
 
             @Override
             public void afterEachBuild(boolean externalRequest) {
+                analyzerStatus.updateAndGet(status -> {
+                    var nonNullStatus = requireNonNull(status);
+                    if (isAnalyzerReady()) {
+                        return AnalyzerStatus.ready(nonNullStatus.total());
+                    }
+                    return AnalyzerStatus.notReady();
+                });
+
                 submitBackgroundTask("Code Intelligence post-build", () -> {
                     if (io instanceof Chrome chrome) {
                         chrome.hideAnalyzerRebuildStatus();
@@ -500,6 +512,10 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
             @Override
             public void onAnalyzerReady() {
                 logger.debug("Analyzer became ready, triggering symbol lookup refresh");
+                analyzerStatus.updateAndGet(status -> {
+                    var nonNullStatus = requireNonNull(status);
+                    return isAnalyzerReady() ? AnalyzerStatus.ready(nonNullStatus.total()) : AnalyzerStatus.notReady();
+                });
                 for (var callback : analyzerCallbacks) {
                     submitBackgroundTask("Code Intelligence ready", callback::onAnalyzerReady);
                 }
@@ -507,6 +523,9 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
 
             @Override
             public void onProgress(int completed, int total, String description) {
+                var percent = total > 0 ? Math.min(100L, Math.max(0L, (completed * 100L) / total)) : 0L;
+                analyzerStatus.set(AnalyzerStatus.building(completed, total, Math.toIntExact(percent), description));
+
                 // Update progress bar on "Rebuilding Code Intelligence" status strip
                 if (io instanceof Chrome chrome) {
                     chrome.updateAnalyzerProgress(completed, total, description);
@@ -1473,6 +1492,18 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
     /** Returns current analyzer readiness without blocking. */
     public boolean isAnalyzerReady() {
         return requireNonNull(analyzerWrapper).getNonBlocking() != null;
+    }
+
+    @Override
+    public AnalyzerStatus getAnalyzerStatus() {
+        var status = requireNonNull(analyzerStatus.get());
+        if (!status.ready() && isAnalyzerReady()) {
+            return requireNonNull(analyzerStatus.updateAndGet(current -> {
+                var nonNullCurrent = requireNonNull(current);
+                return AnalyzerStatus.ready(nonNullCurrent.total());
+            }));
+        }
+        return status;
     }
 
     /** Returns the current session's domain-model task list. Always non-null. */

--- a/app/src/main/java/ai/brokk/IAppContextManager.java
+++ b/app/src/main/java/ai/brokk/IAppContextManager.java
@@ -37,6 +37,28 @@ import org.jetbrains.annotations.Nullable;
 public interface IAppContextManager extends IContextManager {
     Logger logger = LogManager.getLogger(IAppContextManager.class);
 
+    record AnalyzerStatus(
+            String code,
+            boolean ready,
+            boolean building,
+            @Nullable Integer completed,
+            @Nullable Integer total,
+            @Nullable Integer percent,
+            String description) {
+        public static AnalyzerStatus notReady() {
+            return new AnalyzerStatus(
+                    "ANALYZER_NOT_READY", false, false, null, null, null, "Code intelligence not ready");
+        }
+
+        public static AnalyzerStatus building(int completed, int total, int percent, String description) {
+            return new AnalyzerStatus("ANALYZER_BUILDING", false, true, completed, total, percent, description);
+        }
+
+        public static AnalyzerStatus ready(@Nullable Integer total) {
+            return new AnalyzerStatus("ANALYZER_READY", true, false, total, total, 100, "Code intelligence ready");
+        }
+    }
+
     @Override
     IProject getProject();
 
@@ -154,6 +176,11 @@ public interface IAppContextManager extends IContextManager {
     default void addAnalyzerCallback(AnalyzerCallback callback) {}
 
     default void removeAnalyzerCallback(AnalyzerCallback callback) {}
+
+    default AnalyzerStatus getAnalyzerStatus() {
+        var ready = getAnalyzerWrapper().getNonBlocking() != null;
+        return ready ? AnalyzerStatus.ready(1) : AnalyzerStatus.notReady();
+    }
 
     static Context mergeCompressedHistory(Context context, List<TaskEntry> compressedTaskHistory) {
         if (compressedTaskHistory.isEmpty()) {

--- a/app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java
+++ b/app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java
@@ -555,6 +555,7 @@ public final class HeadlessExecutorMain {
             System.out.println("    GET  /v1/dependencies             - list all imported dependencies");
             System.out.println("    GET  /v1/settings                 - get all project settings");
             System.out.println("    POST /v1/settings                 - update all project settings");
+            System.out.println("    GET  /v1/static-analysis/status   - get code intelligence readiness");
             System.out.println("    GET  /v1/agents                   - list custom agent definitions");
             System.out.println("    POST /v1/agents                   - create a custom agent");
             System.out.println("    GET  /v1/agents/{name}            - get an agent definition");

--- a/app/src/main/java/ai/brokk/executor/routers/StaticAnalysisRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/StaticAnalysisRouter.java
@@ -14,21 +14,30 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public final class StaticAnalysisRouter implements SimpleHttpServer.CheckedHttpHandler {
     private final StaticAnalysisSeedService seedService;
     private final StaticAnalysisLeadExpansionService expansionService;
+    private final Supplier<IAppContextManager.AnalyzerStatus> analyzerStatusSupplier;
     private final ExecutorService expansionExecutor;
 
     public StaticAnalysisRouter(IAppContextManager contextManager) {
-        this(new StaticAnalysisSeedService(contextManager), new StaticAnalysisLeadExpansionService(contextManager));
+        this(
+                new StaticAnalysisSeedService(contextManager),
+                new StaticAnalysisLeadExpansionService(contextManager),
+                contextManager::getAnalyzerStatus);
     }
 
-    StaticAnalysisRouter(StaticAnalysisSeedService seedService, StaticAnalysisLeadExpansionService expansionService) {
+    StaticAnalysisRouter(
+            StaticAnalysisSeedService seedService,
+            StaticAnalysisLeadExpansionService expansionService,
+            Supplier<IAppContextManager.AnalyzerStatus> analyzerStatusSupplier) {
         this.seedService = seedService;
         this.expansionService = expansionService;
+        this.analyzerStatusSupplier = analyzerStatusSupplier;
         this.expansionExecutor = Executors.newSingleThreadExecutor(r -> {
             var thread = new Thread(r, "StaticAnalysisLeadExpansion");
             thread.setDaemon(true);
@@ -41,6 +50,15 @@ public final class StaticAnalysisRouter implements SimpleHttpServer.CheckedHttpH
         var method = exchange.getRequestMethod();
         var path = exchange.getRequestURI().getPath();
         var normalizedPath = path.endsWith("/") && path.length() > 1 ? path.substring(0, path.length() - 1) : path;
+
+        if (normalizedPath.equals("/v1/static-analysis/status")) {
+            if (!"GET".equals(method)) {
+                RouterUtil.sendMethodNotAllowed(exchange);
+                return;
+            }
+            SimpleHttpServer.sendJsonResponse(exchange, analyzerStatusSupplier.get());
+            return;
+        }
 
         if (normalizedPath.equals("/v1/static-analysis/seeds")) {
             if (!"POST".equals(method)) {

--- a/app/src/test/java/ai/brokk/executor/routers/StaticAnalysisRouterTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/StaticAnalysisRouterTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.brokk.IAppContextManager;
 import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.CodeUnitType;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.executor.jobs.ErrorPayload;
+import ai.brokk.executor.staticanalysis.StaticAnalysisLeadExpansionService;
+import ai.brokk.executor.staticanalysis.StaticAnalysisSeedService;
 import ai.brokk.testutil.TestAnalyzer;
 import ai.brokk.testutil.TestConsoleIO;
 import ai.brokk.testutil.TestContextManager;
@@ -25,6 +28,60 @@ import org.junit.jupiter.api.io.TempDir;
 
 class StaticAnalysisRouterTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void handleGetStatus_returnsAnalyzerProgress() throws Exception {
+        var contextManager = contextManager();
+        var router = new StaticAnalysisRouter(
+                new StaticAnalysisSeedService(contextManager),
+                new StaticAnalysisLeadExpansionService(contextManager),
+                () -> IAppContextManager.AnalyzerStatus.building(123, 500, 24, "Indexing Java files"));
+        var exchange = TestHttpExchange.jsonRequest("GET", "/v1/static-analysis/status", "");
+
+        router.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        Map<String, Object> body = MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+        assertEquals("ANALYZER_BUILDING", body.get("code"));
+        assertEquals(false, body.get("ready"));
+        assertEquals(true, body.get("building"));
+        assertEquals(123, body.get("completed"));
+        assertEquals(500, body.get("total"));
+        assertEquals(24, body.get("percent"));
+        assertEquals("Indexing Java files", body.get("description"));
+    }
+
+    @Test
+    void handleGetStatus_returnsExplicitNotReadyCode() throws Exception {
+        var contextManager = contextManager();
+        var router = new StaticAnalysisRouter(
+                new StaticAnalysisSeedService(contextManager),
+                new StaticAnalysisLeadExpansionService(contextManager),
+                IAppContextManager.AnalyzerStatus::notReady);
+        var exchange = TestHttpExchange.jsonRequest("GET", "/v1/static-analysis/status", "");
+
+        router.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        Map<String, Object> body = MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+        assertEquals("ANALYZER_NOT_READY", body.get("code"));
+        assertEquals(false, body.get("ready"));
+        assertEquals(false, body.get("building"));
+        assertEquals(null, body.get("completed"));
+        assertEquals(null, body.get("total"));
+        assertEquals(null, body.get("percent"));
+        assertEquals("Code intelligence not ready", body.get("description"));
+    }
+
+    @Test
+    void handlePostStatus_rejectsUnsupportedMethod() throws Exception {
+        var router = emptyRouter();
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/static-analysis/status", "{}");
+
+        router.handle(exchange);
+
+        assertEquals(405, exchange.responseCode());
+    }
 
     @Test
     void handlePostSeeds_returnsRealSeeds(@TempDir Path root) throws Exception {
@@ -139,9 +196,13 @@ class StaticAnalysisRouterTest {
     }
 
     private static StaticAnalysisRouter emptyRouter() {
+        return new StaticAnalysisRouter(contextManager());
+    }
+
+    private static TestContextManager contextManager() {
         var root =
                 Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath().normalize();
-        return new StaticAnalysisRouter(new TestContextManager(
-                new TestProject(root, Languages.JAVA), new TestConsoleIO(), java.util.Set.of(), new TestAnalyzer()));
+        return new TestContextManager(
+                new TestProject(root, Languages.JAVA), new TestConsoleIO(), java.util.Set.of(), new TestAnalyzer());
     }
 }


### PR DESCRIPTION
### Description
Adds an authenticated static-analysis status endpoint so headless clients can poll code-intelligence readiness and progress without blocking analyzer startup or changing process readiness semantics.

**Key Changes**:
- Adds `GET /v1/static-analysis/status` backed by a non-blocking analyzer lifecycle snapshot in `ContextManager`.
- Returns explicit analyzer status codes (`ANALYZER_NOT_READY`, `ANALYZER_BUILDING`, `ANALYZER_READY`) with nullable progress fields when no progress is known.
- Covers building, not-ready, and unsupported-method responses in `StaticAnalysisRouterTest`.

**Touch Points**:
- `app/src/main/java/ai/brokk/IAppContextManager.java`
- `app/src/main/java/ai/brokk/ContextManager.java`
- `app/src/main/java/ai/brokk/executor/routers/StaticAnalysisRouter.java`
- `app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java`
- `app/src/test/java/ai/brokk/executor/routers/StaticAnalysisRouterTest.java`

Validation:
- `./gradlew fix tidy`
- `./gradlew :app:test --tests ai.brokk.executor.routers.StaticAnalysisRouterTest`
- `./gradlew analyze`