### PR TITLE
Avoid warnings for synthetic Java implicit constructors

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1722,6 +1722,9 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
         List<Range> rangesForOverloads = rangesOf(cu);
         if (rangesForOverloads.isEmpty()) {
+            if (cu.isSynthetic()) {
+                return Collections.emptySet();
+            }
             log.warn("No source ranges found for CU {} (fqName {}) although definition was found.", cu, cu.fqName());
             return Collections.emptySet();
         }

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/JavaAnalyzerTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/JavaAnalyzerTest.java
@@ -969,6 +969,10 @@ public class JavaAnalyzerTest {
                     .findFirst()
                     .get();
 
+            assertTrue(constructorCu.isSynthetic(), "Implicit constructor should be synthetic");
+            assertTrue(
+                    analyzer.rangesOf(constructorCu).isEmpty(), "Implicit constructor should not have source ranges");
+
             // Assert direct analyzer methods return empty for synthetic/implicit units
             assertTrue(
                     analyzer.getSources(constructorCu, true).isEmpty(),


### PR DESCRIPTION
### Description

Avoid noisy source-range warnings when Java implicit constructors are synthesized as synthetic function code units without concrete source ranges.

**Key Changes**:
- Return empty sources for synthetic range-less functions before the generic missing-range warning path.
- Extend the Java implicit-constructor regression test to assert the constructor is synthetic, range-less, and still returns empty source.

**Touch Points**:
- `brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java`
- `brokk-shared/src/test/java/ai/brokk/analyzer/JavaAnalyzerTest.java`

Validation:
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.JavaAnalyzerTest`
- `./gradlew fix tidy`
- `./gradlew analyze`

Fixes #3593