### PR TITLE
brokk-acp-rust: add OpenRouter backend with auto-discovery

### DIFF
--- a/brokk-acp-rust/src/discovery.rs
+++ b/brokk-acp-rust/src/discovery.rs
@@ -1,20 +1,25 @@
-//! Auto-discover available LLM models from Codex (`~/.codex/auth.json`) and
-//! a local Ollama daemon (`http://localhost:11434/api/tags`).
+//! Auto-discover available LLM models from Codex (`~/.codex/auth.json`),
+//! a local Ollama daemon (`http://localhost:11434/api/tags`), and
+//! OpenRouter (`https://openrouter.ai/api/v1/models`, gated on the
+//! `OPENROUTER_API_KEY` env var).
 //!
 //! Zero-config by design: the Ollama URL is fixed at the daemon's default
 //! port. If your daemon listens elsewhere, the catalog will simply not
 //! include Ollama models -- run `ollama serve` on `:11434` to make them
-//! discoverable.
+//! discoverable. OpenRouter is enabled only when `OPENROUTER_API_KEY` is
+//! set in the environment; absent the key, the catalog simply omits its
+//! models with no warning.
 //!
 //! Each discovered model carries a `ModelSource` tag so the routing backend
 //! (`MultiBackend`) can pick the right HTTP client at request time. The
 //! catalog is presented to ACP clients as `<source>::<id>` wire ids, e.g.
-//! `codex::gpt-5-codex` and `ollama::llama3:latest`. The double-colon
-//! separator avoids collision with Ollama tags (which themselves contain a
-//! single colon, `model:tag`).
+//! `codex::gpt-5-codex`, `ollama::llama3:latest`, and
+//! `openrouter::anthropic/claude-3.5-sonnet`. The double-colon separator
+//! avoids collision with Ollama tags (`model:tag`) and with OpenRouter
+//! ids (`vendor/model`).
 //!
 //! Failure posture: missing or unreachable sources are logged and skipped,
-//! never propagated. A user with neither Codex nor Ollama still gets a
+//! never propagated. A user with none of the three configured still gets a
 //! working server -- they just see an empty model picker until one of the
 //! sources comes online (and can re-run discovery via `session/new`, which
 //! refreshes the cache).
@@ -30,6 +35,7 @@ use serde::Deserialize;
 pub enum ModelSource {
     Codex,
     Ollama,
+    OpenRouter,
 }
 
 impl ModelSource {
@@ -37,6 +43,7 @@ impl ModelSource {
         match self {
             Self::Codex => "codex",
             Self::Ollama => "ollama",
+            Self::OpenRouter => "openrouter",
         }
     }
 }
@@ -65,6 +72,7 @@ pub fn split_wire_id(wire: &str) -> Option<(ModelSource, &str)> {
     let source = match prefix {
         "codex" => ModelSource::Codex,
         "ollama" => ModelSource::Ollama,
+        "openrouter" => ModelSource::OpenRouter,
         _ => return None,
     };
     Some((source, rest))
@@ -74,6 +82,19 @@ pub fn split_wire_id(wire: &str) -> Option<(ModelSource, &str)> {
 /// zero-config posture is that the user doesn't pick a port -- if the
 /// daemon isn't here, it's not discoverable.
 pub const OLLAMA_DEFAULT_URL: &str = "http://localhost:11434";
+
+/// OpenRouter cloud base URL. Hardcoded; OpenRouter is a single SaaS
+/// endpoint with no self-hosted variant to point at. `OpenAiClient` will
+/// append `/v1/...` when it sees this base URL (already covered by the
+/// existing `api_url` logic).
+pub const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+
+/// Environment variable name carrying the OpenRouter API key. Mirrors the
+/// `OPENROUTER_API_KEY` convention used by OpenRouter's own SDK docs --
+/// brokk-acp-rust deliberately does NOT introduce a `BROKK_OPENROUTER_*`
+/// alias so the same shell that already works with `openrouter` / OpenAI
+/// SDK / litellm works here too.
+pub const OPENROUTER_API_KEY_ENV: &str = "OPENROUTER_API_KEY";
 
 // ---------------------------------------------------------------------------
 // Ollama discovery (native /api/tags)
@@ -134,27 +155,39 @@ pub async fn discover_ollama(
 // Top-level orchestrator
 // ---------------------------------------------------------------------------
 
-/// Run both discovery sources concurrently and merge results. Failures
-/// are logged and treated as "no models from this source" so a dead
-/// Ollama daemon doesn't shadow a working Codex login (or vice versa).
+/// Run all configured discovery sources concurrently and merge results.
+/// Failures are logged and treated as "no models from this source" so a
+/// dead Ollama daemon doesn't shadow a working Codex login (or vice versa).
 ///
 /// `ollama_url` is a parameter purely for test injection -- production
 /// always passes `OLLAMA_DEFAULT_URL`. There's no CLI flag for this; the
 /// zero-config posture means the user doesn't pick a port.
 ///
-/// Codex discovery is delegated to a caller-provided closure because the
-/// `CodexClient` it relies on lives in a sibling module that already
-/// handles auth.json parsing, fallback slugs, and `chatgpt`/`apikey` mode
-/// branching. Keeping the closure here lets `discovery.rs` stay agnostic
-/// of those concerns while still running both sources in parallel.
-pub async fn discover_all<F, Fut>(
+/// Codex and OpenRouter discovery are delegated to caller-provided
+/// closures. For Codex, the `CodexClient` lives in a sibling module that
+/// already handles auth.json parsing, fallback slugs, and
+/// `chatgpt`/`apikey` mode branching. For OpenRouter, the closure lets
+/// the caller short-circuit cleanly when no `OPENROUTER_API_KEY` is set
+/// (returning `Err`) without `discovery.rs` having to know about env
+/// vars. Each closure keeps `discovery.rs` agnostic of those concerns
+/// while still running all sources in parallel.
+///
+/// Output ordering is fixed: Codex first, then OpenRouter, then Ollama.
+/// The first model in the merged list is auto-selected as the session
+/// default elsewhere -- keeping ordering deterministic stops users from
+/// seeing a different default just because one source happened to be
+/// slow on a given boot.
+pub async fn discover_all<FC, FutC, FOR, FutOR>(
     http: &reqwest::Client,
     ollama_url: &str,
-    codex_lookup: F,
+    codex_lookup: FC,
+    openrouter_lookup: FOR,
 ) -> Vec<DiscoveredModel>
 where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = Result<Vec<String>>>,
+    FC: FnOnce() -> FutC,
+    FutC: std::future::Future<Output = Result<Vec<String>>>,
+    FOR: FnOnce() -> FutOR,
+    FutOR: std::future::Future<Output = Result<Vec<String>>>,
 {
     let codex_fut = async {
         match codex_lookup().await {
@@ -172,6 +205,22 @@ where
         }
     };
 
+    let openrouter_fut = async {
+        match openrouter_lookup().await {
+            Ok(ids) => ids
+                .into_iter()
+                .map(|id| DiscoveredModel {
+                    id,
+                    source: ModelSource::OpenRouter,
+                })
+                .collect(),
+            Err(e) => {
+                tracing::info!("openrouter model discovery skipped: {e:#}");
+                Vec::new()
+            }
+        }
+    };
+
     let ollama_fut = async {
         match discover_ollama(http, ollama_url).await {
             Ok(models) => models,
@@ -182,9 +231,10 @@ where
         }
     };
 
-    let (codex, ollama) = tokio::join!(codex_fut, ollama_fut);
-    let mut all = Vec::with_capacity(codex.len() + ollama.len());
+    let (codex, openrouter, ollama) = tokio::join!(codex_fut, openrouter_fut, ollama_fut);
+    let mut all = Vec::with_capacity(codex.len() + openrouter.len() + ollama.len());
     all.extend(codex);
+    all.extend(openrouter);
     all.extend(ollama);
     all
 }
@@ -193,10 +243,12 @@ where
 mod tests {
     use super::*;
 
-    /// `wire_id` round-trips through `split_wire_id` for both sources, and
-    /// preserves Ollama tag suffixes (the inner colon in `llama3:latest`).
+    /// `wire_id` round-trips through `split_wire_id` for every source,
+    /// preserves Ollama tag suffixes (the inner colon in `llama3:latest`),
+    /// and preserves OpenRouter vendor-prefixed ids (the inner slash in
+    /// `anthropic/claude-3.5-sonnet`).
     #[test]
-    fn wire_id_round_trips_for_both_sources() {
+    fn wire_id_round_trips_for_every_source() {
         let codex = DiscoveredModel {
             id: "gpt-5-codex".into(),
             source: ModelSource::Codex,
@@ -218,6 +270,18 @@ mod tests {
         // The inner `:` survives -- our separator is the double-colon, so
         // the bare id keeps its tag suffix and routes correctly to Ollama.
         assert_eq!(id, "llama3:latest");
+
+        let openrouter = DiscoveredModel {
+            id: "anthropic/claude-3.5-sonnet".into(),
+            source: ModelSource::OpenRouter,
+        };
+        let openrouter_wire = openrouter.wire_id();
+        assert_eq!(openrouter_wire, "openrouter::anthropic/claude-3.5-sonnet");
+        let (src, id) = split_wire_id(&openrouter_wire).expect("must parse");
+        assert_eq!(src, ModelSource::OpenRouter);
+        // The inner `/` survives -- OpenRouter's `vendor/model` format
+        // round-trips through the wire id without escaping.
+        assert_eq!(id, "anthropic/claude-3.5-sonnet");
     }
 
     /// Wire ids without the `::` separator or with an unknown source are
@@ -227,6 +291,7 @@ mod tests {
     fn split_wire_id_rejects_bare_or_unknown_prefix() {
         assert!(split_wire_id("gpt-5-codex").is_none());
         assert!(split_wire_id("llama3:latest").is_none());
+        assert!(split_wire_id("anthropic/claude-3.5-sonnet").is_none());
         assert!(split_wire_id("unknown::foo").is_none());
         // Single colon is not enough -- `llama3:latest` is a bare Ollama id,
         // not a wire id, so we must NOT treat it as `source=llama3`.
@@ -238,34 +303,71 @@ mod tests {
     /// happens to have a real Ollama running on the default port.
     const TEST_DEAD_OLLAMA_URL: &str = "http://127.0.0.1:1";
 
-    /// `discover_all` returns Codex first, then Ollama, regardless of which
-    /// future resolves first. Stable ordering matters because the first
-    /// model in the catalog is auto-selected as the session default; we
-    /// don't want users to see a different default just because their
-    /// Ollama daemon was slow to respond on a particular boot.
+    /// `discover_all` returns Codex first, then OpenRouter, then Ollama,
+    /// regardless of which future resolves first. Stable ordering matters
+    /// because the first model in the catalog is auto-selected as the
+    /// session default; we don't want users to see a different default
+    /// just because their Ollama daemon was slow to respond on a
+    /// particular boot.
     #[tokio::test]
-    async fn discover_all_orders_codex_before_ollama() {
+    async fn discover_all_orders_codex_openrouter_ollama() {
         let http = discovery_http_client();
-        let models = discover_all(&http, TEST_DEAD_OLLAMA_URL, || async {
-            Ok(vec!["gpt-5-codex".to_string(), "gpt-4o".to_string()])
-        })
+        let models = discover_all(
+            &http,
+            TEST_DEAD_OLLAMA_URL,
+            || async { Ok(vec!["gpt-5-codex".to_string(), "gpt-4o".to_string()]) },
+            || async {
+                Ok(vec![
+                    "anthropic/claude-3.5-sonnet".to_string(),
+                    "openai/gpt-4o".to_string(),
+                ])
+            },
+        )
         .await;
-        // Codex returned 2; Ollama failed -> 0.
-        assert_eq!(models.len(), 2);
-        assert!(models.iter().all(|m| m.source == ModelSource::Codex));
+        // Codex returned 2; OpenRouter returned 2; Ollama failed -> 0.
+        assert_eq!(models.len(), 4);
+        assert_eq!(models[0].source, ModelSource::Codex);
         assert_eq!(models[0].id, "gpt-5-codex");
+        assert_eq!(models[1].source, ModelSource::Codex);
+        assert_eq!(models[2].source, ModelSource::OpenRouter);
+        assert_eq!(models[2].id, "anthropic/claude-3.5-sonnet");
+        assert_eq!(models[3].source, ModelSource::OpenRouter);
     }
 
-    /// When both sources fail, the merged vec is empty rather than an
-    /// error -- the server still starts and the user can run /codex-login
-    /// or start Ollama, then re-run discovery via the next session/new.
+    /// When every source fails, the merged vec is empty rather than an
+    /// error -- the server still starts and the user can run /codex-login,
+    /// start Ollama, or export `OPENROUTER_API_KEY`, then re-run discovery
+    /// via the next session/new.
     #[tokio::test]
-    async fn discover_all_returns_empty_when_both_sources_fail() {
+    async fn discover_all_returns_empty_when_every_source_fails() {
         let http = discovery_http_client();
-        let models = discover_all(&http, TEST_DEAD_OLLAMA_URL, || async {
-            anyhow::bail!("no auth.json")
-        })
+        let models = discover_all(
+            &http,
+            TEST_DEAD_OLLAMA_URL,
+            || async { anyhow::bail!("no auth.json") },
+            || async { anyhow::bail!("no OPENROUTER_API_KEY") },
+        )
         .await;
         assert!(models.is_empty());
+    }
+
+    /// OpenRouter discovery is treated independently from Codex: a Codex
+    /// failure (no auth.json) must not suppress OpenRouter results, and
+    /// vice versa. Regression for the "missing source shadows working
+    /// source" failure mode the orchestrator is specifically designed to
+    /// prevent.
+    #[tokio::test]
+    async fn discover_all_keeps_openrouter_when_codex_fails() {
+        let http = discovery_http_client();
+        let models = discover_all(
+            &http,
+            TEST_DEAD_OLLAMA_URL,
+            || async { anyhow::bail!("no auth.json") },
+            || async { Ok(vec!["anthropic/claude-3.5-sonnet".to_string()]) },
+        )
+        .await;
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].source, ModelSource::OpenRouter);
+        assert_eq!(models[0].id, "anthropic/claude-3.5-sonnet");
     }
 }

--- a/brokk-acp-rust/src/llm_client.rs
+++ b/brokk-acp-rust/src/llm_client.rs
@@ -358,9 +358,23 @@ impl std::fmt::Debug for OpenAiClient {
 
 impl OpenAiClient {
     pub fn new(base_url: String, api_key: Option<String>) -> Self {
+        Self::with_default_headers(base_url, api_key, reqwest::header::HeaderMap::new())
+    }
+
+    /// Like `new`, but attaches `default_headers` to every request the
+    /// resulting `reqwest::Client` makes. Used by providers that require
+    /// out-of-band attribution headers on every call (today, OpenRouter's
+    /// optional `HTTP-Referer` / `X-Title` leaderboard headers). Plain
+    /// OpenAI / Ollama callers should keep using `new`.
+    pub fn with_default_headers(
+        base_url: String,
+        api_key: Option<String>,
+        default_headers: reqwest::header::HeaderMap,
+    ) -> Self {
         let http = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(600))
+            .default_headers(default_headers)
             .build()
             .expect("failed to build HTTP client");
         let base_url = base_url.trim_end_matches('/').to_string();
@@ -926,5 +940,79 @@ mod tests {
         assert_eq!(calls[0].function.arguments, r#"{"path":"x.txt"}"#);
         assert_eq!(calls[1].id, "call_1");
         assert_eq!(calls[1].function.name, "writeFile");
+    }
+
+    /// `OpenAiClient::with_default_headers` produces an instance that
+    /// `LlmBackend` can be cast over (no panic on construction, headers
+    /// accepted as-is). Wire path is exercised by the integration with
+    /// `MultiBackend` -- this test pins the constructor contract that
+    /// OpenRouter's `HTTP-Referer` / `X-Title` attribution headers rely
+    /// on (`main.rs::build_openrouter_backend`).
+    #[test]
+    fn with_default_headers_constructs_with_attribution_headers() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::HeaderName::from_static("http-referer"),
+            reqwest::header::HeaderValue::from_static("https://example.test"),
+        );
+        headers.insert(
+            reqwest::header::HeaderName::from_static("x-title"),
+            reqwest::header::HeaderValue::from_static("brokk-acp-rust"),
+        );
+        let client = OpenAiClient::with_default_headers(
+            "https://openrouter.ai/api/v1".to_string(),
+            Some("sk-test-key".to_string()),
+            headers,
+        );
+        // Trailing slashes are stripped by both constructors so callers
+        // can interchange `.../v1` and `.../v1/` without double-slashes
+        // showing up in the request URL.
+        let debug = format!("{client:?}");
+        assert!(debug.contains("openrouter.ai"), "got {debug}");
+        assert!(
+            debug.contains("[REDACTED]"),
+            "api_key must be redacted from Debug output: {debug}"
+        );
+    }
+
+    /// OpenRouter's `/v1/models` response carries strictly more fields
+    /// than OpenAI's (`name`, `canonical_slug`, `pricing`, `architecture`,
+    /// etc.). The shared `ModelsResponse` deserializer must round-trip
+    /// the catalog without choking on the extra fields, leaving the
+    /// caller with just the bare `id` strings the routing layer expects.
+    /// Sample shape distilled from a live `GET https://openrouter.ai/api/v1/models`
+    /// response (vendor/model ids, with nested `pricing` and
+    /// `architecture` objects) so a future serde-rename regression is
+    /// caught here rather than at runtime on the user's first session.
+    #[test]
+    fn models_response_parses_openrouter_shape_ignoring_extra_fields() {
+        let raw = r#"{
+            "data": [
+                {
+                    "id": "anthropic/claude-3.5-sonnet",
+                    "name": "Anthropic: Claude 3.5 Sonnet",
+                    "canonical_slug": "anthropic/claude-3.5-sonnet",
+                    "context_length": 200000,
+                    "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+                    "architecture": {"input_modalities": ["text", "image"]},
+                    "top_provider": {"context_length": 200000}
+                },
+                {
+                    "id": "openai/gpt-4o",
+                    "name": "OpenAI: GPT-4o",
+                    "context_length": 128000,
+                    "pricing": {"prompt": "0.0000025", "completion": "0.00001"}
+                }
+            ]
+        }"#;
+        let parsed: ModelsResponse = serde_json::from_str(raw).expect("OpenRouter /models parses");
+        let ids: Vec<String> = parsed.data.into_iter().map(|m| m.id).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "anthropic/claude-3.5-sonnet".to_string(),
+                "openai/gpt-4o".to_string(),
+            ]
+        );
     }
 }

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -204,6 +204,54 @@ fn build_ollama_backend() -> Arc<dyn LlmBackend> {
     Arc::new(llm_client::OpenAiClient::new(chat_url, None))
 }
 
+/// Build the OpenRouter chat backend if `OPENROUTER_API_KEY` is set.
+/// OpenRouter speaks the OpenAI Chat Completions wire format verbatim,
+/// so we reuse `OpenAiClient` with the OpenRouter base URL and attach
+/// the optional `HTTP-Referer` / `X-Title` attribution headers (these
+/// drive the openrouter.ai leaderboard rankings; both are documented as
+/// optional but we always set them so the app shows up consistently).
+///
+/// Auth posture mirrors Codex: zero-config -- if the env var is absent
+/// the backend is skipped silently, no CLI flag, no warning. Whitespace
+/// is trimmed so accidental shell quoting (`export OPENROUTER_API_KEY=" sk-..."`)
+/// doesn't 401 every request.
+fn build_openrouter_backend() -> Option<Arc<dyn LlmBackend>> {
+    let raw = std::env::var(discovery::OPENROUTER_API_KEY_ENV).ok()?;
+    let key = raw.trim();
+    if key.is_empty() {
+        tracing::info!(
+            "{} is set but empty; OpenRouter backend skipped",
+            discovery::OPENROUTER_API_KEY_ENV
+        );
+        return None;
+    }
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    // Both header values are well-known ASCII strings the API expects;
+    // `from_static` panics only on invalid header bytes, which these
+    // literals are not. Doing this once at startup means we don't pay
+    // header-construction overhead per request.
+    headers.insert(
+        reqwest::header::HeaderName::from_static("http-referer"),
+        reqwest::header::HeaderValue::from_static("https://github.com/BrokkAi/brokk"),
+    );
+    headers.insert(
+        reqwest::header::HeaderName::from_static("x-title"),
+        reqwest::header::HeaderValue::from_static("brokk-acp-rust"),
+    );
+
+    tracing::info!(
+        "OpenRouter backend wired at {} (chat + discovery); key length={}",
+        discovery::OPENROUTER_BASE_URL,
+        key.len()
+    );
+    Some(Arc::new(llm_client::OpenAiClient::with_default_headers(
+        discovery::OPENROUTER_BASE_URL.to_string(),
+        Some(key.to_string()),
+        headers,
+    )))
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Configure tracing to stderr only (stdout is reserved for JSON-RPC)
@@ -238,17 +286,29 @@ async fn main() -> Result<()> {
     }
 
     let codex_backend = build_codex_backend().await;
+    let openrouter_backend = build_openrouter_backend();
     let ollama_backend = Some(build_ollama_backend());
 
     if codex_backend.is_none() {
         tracing::info!(
-            "Codex backend not available; the picker will only show Ollama models. \
-             Run /codex-login from a session to add Codex -- the new credentials \
-             are picked up on the next discovery refresh, no restart required."
+            "Codex backend not available; the picker will fall back to OpenRouter \
+             and Ollama (if discovered). Run /codex-login from a session to add \
+             Codex -- the new credentials are picked up on the next discovery \
+             refresh, no restart required."
+        );
+    }
+    if openrouter_backend.is_none() {
+        tracing::info!(
+            "OpenRouter backend not available; set {} to enable it.",
+            discovery::OPENROUTER_API_KEY_ENV
         );
     }
 
-    let llm: Arc<MultiBackend> = Arc::new(MultiBackend::new(codex_backend, ollama_backend));
+    let llm: Arc<MultiBackend> = Arc::new(MultiBackend::new(
+        codex_backend,
+        openrouter_backend,
+        ollama_backend,
+    ));
 
     let limits = session::SessionLimits {
         max_sessions: args.max_sessions,

--- a/brokk-acp-rust/src/multi_backend.rs
+++ b/brokk-acp-rust/src/multi_backend.rs
@@ -3,10 +3,11 @@
 //! `<source>::<id>` wire prefix produced by `discovery.rs`.
 //!
 //! Why a separate type? `OpenAiClient` and `CodexClient` already implement
-//! `LlmBackend` for one transport each. Wrapping both in a third backend
-//! lets `agent.rs` stay oblivious to which model it's talking to -- it
-//! just hands the wire id back to the backend the same way it always has,
-//! and the backend strips the prefix and routes.
+//! `LlmBackend` for one transport each. Wrapping the three (Codex,
+//! OpenRouter, Ollama) in a single routing backend lets `agent.rs` stay
+//! oblivious to which model it's talking to -- it just hands the wire id
+//! back to the backend the same way it always has, and the backend strips
+//! the prefix and routes.
 //!
 //! Bare ids (no `<source>::` prefix) fall back to a configurable preferred
 //! source so manually-typed model ids still route somewhere reasonable.
@@ -28,24 +29,36 @@ use crate::discovery::{
 };
 use crate::llm_client::{ChatMessage, LlmBackend, LlmResponse, ModelMetadata, ToolDefinition};
 
-/// LLM backend that routes by `<source>::<id>` prefix. Either inner
-/// backend may be absent (e.g. no `auth.json`, or no Ollama on the
-/// default port); calls for a source whose backend isn't configured
-/// return a clear error rather than silently falling through.
+/// LLM backend that routes by `<source>::<id>` prefix. Any inner backend
+/// may be absent (e.g. no `auth.json`, no `OPENROUTER_API_KEY`, or no
+/// Ollama on the default port); calls for a source whose backend isn't
+/// configured return a clear error rather than silently falling through.
 ///
 /// The Codex slot is held behind a `RwLock` so a successful
 /// `/codex-login` mid-session can install a backend without a server
 /// restart. The lock is only ever held for the duration of a synchronous
 /// `Option<Arc<...>>` clone -- we never hold it across an `.await`.
+///
+/// OpenRouter is held as a plain `Option<Arc<...>>` (no lock): there's no
+/// runtime install flow for it today -- the API key is read once at
+/// startup from the env var, and we never need to mutate the slot after
+/// construction. Adding a lock later if a `/openrouter-login` slash
+/// command lands would be mechanical.
 pub struct MultiBackend {
     codex: RwLock<Option<Arc<dyn LlmBackend>>>,
+    openrouter: Option<Arc<dyn LlmBackend>>,
     ollama: Option<Arc<dyn LlmBackend>>,
 }
 
 impl MultiBackend {
-    pub fn new(codex: Option<Arc<dyn LlmBackend>>, ollama: Option<Arc<dyn LlmBackend>>) -> Self {
+    pub fn new(
+        codex: Option<Arc<dyn LlmBackend>>,
+        openrouter: Option<Arc<dyn LlmBackend>>,
+        ollama: Option<Arc<dyn LlmBackend>>,
+    ) -> Self {
         Self {
             codex: RwLock::new(codex),
+            openrouter,
             ollama,
         }
     }
@@ -89,6 +102,7 @@ impl MultiBackend {
     fn pick(&self, source: ModelSource) -> Option<Arc<dyn LlmBackend>> {
         match source {
             ModelSource::Codex => self.codex_snapshot(),
+            ModelSource::OpenRouter => self.openrouter.clone(),
             ModelSource::Ollama => self.ollama.clone(),
         }
     }
@@ -96,16 +110,24 @@ impl MultiBackend {
     /// Source to use when a chat request arrives with no `<source>::` prefix.
     /// Computed on demand (rather than cached at construction) so a Codex
     /// login mid-session promotes Codex to the preferred fallback.
+    ///
+    /// Priority is Codex > OpenRouter > Ollama. Codex wins first because
+    /// the more capable backend is more likely to be the user's intent
+    /// for a bare model id like `gpt-5-codex`; OpenRouter sits ahead of
+    /// Ollama because a configured cloud key is a stronger signal of
+    /// intent than a daemon happening to be running locally.
     fn fallback_source(&self) -> Option<ModelSource> {
         let codex_present = self.codex.read().unwrap().is_some();
-        match (codex_present, self.ollama.is_some()) {
-            // Prefer Codex when both are configured -- it's the more
-            // capable backend and more likely to be the user's intent
-            // for a bare model id like "gpt-5-codex".
-            (true, _) => Some(ModelSource::Codex),
-            (false, true) => Some(ModelSource::Ollama),
-            (false, false) => None,
+        if codex_present {
+            return Some(ModelSource::Codex);
         }
+        if self.openrouter.is_some() {
+            return Some(ModelSource::OpenRouter);
+        }
+        if self.ollama.is_some() {
+            return Some(ModelSource::Ollama);
+        }
+        None
     }
 
     /// Resolve a wire-form model id to (backend, bare id). Bare ids (no
@@ -122,8 +144,8 @@ impl MultiBackend {
         }
         let source = self.fallback_source().ok_or_else(|| {
             anyhow::anyhow!(
-                "no LLM backend is configured (neither Codex nor Ollama discovered \
-                 any models, and no `<source>::<id>` wire prefix was provided)"
+                "no LLM backend is configured (none of Codex, OpenRouter, or Ollama \
+                 discovered any models, and no `<source>::<id>` wire prefix was provided)"
             )
         })?;
         let backend = self
@@ -169,9 +191,23 @@ impl LlmBackend for MultiBackend {
             // don't hit `/models` twice during a single list call.
             let codex_ids: Vec<String> = codex_metadata.iter().map(|m| m.id.clone()).collect();
             let codex_lookup = || async move { Ok::<_, anyhow::Error>(codex_ids) };
+
+            // OpenRouter exposes a flat `/v1/models` list with no
+            // reasoning-effort metadata, so we just need bare ids. When
+            // the backend isn't configured (no `OPENROUTER_API_KEY`),
+            // the closure returns an empty list and `discover_all`
+            // logs/skips it like any other absent source.
+            let openrouter_backend = self.openrouter.clone();
+            let openrouter_lookup = move || async move {
+                match openrouter_backend {
+                    Some(or) => or.list_models().await,
+                    None => Ok(Vec::new()),
+                }
+            };
+
             let http = discovery_http_client();
             let discovered: Vec<DiscoveredModel> =
-                discover_all(&http, OLLAMA_DEFAULT_URL, codex_lookup).await;
+                discover_all(&http, OLLAMA_DEFAULT_URL, codex_lookup, openrouter_lookup).await;
             Ok(discovered
                 .into_iter()
                 .map(|m| {
@@ -185,10 +221,13 @@ impl LlmBackend for MultiBackend {
                                 supported_reasoning_levels: meta.supported_reasoning_levels.clone(),
                             })
                             .unwrap_or_else(|| ModelMetadata::id_only(wire)),
-                        // Ollama doesn't publish reasoning presets;
-                        // ids surface with empty metadata so the picker
+                        // Neither Ollama nor OpenRouter publishes
+                        // reasoning presets through its catalog -- ids
+                        // surface with empty metadata so the picker
                         // simply omits the effort selector for them.
-                        ModelSource::Ollama => ModelMetadata::id_only(wire),
+                        ModelSource::Ollama | ModelSource::OpenRouter => {
+                            ModelMetadata::id_only(wire)
+                        }
                     }
                 })
                 .collect())
@@ -298,7 +337,7 @@ mod tests {
     async fn stream_chat_routes_by_wire_prefix() {
         let (codex_backend, codex_handles) = recording("codex");
         let (ollama_backend, ollama_handles) = recording("ollama");
-        let multi = MultiBackend::new(Some(codex_backend), Some(ollama_backend));
+        let multi = MultiBackend::new(Some(codex_backend), None, Some(ollama_backend));
 
         let _ = multi
             .stream_chat(
@@ -346,7 +385,7 @@ mod tests {
     async fn bare_id_routes_to_codex_fallback_when_both_configured() {
         let (codex_backend, codex_handles) = recording("codex");
         let (ollama_backend, ollama_handles) = recording("ollama");
-        let multi = MultiBackend::new(Some(codex_backend), Some(ollama_backend));
+        let multi = MultiBackend::new(Some(codex_backend), None, Some(ollama_backend));
 
         let _ = multi
             .stream_chat(
@@ -374,7 +413,7 @@ mod tests {
     #[tokio::test]
     async fn bare_id_routes_to_ollama_when_codex_absent() {
         let (ollama_backend, ollama_handles) = recording("ollama");
-        let multi = MultiBackend::new(None, Some(ollama_backend));
+        let multi = MultiBackend::new(None, None, Some(ollama_backend));
 
         let _ = multi
             .stream_chat(
@@ -403,7 +442,7 @@ mod tests {
     async fn wire_id_for_absent_backend_returns_error() {
         // Only Ollama is configured; a `codex::` wire id must error.
         let (ollama_backend, _ollama_handles) = recording("ollama");
-        let multi = MultiBackend::new(None, Some(ollama_backend));
+        let multi = MultiBackend::new(None, None, Some(ollama_backend));
 
         let err = multi
             .stream_chat(
@@ -428,7 +467,7 @@ mod tests {
     /// or start Ollama and re-discover) but no model can be routed.
     #[tokio::test]
     async fn empty_multi_backend_errors_on_chat() {
-        let multi = MultiBackend::new(None, None);
+        let multi = MultiBackend::new(None, None, None);
         let err = multi
             .stream_chat(
                 "anything",
@@ -458,7 +497,7 @@ mod tests {
     #[tokio::test]
     async fn codex_installed_after_login_is_routable() {
         // Start with no Codex (mirrors the empty-auth.json startup path).
-        let multi = MultiBackend::new(None, None);
+        let multi = MultiBackend::new(None, None, None);
 
         // Pre-install: a `codex::*` request must fail loudly.
         let err = multi
@@ -510,7 +549,7 @@ mod tests {
     /// fallback was still `None`.
     #[tokio::test]
     async fn bare_id_falls_back_to_codex_after_install() {
-        let multi = MultiBackend::new(None, None);
+        let multi = MultiBackend::new(None, None, None);
 
         let (codex_backend, codex_handles) = recording("codex");
         multi.install_codex(codex_backend);
@@ -541,7 +580,7 @@ mod tests {
     /// model picker would never show Codex models.
     #[tokio::test]
     async fn list_models_reflects_installed_codex() {
-        let multi = MultiBackend::new(None, None);
+        let multi = MultiBackend::new(None, None, None);
         let (codex_backend, _codex_handles) = recording("codex");
         multi.install_codex(codex_backend);
 
@@ -567,7 +606,7 @@ mod tests {
     /// exist on disk.
     #[tokio::test]
     async fn codex_uninstall_unroutes_codex_requests() {
-        let multi = MultiBackend::new(None, None);
+        let multi = MultiBackend::new(None, None, None);
         let (codex_backend, _codex_handles) = recording("codex");
         multi.install_codex(codex_backend);
 
@@ -608,6 +647,133 @@ mod tests {
         );
     }
 
+    /// Wire ids tagged `openrouter::` route to the OpenRouter backend
+    /// with the bare id (slash-separated `vendor/model`), and do NOT
+    /// leak to Codex or Ollama when those are also configured.
+    #[tokio::test]
+    async fn openrouter_wire_id_routes_to_openrouter() {
+        let (codex_backend, codex_handles) = recording("codex");
+        let (openrouter_backend, openrouter_handles) = recording("openrouter");
+        let (ollama_backend, ollama_handles) = recording("ollama");
+        let multi = MultiBackend::new(
+            Some(codex_backend),
+            Some(openrouter_backend),
+            Some(ollama_backend),
+        );
+
+        let _ = multi
+            .stream_chat(
+                "openrouter::anthropic/claude-3.5-sonnet",
+                vec![],
+                None,
+                None,
+                Box::new(|_| {}),
+                Box::new(|_| {}),
+                CancellationToken::new(),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("openrouter route");
+        // The inner slash in `vendor/model` must survive prefix
+        // stripping; OpenRouter expects the slashed id verbatim.
+        assert_eq!(
+            openrouter_handles.last_model.lock().unwrap().as_deref(),
+            Some("anthropic/claude-3.5-sonnet")
+        );
+        assert!(codex_handles.last_model.lock().unwrap().is_none());
+        assert!(ollama_handles.last_model.lock().unwrap().is_none());
+    }
+
+    /// A bare id with only OpenRouter configured falls back to
+    /// OpenRouter rather than erroring -- the same fallback contract
+    /// Ollama gets when it's the only backend.
+    #[tokio::test]
+    async fn bare_id_routes_to_openrouter_when_only_openrouter_configured() {
+        let (openrouter_backend, openrouter_handles) = recording("openrouter");
+        let multi = MultiBackend::new(None, Some(openrouter_backend), None);
+
+        let _ = multi
+            .stream_chat(
+                "anthropic/claude-3.5-sonnet",
+                vec![],
+                None,
+                None,
+                Box::new(|_| {}),
+                Box::new(|_| {}),
+                CancellationToken::new(),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("bare id falls back to openrouter");
+        assert_eq!(
+            openrouter_handles.last_model.lock().unwrap().as_deref(),
+            Some("anthropic/claude-3.5-sonnet")
+        );
+    }
+
+    /// Fallback priority: Codex > OpenRouter > Ollama. With all three
+    /// configured, a bare id routes to Codex (most capable, most likely
+    /// intent). With Codex absent, OpenRouter wins over Ollama because a
+    /// configured cloud key is a stronger signal of intent than a
+    /// happens-to-be-running local daemon.
+    #[tokio::test]
+    async fn bare_id_prefers_openrouter_over_ollama_when_codex_absent() {
+        let (openrouter_backend, openrouter_handles) = recording("openrouter");
+        let (ollama_backend, ollama_handles) = recording("ollama");
+        let multi = MultiBackend::new(None, Some(openrouter_backend), Some(ollama_backend));
+
+        let _ = multi
+            .stream_chat(
+                "some-bare-id",
+                vec![],
+                None,
+                None,
+                Box::new(|_| {}),
+                Box::new(|_| {}),
+                CancellationToken::new(),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("bare id falls back to openrouter");
+        assert_eq!(
+            openrouter_handles.last_model.lock().unwrap().as_deref(),
+            Some("some-bare-id")
+        );
+        assert!(ollama_handles.last_model.lock().unwrap().is_none());
+    }
+
+    /// Wire id requesting an absent OpenRouter backend errors loudly
+    /// rather than silently routing to a different source. Same contract
+    /// as `wire_id_for_absent_backend_returns_error` for Codex -- if the
+    /// user picks `openrouter::vendor/model` from a catalog snapshot and
+    /// the key has since been unexported, we must NOT route the request
+    /// to Codex or Ollama under a different (and probably nonexistent)
+    /// model id.
+    #[tokio::test]
+    async fn openrouter_wire_id_for_absent_backend_returns_error() {
+        let (codex_backend, _codex_handles) = recording("codex");
+        let multi = MultiBackend::new(Some(codex_backend), None, None);
+
+        let err = multi
+            .stream_chat(
+                "openrouter::anthropic/claude-3.5-sonnet",
+                vec![],
+                None,
+                None,
+                Box::new(|_| {}),
+                Box::new(|_| {}),
+                CancellationToken::new(),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect_err("openrouter route must fail when openrouter backend is absent");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("openrouter"),
+            "error must mention openrouter: {msg}"
+        );
+    }
+
     /// `reasoning_effort` threads through the dispatcher unchanged --
     /// it must arrive at the resolved inner backend, not get swallowed
     /// or coerced. (This protects the Codex picker's per-session
@@ -616,7 +782,7 @@ mod tests {
     #[tokio::test]
     async fn stream_chat_forwards_reasoning_effort() {
         let (codex_backend, codex_handles) = recording("codex");
-        let multi = MultiBackend::new(Some(codex_backend), None);
+        let multi = MultiBackend::new(Some(codex_backend), None, None);
 
         let _ = multi
             .stream_chat(


### PR DESCRIPTION
## Summary

Adds OpenRouter as a third LLM provider to `brokk-acp-rust`, alongside the existing Codex and Ollama backends. OpenRouter speaks the OpenAI Chat Completions wire format, so the provider is `OpenAiClient` pointed at `https://openrouter.ai/api/v1` with a new `with_default_headers` constructor that attaches `HTTP-Referer` and `X-Title` (both documented as optional, both pin the app's leaderboard identity, so we always set them).

Configuration follows the existing zero-config pattern:

- Read `OPENROUTER_API_KEY` from the environment at startup
- Attach the backend if the key is present, silently skip if absent
- No CLI flag — the convention matches Codex (`~/.codex/auth.json`) and Ollama (probe `localhost:11434`)

Routing extends `MultiBackend` with a third slot. Wire ids use the `openrouter::vendor/model` form (the inner `/` survives the `::` double-colon separator). Fallback priority for bare ids is **Codex > OpenRouter > Ollama** — capability- and signal-ordered.

Discovery hits `GET https://openrouter.ai/api/v1/models`, shape-compatible with OpenAI (each entry has an `id` string field). The extra OpenRouter fields (`pricing`, `architecture`, `top_provider`, `canonical_slug`, etc.) are ignored by the existing `ModelsResponse` deserializer.

## Files touched

- `brokk-acp-rust/src/llm_client.rs` — new `OpenAiClient::with_default_headers` constructor; new parsing test against an OpenRouter-shaped `/v1/models` response
- `brokk-acp-rust/src/discovery.rs` — `ModelSource::OpenRouter` variant; `discover_all` extended to a third closure; new constants `OPENROUTER_BASE_URL` and `OPENROUTER_API_KEY_ENV`
- `brokk-acp-rust/src/multi_backend.rs` — third `openrouter` slot; `pick`/`fallback_source`/`list_model_metadata` updated; four new routing tests
- `brokk-acp-rust/src/main.rs` — new `build_openrouter_backend()` reading `OPENROUTER_API_KEY`; wired into `MultiBackend::new`

No new dependencies. No root workspace, no other crates touched. Cargo.toml unchanged (license stays as the file already had it — `LGPL-3.0`).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean (CI invocation)
- [x] `cargo test --bin brokk-acp` — 235 passed, 0 failed; 10 new OpenRouter-specific cases:
   - `discovery::wire_id_round_trips_for_every_source`
   - `discovery::split_wire_id_rejects_bare_or_unknown_prefix`
   - `discovery::discover_all_orders_codex_openrouter_ollama`
   - `discovery::discover_all_returns_empty_when_every_source_fails`
   - `discovery::discover_all_keeps_openrouter_when_codex_fails`
   - `llm_client::with_default_headers_constructs_with_attribution_headers`
   - `llm_client::models_response_parses_openrouter_shape_ignoring_extra_fields`
   - `multi_backend::openrouter_wire_id_routes_to_openrouter`
   - `multi_backend::bare_id_routes_to_openrouter_when_only_openrouter_configured`
   - `multi_backend::bare_id_prefers_openrouter_over_ollama_when_codex_absent`
   - `multi_backend::openrouter_wire_id_for_absent_backend_returns_error`
- [ ] Manual: export `OPENROUTER_API_KEY=sk-or-…`, start `brokk-acp`, verify the model picker shows `openrouter::*` entries and a chat against e.g. `openrouter::anthropic/claude-3.5-sonnet` streams correctly

## Notes

- No live HTTP in tests — mocking style matches existing inline `RecordingBackend` / SSE-byte-stream patterns
- Cross-platform: only stdlib `std::env::var` and `reqwest` (already in deps); no Unix-only code paths added
- Spec verified against [OpenRouter's openapi.json](https://openrouter.ai/openapi.json) — `X-Title` (not `X-OpenRouter-Title`) is the canonical attribution header name; the quickstart MDX is out of date

🤖 Generated with [Claude Code](https://claude.com/claude-code)
