### PR TITLE
brokk-core: expose three CodeQualityTools MCP tools

### DIFF
--- a/brokk-core/README.md
+++ b/brokk-core/README.md
@@ -168,9 +168,31 @@ Detects duplicated implementation patterns across functions using normalized tok
 | `astSimilarityPercent` | int | no | 70 | AST refinement threshold (0-100) |
 | `maxFindings` | int | no | 80 | Maximum findings to emit |
 
+#### `reportTestAssertionSmells`
+
+Detects low-value or brittle test assertion smells using language-aware weighted heuristics. Uses analyzer test-marker detection as a fast filter, then scores tautological assertions, shallow assertion-only tests, oversized exact literals, snapshots, and Java anonymous test doubles.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `filePaths` | string[] | yes | -- | File paths relative to project root |
+| `minScore` | int | no | 4 | Minimum score to include a finding |
+| `maxFindings` | int | no | 80 | Maximum findings to emit |
+| `noAssertionWeight` | int | no | (internal default) | Weight for tests with no assertion-equivalent calls |
+| `tautologicalAssertionWeight` | int | no | (internal default) | Weight for self-comparison or tautological assertions |
+| `constantTruthWeight` | int | no | (internal default) | Weight for `assertTrue(true)`, `assertFalse(false)`, and similar constants |
+| `constantEqualityWeight` | int | no | (internal default) | Weight for comparing two constant expressions |
+| `nullnessOnlyWeight` | int | no | (internal default) | Weight for nullness-only assertions |
+| `shallowAssertionOnlyWeight` | int | no | (internal default) | Weight for tests whose assertions are all shallow |
+| `overspecifiedLiteralWeight` | int | no | (internal default) | Weight for oversized exact string literals |
+| `anonymousTestDoubleWeight` | int | no | (internal default) | Weight for inline anonymous test doubles |
+| `repeatedAnonymousTestDoubleWeight` | int | no | (internal default) | Weight for repeated anonymous test double shapes |
+| `meaningfulAssertionCredit` | int | no | (internal default) | Score credit subtracted per meaningful assertion |
+| `meaningfulAssertionCreditCap` | int | no | (internal default) | Maximum meaningful assertions that earn credit |
+| `largeLiteralLengthThreshold` | int | no | (internal default) | String literal length considered oversized |
+
 ## Note on MCP servers
 
 The Brokk codebase has two MCP servers:
 
-1. **`BrokkCoreMcpServer`** (this module, `brokk-core/`) -- Standalone, no LLM dependencies, pure tree-sitter analysis. This is what the Claude Code plugin connects to. Exposes 27 tools.
+1. **`BrokkCoreMcpServer`** (this module, `brokk-core/`) -- Standalone, no LLM dependencies, pure tree-sitter analysis. This is what the Claude Code plugin connects to. Exposes 28 tools.
 2. **`BrokkExternalMcpServer`** (in `app/`) -- Full server with LLM agent capabilities. Not used by the Claude Code plugin.

--- a/brokk-core/README.md
+++ b/brokk-core/README.md
@@ -117,6 +117,23 @@ Comment density tables for the given source files: one section per file and one 
 | `maxTopLevelRows` | int | no | 60 | Maximum declaration rows across all files |
 | `maxFiles` | int | no | 25 | Maximum files to include |
 
+#### `reportLongMethodAndGodObjectSmells`
+
+Reports long methods/functions, god objects/modules, and helper sprawl using analyzer code-unit hierarchy and declaration ranges. Findings are ranked by maintainability impact and bounded by `maxFindings`.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `filePaths` | string[] | yes | -- | File paths relative to project root |
+| `maxFindings` | int | no | 20 | Maximum findings to return |
+| `maxFiles` | int | no | 25 | Maximum existing files to analyze |
+| `longMethodSpanLines` | int | no | (internal default) | Long method/function line threshold |
+| `highComplexityThreshold` | int | no | (internal default) | High cyclomatic complexity threshold |
+| `godObjectSpanLines` | int | no | (internal default) | God object/module line threshold |
+| `godObjectDirectChildren` | int | no | (internal default) | God object/module direct-child threshold |
+| `godObjectFunctions` | int | no | (internal default) | God object/module function-count threshold |
+| `helperSprawlFunctions` | int | no | (internal default) | Helper-sprawl function-count threshold |
+| `helperSprawlWorkflowLines` | int | no | (internal default) | Helper-sprawl workflow line threshold |
+
 #### `reportExceptionHandlingSmells`
 
 Detects suspicious exception handlers using weighted heuristics designed for high-recall triage. Scores generic catches and tiny/empty handlers, then subtracts credit for richer handling bodies.
@@ -155,5 +172,5 @@ Detects duplicated implementation patterns across functions using normalized tok
 
 The Brokk codebase has two MCP servers:
 
-1. **`BrokkCoreMcpServer`** (this module, `brokk-core/`) -- Standalone, no LLM dependencies, pure tree-sitter analysis. This is what the Claude Code plugin connects to. Exposes 25 tools.
+1. **`BrokkCoreMcpServer`** (this module, `brokk-core/`) -- Standalone, no LLM dependencies, pure tree-sitter analysis. This is what the Claude Code plugin connects to. Exposes 27 tools.
 2. **`BrokkExternalMcpServer`** (in `app/`) -- Full server with LLM agent capabilities. Not used by the Claude Code plugin.

--- a/brokk-core/README.md
+++ b/brokk-core/README.md
@@ -89,6 +89,15 @@ Computes heuristic cyclomatic complexity for methods in the given files. Flags m
 | `filePaths` | string[] | yes | -- | File paths relative to project root |
 | `threshold` | int | no | 10 | Complexity threshold; methods above this are flagged |
 
+#### `computeCognitiveComplexity`
+
+Computes heuristic cognitive complexity for methods in the given files. Cognitive complexity grows with control-flow breaks and nested control flow, complementing cyclomatic complexity for maintainability triage. Flags methods above the threshold and returns a markdown report.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `filePaths` | string[] | yes | -- | File paths relative to project root |
+| `threshold` | int | no | 15 | Complexity threshold; methods above this are flagged |
+
 #### `reportCommentDensityForCodeUnit`
 
 Comment density for one symbol identified by fully qualified name. Reports header vs inline comment line counts, declaration span lines, and rolled-up totals for class-like units. Currently Java only.

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -574,6 +574,24 @@ public class BrokkCoreMcpServer {
                 })));
 
         specs.add(tool(
+                "computeCognitiveComplexity",
+                "Computes heuristic cognitive complexity for methods in the given files. "
+                        + "Flags methods above the threshold (typical default 15) for maintainability-focused review or refactor. "
+                        + "Returns a markdown-friendly report of flagged methods.",
+                schema(
+                        Map.of(
+                                "filePaths", arrayProp("File paths relative to the project root."),
+                                "threshold",
+                                        intProp(
+                                                "Complexity threshold; methods above this are flagged. Use 0 or negative for default (15).")),
+                        List.of("filePaths")),
+                (exchange, request) -> withReadLock(() -> {
+                    var filePaths = stringListArg(request, "filePaths");
+                    var threshold = intArg(request, "threshold", 0);
+                    return textResult(codeQualityTools.computeCognitiveComplexity(filePaths, threshold));
+                })));
+
+        specs.add(tool(
                 "reportCommentDensityForCodeUnit",
                 "Java comment density for one symbol identified by fully qualified name. "
                         + "Reports header vs inline comment line counts, declaration span lines, and rolled-up totals for class-like units.",

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -776,6 +776,84 @@ public class BrokkCoreMcpServer {
                             intArg(request, "maxFindings", -1)));
                 })));
 
+        specs.add(tool(
+                "reportTestAssertionSmells",
+                "Detects low-value or brittle test assertion smells using language-aware weighted heuristics. "
+                        + "Uses analyzer test-marker detection as a fast filter, then scores tautological assertions, "
+                        + "shallow assertion-only tests, oversized exact literals, snapshots, and Java anonymous test doubles.",
+                schema(
+                        Map.ofEntries(
+                                entry("filePaths", arrayProp("File paths relative to the project root.")),
+                                entry(
+                                        "minScore",
+                                        intProp("Minimum score to include a finding; values <= 0 default to 4.")),
+                                entry("maxFindings", intProp("Maximum findings to emit; values <= 0 default to 80.")),
+                                entry(
+                                        "noAssertionWeight",
+                                        intProp(
+                                                "Weight for tests with no assertion-equivalent calls; values < 0 use default.")),
+                                entry(
+                                        "tautologicalAssertionWeight",
+                                        intProp(
+                                                "Weight for self-comparison or tautological assertions; values < 0 use default.")),
+                                entry(
+                                        "constantTruthWeight",
+                                        intProp(
+                                                "Weight for assertTrue(true), assertFalse(false), and similar constants; values < 0 use default.")),
+                                entry(
+                                        "constantEqualityWeight",
+                                        intProp(
+                                                "Weight for comparing two constant expressions; values < 0 use default.")),
+                                entry(
+                                        "nullnessOnlyWeight",
+                                        intProp("Weight for nullness-only assertions; values < 0 use default.")),
+                                entry(
+                                        "shallowAssertionOnlyWeight",
+                                        intProp(
+                                                "Weight for tests whose assertions are all shallow; values < 0 use default.")),
+                                entry(
+                                        "overspecifiedLiteralWeight",
+                                        intProp("Weight for oversized exact string literals; values < 0 use default.")),
+                                entry(
+                                        "anonymousTestDoubleWeight",
+                                        intProp("Weight for inline anonymous test doubles; values < 0 use default.")),
+                                entry(
+                                        "repeatedAnonymousTestDoubleWeight",
+                                        intProp(
+                                                "Weight for repeated anonymous test double shapes; values < 0 use default.")),
+                                entry(
+                                        "meaningfulAssertionCredit",
+                                        intProp(
+                                                "Score credit subtracted per meaningful assertion; values < 0 use default.")),
+                                entry(
+                                        "meaningfulAssertionCreditCap",
+                                        intProp(
+                                                "Maximum meaningful assertions that earn credit; values < 0 use default.")),
+                                entry(
+                                        "largeLiteralLengthThreshold",
+                                        intProp(
+                                                "String literal length considered oversized; values < 0 use default."))),
+                        List.of("filePaths")),
+                (exchange, request) -> withReadLock(() -> {
+                    var filePaths = stringListArg(request, "filePaths");
+                    return textResult(codeQualityTools.reportTestAssertionSmells(
+                            filePaths,
+                            intArg(request, "minScore", -1),
+                            intArg(request, "maxFindings", -1),
+                            intArg(request, "noAssertionWeight", -1),
+                            intArg(request, "tautologicalAssertionWeight", -1),
+                            intArg(request, "constantTruthWeight", -1),
+                            intArg(request, "constantEqualityWeight", -1),
+                            intArg(request, "nullnessOnlyWeight", -1),
+                            intArg(request, "shallowAssertionOnlyWeight", -1),
+                            intArg(request, "overspecifiedLiteralWeight", -1),
+                            intArg(request, "anonymousTestDoubleWeight", -1),
+                            intArg(request, "repeatedAnonymousTestDoubleWeight", -1),
+                            intArg(request, "meaningfulAssertionCredit", -1),
+                            intArg(request, "meaningfulAssertionCreditCap", -1),
+                            intArg(request, "largeLiteralLengthThreshold", -1)));
+                })));
+
         // NOTE: analyzeGitHotspots is not exposed here because GitHotspotAnalyzer
         // lives in the app module with dependencies not available in brokk-core.
 

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -629,6 +629,57 @@ public class BrokkCoreMcpServer {
                 })));
 
         specs.add(tool(
+                "reportLongMethodAndGodObjectSmells",
+                "Reports long methods/functions, god objects/modules, and helper sprawl in the given files. "
+                        + "Uses analyzer code-unit hierarchy and declaration ranges, then ranks bounded findings by "
+                        + "maintainability impact. Includes file path, symbol, line range, size/responsibility signals, "
+                        + "and concise rationale.",
+                schema(
+                        Map.ofEntries(
+                                entry("filePaths", arrayProp("File paths relative to the project root.")),
+                                entry("maxFindings", intProp("Maximum findings to return; values <= 0 default to 20.")),
+                                entry(
+                                        "maxFiles",
+                                        intProp("Maximum existing files to analyze; values <= 0 default to 25.")),
+                                entry(
+                                        "longMethodSpanLines",
+                                        intProp("Long method/function line threshold; values <= 0 use default.")),
+                                entry(
+                                        "highComplexityThreshold",
+                                        intProp("High cyclomatic complexity threshold; values <= 0 use default.")),
+                                entry(
+                                        "godObjectSpanLines",
+                                        intProp("God object/module line threshold; values <= 0 use default.")),
+                                entry(
+                                        "godObjectDirectChildren",
+                                        intProp("God object/module direct-child threshold; values <= 0 use default.")),
+                                entry(
+                                        "godObjectFunctions",
+                                        intProp(
+                                                "God object/module function-count threshold; values <= 0 use default.")),
+                                entry(
+                                        "helperSprawlFunctions",
+                                        intProp("Helper-sprawl function-count threshold; values <= 0 use default.")),
+                                entry(
+                                        "helperSprawlWorkflowLines",
+                                        intProp("Helper-sprawl workflow line threshold; values <= 0 use default."))),
+                        List.of("filePaths")),
+                (exchange, request) -> withReadLock(() -> {
+                    var filePaths = stringListArg(request, "filePaths");
+                    return textResult(codeQualityTools.reportLongMethodAndGodObjectSmells(
+                            filePaths,
+                            intArg(request, "maxFindings", 0),
+                            intArg(request, "maxFiles", 0),
+                            intArg(request, "longMethodSpanLines", 0),
+                            intArg(request, "highComplexityThreshold", 0),
+                            intArg(request, "godObjectSpanLines", 0),
+                            intArg(request, "godObjectDirectChildren", 0),
+                            intArg(request, "godObjectFunctions", 0),
+                            intArg(request, "helperSprawlFunctions", 0),
+                            intArg(request, "helperSprawlWorkflowLines", 0)));
+                })));
+
+        specs.add(tool(
                 "reportExceptionHandlingSmells",
                 "Detects suspicious exception handlers using weighted heuristics designed for high-recall triage. "
                         + "Scores generic catches and tiny/empty handlers, then subtracts credit for richer handling bodies. "

--- a/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
@@ -434,6 +434,96 @@ public class CodeQualityToolsMcp {
         return String.join("\n", lines);
     }
 
+    // -- reportTestAssertionSmells --
+
+    public String reportTestAssertionSmells(
+            List<String> filePaths,
+            int minScore,
+            int maxFindings,
+            int noAssertionWeight,
+            int tautologicalAssertionWeight,
+            int constantTruthWeight,
+            int constantEqualityWeight,
+            int nullnessOnlyWeight,
+            int shallowAssertionOnlyWeight,
+            int overspecifiedLiteralWeight,
+            int anonymousTestDoubleWeight,
+            int repeatedAnonymousTestDoubleWeight,
+            int meaningfulAssertionCredit,
+            int meaningfulAssertionCreditCap,
+            int largeLiteralLengthThreshold) {
+
+        int threshold = minScore > 0 ? minScore : 4;
+        int findingsCap = maxFindings > 0 ? maxFindings : 80;
+        var defaults = IAnalyzer.TestAssertionWeights.defaults();
+        var weights = new IAnalyzer.TestAssertionWeights(
+                pickWeight(noAssertionWeight, defaults.noAssertionWeight()),
+                pickWeight(tautologicalAssertionWeight, defaults.tautologicalAssertionWeight()),
+                pickWeight(constantTruthWeight, defaults.constantTruthWeight()),
+                pickWeight(constantEqualityWeight, defaults.constantEqualityWeight()),
+                pickWeight(nullnessOnlyWeight, defaults.nullnessOnlyWeight()),
+                pickWeight(shallowAssertionOnlyWeight, defaults.shallowAssertionOnlyWeight()),
+                pickWeight(overspecifiedLiteralWeight, defaults.overspecifiedLiteralWeight()),
+                pickWeight(anonymousTestDoubleWeight, defaults.anonymousTestDoubleWeight()),
+                pickWeight(repeatedAnonymousTestDoubleWeight, defaults.repeatedAnonymousTestDoubleWeight()),
+                pickWeight(meaningfulAssertionCredit, defaults.meaningfulAssertionCredit()),
+                pickWeight(meaningfulAssertionCreditCap, defaults.meaningfulAssertionCreditCap()),
+                pickWeight(largeLiteralLengthThreshold, defaults.largeLiteralLengthThreshold()));
+
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        var findings = new ArrayList<IAnalyzer.TestAssertionSmell>();
+        for (String path : filePaths) {
+            ProjectFile file = intelligence.toFile(path);
+            if (!file.exists() || !analyzer.containsTests(file)) {
+                continue;
+            }
+            findings.addAll(analyzer.findTestAssertionSmells(file, weights));
+        }
+
+        var filtered = findings.stream()
+                .filter(f -> f.score() >= threshold)
+                .sorted(Comparator.comparingInt(IAnalyzer.TestAssertionSmell::score)
+                        .reversed()
+                        .thenComparing(f -> f.file().toString())
+                        .thenComparing(IAnalyzer.TestAssertionSmell::enclosingFqName)
+                        .thenComparing(IAnalyzer.TestAssertionSmell::assertionKind))
+                .toList();
+
+        if (filtered.isEmpty()) {
+            return "No test assertion smells met minScore " + threshold + ".";
+        }
+        int shown = Math.min(findingsCap, filtered.size());
+        var lines = new ArrayList<String>();
+        lines.add("## Test assertion smells");
+        lines.add("");
+        lines.add("- Min score: %d".formatted(threshold));
+        lines.add("- Findings shown: %d of %d".formatted(shown, filtered.size()));
+        lines.add("- Weights: %s".formatted(formatTestAssertionWeights(weights)));
+        lines.add("");
+        lines.add("| Score | Kind | Assertions | Symbol | File | Reasons | Excerpt |");
+        lines.add("|------:|------|-----------:|--------|------|---------|---------|");
+        for (IAnalyzer.TestAssertionSmell finding : filtered.subList(0, shown)) {
+            String reasons = sanitizeTableCell(String.join(", ", finding.reasons()));
+            String kind = sanitizeTableCell(finding.assertionKind());
+            String symbol = sanitizeTableCell(finding.enclosingFqName());
+            String file = sanitizeTableCell(finding.file().toString());
+            lines.add("| %d | `%s` | %d | `%s` | `%s` | %s | `%s` |"
+                    .formatted(
+                            finding.score(),
+                            kind,
+                            finding.assertionCount(),
+                            symbol,
+                            file,
+                            "`" + reasons + "`",
+                            sanitizeTableCell(finding.excerpt())));
+        }
+        if (filtered.size() > shown) {
+            lines.add("");
+            lines.add("- Note: output truncated; increase maxFindings to see more.");
+        }
+        return String.join("\n", lines);
+    }
+
     // NOTE: analyzeGitHotspots is not available in brokk-core because GitHotspotAnalyzer
     // lives in the app module with dependencies (ai.brokk.concurrent.*) not available here.
     // It could be added if GitHotspotAnalyzer is moved to brokk-core or brokk-shared.
@@ -487,6 +577,27 @@ public class CodeQualityToolsMcp {
                                 w.helperSprawlFunctions(),
                                 w.helperSprawlWorkflowLines(),
                                 w.fileModuleLeewayMultiplier());
+    }
+
+    private static String formatTestAssertionWeights(IAnalyzer.TestAssertionWeights w) {
+        return "noAssertion=%d, tautological=%d, constantTruth=%d, constantEquality=%d, nullnessOnly=%d,"
+                        .formatted(
+                                w.noAssertionWeight(),
+                                w.tautologicalAssertionWeight(),
+                                w.constantTruthWeight(),
+                                w.constantEqualityWeight(),
+                                w.nullnessOnlyWeight())
+                + " shallowOnly=%d, overspecifiedLiteral=%d, anonymousTestDouble=%d, repeatedAnonymousTestDouble=%d,"
+                        .formatted(
+                                w.shallowAssertionOnlyWeight(),
+                                w.overspecifiedLiteralWeight(),
+                                w.anonymousTestDoubleWeight(),
+                                w.repeatedAnonymousTestDoubleWeight())
+                + " meaningfulCredit=%d, meaningfulCreditCap=%d, largeLiteralLength=%d"
+                        .formatted(
+                                w.meaningfulAssertionCredit(),
+                                w.meaningfulAssertionCreditCap(),
+                                w.largeLiteralLengthThreshold());
     }
 
     private static String formatExceptionWeights(IAnalyzer.ExceptionSmellWeights w) {

--- a/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
@@ -7,6 +7,7 @@ import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
@@ -191,6 +192,78 @@ public class CodeQualityToolsMcp {
             footer.add("- Note: narrow the path list or increase caps to see more.");
         }
         lines.addAll(footer);
+        return String.join("\n", lines);
+    }
+
+    // -- reportLongMethodAndGodObjectSmells --
+
+    public String reportLongMethodAndGodObjectSmells(
+            List<String> filePaths,
+            int maxFindings,
+            int maxFiles,
+            int longMethodSpanLines,
+            int highComplexityThreshold,
+            int godObjectSpanLines,
+            int godObjectDirectChildren,
+            int godObjectFunctions,
+            int helperSprawlFunctions,
+            int helperSprawlWorkflowLines) {
+
+        int cap = maxFindings > 0 ? maxFindings : 20;
+        int fileCap = maxFiles > 0 ? maxFiles : 25;
+        var defaults = IAnalyzer.MaintainabilitySizeSmellWeights.defaults();
+        var weights = new IAnalyzer.MaintainabilitySizeSmellWeights(
+                pickPositive(longMethodSpanLines, defaults.longMethodSpanLines()),
+                pickPositive(highComplexityThreshold, defaults.highComplexityThreshold()),
+                pickPositive(godObjectSpanLines, defaults.godObjectSpanLines()),
+                pickPositive(godObjectDirectChildren, defaults.godObjectDirectChildren()),
+                pickPositive(godObjectFunctions, defaults.godObjectFunctions()),
+                pickPositive(helperSprawlFunctions, defaults.helperSprawlFunctions()),
+                pickPositive(helperSprawlWorkflowLines, defaults.helperSprawlWorkflowLines()),
+                defaults.fileModuleLeewayMultiplier());
+
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        var files = filePaths.stream()
+                .map(intelligence::toFile)
+                .filter(ProjectFile::exists)
+                .limit(fileCap)
+                .toList();
+        var selectedFiles = new HashSet<>(files);
+        var findings = files.stream()
+                .flatMap(file -> analyzer.findLongMethodAndGodObjectSmells(file, weights).stream())
+                .filter(smell -> selectedFiles.contains(smell.codeUnit().source()))
+                .sorted(IAnalyzer.maintainabilitySizeSmellComparator())
+                .limit(cap)
+                .toList();
+
+        var lines = new ArrayList<String>();
+        lines.add("Long method and god object smells (max findings: " + cap + "):");
+        lines.add("- Files analyzed cap: " + fileCap);
+        lines.add("- Weights: " + formatSizeWeights(weights));
+        if (findings.isEmpty()) {
+            lines.add("");
+            lines.add("No long method or god object smells found.");
+            return String.join("\n", lines);
+        }
+        for (var smell : findings) {
+            CodeUnit cu = smell.codeUnit();
+            var range = smell.range();
+            int displayStartLine = range.startLine() + 1;
+            int displayEndLine = range.endLine() + 1;
+            lines.add("- `%s` in `%s:%d-%d` [score %d]"
+                    .formatted(cu.fqName(), cu.source(), displayStartLine, displayEndLine, smell.score()));
+            lines.add(
+                    "  - Signals: own %d lines, descendants %d lines, direct children %d, functions %d, nested types %d, max function %d lines, max CC %d"
+                            .formatted(
+                                    smell.ownSpanLines(),
+                                    smell.descendantSpanLines(),
+                                    smell.directChildCount(),
+                                    smell.functionCount(),
+                                    smell.nestedTypeCount(),
+                                    smell.maxFunctionSpanLines(),
+                                    smell.maxCyclomaticComplexity()));
+            lines.add("  - Rationale: " + String.join("; ", smell.reasons()));
+        }
         return String.join("\n", lines);
     }
 
@@ -393,8 +466,27 @@ public class CodeQualityToolsMcp {
         return candidate >= 0 ? candidate : fallback;
     }
 
+    private static int pickPositive(int candidate, int fallback) {
+        return candidate > 0 ? candidate : fallback;
+    }
+
     private static String sanitizeTableCell(String value) {
         return value.replace("|", "\\|");
+    }
+
+    private static String formatSizeWeights(IAnalyzer.MaintainabilitySizeSmellWeights w) {
+        return "longMethodLines=%d, highComplexity=%d, godObjectLines=%d, godObjectDirectChildren=%d,"
+                        .formatted(
+                                w.longMethodSpanLines(),
+                                w.highComplexityThreshold(),
+                                w.godObjectSpanLines(),
+                                w.godObjectDirectChildren())
+                + " godObjectFunctions=%d, helperSprawlFunctions=%d, helperSprawlWorkflowLines=%d, fileModuleLeeway=%dx"
+                        .formatted(
+                                w.godObjectFunctions(),
+                                w.helperSprawlFunctions(),
+                                w.helperSprawlWorkflowLines(),
+                                w.fileModuleLeewayMultiplier());
     }
 
     private static String formatExceptionWeights(IAnalyzer.ExceptionSmellWeights w) {

--- a/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
@@ -62,6 +62,38 @@ public class CodeQualityToolsMcp {
         return flagged;
     }
 
+    // -- computeCognitiveComplexity --
+
+    public String computeCognitiveComplexity(List<String> filePaths, int threshold) {
+        int limit = threshold > 0 ? threshold : 15;
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        var lines = new ArrayList<String>();
+        lines.add("Cognitive complexity (threshold: " + limit + "):");
+        boolean foundAny = false;
+
+        for (String path : filePaths) {
+            ProjectFile file = intelligence.toFile(path);
+            if (!file.exists()) continue;
+
+            var complexities = analyzer.computeCognitiveComplexities(file);
+            for (var entry : complexities.entrySet()) {
+                foundAny |= analyzeUnitCognitiveComplexity(entry.getKey(), entry.getValue(), limit, lines);
+            }
+        }
+
+        return foundAny
+                ? String.join("\n", lines)
+                : "No methods exceeded the cognitive complexity threshold of " + limit + ".";
+    }
+
+    private boolean analyzeUnitCognitiveComplexity(CodeUnit cu, int complexity, int threshold, List<String> lines) {
+        if (cu.isSynthetic() || complexity <= threshold) {
+            return false;
+        }
+        lines.add("- " + cu.fqName() + ": " + complexity);
+        return true;
+    }
+
     // -- reportCommentDensityForCodeUnit --
 
     public String reportCommentDensityForCodeUnit(String fqName, int maxLines) {

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -94,7 +94,8 @@ class BrokkCoreMcpServerTest {
                 "reportCommentDensityForFiles",
                 "reportLongMethodAndGodObjectSmells",
                 "reportExceptionHandlingSmells",
-                "reportStructuralCloneSmells");
+                "reportStructuralCloneSmells",
+                "reportTestAssertionSmells");
 
         for (var expected : expectedTools) {
             assertTrue(toolNames.contains(expected), "Missing tool: " + expected);
@@ -299,6 +300,14 @@ class BrokkCoreMcpServerTest {
     @Test
     void reportStructuralCloneSmellsRunsWithoutError() {
         var result = callTool("reportStructuralCloneSmells", Map.of("filePaths", List.of("README.md")));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportTestAssertionSmellsRunsWithoutError() {
+        var result = callTool("reportTestAssertionSmells", Map.of("filePaths", List.of("README.md")));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -92,6 +92,7 @@ class BrokkCoreMcpServerTest {
                 "computeCognitiveComplexity",
                 "reportCommentDensityForCodeUnit",
                 "reportCommentDensityForFiles",
+                "reportLongMethodAndGodObjectSmells",
                 "reportExceptionHandlingSmells",
                 "reportStructuralCloneSmells");
 
@@ -252,6 +253,14 @@ class BrokkCoreMcpServerTest {
     @Test
     void computeCognitiveComplexityRunsWithoutError() {
         var result = callTool("computeCognitiveComplexity", Map.of("filePaths", List.of("README.md"), "threshold", 15));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportLongMethodAndGodObjectSmellsRunsWithoutError() {
+        var result = callTool("reportLongMethodAndGodObjectSmells", Map.of("filePaths", List.of("README.md")));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -89,6 +89,7 @@ class BrokkCoreMcpServerTest {
                 "xmlSkim",
                 "xmlSelect",
                 "computeCyclomaticComplexity",
+                "computeCognitiveComplexity",
                 "reportCommentDensityForCodeUnit",
                 "reportCommentDensityForFiles",
                 "reportExceptionHandlingSmells",
@@ -243,6 +244,14 @@ class BrokkCoreMcpServerTest {
     void computeCyclomaticComplexityRunsWithoutError() {
         var result =
                 callTool("computeCyclomaticComplexity", Map.of("filePaths", List.of("README.md"), "threshold", 10));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void computeCognitiveComplexityRunsWithoutError() {
+        var result = callTool("computeCognitiveComplexity", Map.of("filePaths", List.of("README.md"), "threshold", 15));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());


### PR DESCRIPTION
## Summary

Wires three existing `CodeQualityTools` capabilities through the brokk-core MCP server. All three are pure tree-sitter static analysis with no LLM, no subprocess, no network — they fit the brokk-core MCP server's invariant of being read-only and deterministic. The implementations already exist in `app/src/main/java/ai/brokk/tools/CodeQualityTools.java`; this PR adds the MCP wrappers (using `ICodeIntelligence` instead of `IAppContextManager`) and the tool registrations.

Brings the brokk-core MCP server from 25 to 28 advertised tools.

| Tool | Issue | App-layer reference |
|------|-------|---------------------|
| `computeCognitiveComplexity` | #3601 | `CodeQualityTools.java:107-148` |
| `reportLongMethodAndGodObjectSmells` | #3602 | `CodeQualityTools.java:150-226` |
| `reportTestAssertionSmells` | #3604 | `CodeQualityTools.java:829-926` |

## What changed

### `brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java`
- Three new wrapper methods, one per tool. Each mirrors the app-layer algorithm but adapts to `ICodeIntelligence` and drops the `IConsoleIO.showNotification(...)` side-effect that has no equivalent in the MCP transport.
- Two new helper methods reusable by future weighted-heuristic tools: `pickPositive(int, int)` (for `> 0` defaults) and `formatSizeWeights(MaintainabilitySizeSmellWeights)`.
- One more formatter `formatTestAssertionWeights(TestAssertionWeights)` for the test-assertion smell output.
- New `HashSet` import for the selected-files set in the long-method/god-object tool.

### `brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java`
- Three new `specs.add(tool(...))` registrations in the existing "Code quality analysis tools" block.
- All handlers are wrapped in `withReadLock(...)` to preserve the read-only invariant.
- Schemas mirror the app-layer `@P` annotations verbatim so external consumers see identical parameter descriptions.

### `brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java`
- Three tool names added to the `expectedTools` set in `registersAllExpectedTools`.
- Three "runs without error" smoke tests, matching the convention already used for the other code-quality tools in this file. Deeper semantic tests are already covered in `app/src/test/java/ai/brokk/tools/CodeQualityToolsCognitiveComplexityTest.java`, `CodeQualityToolsLongMethodAndGodObjectTest.java`, and the per-language test fixtures under `brokk-shared/src/test/java/ai/brokk/analyzer/complexity/`.

### `brokk-core/README.md`
- New documentation sections for each tool with the full parameter table.
- Tool count bumped from 25 to 28.

## Why

These tools were already implemented and tested in the app module but only reachable through the LLM-bound headless executor. Exposing them via the brokk-core MCP server makes them available to consumers that need static-analysis tooling under a sandbox-friendly, credential-free, no-network MCP boundary — for example, agent runtimes that want to outsource scanning work to brokk's analyzer suite without granting LLM access.

## Verification

```bash
./gradlew :brokk-core:check
```

passes locally: spotless, errorprone/NullAway, compile, tests.

## Out of scope

This PR covers three of the seven brokk-core MCP gap issues opened today (#3601, #3602, #3604). The remaining four (#3603, #3605, #3606, #3607) ship in follow-up PRs because they require additional work:

- **#3605** (`reportSecretLikeCode`) — depends on `GitSecretScanner` which currently lives in `app/`; will need migration or duplication into brokk-core.
- **#3606** (`analyzeGitHotspots`) — depends on `GitHotspotAnalyzer` with the same module-location problem as the secret scanner.
- **#3607** (`getCommitDiff`) — a new deterministic tool, not a wrapper of existing app-layer code; lands in its own PR for clarity.
- **#3603** (`reportDeadCodeAndUnusedAbstractionSmells`) — the most complex of the set, depends on `UsageFinder` reachability in brokk-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
