### PR TITLE
Optimize regex-heavy search paths

### DIFF
--- a/app/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/app/src/main/java/ai/brokk/tools/SearchTools.java
@@ -28,6 +28,7 @@ import ai.brokk.util.FilenamePatternMatcher;
 import ai.brokk.util.Lines;
 import ai.brokk.util.Messages;
 import ai.brokk.util.SearchToolSupport;
+import ai.brokk.util.TextMatcher;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
@@ -60,7 +61,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.xml.XMLConstants;
@@ -155,7 +155,7 @@ public class SearchTools {
                     .maximumSize(4L * Runtime.getRuntime().availableProcessors())
                     .build());
 
-    private static final ThreadLocal<Cache<String, Pattern>> searchPatterns =
+    private static final ThreadLocal<Cache<String, TextMatcher>> searchPatterns =
             ThreadLocal.withInitial(() -> Caffeine.newBuilder()
                     .maximumSize(64L * Runtime.getRuntime().availableProcessors())
                     .build());
@@ -687,35 +687,30 @@ public class SearchTools {
         return String.join("\n", lines);
     }
 
-    public static List<Pattern> compilePatterns(List<String> patterns) {
+    public static List<TextMatcher> compilePatterns(List<String> patterns) {
         List<String> nonBlank = patterns.stream().filter(p -> !p.isBlank()).toList();
         if (nonBlank.isEmpty()) {
             return List.of();
         }
 
-        Cache<String, Pattern> cache = searchPatterns.get();
+        Cache<String, TextMatcher> cache = searchPatterns.get();
 
-        List<Pattern> compiled = new ArrayList<>(nonBlank.size());
+        List<TextMatcher> compiled = new ArrayList<>(nonBlank.size());
         List<String> errors = new ArrayList<>();
 
         for (String pat : nonBlank) {
             try {
-                Pattern cached = cache.getIfPresent(pat);
+                TextMatcher cached = cache.getIfPresent(pat);
                 if (cached != null) {
                     compiled.add(cached);
                     continue;
                 }
 
-                Pattern newlyCompiled = Pattern.compile(pat);
+                TextMatcher newlyCompiled = TextMatcher.compile(pat, 0);
                 cache.put(pat, newlyCompiled);
                 compiled.add(newlyCompiled);
             } catch (StackOverflowError e) {
                 errors.add("'%s': pattern is too complex (StackOverflowError)".formatted(pat));
-            } catch (PatternSyntaxException e) {
-                logger.debug("Pattern '{}' is not valid regex, falling back to literal match", pat);
-                Pattern literal = Pattern.compile(Pattern.quote(pat));
-                cache.put(pat, literal);
-                compiled.add(literal);
             } catch (RuntimeException e) {
                 String message = e.getMessage() == null ? e.toString() : e.getMessage();
                 errors.add("'%s': %s".formatted(pat, message));
@@ -729,36 +724,31 @@ public class SearchTools {
         return List.copyOf(compiled);
     }
 
-    private static List<Pattern> compilePatternsWithFlags(List<String> patterns, int flags) {
+    private static List<TextMatcher> compilePatternsWithFlags(List<String> patterns, int flags) {
         List<String> nonBlank = patterns.stream().filter(p -> !p.isBlank()).toList();
         if (nonBlank.isEmpty()) {
             return List.of();
         }
 
-        Cache<String, Pattern> cache = searchPatterns.get();
+        Cache<String, TextMatcher> cache = searchPatterns.get();
 
-        List<Pattern> compiled = new ArrayList<>(nonBlank.size());
+        List<TextMatcher> compiled = new ArrayList<>(nonBlank.size());
         List<String> errors = new ArrayList<>();
 
         for (String pat : nonBlank) {
             String cacheKey = pat + "::flags=" + flags;
             try {
-                Pattern cached = cache.getIfPresent(cacheKey);
+                TextMatcher cached = cache.getIfPresent(cacheKey);
                 if (cached != null) {
                     compiled.add(cached);
                     continue;
                 }
 
-                Pattern newlyCompiled = Pattern.compile(pat, flags);
+                TextMatcher newlyCompiled = TextMatcher.compile(pat, flags);
                 cache.put(cacheKey, newlyCompiled);
                 compiled.add(newlyCompiled);
             } catch (StackOverflowError e) {
                 errors.add("'%s': pattern is too complex (StackOverflowError)".formatted(pat));
-            } catch (PatternSyntaxException e) {
-                logger.debug("Pattern '{}' is not valid regex, falling back to literal match", pat);
-                Pattern literal = Pattern.compile(Pattern.quote(pat), flags);
-                cache.put(cacheKey, literal);
-                compiled.add(literal);
             } catch (RuntimeException e) {
                 String message = e.getMessage() == null ? e.toString() : e.getMessage();
                 errors.add("'%s': %s".formatted(pat, message));
@@ -1549,7 +1539,7 @@ public class SearchTools {
 
         logger.debug("Searching file contents for patterns: {}", patterns);
 
-        final List<Pattern> compiledPatterns;
+        final List<TextMatcher> compiledPatterns;
         try {
             compiledPatterns = compilePatterns(patterns);
         } catch (IllegalArgumentException e) {
@@ -1602,7 +1592,7 @@ public class SearchTools {
     }
 
     public static AlmostGrep.FindFilesContainingResult findFilesContainingPatterns(
-            List<Pattern> patterns, Set<ProjectFile> filesToSearch) throws InterruptedException {
+            List<TextMatcher> patterns, Set<ProjectFile> filesToSearch) throws InterruptedException {
         return AlmostGrep.findFilesContainingPatterns(patterns, filesToSearch);
     }
 
@@ -1757,7 +1747,7 @@ public class SearchTools {
             flags |= Pattern.MULTILINE;
         }
 
-        final List<Pattern> compiledPatterns;
+        final List<TextMatcher> compiledPatterns;
         try {
             compiledPatterns = compilePatternsWithFlags(patterns, flags);
             if (compiledPatterns.isEmpty()) {

--- a/app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java
+++ b/app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java
@@ -88,7 +88,7 @@ public final class LlmUsageAnalyzer implements UsageAnalyzer {
                         .collect(Collectors.toSet());
         var isUnique = matchingCodeUnits.size() == 1;
 
-        var hits = extractUsageHits(candidateFiles, searchPatterns).stream()
+        var hits = extractUsageHits(candidateFiles, identifier, searchPatterns).stream()
                 .filter(h -> !h.enclosing().equals(target))
                 .collect(Collectors.toSet());
         logger.debug(
@@ -171,14 +171,15 @@ public final class LlmUsageAnalyzer implements UsageAnalyzer {
         return new FuzzyResult.Ambiguous(target.shortName(), matchingCodeUnits, Map.of(target, hits));
     }
 
-    private Set<UsageHit> extractUsageHits(Set<ProjectFile> candidateFiles, Set<String> searchPatterns)
+    private Set<UsageHit> extractUsageHits(
+            Set<ProjectFile> candidateFiles, String identifier, Set<String> searchPatterns)
             throws InterruptedException {
         var hits = new ConcurrentHashMap<UsageHit, Boolean>();
         final var patterns = searchPatterns.stream().map(Pattern::compile).toList();
 
         List<Callable<Void>> tasks = candidateFiles.stream()
                 .map(file -> (Callable<Void>) () -> {
-                    scanFileForUsageHits(file, patterns, hits);
+                    scanFileForUsageHits(file, identifier, patterns, hits);
                     return null;
                 })
                 .toList();
@@ -195,12 +196,13 @@ public final class LlmUsageAnalyzer implements UsageAnalyzer {
     }
 
     private void scanFileForUsageHits(
-            ProjectFile file, List<Pattern> patterns, ConcurrentHashMap<UsageHit, Boolean> hits) {
+            ProjectFile file, String identifier, List<Pattern> patterns, ConcurrentHashMap<UsageHit, Boolean> hits) {
         try {
             var scanInputOpt = scanInput(file);
             if (scanInputOpt.isEmpty()) return;
             var scanInput = scanInputOpt.get();
             var content = scanInput.content();
+            if (!content.contains(identifier)) return;
 
             for (var pattern : patterns) {
                 var matcher = pattern.matcher(content);

--- a/app/src/test/java/ai/brokk/tools/SearchToolsTest.java
+++ b/app/src/test/java/ai/brokk/tools/SearchToolsTest.java
@@ -21,6 +21,7 @@ import ai.brokk.testutil.TestAnalyzer;
 import ai.brokk.testutil.TestConsoleIO;
 import ai.brokk.testutil.TestContextManager;
 import ai.brokk.testutil.TestProject;
+import ai.brokk.util.TextMatcher;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -38,7 +39,6 @@ import java.util.Map;
 import java.util.SequencedSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -978,35 +978,38 @@ public class SearchToolsTest {
     void testCompilePatterns_InvalidRegexFallsBackToLiteral() {
         // Invalid regex patterns should fall back to literal matching instead of throwing
         List<String> mixedPatterns = List.of("valid", "[", "(", "   ");
-        List<Pattern> compiled = SearchTools.compilePatterns(mixedPatterns);
+        List<TextMatcher> compiled = SearchTools.compilePatterns(mixedPatterns);
 
         // Should compile 3 patterns (blank "   " is filtered out)
         assertEquals(3, compiled.size(), "Should compile valid + two literal fallbacks, filtering blank");
         // The valid pattern should match as regex
-        assertTrue(compiled.get(0).matcher("valid").find(), "First pattern should match 'valid'");
+        assertInstanceOf(TextMatcher.Literal.class, compiled.get(0), "Plain text should use literal matching");
+        assertTrue(compiled.get(0).find("valid", null), "First pattern should match 'valid'");
         // The fallback patterns should match their literal characters
-        assertTrue(compiled.get(1).matcher("a[b").find(), "Literal '[' should match in 'a[b'");
-        assertTrue(compiled.get(2).matcher("foo(bar").find(), "Literal '(' should match in 'foo(bar'");
+        assertTrue(compiled.get(1).find("a[b", null), "Literal '[' should match in 'a[b'");
+        assertTrue(compiled.get(2).find("foo(bar", null), "Literal '(' should match in 'foo(bar'");
     }
 
     @Test
     void testCompilePatterns_ValidRegexStillWorksAsRegex() {
-        List<Pattern> compiled = SearchTools.compilePatterns(List.of("foo.*bar"));
+        List<TextMatcher> compiled = SearchTools.compilePatterns(List.of("foo.*bar"));
         assertEquals(1, compiled.size());
-        assertTrue(compiled.getFirst().matcher("fooXYZbar").find(), "Should match as regex, not literal");
+        assertInstanceOf(
+                TextMatcher.Regex.class, compiled.getFirst(), "Regex metacharacters should keep regex matching");
+        assertTrue(compiled.getFirst().find("fooXYZbar", null), "Should match as regex, not literal");
         assertFalse(
-                compiled.getFirst().matcher("foo.*bar").find()
-                        && !compiled.getFirst().matcher("foobar").find(),
+                compiled.getFirst().find("foo.*bar", null)
+                        && !compiled.getFirst().find("foobar", null),
                 "Should be regex, not literal");
     }
 
     @Test
     void testCompilePatterns_IssueScenario() {
         // Exact scenario from issue #3199: _show_welcome_message( should not throw
-        List<Pattern> compiled = SearchTools.compilePatterns(List.of("_show_welcome_message("));
+        List<TextMatcher> compiled = SearchTools.compilePatterns(List.of("_show_welcome_message("));
         assertEquals(1, compiled.size());
         assertTrue(
-                compiled.getFirst().matcher("def _show_welcome_message(self):").find(),
+                compiled.getFirst().find("def _show_welcome_message(self):", null),
                 "Should match the literal string including the parenthesis");
     }
 

--- a/app/src/test/java/ai/brokk/usages/LlmUsageAnalyzerTest.java
+++ b/app/src/test/java/ai/brokk/usages/LlmUsageAnalyzerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import ai.brokk.OfflineService;
 import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.CodeUnitType;
+import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.testutil.InlineTestProjectCreator;
 import ai.brokk.testutil.TestAnalyzer;
@@ -106,6 +107,37 @@ class LlmUsageAnalyzerTest {
         }
     }
 
+    @Test
+    void skipsPatternScanWhenFileDoesNotContainIdentifier() throws IOException, InterruptedException {
+        String source =
+                """
+                package com.example;
+                class Caller {
+                    void call(Target target) {
+                        target.bar();
+                    }
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.empty().build()) {
+            var file = new CountingProjectFile(project.getRoot(), "src/main/java/com/example/Caller.java");
+            Files.createDirectories(file.absPath().getParent());
+            Files.writeString(file.absPath(), source);
+
+            var caller = new CodeUnit(file, CodeUnitType.CLASS, "com.example", "Caller");
+            var foo = new CodeUnit(file, CodeUnitType.FUNCTION, "com.example", "Target.foo");
+
+            var analyzer = new CountingAnalyzer(List.of(caller, foo), project);
+            analyzer.setRanges(caller, List.of(new IAnalyzer.Range(0, source.length(), 1, 6, 6)));
+
+            var usageAnalyzer = new LlmUsageAnalyzer(project, analyzer, new OfflineService(project), null);
+
+            usageAnalyzer.findUsages(List.of(foo), Set.of(file), 100);
+
+            assertEquals(0, analyzer.accessExpressionCheckCount());
+        }
+    }
+
     private static final class CountingProjectFile extends ProjectFile {
         private final AtomicInteger readCount = new AtomicInteger();
         private final AtomicInteger mtime = new AtomicInteger(1);
@@ -131,6 +163,24 @@ class LlmUsageAnalyzerTest {
 
         private void advanceMtime() {
             mtime.incrementAndGet();
+        }
+    }
+
+    private static final class CountingAnalyzer extends TestAnalyzer {
+        private final AtomicInteger accessExpressionCheckCount = new AtomicInteger();
+
+        private CountingAnalyzer(List<CodeUnit> declarations, ai.brokk.project.ICoreProject project) {
+            super(declarations, java.util.Map.of(), project);
+        }
+
+        @Override
+        public boolean isAccessExpression(ProjectFile file, int startByte, int endByte) {
+            accessExpressionCheckCount.incrementAndGet();
+            return true;
+        }
+
+        private int accessExpressionCheckCount() {
+            return accessExpressionCheckCount.get();
         }
     }
 }

--- a/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
@@ -30,6 +30,7 @@ import ai.brokk.util.Lines;
 import ai.brokk.util.Messages;
 import ai.brokk.util.PathExpander;
 import ai.brokk.util.SearchToolSupport;
+import ai.brokk.util.TextMatcher;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
@@ -60,7 +61,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.xml.XMLConstants;
@@ -168,7 +168,7 @@ public class SearchTools {
                     .maximumSize(4L * Runtime.getRuntime().availableProcessors())
                     .build());
 
-    private static final ThreadLocal<Cache<String, Pattern>> searchPatterns =
+    private static final ThreadLocal<Cache<String, TextMatcher>> searchPatterns =
             ThreadLocal.withInitial(() -> Caffeine.newBuilder()
                     .maximumSize(64L * Runtime.getRuntime().availableProcessors())
                     .build());
@@ -703,35 +703,30 @@ public class SearchTools {
         return String.join("\n", lines);
     }
 
-    public static List<Pattern> compilePatterns(List<String> patterns) {
+    public static List<TextMatcher> compilePatterns(List<String> patterns) {
         List<String> nonBlank = patterns.stream().filter(p -> !p.isBlank()).toList();
         if (nonBlank.isEmpty()) {
             return List.of();
         }
 
-        Cache<String, Pattern> cache = searchPatterns.get();
+        Cache<String, TextMatcher> cache = searchPatterns.get();
 
-        List<Pattern> compiled = new ArrayList<>(nonBlank.size());
+        List<TextMatcher> compiled = new ArrayList<>(nonBlank.size());
         List<String> errors = new ArrayList<>();
 
         for (String pat : nonBlank) {
             try {
-                Pattern cached = cache.getIfPresent(pat);
+                TextMatcher cached = cache.getIfPresent(pat);
                 if (cached != null) {
                     compiled.add(cached);
                     continue;
                 }
 
-                Pattern newlyCompiled = Pattern.compile(pat);
+                TextMatcher newlyCompiled = TextMatcher.compile(pat, 0);
                 cache.put(pat, newlyCompiled);
                 compiled.add(newlyCompiled);
             } catch (StackOverflowError e) {
                 errors.add("'%s': pattern is too complex (StackOverflowError)".formatted(pat));
-            } catch (PatternSyntaxException e) {
-                logger.debug("Pattern '{}' is not valid regex, falling back to literal match", pat);
-                Pattern literal = Pattern.compile(Pattern.quote(pat));
-                cache.put(pat, literal);
-                compiled.add(literal);
             } catch (RuntimeException e) {
                 String message = e.getMessage() == null ? e.toString() : e.getMessage();
                 errors.add("'%s': %s".formatted(pat, message));
@@ -745,36 +740,31 @@ public class SearchTools {
         return List.copyOf(compiled);
     }
 
-    private static List<Pattern> compilePatternsWithFlags(List<String> patterns, int flags) {
+    private static List<TextMatcher> compilePatternsWithFlags(List<String> patterns, int flags) {
         List<String> nonBlank = patterns.stream().filter(p -> !p.isBlank()).toList();
         if (nonBlank.isEmpty()) {
             return List.of();
         }
 
-        Cache<String, Pattern> cache = searchPatterns.get();
+        Cache<String, TextMatcher> cache = searchPatterns.get();
 
-        List<Pattern> compiled = new ArrayList<>(nonBlank.size());
+        List<TextMatcher> compiled = new ArrayList<>(nonBlank.size());
         List<String> errors = new ArrayList<>();
 
         for (String pat : nonBlank) {
             String cacheKey = pat + "::flags=" + flags;
             try {
-                Pattern cached = cache.getIfPresent(cacheKey);
+                TextMatcher cached = cache.getIfPresent(cacheKey);
                 if (cached != null) {
                     compiled.add(cached);
                     continue;
                 }
 
-                Pattern newlyCompiled = Pattern.compile(pat, flags);
+                TextMatcher newlyCompiled = TextMatcher.compile(pat, flags);
                 cache.put(cacheKey, newlyCompiled);
                 compiled.add(newlyCompiled);
             } catch (StackOverflowError e) {
                 errors.add("'%s': pattern is too complex (StackOverflowError)".formatted(pat));
-            } catch (PatternSyntaxException e) {
-                logger.debug("Pattern '{}' is not valid regex, falling back to literal match", pat);
-                Pattern literal = Pattern.compile(Pattern.quote(pat), flags);
-                cache.put(cacheKey, literal);
-                compiled.add(literal);
             } catch (RuntimeException e) {
                 String message = e.getMessage() == null ? e.toString() : e.getMessage();
                 errors.add("'%s': %s".formatted(pat, message));
@@ -1493,7 +1483,7 @@ public class SearchTools {
 
         logger.debug("Searching file contents for patterns: {}", patterns);
 
-        final List<Pattern> compiledPatterns;
+        final List<TextMatcher> compiledPatterns;
         try {
             compiledPatterns = compilePatterns(patterns);
         } catch (IllegalArgumentException e) {
@@ -1546,7 +1536,7 @@ public class SearchTools {
     }
 
     public static AlmostGrep.FindFilesContainingResult findFilesContainingPatterns(
-            List<Pattern> patterns, Set<ProjectFile> filesToSearch) throws InterruptedException {
+            List<TextMatcher> patterns, Set<ProjectFile> filesToSearch) throws InterruptedException {
         return AlmostGrep.findFilesContainingPatterns(patterns, filesToSearch);
     }
 
@@ -1687,7 +1677,7 @@ public class SearchTools {
             flags |= Pattern.MULTILINE;
         }
 
-        final List<Pattern> compiledPatterns;
+        final List<TextMatcher> compiledPatterns;
         try {
             compiledPatterns = compilePatternsWithFlags(patterns, flags);
             if (compiledPatterns.isEmpty()) {

--- a/brokk-shared/src/main/java/ai/brokk/util/AlmostGrep.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/AlmostGrep.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -95,7 +94,7 @@ public final class AlmostGrep {
     }
 
     public static FindFilesContainingResult findFilesContainingPatterns(
-            List<Pattern> patterns, Set<ProjectFile> filesToSearch) throws InterruptedException {
+            List<TextMatcher> patterns, Set<ProjectFile> filesToSearch) throws InterruptedException {
         if (patterns.isEmpty()) {
             return new FindFilesContainingResult(Set.of(), List.of());
         }
@@ -127,7 +126,8 @@ public final class AlmostGrep {
                                 String fileContents = fileContentsOpt.get();
                                 boolean matched;
                                 try {
-                                    matched = patterns.stream().anyMatch(p -> findWithOverflowGuard(p, fileContents));
+                                    String lowerContents = lowerContentsIfNeeded(patterns, fileContents);
+                                    matched = patterns.stream().anyMatch(p -> p.find(fileContents, lowerContents));
                                 } catch (RegexMatchOverflowException e) {
                                     String message = "regex '%s' caused StackOverflowError".formatted(e.pattern());
                                     return new FilePatternSearchResult(null, file + ": " + message);
@@ -180,7 +180,7 @@ public final class AlmostGrep {
 
     public static @Nullable FileContentSearchResult searchFileContentsInFile(
             ProjectFile file,
-            List<Pattern> patterns,
+            List<TextMatcher> patterns,
             int contextLines,
             IAnalyzer analyzer,
             FileContentSearchType searchType) {
@@ -193,7 +193,8 @@ public final class AlmostGrep {
         if (content.isEmpty()) {
             return null;
         }
-        if (patterns.stream().noneMatch(pattern -> findWithOverflowGuard(pattern, content))) {
+        String lowerContent = lowerContentsIfNeeded(patterns, content);
+        if (patterns.stream().noneMatch(pattern -> pattern.find(content, lowerContent))) {
             return null;
         }
 
@@ -207,12 +208,12 @@ public final class AlmostGrep {
         String filePath = file.toString().replace('\\', '/');
         Set<Integer> retainedMatchLines = new LinkedHashSet<>();
 
-        for (Pattern pattern : patterns) {
+        for (TextMatcher pattern : patterns) {
             byte[] lineStates = new byte[lineCount + 1];
             int matchesTaken = 0;
 
             try {
-                Matcher matcher = pattern.matcher(content);
+                var matcher = pattern.cursor(content, lowerContent);
                 int lineIdx = 0;
                 while (matcher.find()) {
                     int matchStart = matcher.start();
@@ -235,7 +236,7 @@ public final class AlmostGrep {
                     }
                 }
             } catch (StackOverflowError e) {
-                throw new RegexMatchOverflowException(pattern.pattern(), e);
+                throw new RegexMatchOverflowException(pattern.rawPattern(), e);
             }
         }
 
@@ -583,6 +584,12 @@ public final class AlmostGrep {
         } catch (StackOverflowError e) {
             throw new RegexMatchOverflowException(pattern.pattern(), e);
         }
+    }
+
+    private static @Nullable String lowerContentsIfNeeded(List<TextMatcher> patterns, String content) {
+        boolean needsLowerContent = patterns.stream()
+                .anyMatch(pattern -> pattern instanceof TextMatcher.Literal literal && literal.caseInsensitive());
+        return needsLowerContent ? content.toLowerCase(Locale.ROOT) : null;
     }
 
     private record LineRef(int lineNo, int startInclusive, int endExclusive) {}

--- a/brokk-shared/src/main/java/ai/brokk/util/FilenamePatternMatcher.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/FilenamePatternMatcher.java
@@ -1,20 +1,24 @@
 package ai.brokk.util;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import org.jetbrains.annotations.Nullable;
 
 public final class FilenamePatternMatcher {
     private FilenamePatternMatcher() {}
 
-    public record FilenamePattern(Pattern pattern, boolean glob, boolean matchFullPath) {
+    public record FilenamePattern(
+            @Nullable TextMatcher matcher, @Nullable Pattern pattern, boolean glob, boolean matchFullPath) {
         public boolean matches(String filePath) {
             if (!glob) {
-                return AlmostGrep.findWithOverflowGuard(pattern, filePath);
+                return requireNonNull(matcher).find(filePath, null);
             }
             String candidate = matchFullPath ? filePath : basename(filePath);
-            return pattern.matcher(candidate).matches();
+            return requireNonNull(pattern).matcher(candidate).matches();
         }
     }
 
@@ -70,7 +74,7 @@ public final class FilenamePatternMatcher {
 
     private static FilenamePattern compilePattern(String regexPattern, String globPattern, int flags) {
         try {
-            return new FilenamePattern(Pattern.compile(regexPattern, flags), false, true);
+            return new FilenamePattern(TextMatcher.compile(regexPattern, flags), null, false, true);
         } catch (PatternSyntaxException e) {
             return compileGlobPattern(globPattern, flags);
         }
@@ -80,7 +84,7 @@ public final class FilenamePatternMatcher {
         String normalizedGlob = normalizeGlobPattern(globPattern);
         Pattern globRegex = globToRegex(normalizedGlob);
         Pattern compiledGlob = Pattern.compile(globRegex.pattern(), flags);
-        return new FilenamePattern(compiledGlob, true, normalizedGlob.contains("/"));
+        return new FilenamePattern(null, compiledGlob, true, normalizedGlob.contains("/"));
     }
 
     private static boolean hasGlobMetacharacter(String pattern) {

--- a/brokk-shared/src/main/java/ai/brokk/util/TextMatcher.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/TextMatcher.java
@@ -1,0 +1,148 @@
+package ai.brokk.util;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.jetbrains.annotations.Nullable;
+
+public sealed interface TextMatcher permits TextMatcher.Literal, TextMatcher.Regex {
+    String rawPattern();
+
+    MatchCursor cursor(String input, @Nullable String lowerInput);
+
+    default boolean find(String input, @Nullable String lowerInput) {
+        return cursor(input, lowerInput).find();
+    }
+
+    static TextMatcher compile(String pattern, int flags) {
+        if (isLiteralPattern(pattern)) {
+            return Literal.create(pattern, flags);
+        }
+        try {
+            return new Regex(pattern, Pattern.compile(pattern, flags));
+        } catch (PatternSyntaxException e) {
+            return Literal.create(pattern, flags);
+        }
+    }
+
+    static boolean isLiteralPattern(String pattern) {
+        for (int i = 0; i < pattern.length(); i++) {
+            if (".^$*+?{}[]\\|()".indexOf(pattern.charAt(i)) >= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    interface MatchCursor {
+        boolean find();
+
+        int start();
+
+        int end();
+
+        String group();
+    }
+
+    record Literal(String rawPattern, String needle, boolean caseInsensitive) implements TextMatcher {
+        private static Literal create(String pattern, int flags) {
+            boolean caseInsensitive = (flags & Pattern.CASE_INSENSITIVE) != 0;
+            String needle = caseInsensitive ? pattern.toLowerCase(Locale.ROOT) : pattern;
+            return new Literal(pattern, needle, caseInsensitive);
+        }
+
+        @Override
+        public MatchCursor cursor(String input, @Nullable String lowerInput) {
+            String haystack = caseInsensitive ? lowerInputOrCompute(input, lowerInput) : input;
+            return new LiteralCursor(input, haystack, needle);
+        }
+
+        private static String lowerInputOrCompute(String input, @Nullable String lowerInput) {
+            return lowerInput == null ? input.toLowerCase(Locale.ROOT) : lowerInput;
+        }
+    }
+
+    record Regex(String rawPattern, Pattern pattern) implements TextMatcher {
+        @Override
+        public MatchCursor cursor(String input, @Nullable String lowerInput) {
+            return new RegexCursor(pattern.matcher(input), rawPattern);
+        }
+    }
+
+    final class LiteralCursor implements MatchCursor {
+        private final String input;
+        private final String haystack;
+        private final String needle;
+        private int nextStart = 0;
+        private int start = -1;
+        private int end = -1;
+
+        private LiteralCursor(String input, String haystack, String needle) {
+            this.input = input;
+            this.haystack = haystack;
+            this.needle = needle;
+        }
+
+        @Override
+        public boolean find() {
+            start = haystack.indexOf(needle, nextStart);
+            if (start < 0) {
+                end = -1;
+                return false;
+            }
+            end = start + needle.length();
+            nextStart = Math.max(start + 1, end);
+            return true;
+        }
+
+        @Override
+        public int start() {
+            return start;
+        }
+
+        @Override
+        public int end() {
+            return end;
+        }
+
+        @Override
+        public String group() {
+            return input.substring(start, end);
+        }
+    }
+
+    final class RegexCursor implements MatchCursor {
+        private final Matcher matcher;
+        private final String rawPattern;
+
+        private RegexCursor(Matcher matcher, String rawPattern) {
+            this.matcher = matcher;
+            this.rawPattern = rawPattern;
+        }
+
+        @Override
+        public boolean find() {
+            try {
+                return matcher.find();
+            } catch (StackOverflowError e) {
+                throw new AlmostGrep.RegexMatchOverflowException(rawPattern, e);
+            }
+        }
+
+        @Override
+        public int start() {
+            return matcher.start();
+        }
+
+        @Override
+        public int end() {
+            return matcher.end();
+        }
+
+        @Override
+        public String group() {
+            return matcher.group();
+        }
+    }
+}


### PR DESCRIPTION
### Description
Optimizes regex-heavy search paths by routing provably literal content and filename patterns through literal matchers while preserving regex/glob behavior. Adds a lightweight shared matcher abstraction and a fuzzy usage prefilter to avoid regex/access-expression work for files that do not contain the target identifier.

**Key Changes**:
- Added shared literal/regex matching via TextMatcher and wired content search through it in app, brokk-core, and AlmostGrep.
- Updated filename matching to use literal containment for plain filename fragments while preserving glob and regex semantics.
- Added an identifier prefilter for LlmUsageAnalyzer fuzzy scans plus regression coverage for literal, regex, invalid-regex fallback, and usage-scan skip behavior.

**Touch Points**:
- app/src/main/java/ai/brokk/tools/SearchTools.java
- app/src/main/java/ai/brokk/usages/LlmUsageAnalyzer.java
- brokk-core/src/main/java/ai/brokk/tools/SearchTools.java
- brokk-shared/src/main/java/ai/brokk/util/AlmostGrep.java
- brokk-shared/src/main/java/ai/brokk/util/FilenamePatternMatcher.java
- brokk-shared/src/main/java/ai/brokk/util/TextMatcher.java

Verification:
- ./gradlew fix tidy
- ./gradlew :app:test --tests ai.brokk.tools.SearchToolsTest --tests ai.brokk.usages.LlmUsageAnalyzerTest
- ./gradlew :brokk-core:compileJava
- ./gradlew analyze