### PR TITLE
Optimize regex usage scans

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/SourceContent.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/SourceContent.java
@@ -19,6 +19,7 @@ public final class SourceContent {
 
     private final String text;
     private final byte[] utf8Bytes;
+    private int @Nullable [] charToByteOffsets;
 
     private SourceContent(String text, byte[] utf8Bytes) {
         this.text = text;
@@ -96,7 +97,13 @@ public final class SourceContent {
      * If charPosition <= 0 returns 0. If charPosition >= source.length() returns byteLength.
      */
     public int charPositionToByteOffset(int charPosition) {
-        return ASTTraversalUtils.charPositionToUtf8ByteOffset(text, charPosition);
+        if (charPosition <= 0) {
+            return 0;
+        }
+        if (charPosition >= text.length()) {
+            return utf8Bytes.length;
+        }
+        return charToByteOffsets()[charPosition];
     }
 
     public String text() {
@@ -137,5 +144,32 @@ public final class SourceContent {
             return "";
         }
         return substringFromBytes(node.getStartByte(), node.getEndByte());
+    }
+
+    private int[] charToByteOffsets() {
+        if (charToByteOffsets == null) {
+            charToByteOffsets = computeCharToByteOffsets();
+        }
+        return charToByteOffsets;
+    }
+
+    private int[] computeCharToByteOffsets() {
+        var offsets = new int[text.length() + 1];
+        int byteOffset = 0;
+        int charIndex = 0;
+        while (charIndex < text.length()) {
+            offsets[charIndex] = byteOffset;
+            int codePoint = text.codePointAt(charIndex);
+            int charCount = Character.charCount(codePoint);
+            int nextByteOffset =
+                    byteOffset + new String(Character.toChars(codePoint)).getBytes(StandardCharsets.UTF_8).length;
+            if (charCount == 2) {
+                offsets[charIndex + 1] = byteOffset;
+            }
+            charIndex += charCount;
+            byteOffset = nextByteOffset;
+            offsets[charIndex] = byteOffset;
+        }
+        return offsets;
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/usages/RegexUsageAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/usages/RegexUsageAnalyzer.java
@@ -1,15 +1,16 @@
 package ai.brokk.analyzer.usages;
 
-import ai.brokk.analyzer.ASTTraversalUtils;
 import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.Language;
 import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.analyzer.SourceContent;
 import ai.brokk.util.FileUtil;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,42 +41,32 @@ public final class RegexUsageAnalyzer implements UsageAnalyzer {
         if (overloads.isEmpty()) {
             return new FuzzyResult.Success(Map.of());
         }
+        assertSameIdentifier(overloads);
+
+        var queryPlan = QueryPlan.create(overloads, analyzer);
+        var hitsByTarget = extractUsageHits(candidateFiles, queryPlan, maxUsages);
+
+        for (var target : overloads) {
+            var hits = hitsByTarget.getOrDefault(target, Set.of());
+            if (hits.size() > maxUsages) {
+                logger.debug("Too many usage hits for {}: {} > {}", target.fqName(), hits.size(), maxUsages);
+                return new FuzzyResult.TooManyCallsites(target.shortName(), hits.size(), maxUsages);
+            }
+        }
+
+        if (queryPlan.isUnique()) {
+            return new FuzzyResult.Success(hitsByTarget);
+        }
 
         var target = overloads.getFirst();
-        final String identifier = target.identifier();
-        Language lang = Languages.fromExtension(target.source().extension());
-
-        var templates = lang.getSearchPatterns(target.kind());
-        var searchPatterns = templates.stream()
-                .map(template -> template.replace("$ident", Pattern.quote(identifier)))
-                .collect(Collectors.toSet());
-
-        var matchingCodeUnits =
-                analyzer.searchDefinitions("\\b%s\\b".formatted(Pattern.quote(identifier)), false).stream()
-                        .filter(cu -> cu.identifier().equals(identifier))
-                        .collect(Collectors.toSet());
-        var isUnique = matchingCodeUnits.size() == 1;
-
-        var hits = extractUsageHits(candidateFiles, searchPatterns).stream()
-                .filter(h -> !h.enclosing().equals(target))
-                .collect(Collectors.toSet());
-
-        if (hits.size() > maxUsages) {
-            logger.debug("Too many usage hits for {}: {} > {}", target.fqName(), hits.size(), maxUsages);
-            return new FuzzyResult.TooManyCallsites(target.shortName(), hits.size(), maxUsages);
-        }
-
-        if (isUnique) {
-            return new FuzzyResult.Success(Map.of(target, hits));
-        }
-
-        return new FuzzyResult.Ambiguous(target.shortName(), matchingCodeUnits, Map.of(target, hits));
+        return new FuzzyResult.Ambiguous(target.shortName(), queryPlan.matchingCodeUnits(), hitsByTarget);
     }
 
-    private Set<UsageHit> extractUsageHits(Set<ProjectFile> candidateFiles, Set<String> searchPatterns)
-            throws InterruptedException {
-        var hits = new ConcurrentHashMap<UsageHit, Boolean>();
-        final var patterns = searchPatterns.stream().map(Pattern::compile).toList();
+    private Map<CodeUnit, Set<UsageHit>> extractUsageHits(
+            Set<ProjectFile> candidateFiles, QueryPlan queryPlan, int maxUsages) throws InterruptedException {
+        var hitsByTarget = new ConcurrentHashMap<CodeUnit, Set<UsageHit>>();
+        queryPlan.targets().forEach(target -> hitsByTarget.put(target, ConcurrentHashMap.newKeySet()));
+        var exceededTargets = ConcurrentHashMap.<CodeUnit>newKeySet();
 
         var tasks = candidateFiles.stream()
                 .<Callable<Void>>map(file -> () -> {
@@ -85,39 +76,46 @@ public final class RegexUsageAnalyzer implements UsageAnalyzer {
                         if (contentOpt.isEmpty()) return null;
                         var content = contentOpt.get();
                         if (content.isEmpty()) return null;
+                        var sourceContent = SourceContent.of(content);
+                        var sourceText = sourceContent.text();
+                        if (sourceText.isEmpty()) return null;
 
-                        String[] lines = null;
-                        int[] lineStarts = null;
+                        var scan = new FileScanContext(sourceContent);
 
-                        for (var pattern : patterns) {
-                            var matcher = pattern.matcher(content);
+                        for (var searchPattern : queryPlan.searchPatterns()) {
+                            var matcher = searchPattern.pattern().matcher(sourceText);
                             while (matcher.find()) {
                                 int start = matcher.start();
                                 int end = matcher.end();
-                                int startByte = ASTTraversalUtils.charPositionToUtf8ByteOffset(content, start);
-                                int endByte = ASTTraversalUtils.charPositionToUtf8ByteOffset(content, end);
+                                int startByte = scan.charOffsetToUtf8ByteOffset(start);
+                                int endByte = scan.charOffsetToUtf8ByteOffset(end);
 
                                 if (!analyzer.isAccessExpression(file, startByte, endByte)) continue;
 
-                                if (lines == null) {
-                                    lines = content.split("\\R", -1);
-                                    lineStarts = FileUtil.computeLineStarts(content);
-                                }
-                                int[] starts = Objects.requireNonNull(lineStarts);
-
-                                int lineIdx = FileUtil.findLineIndexForOffset(starts, start);
-                                int startLine = Math.max(0, lineIdx - 3);
-                                int endLine = Math.min(lines.length - 1, lineIdx + 3);
-                                String[] snippetLines = lines;
-                                var snippet = IntStream.rangeClosed(startLine, endLine)
-                                        .mapToObj(i -> snippetLines[i])
-                                        .collect(Collectors.joining("\n"));
+                                int lineIdx = scan.lineIndex(start);
+                                var snippet = scan.snippetAround(lineIdx);
 
                                 var range = new IAnalyzer.Range(startByte, endByte, lineIdx, lineIdx, lineIdx);
                                 var enclosingCodeUnit = analyzer.enclosingCodeUnit(file, range);
 
-                                enclosingCodeUnit.ifPresent(codeUnit -> hits.put(
-                                        new UsageHit(file, lineIdx + 1, start, end, codeUnit, 1.0, snippet), true));
+                                enclosingCodeUnit.ifPresent(codeUnit -> {
+                                    for (var target : searchPattern.targets()) {
+                                        if (codeUnit.equals(target) || exceededTargets.contains(target)) {
+                                            continue;
+                                        }
+                                        var targetHits = hitsByTarget.computeIfAbsent(
+                                                target, ignored -> ConcurrentHashMap.newKeySet());
+                                        if (targetHits.size() > maxUsages) {
+                                            exceededTargets.add(target);
+                                            continue;
+                                        }
+                                        targetHits.add(
+                                                new UsageHit(file, lineIdx + 1, start, end, codeUnit, 1.0, snippet));
+                                        if (targetHits.size() > maxUsages) {
+                                            exceededTargets.add(target);
+                                        }
+                                    }
+                                });
                             }
                         }
                     } catch (Exception e) {
@@ -137,6 +135,88 @@ public final class RegexUsageAnalyzer implements UsageAnalyzer {
                 throw new RuntimeException("Regex usage scan failed", e.getCause());
             }
         }
-        return Set.copyOf(hits.keySet());
+        return hitsByTarget.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Set.copyOf(entry.getValue())));
+    }
+
+    private static void assertSameIdentifier(List<CodeUnit> overloads) {
+        var identifier = overloads.getFirst().identifier();
+        assert overloads.stream().allMatch(target -> target.identifier().equals(identifier))
+                : "RegexUsageAnalyzer.findUsages expects same-identifier overloads";
+    }
+
+    private record QueryPlan(
+            List<CodeUnit> targets,
+            List<SearchPattern> searchPatterns,
+            Set<CodeUnit> matchingCodeUnits,
+            boolean isUnique) {
+        private static QueryPlan create(List<CodeUnit> targets, IAnalyzer analyzer) {
+            var targetsByPattern = new HashMap<String, Set<CodeUnit>>();
+            var identifier = targets.getFirst().identifier();
+            var matchingCodeUnits =
+                    analyzer.searchDefinitions("\\b%s\\b".formatted(Pattern.quote(identifier)), false).stream()
+                            .filter(cu -> cu.identifier().equals(identifier))
+                            .collect(Collectors.toSet());
+
+            for (var target : targets) {
+                Language lang = Languages.fromExtension(target.source().extension());
+                var templates = lang.getSearchPatterns(target.kind());
+                for (String template : templates) {
+                    var searchPattern = template.replace("$ident", Pattern.quote(target.identifier()));
+                    targetsByPattern
+                            .computeIfAbsent(searchPattern, ignored -> new HashSet<>())
+                            .add(target);
+                }
+            }
+
+            var searchPatterns = targetsByPattern.entrySet().stream()
+                    .map(entry -> new SearchPattern(Pattern.compile(entry.getKey()), Set.copyOf(entry.getValue())))
+                    .toList();
+            return new QueryPlan(
+                    List.copyOf(targets), searchPatterns, Set.copyOf(matchingCodeUnits), matchingCodeUnits.size() == 1);
+        }
+    }
+
+    private record SearchPattern(Pattern pattern, Set<CodeUnit> targets) {}
+
+    private static final class FileScanContext {
+        private final SourceContent content;
+        private @org.jetbrains.annotations.Nullable String[] lines;
+        private int @org.jetbrains.annotations.Nullable [] lineStarts;
+
+        private FileScanContext(SourceContent content) {
+            this.content = content;
+        }
+
+        private int charOffsetToUtf8ByteOffset(int charOffset) {
+            return content.charPositionToByteOffset(charOffset);
+        }
+
+        private int lineIndex(int charOffset) {
+            return FileUtil.findLineIndexForOffset(lineStarts(), charOffset);
+        }
+
+        private String snippetAround(int lineIdx) {
+            var snippetLines = lines();
+            int startLine = Math.max(0, lineIdx - 3);
+            int endLine = Math.min(snippetLines.length - 1, lineIdx + 3);
+            return IntStream.rangeClosed(startLine, endLine)
+                    .mapToObj(i -> snippetLines[i])
+                    .collect(Collectors.joining("\n"));
+        }
+
+        private String[] lines() {
+            if (lines == null) {
+                lines = content.text().split("\\R", -1);
+            }
+            return lines;
+        }
+
+        private int[] lineStarts() {
+            if (lineStarts == null) {
+                lineStarts = FileUtil.computeLineStarts(content.text());
+            }
+            return lineStarts;
+        }
     }
 }

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/SourceContentTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/SourceContentTest.java
@@ -240,6 +240,27 @@ class SourceContentTest {
     }
 
     @Test
+    @DisplayName("charPositionToByteOffset remains stable across repeated calls")
+    void testCharPositionToByteOffsetRepeatedCalls() {
+        SourceContent content = SourceContent.of("ascii Target\nCafé Target\nemoji \uD83D\uDE80 Target");
+
+        int asciiTarget = content.text().indexOf("Target");
+        int cafeTarget = content.text().indexOf("Target", asciiTarget + 1);
+        int emojiTarget = content.text().indexOf("Target", cafeTarget + 1);
+
+        assertEquals(asciiTarget, content.charPositionToByteOffset(asciiTarget));
+        assertEquals(asciiTarget, content.charPositionToByteOffset(asciiTarget));
+
+        int expectedCafeByte = content.text().substring(0, cafeTarget).getBytes(StandardCharsets.UTF_8).length;
+        assertEquals(expectedCafeByte, content.charPositionToByteOffset(cafeTarget));
+        assertEquals(expectedCafeByte, content.charPositionToByteOffset(cafeTarget));
+
+        int expectedEmojiByte = content.text().substring(0, emojiTarget).getBytes(StandardCharsets.UTF_8).length;
+        assertEquals(expectedEmojiByte, content.charPositionToByteOffset(emojiTarget));
+        assertEquals(expectedEmojiByte, content.charPositionToByteOffset(emojiTarget));
+    }
+
+    @Test
     @DisplayName("Round-trip conversion between byte offset and char position")
     void testRoundTripOffsetConversion() {
         SourceContent content = SourceContent.of("Hello Café World");

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/usages/RegexUsageAnalyzerTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/usages/RegexUsageAnalyzerTest.java
@@ -1,0 +1,225 @@
+package ai.brokk.analyzer.usages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.JavaAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.project.ICoreProject;
+import ai.brokk.testutil.InlineTestProjectCreator;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import org.junit.jupiter.api.Test;
+
+class RegexUsageAnalyzerTest {
+
+    @Test
+    void multipleTargetsScannedTogetherMatchIndividualResults() throws Exception {
+        String targetCode =
+                """
+                package com.example;
+                public class Target {
+                    public void action() {}
+                    public void action(int value) {}
+                }
+                """;
+        String consumerCode =
+                """
+                package com.example;
+                public class Consumer {
+                    public void run(Target target) {
+                        target.action();
+                        target.action(1);
+                    }
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.code(targetCode, "com/example/Target.java")
+                .addFileContents(consumerCode, "com/example/Consumer.java")
+                .build()) {
+            var analyzer = new JavaAnalyzer(project);
+            var usageAnalyzer = new RegexUsageAnalyzer(analyzer);
+            var overloads = List.copyOf(analyzer.getDefinitions("com.example.Target.action"));
+            assertEquals(2, overloads.size());
+            var noArg = overloads.get(0);
+            var intArg = overloads.get(1);
+            var consumerFile = projectFile(project.getAllFiles(), "com/example/Consumer.java");
+
+            var batched = assertInstanceOf(
+                    FuzzyResult.Ambiguous.class, usageAnalyzer.findUsages(overloads, Set.of(consumerFile), 100));
+            var noArgOnly = assertInstanceOf(
+                    FuzzyResult.Ambiguous.class, usageAnalyzer.findUsages(List.of(noArg), Set.of(consumerFile), 100));
+            var intArgOnly = assertInstanceOf(
+                    FuzzyResult.Ambiguous.class, usageAnalyzer.findUsages(List.of(intArg), Set.of(consumerFile), 100));
+
+            assertEquals(
+                    noArgOnly.hitsByOverload().get(noArg),
+                    batched.hitsByOverload().get(noArg));
+            assertEquals(
+                    intArgOnly.hitsByOverload().get(intArg),
+                    batched.hitsByOverload().get(intArg));
+        }
+    }
+
+    @Test
+    void asciiContentReportsCharacterOffsets() throws Exception {
+        String targetCode =
+                """
+                package com.example;
+                public class Target {}
+                """;
+        String consumerCode =
+                """
+                package com.example;
+                public class Consumer {
+                    private Target target;
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.code(targetCode, "com/example/Target.java")
+                .addFileContents(consumerCode, "com/example/Consumer.java")
+                .build()) {
+            var analyzer = new JavaAnalyzer(project);
+            var target = singleDefinition(analyzer, "com.example.Target");
+            var consumerFile = projectFile(project.getAllFiles(), "com/example/Consumer.java");
+
+            var result = assertInstanceOf(
+                    FuzzyResult.Success.class,
+                    new RegexUsageAnalyzer(analyzer).findUsages(List.of(target), Set.of(consumerFile), 100));
+
+            var hit = result.hitsByOverload().get(target).iterator().next();
+            assertEquals(consumerCode.indexOf("Target"), hit.startOffset());
+            assertEquals("Target target;", consumerCode.substring(hit.startOffset(), hit.endOffset()));
+        }
+    }
+
+    @Test
+    void nonAsciiContentPreservesUtf8ByteOffsetsForAccessChecks() throws Exception {
+        String targetCode =
+                """
+                package com.example;
+                public class Target {}
+                """;
+        String consumerCode =
+                """
+                package com.example;
+                public class Consumer {
+                    String label = "cafe \u00e9 \uD83D\uDE80";
+                    private Target target;
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.code(targetCode, "com/example/Target.java")
+                .addFileContents(consumerCode, "com/example/Consumer.java")
+                .build()) {
+            var analyzer = new RecordingJavaAnalyzer(project);
+            var target = singleDefinition(analyzer, "com.example.Target");
+            var consumerFile = projectFile(project.getAllFiles(), "com/example/Consumer.java");
+            int charStart = consumerCode.indexOf("Target");
+            int expectedByteStart = consumerCode.substring(0, charStart).getBytes(StandardCharsets.UTF_8).length;
+
+            var result = assertInstanceOf(
+                    FuzzyResult.Success.class,
+                    new RegexUsageAnalyzer(analyzer).findUsages(List.of(target), Set.of(consumerFile), 100));
+
+            assertEquals(1, result.hitsByOverload().get(target).size());
+            assertTrue(analyzer.seenStartBytes().contains(expectedByteStart));
+        }
+    }
+
+    @Test
+    void tooManyCallsitesStillTriggersPerTarget() throws Exception {
+        String targetCode =
+                """
+                package com.example;
+                public class Target {}
+                """;
+        String consumerCode =
+                """
+                package com.example;
+                public class Consumer {
+                    private Target first;
+                    private Target second;
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.code(targetCode, "com/example/Target.java")
+                .addFileContents(consumerCode, "com/example/Consumer.java")
+                .build()) {
+            var analyzer = new JavaAnalyzer(project);
+            var target = singleDefinition(analyzer, "com.example.Target");
+            var consumerFile = projectFile(project.getAllFiles(), "com/example/Consumer.java");
+
+            var result = new RegexUsageAnalyzer(analyzer).findUsages(List.of(target), Set.of(consumerFile), 1);
+
+            assertInstanceOf(FuzzyResult.TooManyCallsites.class, result);
+        }
+    }
+
+    @Test
+    void ambiguousIdentifierStillReturnsAmbiguousResult() throws Exception {
+        String first = """
+                package first;
+                public class Dupe {}
+                """;
+        String second = """
+                package second;
+                public class Dupe {}
+                """;
+        String consumer =
+                """
+                package use;
+                public class Consumer {
+                    private Dupe dupe;
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.code(first, "first/Dupe.java")
+                .addFileContents(second, "second/Dupe.java")
+                .addFileContents(consumer, "use/Consumer.java")
+                .build()) {
+            var analyzer = new JavaAnalyzer(project);
+            var target = singleDefinition(analyzer, "first.Dupe");
+            var consumerFile = projectFile(project.getAllFiles(), "use/Consumer.java");
+
+            var result = new RegexUsageAnalyzer(analyzer).findUsages(List.of(target), Set.of(consumerFile), 100);
+
+            assertInstanceOf(FuzzyResult.Ambiguous.class, result);
+        }
+    }
+
+    private static CodeUnit singleDefinition(IAnalyzer analyzer, String fqName) {
+        return analyzer.getDefinitions(fqName).stream().findFirst().orElseThrow();
+    }
+
+    private static ProjectFile projectFile(Set<ProjectFile> files, String suffix) {
+        String normalizedSuffix = suffix.replace('\\', '/');
+        return files.stream()
+                .filter(file -> file.toString().replace('\\', '/').endsWith(normalizedSuffix))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static final class RecordingJavaAnalyzer extends JavaAnalyzer {
+        private final Set<Integer> seenStartBytes = new ConcurrentSkipListSet<>();
+
+        private RecordingJavaAnalyzer(ICoreProject project) {
+            super(project);
+        }
+
+        @Override
+        public boolean isAccessExpression(ProjectFile file, int startByte, int endByte) {
+            seenStartBytes.add(startByte);
+            return super.isAccessExpression(file, startByte, endByte);
+        }
+
+        private Set<Integer> seenStartBytes() {
+            return seenStartBytes;
+        }
+    }
+}


### PR DESCRIPTION
### Description
Refactors the regex fallback usage analyzer to scan candidate files once per overload set while preserving the existing usage result contract. Moves cached character-to-byte offset conversion into SourceContent so byte-offset semantics stay centralized.

**Key Changes**:
- Batch regex fallback matching per candidate file for same-identifier overload sets, with per-file scan state for snippets, line starts, and source offsets.
- Add lazy cached char-position to UTF-8 byte-offset conversion to SourceContent and cover it with regression tests.
- Add focused RegexUsageAnalyzer tests for overload batching, offsets, ambiguity, and callsite caps.

**Touch Points**:
- brokk-shared/src/main/java/ai/brokk/analyzer/usages/RegexUsageAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/SourceContent.java
- brokk-shared/src/test/java/ai/brokk/analyzer/usages/RegexUsageAnalyzerTest.java
- brokk-shared/src/test/java/ai/brokk/analyzer/SourceContentTest.java