### PR TITLE
brokk-tui: slash-command autocomplete popover

### DIFF
--- a/brokk-tui-rust/src/app.rs
+++ b/brokk-tui-rust/src/app.rs
@@ -112,12 +112,26 @@ pub struct AppState {
     pub should_quit: bool,
     /// Transient status line (cleared on next event).
     pub status_line: Option<String>,
+    /// Slash-command autocomplete state, recomputed on every input edit.
+    pub autocomplete: Autocomplete,
 }
 
 #[derive(Debug)]
 pub struct PendingPermission {
     pub prompt: PermissionPrompt,
     pub selected: usize,
+}
+
+/// Autocomplete popover for slash-commands.
+///
+/// `matches` holds indices into `AppState.available_commands` so the
+/// popup keeps pointing at the right command even if the agent pushes a
+/// new `AvailableCommandsUpdate` (we just recompute the list).
+#[derive(Debug, Default)]
+pub struct Autocomplete {
+    pub visible: bool,
+    pub selected: usize,
+    pub matches: Vec<usize>,
 }
 
 impl AppState {
@@ -136,6 +150,7 @@ impl AppState {
             scroll_offset: 0,
             should_quit: false,
             status_line: None,
+            autocomplete: Autocomplete::default(),
         }
     }
 
@@ -145,6 +160,118 @@ impl AppState {
         self.transcript.push(Entry::UserPrompt(text));
         self.turn = TurnState::Streaming;
         self.scroll_offset = 0;
+        // Sending the prompt clears the input; tear down any open
+        // autocomplete popover so it doesn't linger over an empty buffer.
+        self.autocomplete = Autocomplete::default();
+    }
+
+    /// Recompute the slash-command autocomplete popover from the current
+    /// `input` buffer. Call this every time the input is mutated.
+    ///
+    /// The popover is shown when:
+    /// - the input starts with `/`,
+    /// - no permission modal is open (it owns the keyboard),
+    /// - we're not mid-stream (the input is greyed-out anyway).
+    ///
+    /// Filtering: case-insensitive prefix match on the slug after `/`,
+    /// and falls back to substring match if no prefix hits, so a typo
+    /// like `/plan` still surfaces `/create_plan`. The original ordering
+    /// of `available_commands` is preserved (the agent's emit order is
+    /// usually significant -- e.g. brokk-acp groups by category).
+    pub fn update_autocomplete(&mut self) {
+        let trigger_active = self.input.starts_with('/')
+            && self.pending_permission.is_none()
+            && self.turn == TurnState::Idle;
+        if !trigger_active {
+            self.autocomplete = Autocomplete::default();
+            return;
+        }
+
+        // Slug = chars between the leading `/` and the first whitespace
+        // or end-of-input. Once the user has typed an argument we stop
+        // suggesting (they've committed to a command).
+        let after_slash = &self.input[1..];
+        if after_slash.contains(char::is_whitespace) {
+            self.autocomplete = Autocomplete::default();
+            return;
+        }
+        let query = after_slash.to_lowercase();
+
+        let prev_selected_name = self
+            .autocomplete
+            .matches
+            .get(self.autocomplete.selected)
+            .and_then(|&i| self.available_commands.get(i))
+            .map(|c| c.name.clone());
+
+        let prefix: Vec<usize> = self
+            .available_commands
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.name.to_lowercase().starts_with(&query))
+            .map(|(i, _)| i)
+            .collect();
+        let matches = if prefix.is_empty() {
+            self.available_commands
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| c.name.to_lowercase().contains(&query))
+                .map(|(i, _)| i)
+                .collect()
+        } else {
+            prefix
+        };
+
+        // Keep the user's selection on the same command if it survived
+        // the new filter; otherwise reset to the top.
+        let selected = prev_selected_name
+            .and_then(|name| {
+                matches
+                    .iter()
+                    .position(|&i| self.available_commands[i].name == name)
+            })
+            .unwrap_or(0);
+
+        self.autocomplete = Autocomplete {
+            visible: !matches.is_empty(),
+            selected,
+            matches,
+        };
+    }
+
+    /// Move the autocomplete cursor by `delta`, wrapping at both ends.
+    /// No-op when the popover is hidden or empty.
+    pub fn autocomplete_move(&mut self, delta: i32) {
+        let len = self.autocomplete.matches.len();
+        if !self.autocomplete.visible || len == 0 {
+            return;
+        }
+        let cur = self.autocomplete.selected as i32;
+        let new = (cur + delta).rem_euclid(len as i32);
+        self.autocomplete.selected = new as usize;
+    }
+
+    /// Replace the input buffer with the currently-selected command,
+    /// followed by a trailing space so the user can keep typing
+    /// arguments. Returns `true` if a command was actually inserted.
+    pub fn autocomplete_accept(&mut self) -> bool {
+        if !self.autocomplete.visible {
+            return false;
+        }
+        let Some(&idx) = self.autocomplete.matches.get(self.autocomplete.selected) else {
+            return false;
+        };
+        let Some(cmd) = self.available_commands.get(idx) else {
+            return false;
+        };
+        self.input = format!("/{} ", cmd.name);
+        self.autocomplete = Autocomplete::default();
+        true
+    }
+
+    /// Hide the popover without modifying the input buffer.
+    pub fn autocomplete_dismiss(&mut self) {
+        self.autocomplete = Autocomplete::default();
     }
 
     pub fn apply_event(&mut self, event: UiEvent) {
@@ -253,6 +380,10 @@ impl AppState {
             }
             SessionUpdate::AvailableCommandsUpdate(u) => {
                 self.available_commands = u.available_commands;
+                // The catalog changed mid-typing; rebuild the popover so
+                // a `/` already in the buffer reflects the new commands
+                // (and so a previously-empty filter can become non-empty).
+                self.update_autocomplete();
             }
             SessionUpdate::CurrentModeUpdate(u) => {
                 let mode = u.current_mode_id.to_string();
@@ -417,5 +548,137 @@ mod tests {
             Entry::UserPrompt(t) => assert_eq!(t, "replayed"),
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    fn cmd(name: &str) -> AvailableCommand {
+        AvailableCommand::new(name, format!("does {name}"))
+    }
+
+    fn seed_commands(s: &mut AppState) {
+        s.available_commands = vec![
+            cmd("create_plan"),
+            cmd("review_pr"),
+            cmd("research_codebase"),
+            cmd("clear"),
+        ];
+    }
+
+    #[test]
+    fn autocomplete_hidden_when_input_does_not_start_with_slash() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "hello".to_string();
+        s.update_autocomplete();
+        assert!(!s.autocomplete.visible);
+        assert!(s.autocomplete.matches.is_empty());
+    }
+
+    #[test]
+    fn autocomplete_filters_by_prefix() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "/cre".to_string();
+        s.update_autocomplete();
+        assert!(s.autocomplete.visible);
+        let names: Vec<&str> = s
+            .autocomplete
+            .matches
+            .iter()
+            .map(|&i| s.available_commands[i].name.as_str())
+            .collect();
+        assert_eq!(names, vec!["create_plan"]);
+    }
+
+    #[test]
+    fn autocomplete_falls_back_to_substring_when_no_prefix_matches() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        // Nothing starts with "plan" but "create_plan" contains it.
+        s.input = "/plan".to_string();
+        s.update_autocomplete();
+        assert!(s.autocomplete.visible);
+        let names: Vec<&str> = s
+            .autocomplete
+            .matches
+            .iter()
+            .map(|&i| s.available_commands[i].name.as_str())
+            .collect();
+        assert_eq!(names, vec!["create_plan"]);
+    }
+
+    #[test]
+    fn autocomplete_hides_once_user_types_an_argument() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "/create_plan ".to_string();
+        s.update_autocomplete();
+        assert!(
+            !s.autocomplete.visible,
+            "popover must close once the user commits to a command + arg"
+        );
+    }
+
+    #[test]
+    fn autocomplete_movement_wraps_at_both_ends() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "/".to_string();
+        s.update_autocomplete();
+        let total = s.autocomplete.matches.len();
+        assert!(total >= 2);
+        assert_eq!(s.autocomplete.selected, 0);
+        s.autocomplete_move(-1);
+        assert_eq!(s.autocomplete.selected, total - 1, "wraps to end on Up");
+        s.autocomplete_move(1);
+        assert_eq!(s.autocomplete.selected, 0, "wraps back to start on Down");
+    }
+
+    #[test]
+    fn autocomplete_accept_replaces_input_with_command_and_trailing_space() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "/cre".to_string();
+        s.update_autocomplete();
+        assert!(s.autocomplete.visible);
+        assert!(s.autocomplete_accept());
+        assert_eq!(s.input, "/create_plan ");
+        assert!(!s.autocomplete.visible, "popover closes after acceptance");
+    }
+
+    #[test]
+    fn autocomplete_keeps_selection_on_same_command_when_filter_narrows() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "/r".to_string();
+        s.update_autocomplete();
+        // Walk down to "research_codebase" (second of the two `/r*` matches).
+        s.autocomplete_move(1);
+        let chosen = s.available_commands[s.autocomplete.matches[s.autocomplete.selected]]
+            .name
+            .clone();
+        assert_eq!(chosen, "research_codebase");
+
+        s.input = "/res".to_string();
+        s.update_autocomplete();
+        let still_chosen = s.available_commands[s.autocomplete.matches[s.autocomplete.selected]]
+            .name
+            .clone();
+        assert_eq!(
+            still_chosen, "research_codebase",
+            "selection should follow the command across filter changes"
+        );
+    }
+
+    #[test]
+    fn autocomplete_hidden_during_streaming_or_with_pending_permission() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "/cre".to_string();
+        s.turn = TurnState::Streaming;
+        s.update_autocomplete();
+        assert!(
+            !s.autocomplete.visible,
+            "input is greyed out during streaming; popover must hide"
+        );
     }
 }

--- a/brokk-tui-rust/src/app.rs
+++ b/brokk-tui-rust/src/app.rs
@@ -297,10 +297,12 @@ impl AppState {
                     prompt,
                     selected: 0,
                 });
+                self.update_autocomplete();
             }
             UiEvent::PromptDone { stop_reason } => {
                 self.turn = TurnState::Idle;
                 self.status_line = Some(format!("turn done: {stop_reason:?}"));
+                self.update_autocomplete();
             }
             UiEvent::Warning(msg) => {
                 self.status_line = Some(msg);
@@ -468,7 +470,9 @@ pub fn stop_reason_label(reason: StopReason) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agent_client_protocol::schema::{ContentBlock, ContentChunk, TextContent};
+    use agent_client_protocol::schema::{
+        ContentBlock, ContentChunk, PermissionOption, PermissionOptionKind, TextContent,
+    };
 
     fn text_chunk(s: &str) -> ContentChunk {
         ContentChunk::new(ContentBlock::Text(TextContent::new(s)))
@@ -561,6 +565,22 @@ mod tests {
             cmd("research_codebase"),
             cmd("clear"),
         ];
+    }
+
+    fn permission_prompt() -> PermissionPrompt {
+        let (responder, _rx) = tokio::sync::oneshot::channel();
+        PermissionPrompt {
+            tool_call: ToolCallUpdate::new(
+                "call-1",
+                agent_client_protocol::schema::ToolCallUpdateFields::default(),
+            ),
+            options: vec![PermissionOption::new(
+                "allow",
+                "Allow",
+                PermissionOptionKind::AllowOnce,
+            )],
+            responder,
+        }
     }
 
     #[test]
@@ -680,5 +700,32 @@ mod tests {
             !s.autocomplete.visible,
             "input is greyed out during streaming; popover must hide"
         );
+    }
+
+    #[test]
+    fn autocomplete_reappears_when_streaming_finishes() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "/cre".to_string();
+        s.turn = TurnState::Streaming;
+        s.update_autocomplete();
+        assert!(!s.autocomplete.visible);
+
+        s.apply_event(UiEvent::PromptDone {
+            stop_reason: StopReason::EndTurn,
+        });
+        assert!(s.autocomplete.visible);
+    }
+
+    #[test]
+    fn autocomplete_hides_when_permission_request_arrives() {
+        let mut s = AppState::new();
+        seed_commands(&mut s);
+        s.input = "/cre".to_string();
+        s.update_autocomplete();
+        assert!(s.autocomplete.visible);
+
+        s.apply_event(UiEvent::PermissionRequest(permission_prompt()));
+        assert!(!s.autocomplete.visible);
     }
 }

--- a/brokk-tui-rust/src/ui.rs
+++ b/brokk-tui-rust/src/ui.rs
@@ -221,10 +221,12 @@ fn handle_permission_key(state: &mut AppState, code: KeyCode) {
                 .map(|o| PermissionDecision::Selected(o.option_id.to_string()))
                 .unwrap_or(PermissionDecision::Cancelled);
             let _ = prompt.responder.send(decision);
+            state.update_autocomplete();
         }
         KeyCode::Esc => {
             let pending = state.pending_permission.take().expect("checked above");
             let _ = pending.prompt.responder.send(PermissionDecision::Cancelled);
+            state.update_autocomplete();
         }
         _ => {}
     }
@@ -504,22 +506,24 @@ fn draw_permission_modal(f: &mut ratatui::Frame, area: Rect, pending: &PendingPe
 /// at 8 visible rows + 2 borders.
 fn draw_autocomplete_popover(f: &mut ratatui::Frame, input_area: Rect, state: &AppState) {
     let max_visible_rows = 8u16;
-    let row_count = (state.autocomplete.matches.len() as u16).min(max_visible_rows);
-    if row_count == 0 {
+    let desired_rows = (state.autocomplete.matches.len() as u16).min(max_visible_rows);
+    if desired_rows == 0 {
         return;
     }
-    let height = row_count + 2; // +2 for borders
-    let width = input_area.width;
-    // Place the popover so its bottom edge sits one row above the input
-    // box's top border, which keeps both visible.
-    let bottom = input_area.y;
-    let top = bottom.saturating_sub(height);
-    // If the transcript pane is too small to fit the popover, clamp.
-    let height = bottom.saturating_sub(top);
+    // Place the popover so its bottom border sits just above the input
+    // box. If the transcript pane is short, shrink the number of rows
+    // to keep the highlighted item visible.
+    let height = (desired_rows + 2).min(input_area.y);
     if height < 3 {
         return;
     }
-    let rect = Rect::new(input_area.x, top, width, height);
+    let visible_rows = (height - 2) as usize;
+    let rect = Rect::new(
+        input_area.x,
+        input_area.y - height,
+        input_area.width,
+        height,
+    );
 
     f.render_widget(Clear, rect);
     let block = Block::default()
@@ -529,10 +533,10 @@ fn draw_autocomplete_popover(f: &mut ratatui::Frame, input_area: Rect, state: &A
     let inner = block.inner(rect);
     f.render_widget(block, rect);
 
-    // Compute a window of `row_count` rows centered on `selected`.
+    // Compute a window of visible rows centered on `selected`.
     let total = state.autocomplete.matches.len();
     let selected = state.autocomplete.selected;
-    let view_size = row_count as usize;
+    let view_size = visible_rows;
     let start = if total <= view_size {
         0
     } else {
@@ -565,9 +569,13 @@ fn draw_autocomplete_popover(f: &mut ratatui::Frame, input_area: Rect, state: &A
             }
             // Truncate to the visible width so the description doesn't
             // wrap and break the row alignment.
-            let cap = (inner.width as usize).saturating_sub(1);
+            let cap = inner.width as usize;
             if line.chars().count() > cap {
-                line = line.chars().take(cap.saturating_sub(3)).collect::<String>() + "...";
+                line = if cap > 3 {
+                    line.chars().take(cap - 3).collect::<String>() + "..."
+                } else {
+                    line.chars().take(cap).collect()
+                };
             }
             let style = if absolute == selected {
                 Style::default()

--- a/brokk-tui-rust/src/ui.rs
+++ b/brokk-tui-rust/src/ui.rs
@@ -8,6 +8,7 @@
 use std::io::{self, Stdout};
 use std::time::Duration;
 
+use agent_client_protocol::schema::AvailableCommandInput;
 use anyhow::{Context, Result};
 use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event as CtEvent, EventStream, KeyCode, KeyEventKind,
@@ -111,6 +112,32 @@ fn handle_crossterm(state: &mut AppState, cmd_tx: &mpsc::UnboundedSender<UiComma
         return;
     }
 
+    // Slash-command autocomplete owns Tab and Up/Down while it's
+    // visible, and intercepts Enter/Esc before the normal handlers see
+    // them. Plain typing still falls through so the user can refine the
+    // filter.
+    if state.autocomplete.visible {
+        match (key.modifiers, key.code) {
+            (_, KeyCode::Tab) | (_, KeyCode::Enter) => {
+                state.autocomplete_accept();
+                return;
+            }
+            (_, KeyCode::Up) => {
+                state.autocomplete_move(-1);
+                return;
+            }
+            (_, KeyCode::Down) => {
+                state.autocomplete_move(1);
+                return;
+            }
+            (_, KeyCode::Esc) => {
+                state.autocomplete_dismiss();
+                return;
+            }
+            _ => {}
+        }
+    }
+
     match (key.modifiers, key.code) {
         (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
             if state.turn == TurnState::Streaming {
@@ -120,6 +147,7 @@ fn handle_crossterm(state: &mut AppState, cmd_tx: &mpsc::UnboundedSender<UiComma
                 state.should_quit = true;
             } else {
                 state.input.clear();
+                state.update_autocomplete();
             }
         }
         (KeyModifiers::CONTROL, KeyCode::Char('d')) if state.input.is_empty() => {
@@ -128,9 +156,11 @@ fn handle_crossterm(state: &mut AppState, cmd_tx: &mpsc::UnboundedSender<UiComma
         (_, KeyCode::Enter) => submit_prompt(state, cmd_tx),
         (_, KeyCode::Char(c)) => {
             state.input.push(c);
+            state.update_autocomplete();
         }
         (_, KeyCode::Backspace) => {
             state.input.pop();
+            state.update_autocomplete();
         }
         (_, KeyCode::PageUp) => {
             state.scroll_offset = state.scroll_offset.saturating_add(5);
@@ -140,6 +170,7 @@ fn handle_crossterm(state: &mut AppState, cmd_tx: &mpsc::UnboundedSender<UiComma
         }
         (_, KeyCode::Esc) => {
             state.input.clear();
+            state.update_autocomplete();
         }
         _ => {}
     }
@@ -234,6 +265,14 @@ fn draw(f: &mut ratatui::Frame, state: &AppState) {
     draw_transcript(f, chunks[1], state);
     draw_input(f, chunks[2], state);
     draw_status(f, chunks[3], state);
+
+    // Autocomplete sits above the input box (so it doesn't collide with
+    // the cursor) and is rendered last among the input-area widgets so
+    // it overlays the transcript pane. The permission modal trumps it
+    // and renders on top.
+    if state.autocomplete.visible {
+        draw_autocomplete_popover(f, chunks[2], state);
+    }
 
     if let Some(pending) = state.pending_permission.as_ref() {
         draw_permission_modal(f, f.area(), pending);
@@ -457,4 +496,91 @@ fn draw_permission_modal(f: &mut ratatui::Frame, area: Rect, pending: &PendingPe
     let footer = Paragraph::new("Up/Down to choose | Enter to confirm | Esc to cancel")
         .style(Style::default().fg(Color::DarkGray));
     f.render_widget(footer, layout[2]);
+}
+
+/// Slash-command autocomplete popover. Anchored to the top edge of the
+/// input box and grows upward into the transcript pane so it never
+/// covers the user's cursor. Width matches the input box; height caps
+/// at 8 visible rows + 2 borders.
+fn draw_autocomplete_popover(f: &mut ratatui::Frame, input_area: Rect, state: &AppState) {
+    let max_visible_rows = 8u16;
+    let row_count = (state.autocomplete.matches.len() as u16).min(max_visible_rows);
+    if row_count == 0 {
+        return;
+    }
+    let height = row_count + 2; // +2 for borders
+    let width = input_area.width;
+    // Place the popover so its bottom edge sits one row above the input
+    // box's top border, which keeps both visible.
+    let bottom = input_area.y;
+    let top = bottom.saturating_sub(height);
+    // If the transcript pane is too small to fit the popover, clamp.
+    let height = bottom.saturating_sub(top);
+    if height < 3 {
+        return;
+    }
+    let rect = Rect::new(input_area.x, top, width, height);
+
+    f.render_widget(Clear, rect);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" commands (Tab/Enter accept, Esc cancel) ")
+        .style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(rect);
+    f.render_widget(block, rect);
+
+    // Compute a window of `row_count` rows centered on `selected`.
+    let total = state.autocomplete.matches.len();
+    let selected = state.autocomplete.selected;
+    let view_size = row_count as usize;
+    let start = if total <= view_size {
+        0
+    } else {
+        let half = view_size / 2;
+        selected.saturating_sub(half).min(total - view_size)
+    };
+    let end = (start + view_size).min(total);
+
+    let items: Vec<ListItem> = state.autocomplete.matches[start..end]
+        .iter()
+        .enumerate()
+        .map(|(offset, &cmd_idx)| {
+            let absolute = start + offset;
+            let cmd = &state.available_commands[cmd_idx];
+            let marker = if absolute == selected { ">" } else { " " };
+            let hint = cmd
+                .input
+                .as_ref()
+                .map(|i| match i {
+                    AvailableCommandInput::Unstructured(u) => format!(" <{}>", u.hint),
+                    _ => String::new(),
+                })
+                .unwrap_or_default();
+            let mut line = format!("{marker} /{}{hint}", cmd.name);
+            // Append a trimmed description on the same row.
+            let description = cmd.description.trim();
+            if !description.is_empty() {
+                line.push_str("  -- ");
+                line.push_str(description);
+            }
+            // Truncate to the visible width so the description doesn't
+            // wrap and break the row alignment.
+            let cap = (inner.width as usize).saturating_sub(1);
+            if line.chars().count() > cap {
+                line = line.chars().take(cap.saturating_sub(3)).collect::<String>() + "...";
+            }
+            let style = if absolute == selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            ListItem::new(line).style(style)
+        })
+        .collect();
+
+    let list = List::new(items);
+    f.render_widget(list, inner);
 }


### PR DESCRIPTION
## Summary

Surfaces `AvailableCommandsUpdate` in the UI as a slash-command autocomplete popover. The previous MVP captured the commands into `AppState.available_commands` but never rendered them — typing `/foo` was just dead text.

Now: typing `/` opens an autocomplete popover anchored above the input box (so it never covers the cursor). It filters commands as the user types, accepts with Tab or Enter, and inserts `/<name> ` so the user can keep typing arguments.

## State (`src/app.rs`)

- `Autocomplete { visible, selected, matches: Vec<usize> }` on `AppState`. `matches` are indices into `available_commands` so the popover survives `AvailableCommandsUpdate` rebuilds without dangling pointers.
- `update_autocomplete()` — single source of truth, called after every input mutation **and** after `AvailableCommandsUpdate`. Visible iff `input.starts_with('/')`, no permission modal is open, and turn is `Idle`. Hides as soon as the user types whitespace (commits to `cmd + args`).
- Filtering is case-insensitive prefix, with substring fallback so `/plan` still surfaces `/create_plan`. Original ordering is preserved (agent emit order is usually significant — brokk-acp groups by category).
- Selection is carried across filter changes when the highlighted command survives the narrower filter.
- `autocomplete_move(delta)` wraps at both ends; `autocomplete_accept()` writes `/<name> ` to the buffer and dismisses; `autocomplete_dismiss()` hides without mutation.
- `record_user_prompt()` also clears the popover.

## UI (`src/ui.rs`)

- `draw_autocomplete_popover` renders a `Clear` + `Block` + `List` anchored above the input box, growing upward into the transcript pane. Up to 8 visible rows windowed around `selected`.
- Each row: `> /name <hint>  -- description`, with the selected row in reverse-color cyan + bold. Long rows truncate with an ASCII `...` (per project no-Unicode rule).
- Keybindings while visible: **Tab/Enter** accept, **Up/Down** navigate (wrap), **Esc** dismiss. Enter outside the popover still submits the prompt.

## Tests

14/14 green. 8 new unit tests in `app::tests`:

- `autocomplete_hidden_when_input_does_not_start_with_slash`
- `autocomplete_filters_by_prefix`
- `autocomplete_falls_back_to_substring_when_no_prefix_matches`
- `autocomplete_hides_once_user_types_an_argument`
- `autocomplete_movement_wraps_at_both_ends`
- `autocomplete_accept_replaces_input_with_command_and_trailing_space`
- `autocomplete_keeps_selection_on_same_command_when_filter_narrows`
- `autocomplete_hidden_during_streaming_or_with_pending_permission`

## Test plan

- [ ] `cd brokk-tui-rust && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test`
- [ ] CI green on Linux, macOS, Windows
- [ ] Type `/` in the TUI against `brokk-acp`: popover opens with the agent's command catalog
- [ ] Type more characters: list narrows live
- [ ] Up/Down move selection and wrap; Tab/Enter inserts `/<name> ` and closes the popover
- [ ] Esc closes the popover without modifying the buffer; Ctrl-C clears buffer + closes popover
- [ ] Sending a prompt clears any open popover
- [ ] Permission modal preempts the popover keys; popover does not appear during streaming

## Constraints satisfied

- Touches only `brokk-tui-rust/src/app.rs` and `brokk-tui-rust/src/ui.rs`. No CI workflow change (existing matrix already runs on Linux/macOS/Windows).
- No unicode in code (the popover uses ASCII `...` for truncation).
- License remains GPL-3.0; no root `Cargo.toml`.

Generated with [Claude Code](https://claude.com/claude-code)
