### PR TITLE
brokk-tui-rust: full interactive ACP chat client

### DIFF
--- a/.github/workflows/brokk-tui-ci.yml
+++ b/.github/workflows/brokk-tui-ci.yml
@@ -14,7 +14,11 @@ on:
 
 jobs:
   brokk-tui:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4

--- a/brokk-tui-rust/Cargo.lock
+++ b/brokk-tui-rust/Cargo.lock
@@ -3,5 +3,1996 @@
 version = 4
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "anyhow",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "brokk-tui"
-version = "0.0.1"
+version = "0.1.0"
+dependencies = [
+ "agent-client-protocol",
+ "anyhow",
+ "clap",
+ "crossterm",
+ "futures",
+ "ratatui",
+ "serde_json",
+ "shell-words",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/brokk-tui-rust/Cargo.toml
+++ b/brokk-tui-rust/Cargo.toml
@@ -1,11 +1,25 @@
 [package]
 name = "brokk-tui"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 description = "Terminal UI client for the Agent Client Protocol (ACP)"
-license = "LGPL-3.0"
+license = "GPL-3.0"
 publish = false
 
 [[bin]]
 name = "brokk-tui"
 path = "src/main.rs"
+
+[dependencies]
+agent-client-protocol = "0.11"
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+crossterm = { version = "0.28", features = ["event-stream"] }
+futures = "0.3"
+ratatui = "0.29"
+serde_json = "1"
+shell-words = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["compat", "rt"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/brokk-tui-rust/src/acp.rs
+++ b/brokk-tui-rust/src/acp.rs
@@ -1,0 +1,352 @@
+//! ACP client runtime: spawns the agent subprocess, wires JSON-RPC over
+//! stdio, and bridges UI commands/events through two mpsc channels.
+
+use std::path::PathBuf;
+
+use agent_client_protocol::schema::{
+    CancelNotification, ClientCapabilities, ContentBlock, FileSystemCapabilities,
+    InitializeRequest, NewSessionRequest, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, SessionId,
+    SessionNotification, TextContent,
+};
+use agent_client_protocol::{Agent, ByteStreams, Client, ConnectTo, ConnectionTo};
+use anyhow::{Context, Result};
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+use crate::event::{PermissionDecision, PermissionPrompt, UiCommand, UiEvent};
+
+pub struct AcpRuntimeConfig {
+    pub command: PathBuf,
+    pub args: Vec<String>,
+    pub cwd: PathBuf,
+    /// Where the agent's stderr should go. `None` redirects to /dev/null
+    /// so the agent's logs don't bleed into the TUI. Pass a path to capture
+    /// for debugging.
+    pub agent_stderr: Option<PathBuf>,
+}
+
+/// Spawn the agent subprocess and run the ACP client to completion.
+/// Pumps `ui_rx` for `UiCommand`s and emits `UiEvent`s onto `ui_tx`.
+///
+/// Returns once the connection is closed or the user requests shutdown.
+pub async fn run(
+    cfg: AcpRuntimeConfig,
+    ui_tx: mpsc::UnboundedSender<UiEvent>,
+    ui_rx: mpsc::UnboundedReceiver<UiCommand>,
+) -> Result<()> {
+    let (mut child, child_stdin, child_stdout) =
+        spawn_agent(&cfg.command, &cfg.args, cfg.agent_stderr.as_deref())?;
+    let transport = ByteStreams::new(child_stdin.compat_write(), child_stdout.compat());
+
+    let result = drive_client(transport, cfg.cwd.clone(), ui_tx.clone(), ui_rx).await;
+
+    let kill = child.kill().await;
+    if let Err(e) = kill {
+        tracing::warn!("kill child: {e}");
+    }
+    if let Err(e) = &result {
+        let _ = ui_tx.send(UiEvent::Fatal(format!("acp: {e}")));
+    }
+    result
+}
+
+/// Run the full ACP client state machine over an arbitrary transport.
+/// Factored out of `run` so integration tests can plug in an in-process
+/// duplex stream and drive a mock agent without spawning a subprocess.
+pub async fn drive_client<T>(
+    transport: T,
+    cwd: PathBuf,
+    ui_tx: mpsc::UnboundedSender<UiEvent>,
+    mut ui_rx: mpsc::UnboundedReceiver<UiCommand>,
+) -> Result<()>
+where
+    T: ConnectTo<Client>,
+{
+    // Channel for permission prompts that the UI needs to answer.
+    // The on_receive_request closure forwards (req, responder) here and
+    // returns immediately so the JSON-RPC dispatch loop stays unblocked.
+    let perm_ui_tx = ui_tx.clone();
+    let notif_ui_tx = ui_tx.clone();
+    let session_ui_tx = ui_tx.clone();
+    let result = Client
+        .builder()
+        .on_receive_notification(
+            async move |notification: SessionNotification, _cx| {
+                let _ = notif_ui_tx.send(UiEvent::SessionUpdate(notification.update));
+                Ok(())
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .on_receive_request(
+            async move |request: RequestPermissionRequest, responder, _cx| {
+                let (tx, rx) = oneshot::channel::<PermissionDecision>();
+                let prompt = PermissionPrompt {
+                    tool_call: request.tool_call,
+                    options: request.options,
+                    responder: tx,
+                };
+                if perm_ui_tx.send(UiEvent::PermissionRequest(prompt)).is_err() {
+                    return responder.respond(RequestPermissionResponse::new(
+                        RequestPermissionOutcome::Cancelled,
+                    ));
+                }
+                let outcome = match rx.await {
+                    Ok(PermissionDecision::Selected(id)) => {
+                        RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(id))
+                    }
+                    _ => RequestPermissionOutcome::Cancelled,
+                };
+                responder.respond(RequestPermissionResponse::new(outcome))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .connect_with(transport, |conn: ConnectionTo<Agent>| async move {
+            if let Err(e) = drive_session(conn, cwd, &session_ui_tx, &mut ui_rx).await {
+                let msg = format!("{e:#}");
+                let _ = session_ui_tx.send(UiEvent::Fatal(msg.clone()));
+                return Err(agent_client_protocol::Error::internal_error()
+                    .data(serde_json::Value::String(msg)));
+            }
+            Ok(())
+        })
+        .await;
+
+    result.map_err(|e| anyhow::anyhow!("acp client error: {e}"))?;
+    Ok(())
+}
+
+/// Initialize the agent, open a session, then loop forwarding prompts and
+/// cancellations until the UI requests shutdown or the agent closes the
+/// connection.
+async fn drive_session(
+    conn: ConnectionTo<Agent>,
+    cwd: PathBuf,
+    ui_tx: &mpsc::UnboundedSender<UiEvent>,
+    ui_rx: &mut mpsc::UnboundedReceiver<UiCommand>,
+) -> Result<()> {
+    // Advertise our client capabilities. We do not yet implement
+    // `fs/read_text_file` or `fs/write_text_file`, so we declare both as
+    // false; same for terminals. Permission prompts always work.
+    let init_req = InitializeRequest::new(ProtocolVersion::V1).client_capabilities(
+        ClientCapabilities::new()
+            .fs(FileSystemCapabilities::new()
+                .read_text_file(false)
+                .write_text_file(false))
+            .terminal(false),
+    );
+    let init_resp = conn
+        .send_request(init_req)
+        .block_task()
+        .await
+        .context("initialize")?;
+    let _ = ui_tx.send(UiEvent::Connected {
+        agent_name: init_resp.agent_info.as_ref().map(|i| i.name.clone()),
+        agent_version: init_resp.agent_info.as_ref().map(|i| i.version.clone()),
+    });
+
+    let session = conn
+        .send_request(NewSessionRequest::new(cwd))
+        .block_task()
+        .await
+        .context("new_session")?;
+    let session_id: SessionId = session.session_id;
+    let _ = ui_tx.send(UiEvent::SessionStarted {
+        session_id: session_id.to_string(),
+    });
+
+    while let Some(cmd) = ui_rx.recv().await {
+        match cmd {
+            UiCommand::SendPrompt { text } => {
+                let req = PromptRequest::new(
+                    session_id.clone(),
+                    vec![ContentBlock::Text(TextContent::new(text))],
+                );
+                match conn.send_request(req).block_task().await {
+                    Ok(resp) => {
+                        let _ = ui_tx.send(UiEvent::PromptDone {
+                            stop_reason: resp.stop_reason,
+                        });
+                    }
+                    Err(e) => {
+                        let _ = ui_tx.send(UiEvent::Warning(format!("prompt failed: {e}")));
+                    }
+                }
+            }
+            UiCommand::CancelPrompt => {
+                if let Err(e) = conn.send_notification(CancelNotification::new(session_id.clone()))
+                {
+                    let _ = ui_tx.send(UiEvent::Warning(format!("cancel failed: {e}")));
+                }
+            }
+            UiCommand::Shutdown => break,
+        }
+    }
+    Ok(())
+}
+
+fn spawn_agent(
+    command: &PathBuf,
+    args: &[String],
+    stderr_path: Option<&std::path::Path>,
+) -> Result<(
+    Child,
+    tokio::process::ChildStdin,
+    tokio::process::ChildStdout,
+)> {
+    let mut cmd = Command::new(command);
+    cmd.args(args);
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped());
+    match stderr_path {
+        Some(path) => {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .with_context(|| format!("open agent stderr {path:?}"))?;
+            cmd.stderr(std::process::Stdio::from(file));
+        }
+        None => {
+            cmd.stderr(std::process::Stdio::null());
+        }
+    }
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("spawning agent {command:?}"))?;
+    let stdin = child.stdin.take().context("child stdin not piped")?;
+    let stdout = child.stdout.take().context("child stdout not piped")?;
+    Ok((child, stdin, stdout))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::Agent as AgentRole;
+    use agent_client_protocol::schema::{
+        ContentBlock, ContentChunk, InitializeResponse, NewSessionResponse, PromptResponse,
+        SessionId, SessionNotification, SessionUpdate, StopReason, TextContent,
+    };
+    use std::time::Duration;
+    use tokio::io::split;
+
+    /// Spawn a minimal in-process ACP agent over a duplex stream. The
+    /// agent answers Initialize/NewSession/Prompt, streams one chunk back
+    /// on every prompt, and reports EndTurn.
+    async fn run_mock_agent(stream: tokio::io::DuplexStream) {
+        let (r, w) = split(stream);
+        let transport = ByteStreams::new(w.compat_write(), r.compat());
+        let _ = AgentRole
+            .builder()
+            .on_receive_request(
+                async move |_req: agent_client_protocol::schema::InitializeRequest,
+                            responder,
+                            _cx| {
+                    responder.respond(InitializeResponse::new(
+                        agent_client_protocol::schema::ProtocolVersion::V1,
+                    ))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |_req: agent_client_protocol::schema::NewSessionRequest,
+                            responder,
+                            _cx| {
+                    responder.respond(NewSessionResponse::new(SessionId::new("test-session")))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |req: agent_client_protocol::schema::PromptRequest,
+                            responder,
+                            cx: ConnectionTo<agent_client_protocol::Client>| {
+                    let session_id = req.session_id.clone();
+                    // Stream one chunk so the client sees a SessionUpdate
+                    // before the prompt resolves.
+                    let _ = cx.send_notification(SessionNotification::new(
+                        session_id,
+                        SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                            TextContent::new("ack"),
+                        ))),
+                    ));
+                    responder.respond(PromptResponse::new(StopReason::EndTurn))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .connect_with(transport, |_cx| async move {
+                // Keep the agent alive until the client side closes.
+                futures::future::pending::<()>().await;
+                Ok(())
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn full_prompt_turn_against_mock_agent() {
+        let (client_side, agent_side) = tokio::io::duplex(64 * 1024);
+        let (cr, cw) = split(client_side);
+        let client_transport = ByteStreams::new(cw.compat_write(), cr.compat());
+
+        let agent_task = tokio::spawn(run_mock_agent(agent_side));
+
+        let (ui_tx, mut ui_rx) = mpsc::unbounded_channel::<UiEvent>();
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<UiCommand>();
+
+        let client_task = tokio::spawn(drive_client(
+            client_transport,
+            std::env::temp_dir(),
+            ui_tx,
+            cmd_rx,
+        ));
+
+        // Pull Connected + SessionStarted.
+        let mut saw_connected = false;
+        let mut saw_session = false;
+        while !(saw_connected && saw_session) {
+            let ev = tokio::time::timeout(Duration::from_secs(5), ui_rx.recv())
+                .await
+                .expect("timeout waiting for handshake")
+                .expect("channel closed");
+            match ev {
+                UiEvent::Connected { .. } => saw_connected = true,
+                UiEvent::SessionStarted { .. } => saw_session = true,
+                UiEvent::Warning(_) | UiEvent::Fatal(_) => panic!("unexpected: {ev:?}"),
+                _ => {}
+            }
+        }
+
+        cmd_tx
+            .send(UiCommand::SendPrompt {
+                text: "hello".to_string(),
+            })
+            .expect("send prompt");
+
+        let mut saw_update = false;
+        let mut saw_done = false;
+        while !(saw_update && saw_done) {
+            let ev = tokio::time::timeout(Duration::from_secs(5), ui_rx.recv())
+                .await
+                .expect("timeout waiting for prompt turn")
+                .expect("channel closed");
+            match ev {
+                UiEvent::SessionUpdate(SessionUpdate::AgentMessageChunk(c)) => {
+                    if let ContentBlock::Text(t) = &c.content {
+                        assert_eq!(t.text, "ack");
+                    }
+                    saw_update = true;
+                }
+                UiEvent::PromptDone { stop_reason } => {
+                    assert!(matches!(stop_reason, StopReason::EndTurn));
+                    saw_done = true;
+                }
+                UiEvent::Warning(_) | UiEvent::Fatal(_) => panic!("unexpected: {ev:?}"),
+                _ => {}
+            }
+        }
+
+        cmd_tx.send(UiCommand::Shutdown).expect("shutdown");
+        let _ = tokio::time::timeout(Duration::from_secs(2), client_task).await;
+        agent_task.abort();
+    }
+}

--- a/brokk-tui-rust/src/acp.rs
+++ b/brokk-tui-rust/src/acp.rs
@@ -21,9 +21,10 @@ pub struct AcpRuntimeConfig {
     pub command: PathBuf,
     pub args: Vec<String>,
     pub cwd: PathBuf,
-    /// Where the agent's stderr should go. `None` redirects to /dev/null
-    /// so the agent's logs don't bleed into the TUI. Pass a path to capture
-    /// for debugging.
+    /// Where the agent's stderr should go. `None` discards it (via
+    /// `Stdio::null()`, which maps to /dev/null on Unix and NUL on
+    /// Windows) so the agent's logs don't bleed into the TUI. Pass a
+    /// path to capture for debugging.
     pub agent_stderr: Option<PathBuf>,
 }
 

--- a/brokk-tui-rust/src/acp.rs
+++ b/brokk-tui-rust/src/acp.rs
@@ -350,4 +350,51 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_secs(2), client_task).await;
         agent_task.abort();
     }
+
+    /// Dropping the command channel must drive `drive_client` to a clean
+    /// return promptly -- this is the graceful shutdown path the main
+    /// binary relies on (UI exits, `cmd_tx` is dropped, the ACP task
+    /// joins within the timeout instead of needing `abort()`).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drive_client_returns_when_command_channel_drops() {
+        let (client_side, agent_side) = tokio::io::duplex(64 * 1024);
+        let (cr, cw) = split(client_side);
+        let client_transport = ByteStreams::new(cw.compat_write(), cr.compat());
+
+        let agent_task = tokio::spawn(run_mock_agent(agent_side));
+
+        let (ui_tx, mut ui_rx) = mpsc::unbounded_channel::<UiEvent>();
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<UiCommand>();
+
+        let client_task = tokio::spawn(drive_client(
+            client_transport,
+            std::env::temp_dir(),
+            ui_tx,
+            cmd_rx,
+        ));
+
+        // Wait for the handshake so we know the loop is actually inside
+        // its `recv()` waiting on commands.
+        let mut saw_session = false;
+        while !saw_session {
+            let ev = tokio::time::timeout(Duration::from_secs(5), ui_rx.recv())
+                .await
+                .expect("handshake timeout")
+                .expect("channel closed");
+            if matches!(ev, UiEvent::SessionStarted { .. }) {
+                saw_session = true;
+            }
+        }
+
+        // Drop the sender side. drive_session sees `None` on its
+        // `recv()` and must return; drive_client must then resolve.
+        drop(cmd_tx);
+
+        let join = tokio::time::timeout(Duration::from_secs(2), client_task)
+            .await
+            .expect("drive_client did not return after cmd channel drop");
+        join.expect("client task panicked")
+            .expect("drive_client returned error");
+        agent_task.abort();
+    }
 }

--- a/brokk-tui-rust/src/app.rs
+++ b/brokk-tui-rust/src/app.rs
@@ -190,7 +190,18 @@ impl AppState {
         self.scroll_offset = 0;
         match update {
             SessionUpdate::UserMessageChunk(c) => {
-                // Server-side replay of a user message: append.
+                // During an active prompt turn (`Streaming`), the user's
+                // message was already echoed locally via
+                // `record_user_prompt` for immediate feedback. The agent
+                // may replay the same text as a `UserMessageChunk`;
+                // suppressing it here keeps the transcript from showing
+                // the prompt twice. When the session is `Idle`, this
+                // chunk is part of a session replay (e.g. from
+                // `session/load`) and the only source of that user
+                // message, so we render it.
+                if self.turn == TurnState::Streaming {
+                    return;
+                }
                 let text = content_block_text(&c.content);
                 append_or_start(&mut self.transcript, EntryKind::User, text);
             }
@@ -373,5 +384,38 @@ mod tests {
             stop_reason: StopReason::EndTurn,
         });
         assert_eq!(s.turn, TurnState::Idle);
+    }
+
+    #[test]
+    fn user_chunk_suppressed_during_streaming_but_kept_on_replay() {
+        // While a prompt is in flight, the local echo from
+        // `record_user_prompt` is the source of truth -- any
+        // `UserMessageChunk` the agent sends back is a duplicate and
+        // must be dropped.
+        let mut s = AppState::new();
+        s.record_user_prompt("hello".to_string());
+        assert_eq!(s.transcript.len(), 1);
+        s.apply_event(UiEvent::SessionUpdate(SessionUpdate::UserMessageChunk(
+            text_chunk("hello"),
+        )));
+        assert_eq!(
+            s.transcript.len(),
+            1,
+            "agent echo must not double the user prompt while streaming"
+        );
+
+        // When the session is idle (e.g. mid-`session/load` replay), the
+        // same chunk is the only source of truth for the user message
+        // and must be rendered.
+        let mut s = AppState::new();
+        assert_eq!(s.turn, TurnState::Idle);
+        s.apply_event(UiEvent::SessionUpdate(SessionUpdate::UserMessageChunk(
+            text_chunk("replayed"),
+        )));
+        assert_eq!(s.transcript.len(), 1);
+        match &s.transcript[0] {
+            Entry::UserPrompt(t) => assert_eq!(t, "replayed"),
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 }

--- a/brokk-tui-rust/src/app.rs
+++ b/brokk-tui-rust/src/app.rs
@@ -1,0 +1,377 @@
+//! UI state machine.
+//!
+//! Holds the transcript, current tool-call table, input buffer, and the
+//! at-most-one pending permission prompt. Every incoming ACP event is
+//! folded in through `apply_event`; ratatui then renders from this state.
+
+use std::collections::HashMap;
+
+use agent_client_protocol::schema::{
+    AvailableCommand, Plan, PlanEntry, SessionUpdate, StopReason, ToolCall, ToolCallContent,
+    ToolCallStatus, ToolCallUpdate, ToolKind,
+};
+
+use crate::event::{PermissionPrompt, UiEvent, content_block_text};
+
+/// One entry in the scrolling transcript.
+#[derive(Debug, Clone)]
+pub enum Entry {
+    /// Plain user prompt (echoed locally as soon as it is sent).
+    UserPrompt(String),
+    /// Streaming agent reply. Mutated in place as chunks arrive.
+    AgentMessage(String),
+    /// Streaming agent reasoning ("thoughts").
+    AgentThought(String),
+    /// A tool call slot identified by id. The body is rendered from
+    /// `tool_calls[id]`; we keep an entry pointer so it shows up in order.
+    ToolCall(String),
+    /// Latest plan posted by the agent.
+    Plan(Vec<PlanEntry>),
+    /// System-level note (errors, warnings, mode changes).
+    System(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolCallView {
+    pub title: String,
+    pub kind: ToolKind,
+    pub status: ToolCallStatus,
+    pub body: Vec<String>,
+}
+
+impl ToolCallView {
+    fn from_tool_call(tc: &ToolCall) -> Self {
+        let mut v = Self {
+            title: tc.title.clone(),
+            kind: tc.kind,
+            status: tc.status,
+            body: Vec::new(),
+        };
+        v.set_content(&tc.content);
+        v
+    }
+
+    fn apply_update(&mut self, u: &ToolCallUpdate) {
+        if let Some(t) = &u.fields.title {
+            self.title = t.clone();
+        }
+        if let Some(k) = u.fields.kind {
+            self.kind = k;
+        }
+        if let Some(s) = u.fields.status {
+            self.status = s;
+        }
+        if let Some(c) = &u.fields.content {
+            self.set_content(c);
+        }
+    }
+
+    fn set_content(&mut self, content: &[ToolCallContent]) {
+        self.body.clear();
+        for c in content {
+            match c {
+                ToolCallContent::Content(block) => {
+                    self.body.push(content_block_text(&block.content));
+                }
+                ToolCallContent::Diff(d) => {
+                    self.body.push(format!("[diff {}]", d.path.display()));
+                }
+                ToolCallContent::Terminal(t) => {
+                    self.body.push(format!("[terminal {}]", t.terminal_id));
+                }
+                _ => self.body.push("[unsupported tool content]".to_string()),
+            }
+        }
+    }
+}
+
+/// Status of the current prompt turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnState {
+    /// No prompt in flight; user can type and send.
+    Idle,
+    /// We sent a PromptRequest and are waiting for chunks.
+    Streaming,
+}
+
+#[derive(Debug)]
+pub struct AppState {
+    pub agent_label: String,
+    pub session_id: Option<String>,
+    pub connection_status: String,
+    pub current_mode: Option<String>,
+    pub available_commands: Vec<AvailableCommand>,
+    pub transcript: Vec<Entry>,
+    pub tool_calls: HashMap<String, ToolCallView>,
+    pub input: String,
+    pub turn: TurnState,
+    pub pending_permission: Option<PendingPermission>,
+    /// Scroll offset measured in rendered lines from the bottom of the
+    /// transcript. `0` keeps the view pinned to the newest line.
+    pub scroll_offset: u16,
+    pub should_quit: bool,
+    /// Transient status line (cleared on next event).
+    pub status_line: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct PendingPermission {
+    pub prompt: PermissionPrompt,
+    pub selected: usize,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {
+            agent_label: String::new(),
+            session_id: None,
+            connection_status: "connecting...".to_string(),
+            current_mode: None,
+            available_commands: Vec::new(),
+            transcript: Vec::new(),
+            tool_calls: HashMap::new(),
+            input: String::new(),
+            turn: TurnState::Idle,
+            pending_permission: None,
+            scroll_offset: 0,
+            should_quit: false,
+            status_line: None,
+        }
+    }
+
+    /// Push a user prompt into the transcript immediately, before the
+    /// command reaches the runtime. Keeps the UI responsive.
+    pub fn record_user_prompt(&mut self, text: String) {
+        self.transcript.push(Entry::UserPrompt(text));
+        self.turn = TurnState::Streaming;
+        self.scroll_offset = 0;
+    }
+
+    pub fn apply_event(&mut self, event: UiEvent) {
+        match event {
+            UiEvent::Connected {
+                agent_name,
+                agent_version,
+            } => {
+                self.agent_label = match (agent_name, agent_version) {
+                    (Some(n), Some(v)) => format!("{n} {v}"),
+                    (Some(n), None) => n,
+                    _ => "agent".to_string(),
+                };
+                self.connection_status = format!("connected to {}", self.agent_label);
+            }
+            UiEvent::SessionStarted { session_id } => {
+                self.session_id = Some(session_id);
+                self.connection_status = format!("session ready ({})", self.agent_label);
+            }
+            UiEvent::SessionUpdate(u) => self.apply_session_update(u),
+            UiEvent::PermissionRequest(prompt) => {
+                self.pending_permission = Some(PendingPermission {
+                    prompt,
+                    selected: 0,
+                });
+            }
+            UiEvent::PromptDone { stop_reason } => {
+                self.turn = TurnState::Idle;
+                self.status_line = Some(format!("turn done: {stop_reason:?}"));
+            }
+            UiEvent::Warning(msg) => {
+                self.status_line = Some(msg);
+            }
+            UiEvent::Fatal(msg) => {
+                self.transcript.push(Entry::System(format!("fatal: {msg}")));
+                self.connection_status = "disconnected".to_string();
+                self.turn = TurnState::Idle;
+            }
+        }
+    }
+
+    fn apply_session_update(&mut self, update: SessionUpdate) {
+        self.scroll_offset = 0;
+        match update {
+            SessionUpdate::UserMessageChunk(c) => {
+                // Server-side replay of a user message: append.
+                let text = content_block_text(&c.content);
+                append_or_start(&mut self.transcript, EntryKind::User, text);
+            }
+            SessionUpdate::AgentMessageChunk(c) => {
+                let text = content_block_text(&c.content);
+                append_or_start(&mut self.transcript, EntryKind::Agent, text);
+            }
+            SessionUpdate::AgentThoughtChunk(c) => {
+                let text = content_block_text(&c.content);
+                append_or_start(&mut self.transcript, EntryKind::Thought, text);
+            }
+            SessionUpdate::ToolCall(tc) => {
+                let id = tc.tool_call_id.to_string();
+                self.tool_calls
+                    .insert(id.clone(), ToolCallView::from_tool_call(&tc));
+                self.transcript.push(Entry::ToolCall(id));
+            }
+            SessionUpdate::ToolCallUpdate(u) => {
+                let id = u.tool_call_id.to_string();
+                if let Some(view) = self.tool_calls.get_mut(&id) {
+                    view.apply_update(&u);
+                } else {
+                    // Update before create; synthesize a placeholder.
+                    let mut view = ToolCallView {
+                        title: u.fields.title.clone().unwrap_or_else(|| "tool".to_string()),
+                        kind: u.fields.kind.unwrap_or(ToolKind::Other),
+                        status: u.fields.status.unwrap_or(ToolCallStatus::Pending),
+                        body: Vec::new(),
+                    };
+                    if let Some(content) = &u.fields.content {
+                        view.set_content(content);
+                    }
+                    self.tool_calls.insert(id.clone(), view);
+                    self.transcript.push(Entry::ToolCall(id));
+                }
+            }
+            SessionUpdate::Plan(Plan { entries, .. }) => {
+                // Replace the most recent Plan entry if present, else push.
+                if let Some(Entry::Plan(existing)) = self
+                    .transcript
+                    .iter_mut()
+                    .rev()
+                    .find(|e| matches!(e, Entry::Plan(_)))
+                {
+                    *existing = entries;
+                } else {
+                    self.transcript.push(Entry::Plan(entries));
+                }
+            }
+            SessionUpdate::AvailableCommandsUpdate(u) => {
+                self.available_commands = u.available_commands;
+            }
+            SessionUpdate::CurrentModeUpdate(u) => {
+                let mode = u.current_mode_id.to_string();
+                self.current_mode = Some(mode.clone());
+                self.transcript.push(Entry::System(format!("mode: {mode}")));
+            }
+            SessionUpdate::ConfigOptionUpdate(_) => {
+                // Config options are rendered through the available list;
+                // we surface the raw event as a system note for now.
+                self.transcript
+                    .push(Entry::System("config option updated".to_string()));
+            }
+            SessionUpdate::SessionInfoUpdate(info) => {
+                if let Some(title) = info.title.value() {
+                    self.transcript
+                        .push(Entry::System(format!("session title: {title}")));
+                }
+            }
+            _ => {
+                self.transcript
+                    .push(Entry::System("unsupported session update".to_string()));
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum EntryKind {
+    User,
+    Agent,
+    Thought,
+}
+
+/// Append `text` to the trailing entry of the same kind, or start a new
+/// entry. Streaming chunks for the same logical message land in one entry.
+fn append_or_start(transcript: &mut Vec<Entry>, kind: EntryKind, text: String) {
+    if let Some(last) = transcript.last_mut() {
+        match (&kind, last) {
+            (EntryKind::User, Entry::UserPrompt(s))
+            | (EntryKind::Agent, Entry::AgentMessage(s))
+            | (EntryKind::Thought, Entry::AgentThought(s)) => {
+                s.push_str(&text);
+                return;
+            }
+            _ => {}
+        }
+    }
+    transcript.push(match kind {
+        EntryKind::User => Entry::UserPrompt(text),
+        EntryKind::Agent => Entry::AgentMessage(text),
+        EntryKind::Thought => Entry::AgentThought(text),
+    });
+}
+
+/// Format a permission option label for the modal. Returned strings are
+/// printable without further processing.
+pub fn permission_kind_label(
+    kind: agent_client_protocol::schema::PermissionOptionKind,
+) -> &'static str {
+    use agent_client_protocol::schema::PermissionOptionKind as K;
+    match kind {
+        K::AllowOnce => "allow once",
+        K::AllowAlways => "allow always",
+        K::RejectOnce => "reject once",
+        K::RejectAlways => "reject always",
+        _ => "other",
+    }
+}
+
+/// Pretty-print a `StopReason` for the status bar.
+pub fn stop_reason_label(reason: StopReason) -> &'static str {
+    match reason {
+        StopReason::EndTurn => "end_turn",
+        StopReason::MaxTokens => "max_tokens",
+        StopReason::MaxTurnRequests => "max_turn_requests",
+        StopReason::Refusal => "refusal",
+        StopReason::Cancelled => "cancelled",
+        _ => "other",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::{ContentBlock, ContentChunk, TextContent};
+
+    fn text_chunk(s: &str) -> ContentChunk {
+        ContentChunk::new(ContentBlock::Text(TextContent::new(s)))
+    }
+
+    #[test]
+    fn streaming_agent_chunks_coalesce() {
+        let mut s = AppState::new();
+        s.apply_event(UiEvent::SessionUpdate(SessionUpdate::AgentMessageChunk(
+            text_chunk("hello "),
+        )));
+        s.apply_event(UiEvent::SessionUpdate(SessionUpdate::AgentMessageChunk(
+            text_chunk("world"),
+        )));
+        assert_eq!(s.transcript.len(), 1);
+        match &s.transcript[0] {
+            Entry::AgentMessage(s) => assert_eq!(s, "hello world"),
+            other => panic!("unexpected entry: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_call_update_merges() {
+        let mut s = AppState::new();
+        let tc = ToolCall::new("call-1", "running ls");
+        s.apply_event(UiEvent::SessionUpdate(SessionUpdate::ToolCall(tc)));
+        let mut fields = agent_client_protocol::schema::ToolCallUpdateFields::default();
+        fields.status = Some(ToolCallStatus::Completed);
+        let update = ToolCallUpdate::new("call-1", fields);
+        s.apply_event(UiEvent::SessionUpdate(SessionUpdate::ToolCallUpdate(
+            update,
+        )));
+        let view = s.tool_calls.get("call-1").expect("view");
+        assert_eq!(view.status, ToolCallStatus::Completed);
+        assert_eq!(view.title, "running ls");
+    }
+
+    #[test]
+    fn prompt_done_returns_to_idle() {
+        let mut s = AppState::new();
+        s.record_user_prompt("test".to_string());
+        assert_eq!(s.turn, TurnState::Streaming);
+        s.apply_event(UiEvent::PromptDone {
+            stop_reason: StopReason::EndTurn,
+        });
+        assert_eq!(s.turn, TurnState::Idle);
+    }
+}

--- a/brokk-tui-rust/src/event.rs
+++ b/brokk-tui-rust/src/event.rs
@@ -1,0 +1,80 @@
+//! Types crossing the boundary between the ACP runtime and the UI task.
+//!
+//! The ACP runtime owns the JSON-RPC dispatch loop and must never block on
+//! terminal I/O; the UI task owns the terminal and must never block on
+//! network I/O. They communicate over two unbounded mpsc channels.
+
+use agent_client_protocol::schema::{
+    ContentBlock, PermissionOption, SessionUpdate, StopReason, ToolCallUpdate,
+};
+use tokio::sync::oneshot;
+
+/// Events flowing from the ACP runtime into the UI task.
+#[derive(Debug)]
+pub enum UiEvent {
+    /// Agent finished initialization handshake; UI can flip out of the
+    /// "connecting" splash.
+    Connected {
+        agent_name: Option<String>,
+        agent_version: Option<String>,
+    },
+    /// A new session has been opened; future updates carry this session id.
+    SessionStarted { session_id: String },
+    /// A streaming or status update from the agent. We forward the raw
+    /// `SessionUpdate` enum and let the UI state machine decide how to
+    /// fold each variant into the transcript.
+    SessionUpdate(SessionUpdate),
+    /// `session/request_permission` from the agent. The UI is expected to
+    /// render a modal and answer through `responder` exactly once.
+    PermissionRequest(PermissionPrompt),
+    /// The prompt turn completed (PromptRequest returned). UI can re-enable
+    /// the input prompt.
+    PromptDone { stop_reason: StopReason },
+    /// A non-fatal error from the runtime (e.g. transport hiccup we
+    /// recovered from). Shown in the status line.
+    Warning(String),
+    /// Fatal error; the runtime is shutting down. UI should display the
+    /// message and exit.
+    Fatal(String),
+}
+
+/// A pending permission request. The UI owns `responder` until the user
+/// picks an option or cancels with Esc.
+#[derive(Debug)]
+pub struct PermissionPrompt {
+    pub tool_call: ToolCallUpdate,
+    pub options: Vec<PermissionOption>,
+    /// One-shot to the ACP runtime. Sending `Some(option_id)` selects an
+    /// option; `None` cancels. Dropping the sender is treated as cancel.
+    pub responder: oneshot::Sender<PermissionDecision>,
+}
+
+#[derive(Debug, Clone)]
+pub enum PermissionDecision {
+    Selected(String),
+    Cancelled,
+}
+
+/// Commands flowing from the UI task into the ACP runtime.
+#[derive(Debug)]
+pub enum UiCommand {
+    /// Send a user prompt for the current session.
+    SendPrompt { text: String },
+    /// Cancel the in-flight prompt turn (Ctrl-C while streaming).
+    CancelPrompt,
+    /// Tear down: kill the agent child and exit.
+    Shutdown,
+}
+
+/// Convenience: pull plain text out of a content block for rendering.
+/// Non-text blocks are summarized so the user knows something was sent.
+pub fn content_block_text(block: &ContentBlock) -> String {
+    match block {
+        ContentBlock::Text(t) => t.text.clone(),
+        ContentBlock::Image(_) => "[image]".to_string(),
+        ContentBlock::Audio(_) => "[audio]".to_string(),
+        ContentBlock::ResourceLink(link) => format!("[link {}]", link.uri),
+        ContentBlock::Resource(_) => "[resource]".to_string(),
+        _ => "[unknown content]".to_string(),
+    }
+}

--- a/brokk-tui-rust/src/main.rs
+++ b/brokk-tui-rust/src/main.rs
@@ -1,3 +1,113 @@
-fn main() {
-    println!("brokk-tui {} - phase 0 skeleton", env!("CARGO_PKG_VERSION"));
+//! brokk-tui: an interactive terminal client for an ACP-speaking agent.
+//!
+//! Spawns the agent as a child process, talks JSON-RPC over its stdio,
+//! and renders the session in a ratatui chat UI.
+
+mod acp;
+mod app;
+mod event;
+mod ui;
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use tokio::sync::mpsc;
+
+#[derive(Parser)]
+#[command(name = "brokk-tui", version, about = "Interactive ACP chat TUI")]
+struct Cli {
+    /// Command to spawn the ACP agent. Parsed with shell-words so quoted
+    /// arguments are honored. Defaults to `brokk-acp` on PATH.
+    #[arg(short, long, default_value = "brokk-acp")]
+    command: String,
+
+    /// Working directory used when opening a new session. Defaults to
+    /// the current directory.
+    #[arg(long)]
+    cwd: Option<PathBuf>,
+
+    /// Path to a log file. When unset, logging is disabled because the
+    /// TUI owns the terminal and stderr would corrupt the screen.
+    #[arg(long, env = "BROKK_TUI_LOG")]
+    log_file: Option<PathBuf>,
+
+    /// Capture the agent subprocess's stderr to this file. When unset
+    /// the agent's stderr is redirected to /dev/null so it doesn't
+    /// scribble over the TUI.
+    #[arg(long, env = "BROKK_TUI_AGENT_STDERR")]
+    agent_stderr: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    init_logging(cli.log_file.as_deref())?;
+
+    let (command, args) = parse_command(&cli.command)?;
+    let cwd = match cli.cwd {
+        Some(p) => p,
+        None => std::env::current_dir().context("current dir")?,
+    };
+
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+
+    let runtime_cfg = acp::AcpRuntimeConfig {
+        command,
+        args,
+        cwd,
+        agent_stderr: cli.agent_stderr,
+    };
+
+    // Drive the ACP runtime on its own task so the UI can own the
+    // current task's stdio (ratatui draws through stdout while ACP
+    // talks to the agent's stdout/stdin, which are separate file
+    // descriptors).
+    let acp_handle = tokio::spawn(async move {
+        if let Err(e) = acp::run(runtime_cfg, event_tx, cmd_rx).await {
+            tracing::error!("acp runtime error: {e:#}");
+        }
+    });
+
+    let ui_result = ui::run(cmd_tx, event_rx).await;
+
+    // UI exited (user quit or runtime closed channel); ensure the ACP
+    // task observes shutdown and join it.
+    acp_handle.abort();
+    let _ = acp_handle.await;
+
+    ui_result
+}
+
+fn parse_command(s: &str) -> Result<(PathBuf, Vec<String>)> {
+    let parts = shell_words::split(s).context("split command string")?;
+    let mut iter = parts.into_iter();
+    let program = iter.next().context("empty command string")?;
+    Ok((PathBuf::from(program), iter.collect()))
+}
+
+fn init_logging(path: Option<&std::path::Path>) -> Result<()> {
+    use tracing_subscriber::{EnvFilter, fmt};
+
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    if let Some(parent) = parent {
+        std::fs::create_dir_all(parent).with_context(|| format!("create log dir {parent:?}"))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open log {path:?}"))?;
+    let filter =
+        EnvFilter::try_from_env("BROKK_TUI_LOG_LEVEL").unwrap_or_else(|_| EnvFilter::new("info"));
+    fmt()
+        .with_writer(file)
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .init();
+    Ok(())
 }

--- a/brokk-tui-rust/src/main.rs
+++ b/brokk-tui-rust/src/main.rs
@@ -72,10 +72,27 @@ async fn main() -> Result<()> {
 
     let ui_result = ui::run(cmd_tx, event_rx).await;
 
-    // UI exited (user quit or runtime closed channel); ensure the ACP
-    // task observes shutdown and join it.
-    acp_handle.abort();
-    let _ = acp_handle.await;
+    // UI exited. `cmd_tx` was moved into `ui::run` and is now dropped,
+    // which causes `drive_session` to see `None` on its `recv()` and
+    // return, after which `acp::run` calls `child.kill().await` and
+    // cleans up. Wait for that natural shutdown for a bounded window so
+    // the agent process is reaped, and only abort as a last resort if
+    // the runtime is wedged (e.g. blocked on a `block_task().await` for
+    // a never-arriving response).
+    let abort_handle = acp_handle.abort_handle();
+    match tokio::time::timeout(std::time::Duration::from_secs(2), acp_handle).await {
+        Ok(join_res) => {
+            if let Err(e) = join_res {
+                tracing::warn!("acp task join: {e}");
+            }
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                "acp runtime did not exit within 2s; aborting (child may not be reaped)"
+            );
+            abort_handle.abort();
+        }
+    }
 
     ui_result
 }

--- a/brokk-tui-rust/src/main.rs
+++ b/brokk-tui-rust/src/main.rs
@@ -33,8 +33,8 @@ struct Cli {
     log_file: Option<PathBuf>,
 
     /// Capture the agent subprocess's stderr to this file. When unset
-    /// the agent's stderr is redirected to /dev/null so it doesn't
-    /// scribble over the TUI.
+    /// the agent's stderr is discarded via `Stdio::null()` (/dev/null on
+    /// Unix, NUL on Windows) so it doesn't scribble over the TUI.
     #[arg(long, env = "BROKK_TUI_AGENT_STDERR")]
     agent_stderr: Option<PathBuf>,
 }

--- a/brokk-tui-rust/src/ui.rs
+++ b/brokk-tui-rust/src/ui.rs
@@ -1,0 +1,447 @@
+//! Ratatui-based terminal UI.
+//!
+//! Owns the terminal alternate screen and the crossterm event stream.
+//! Pulls `UiEvent`s from the ACP runtime through `event_rx`, folds them
+//! into `AppState`, redraws on every tick, and emits `UiCommand`s back
+//! to the runtime when the user submits prompts or cancels.
+
+use std::io::{self, Stdout};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use crossterm::event::{
+    DisableMouseCapture, EnableMouseCapture, Event as CtEvent, EventStream, KeyCode, KeyEventKind,
+    KeyModifiers,
+};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use futures::StreamExt;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
+use tokio::sync::mpsc;
+
+use crate::app::{
+    AppState, Entry, PendingPermission, TurnState, permission_kind_label, stop_reason_label,
+};
+use crate::event::{PermissionDecision, UiCommand, UiEvent};
+
+/// Run the UI loop until the user quits or the runtime closes.
+pub async fn run(
+    cmd_tx: mpsc::UnboundedSender<UiCommand>,
+    mut event_rx: mpsc::UnboundedReceiver<UiEvent>,
+) -> Result<()> {
+    let mut terminal = setup_terminal().context("setup terminal")?;
+    let result = ui_loop(&mut terminal, &cmd_tx, &mut event_rx).await;
+    if let Err(e) = restore_terminal(&mut terminal) {
+        tracing::warn!("restore terminal failed: {e}");
+    }
+    result
+}
+
+async fn ui_loop(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    cmd_tx: &mpsc::UnboundedSender<UiCommand>,
+    event_rx: &mut mpsc::UnboundedReceiver<UiEvent>,
+) -> Result<()> {
+    let mut state = AppState::new();
+    let mut crossterm_events = EventStream::new();
+    let mut tick = tokio::time::interval(Duration::from_millis(100));
+
+    terminal.draw(|f| draw(f, &state))?;
+
+    loop {
+        tokio::select! {
+            biased;
+            maybe_ct = crossterm_events.next() => {
+                match maybe_ct {
+                    Some(Ok(ev)) => {
+                        handle_crossterm(&mut state, cmd_tx, ev);
+                    }
+                    Some(Err(e)) => {
+                        state.status_line = Some(format!("input error: {e}"));
+                    }
+                    None => break,
+                }
+            }
+            Some(ev) = event_rx.recv() => {
+                state.apply_event(ev);
+            }
+            _ = tick.tick() => {}
+        }
+
+        if state.should_quit {
+            let _ = cmd_tx.send(UiCommand::Shutdown);
+            break;
+        }
+        terminal.draw(|f| draw(f, &state))?;
+    }
+    Ok(())
+}
+
+fn handle_crossterm(state: &mut AppState, cmd_tx: &mpsc::UnboundedSender<UiCommand>, ev: CtEvent) {
+    let CtEvent::Key(key) = ev else {
+        return;
+    };
+    if key.kind != KeyEventKind::Press {
+        return;
+    }
+
+    // Permission modal owns the keyboard while it's open.
+    if state.pending_permission.is_some() {
+        handle_permission_key(state, key.code);
+        return;
+    }
+
+    match (key.modifiers, key.code) {
+        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+            if state.turn == TurnState::Streaming {
+                let _ = cmd_tx.send(UiCommand::CancelPrompt);
+                state.status_line = Some("cancelling...".to_string());
+            } else if state.input.is_empty() {
+                state.should_quit = true;
+            } else {
+                state.input.clear();
+            }
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('d')) if state.input.is_empty() => {
+            state.should_quit = true;
+        }
+        (_, KeyCode::Enter) => submit_prompt(state, cmd_tx),
+        (_, KeyCode::Char(c)) => {
+            state.input.push(c);
+        }
+        (_, KeyCode::Backspace) => {
+            state.input.pop();
+        }
+        (_, KeyCode::PageUp) => {
+            state.scroll_offset = state.scroll_offset.saturating_add(5);
+        }
+        (_, KeyCode::PageDown) => {
+            state.scroll_offset = state.scroll_offset.saturating_sub(5);
+        }
+        (_, KeyCode::Esc) => {
+            state.input.clear();
+        }
+        _ => {}
+    }
+}
+
+fn submit_prompt(state: &mut AppState, cmd_tx: &mpsc::UnboundedSender<UiCommand>) {
+    if state.turn == TurnState::Streaming {
+        state.status_line = Some("a prompt is already in flight".to_string());
+        return;
+    }
+    if state.session_id.is_none() {
+        state.status_line = Some("waiting for session...".to_string());
+        return;
+    }
+    let text = std::mem::take(&mut state.input);
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    state.record_user_prompt(trimmed.to_string());
+    let _ = cmd_tx.send(UiCommand::SendPrompt {
+        text: trimmed.to_string(),
+    });
+}
+
+fn handle_permission_key(state: &mut AppState, code: KeyCode) {
+    let Some(pending) = state.pending_permission.as_mut() else {
+        return;
+    };
+    let len = pending.prompt.options.len().max(1);
+    match code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            if pending.selected == 0 {
+                pending.selected = len - 1;
+            } else {
+                pending.selected -= 1;
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            pending.selected = (pending.selected + 1) % len;
+        }
+        KeyCode::Enter => {
+            let pending = state.pending_permission.take().expect("checked above");
+            let PendingPermission { prompt, selected } = pending;
+            let decision = prompt
+                .options
+                .get(selected)
+                .map(|o| PermissionDecision::Selected(o.option_id.to_string()))
+                .unwrap_or(PermissionDecision::Cancelled);
+            let _ = prompt.responder.send(decision);
+        }
+        KeyCode::Esc => {
+            let pending = state.pending_permission.take().expect("checked above");
+            let _ = pending.prompt.responder.send(PermissionDecision::Cancelled);
+        }
+        _ => {}
+    }
+}
+
+fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let terminal = Terminal::new(backend)?;
+    Ok(terminal)
+}
+
+fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+fn draw(f: &mut ratatui::Frame, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(3),
+            Constraint::Length(3),
+            Constraint::Length(1),
+        ])
+        .split(f.area());
+
+    draw_header(f, chunks[0], state);
+    draw_transcript(f, chunks[1], state);
+    draw_input(f, chunks[2], state);
+    draw_status(f, chunks[3], state);
+
+    if let Some(pending) = state.pending_permission.as_ref() {
+        draw_permission_modal(f, f.area(), pending);
+    }
+}
+
+fn draw_header(f: &mut ratatui::Frame, area: Rect, state: &AppState) {
+    let session = state
+        .session_id
+        .as_deref()
+        .map(|s| {
+            let mut t = s.to_string();
+            if t.len() > 12 {
+                t.truncate(12);
+                t.push_str("...");
+            }
+            t
+        })
+        .unwrap_or_else(|| "no session".to_string());
+    let mode = state.current_mode.as_deref().unwrap_or("-");
+    let header = format!(
+        " brokk-tui | {} | session {} | mode {} ",
+        state.connection_status, session, mode
+    );
+    let p = Paragraph::new(header).style(Style::default().add_modifier(Modifier::REVERSED));
+    f.render_widget(p, area);
+}
+
+fn draw_transcript(f: &mut ratatui::Frame, area: Rect, state: &AppState) {
+    let block = Block::default().borders(Borders::ALL).title(" transcript ");
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let lines = render_transcript_lines(state, inner.width);
+    let total = lines.len() as u16;
+    let visible = inner.height;
+    // Scroll so the bottom of the transcript is pinned at the bottom of
+    // the pane, unless the user has scrolled up.
+    let top = total
+        .saturating_sub(visible)
+        .saturating_sub(state.scroll_offset);
+    let paragraph = Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .scroll((top, 0));
+    f.render_widget(paragraph, inner);
+}
+
+fn render_transcript_lines<'a>(state: &'a AppState, _width: u16) -> Vec<Line<'a>> {
+    let mut out: Vec<Line<'a>> = Vec::new();
+    for entry in &state.transcript {
+        match entry {
+            Entry::UserPrompt(text) => push_block(&mut out, "you", Color::Cyan, text),
+            Entry::AgentMessage(text) => push_block(&mut out, "agent", Color::Green, text),
+            Entry::AgentThought(text) => push_block(&mut out, "thought", Color::DarkGray, text),
+            Entry::Plan(entries) => {
+                out.push(Line::from(Span::styled(
+                    "plan",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                )));
+                for e in entries {
+                    let bullet = match e.priority {
+                        agent_client_protocol::schema::PlanEntryPriority::High => "[!]",
+                        agent_client_protocol::schema::PlanEntryPriority::Medium => "[*]",
+                        agent_client_protocol::schema::PlanEntryPriority::Low => "[ ]",
+                        _ => "[?]",
+                    };
+                    let status = match e.status {
+                        agent_client_protocol::schema::PlanEntryStatus::Pending => " ",
+                        agent_client_protocol::schema::PlanEntryStatus::InProgress => "~",
+                        agent_client_protocol::schema::PlanEntryStatus::Completed => "x",
+                        _ => "?",
+                    };
+                    out.push(Line::from(format!("  {bullet}{status} {}", e.content)));
+                }
+                out.push(Line::from(""));
+            }
+            Entry::ToolCall(id) => {
+                if let Some(view) = state.tool_calls.get(id) {
+                    let status_label = match view.status {
+                        agent_client_protocol::schema::ToolCallStatus::Pending => "pending",
+                        agent_client_protocol::schema::ToolCallStatus::InProgress => "running",
+                        agent_client_protocol::schema::ToolCallStatus::Completed => "done",
+                        agent_client_protocol::schema::ToolCallStatus::Failed => "failed",
+                        _ => "?",
+                    };
+                    let color = match view.status {
+                        agent_client_protocol::schema::ToolCallStatus::Failed => Color::Red,
+                        agent_client_protocol::schema::ToolCallStatus::Completed => Color::Yellow,
+                        _ => Color::LightYellow,
+                    };
+                    out.push(Line::from(vec![
+                        Span::styled(
+                            format!("tool [{}] ", status_label),
+                            Style::default().fg(color).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::raw(view.title.clone()),
+                    ]));
+                    for body in &view.body {
+                        for raw in body.split('\n') {
+                            out.push(Line::from(format!("  {raw}")));
+                        }
+                    }
+                    out.push(Line::from(""));
+                }
+            }
+            Entry::System(text) => {
+                out.push(Line::from(Span::styled(
+                    text.clone(),
+                    Style::default().fg(Color::DarkGray),
+                )));
+                out.push(Line::from(""));
+            }
+        }
+    }
+    out
+}
+
+fn push_block<'a>(out: &mut Vec<Line<'a>>, label: &str, color: Color, text: &'a str) {
+    out.push(Line::from(Span::styled(
+        format!("{label}:"),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    )));
+    for raw in text.split('\n') {
+        out.push(Line::from(raw));
+    }
+    out.push(Line::from(""));
+}
+
+fn draw_input(f: &mut ratatui::Frame, area: Rect, state: &AppState) {
+    let title = match state.turn {
+        TurnState::Idle => " prompt (Enter to send | Ctrl-C to quit) ",
+        TurnState::Streaming => " streaming... (Ctrl-C to cancel) ",
+    };
+    let style = if state.turn == TurnState::Streaming {
+        Style::default().fg(Color::DarkGray)
+    } else {
+        Style::default()
+    };
+    let block = Block::default().borders(Borders::ALL).title(title);
+    let paragraph = Paragraph::new(state.input.as_str())
+        .style(style)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    f.render_widget(paragraph, area);
+
+    if state.turn != TurnState::Streaming && state.pending_permission.is_none() {
+        // Place a fake cursor at end of input. Estimated, ASCII only.
+        let cursor_x = area.x + 1 + (state.input.len().min((area.width - 2) as usize) as u16);
+        let cursor_y = area.y + 1;
+        f.set_cursor_position((cursor_x, cursor_y));
+    }
+}
+
+fn draw_status(f: &mut ratatui::Frame, area: Rect, state: &AppState) {
+    let msg = state.status_line.clone().unwrap_or_else(|| {
+        if let Some(reason) = state.transcript.iter().rev().find_map(|e| match e {
+            Entry::System(s) if s.starts_with("turn done:") => Some(s.clone()),
+            _ => None,
+        }) {
+            reason
+        } else {
+            "ready".to_string()
+        }
+    });
+    let _ = stop_reason_label; // referenced from app::stop_reason_label users
+    let p = Paragraph::new(msg).style(Style::default().fg(Color::DarkGray));
+    f.render_widget(p, area);
+}
+
+fn draw_permission_modal(f: &mut ratatui::Frame, area: Rect, pending: &PendingPermission) {
+    let width = area.width.saturating_sub(8).min(80);
+    let height = (pending.prompt.options.len() as u16 + 6).min(area.height.saturating_sub(4));
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let rect = Rect::new(x, y, width, height);
+
+    f.render_widget(Clear, rect);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" permission request ")
+        .style(Style::default().fg(Color::Yellow));
+    let inner = block.inner(rect);
+    f.render_widget(block, rect);
+
+    let title = pending
+        .prompt
+        .tool_call
+        .fields
+        .title
+        .clone()
+        .unwrap_or_else(|| pending.prompt.tool_call.tool_call_id.to_string());
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let header = Paragraph::new(title).style(Style::default().add_modifier(Modifier::BOLD));
+    f.render_widget(header, layout[0]);
+
+    let items: Vec<ListItem> = pending
+        .prompt
+        .options
+        .iter()
+        .enumerate()
+        .map(|(i, opt)| {
+            let marker = if i == pending.selected { ">" } else { " " };
+            let kind = permission_kind_label(opt.kind);
+            ListItem::new(format!("{marker} {} ({kind})", opt.name))
+        })
+        .collect();
+    let list = List::new(items);
+    f.render_widget(list, layout[1]);
+
+    let footer = Paragraph::new("Up/Down to choose | Enter to confirm | Esc to cancel")
+        .style(Style::default().fg(Color::DarkGray));
+    f.render_widget(footer, layout[2]);
+}

--- a/brokk-tui-rust/src/ui.rs
+++ b/brokk-tui-rust/src/ui.rs
@@ -69,8 +69,21 @@ async fn ui_loop(
                     None => break,
                 }
             }
-            Some(ev) = event_rx.recv() => {
-                state.apply_event(ev);
+            // Use the unconditional form (no `Some(ev) = ...`) so the
+            // None case (runtime dropped the sender) reaches the match
+            // arm and exits the loop. The conditional pattern disables
+            // the branch when the channel closes, which would leave the
+            // TUI spinning on tick + crossterm forever.
+            maybe_ev = event_rx.recv() => {
+                match maybe_ev {
+                    Some(ev) => state.apply_event(ev),
+                    None => {
+                        state.status_line =
+                            Some("acp runtime closed; exiting".to_string());
+                        terminal.draw(|f| draw(f, &state))?;
+                        break;
+                    }
+                }
             }
             _ = tick.tick() => {}
         }


### PR DESCRIPTION
## Summary

Replaces the phase-0 stub in `brokk-tui-rust/` with a working interactive ACP chat client. Spawns any ACP agent (defaults to `brokk-acp` on PATH), runs a ratatui chat UI, and supports the full prompt-turn lifecycle including streaming, tool calls, plans, mode updates, and permission modals.

- **`src/acp.rs`** wraps `Client.builder()` from `agent-client-protocol = "0.11"`. Notifications (`SessionNotification`) and requests (`RequestPermissionRequest`) are forwarded to the UI through two `mpsc::UnboundedSender<UiEvent>` channels. The permission `Responder` is parked behind a `oneshot` so the JSON-RPC dispatch loop stays unblocked while the user answers a modal.
- **`src/app.rs`** folds every `SessionUpdate` variant (user/agent/thought chunks, `ToolCall` / `ToolCallUpdate`, `Plan`, `AvailableCommandsUpdate`, `CurrentModeUpdate`, `SessionInfoUpdate`, `ConfigOptionUpdate`) into a scrolling transcript with coalesced streaming chunks and a stable tool-call slot table.
- **`src/ui.rs`** is the ratatui + crossterm render loop: transcript pane, input pane with cursor, status line, and a centered permission modal that owns the keyboard while open. `Ctrl-C` cancels an in-flight prompt or quits when idle, `Ctrl-D` quits cleanly on an empty buffer, `PageUp/PageDown` scroll.
- **`src/main.rs`** parses `--command`, `--cwd`, `--log-file`, `--agent-stderr`; logging only writes to `--log-file` (TUI owns stdout/stderr otherwise). Agent stderr defaults to the OS null device so its tracing output doesn't scribble over the TUI.

License flipped from `LGPL-3.0` to `GPL-3.0` to match the repo root.

## Architecture

```
+---------+ UiCommand ch  +-------------+ stdio  +-----------+
|   UI    | ------------> |  ACP RT     | -----> | brokk-acp |
| ratatui | <------------ |  acp::run   | <----- |  child    |
+---------+ UiEvent  ch   +-------------+ JSON   +-----------+
```

Two unbounded mpsc channels keep terminal I/O and network I/O on separate task boundaries. `acp::drive_client` is generic over `ConnectTo<Client>` so integration tests can plug in a `tokio::io::duplex` transport.

## Cross-platform

CI runs on **`ubuntu-latest`, `macos-latest`, and `windows-latest`** (matrix copied from `rust-acp.yml`, `fail-fast: false`). Each leg runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, and `cargo test`.

Audit of `brokk-tui-rust/src/` for platform-specific assumptions:

| Risk | Status |
|---|---|
| `#[cfg(unix)]` blocks without Windows counterparts | None present |
| Fork/exec / `pre_exec` / `setrlimit` | Not used |
| `SIGPIPE` / `SIGINT` / signal handling | Not used (Ctrl-C captured via crossterm key event in raw mode) |
| Hardcoded `/dev/null`, `/dev/tty`, `/etc/...` paths | None in code; two doc comments mention "/dev/null on Unix, NUL on Windows" |
| Path manipulation | `PathBuf`/`Path` throughout; no `/`-hardcoded strings |
| Agent process discovery | `tokio::process::Command::new(...)` — Windows resolves `.exe` automatically via `PATHEXT` |
| `Stdio::null()` | Maps to `/dev/null` on Unix and `NUL` on Windows transparently |
| Raw mode / alternate screen | `crossterm` 0.28 ships a ConPTY backend on Windows |
| Async terminal event stream | `crossterm` `event-stream` feature uses a background thread on Windows (transparent) |
| In-process integration test transport | `tokio::io::duplex` (pure user-space, no OS handles) |

No `cfg`-gating was needed because the dependencies (`crossterm`, `tokio::process`, `tokio::io::duplex`) already abstract over the OS. The only Unix-flavored strings in the tree are now explanatory doc comments.

## Tests

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build --release` all pass locally on macOS arm64.
- 4 tests, including `acp::tests::full_prompt_turn_against_mock_agent` which spins up an in-process mock `Agent` over an in-memory duplex stream and asserts the client emits `Connected` -> `SessionStarted` -> `SessionUpdate(AgentMessageChunk)` -> `PromptDone(EndTurn)`.
- Manual smoke test driving the real binary against locally-spawned `brokk-acp` via `expect` confirmed: agent log shows `ACP initialize` and `ACP session/new, cwd=...` (the worktree path), and the TUI exits cleanly via Ctrl-D.

## Test plan

- [ ] `cd brokk-tui-rust && cargo fmt --check`
- [ ] `cd brokk-tui-rust && cargo clippy --all-targets -- -D warnings`
- [ ] `cd brokk-tui-rust && cargo test`
- [ ] `cd brokk-tui-rust && cargo build --release`
- [ ] CI green on Linux, macOS, and Windows
- [ ] `target/release/brokk-tui --command /path/to/brokk-acp` opens an interactive chat with a Codex/Ollama-backed brokk-acp
- [ ] Ctrl-C while streaming sends a `CancelNotification` and the agent reports `StopReason::Cancelled`
- [ ] A tool requiring permission shows the modal; arrow keys + Enter pick an option; Esc cancels

## Constraints satisfied

- No root `Cargo.toml` (verified: `ls /Users/ryansvihla/code/brokk/Cargo.toml` -> not found)
- License is `GPL-3.0`
- Diff against `origin/master` only touches files under `brokk-tui-rust/` and `.github/workflows/brokk-tui-ci.yml` -- no other crates, no Java/Python sources, no other CI workflows

Generated with [Claude Code](https://claude.com/claude-code)
