### PR TITLE
brokk-acp-rust: respond before publishing available_commands_update (fix /codex-login in Zed)

### DIFF
--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "brokk-acp-rust"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["."]
 
 [package]
 name = "brokk-acp-rust"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Rust ACP server for Brokk with auto-discovery for Codex (~/.codex/auth.json) and Ollama"
 license = "LGPL-3.0"

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -476,9 +476,13 @@ pub async fn run_agent(
                     ))
                     .meta(meta_map);
 
+                // Respond first so the client registers the session ID before
+                // notifications referencing it; ACP uses a single FIFO outbound
+                // channel, so enqueue order is wire order. Notifying first made
+                // Zed drop AvailableCommandsUpdate as "unknown session".
+                let result = responder.respond(response);
                 send_available_commands_update(&cx, &session.id, &session.skills);
-
-                responder.respond(response)
+                result
             },
             on_receive_request!(),
         )
@@ -515,9 +519,7 @@ pub async fn run_agent(
                 }
 
                 let catalog = sessions_load.available_model_metadata().await;
-                send_available_commands_update(&cx, &session_id, &session.skills);
-
-                responder.respond(
+                let result = responder.respond(
                     LoadSessionResponse::new()
                         .modes(mode_state(session.mode.as_str()))
                         .config_options(all_config_options(
@@ -527,7 +529,9 @@ pub async fn run_agent(
                             &catalog,
                             session.selected_reasoning_effort.as_deref(),
                         )),
-                )
+                );
+                send_available_commands_update(&cx, &session_id, &session.skills);
+                result
             },
             on_receive_request!(),
         )
@@ -544,8 +548,7 @@ pub async fn run_agent(
                     Some(session) => {
                         sessions_resume.update_cwd(&session_id, cwd).await;
                         let catalog = sessions_resume.available_model_metadata().await;
-                        send_available_commands_update(&cx, &session_id, &session.skills);
-                        responder.respond(
+                        let result = responder.respond(
                             ResumeSessionResponse::new()
                                 .modes(mode_state(session.mode.as_str()))
                                 .config_options(all_config_options(
@@ -555,7 +558,9 @@ pub async fn run_agent(
                                     &catalog,
                                     session.selected_reasoning_effort.as_deref(),
                                 )),
-                        )
+                        );
+                        send_available_commands_update(&cx, &session_id, &session.skills);
+                        result
                     }
                     None => {
                         tracing::warn!("session/resume: unknown session {session_id}");


### PR DESCRIPTION
## Summary

- Fixes `/codex-login` (and the other built-in slash commands `/context`, `/idle-timeout`) showing "Available commands: none" in Zed against brokk-acp-rust 0.3.0.
- Inverts the order in `session/new`, `session/load`, and `session/resume` handlers: response goes on the wire before the `AvailableCommandsUpdate` notification.
- Bumps `brokk-acp-rust` 0.3.0 -> 0.3.1.

## Why

The `agent-client-protocol` 0.11.x crate uses a **single FIFO `mpsc::unbounded` channel** for outbound messages (confirmed by reading `jsonrpc.rs` lines 1189 / 1751 / 1924-1931). Enqueue order is wire order.

Brokk's `session/new` handler was enqueueing the `AvailableCommandsUpdate` notification BEFORE calling `responder.respond(...)`. That means:

1. Server creates session with new ID.
2. Server enqueues `session/update` (carrying `AvailableCommandsUpdate` with `codex-login` etc.) referencing that ID.
3. Server enqueues the `session/new` response that finally announces the ID to the client.
4. Wire order: notification first, response second.
5. Zed receives the notification, doesn't know that session ID yet (its session record is created when the response lands), and **drops the notification** with a warning visible in `~/Library/Logs/Zed/Zed.log`:

   ```
   [agent_servers::acp] Received session notification for unknown session: SessionId("fbd14ae2-...")
   ```

6. Client's slash-command palette is empty -> user types `/codex-login` -> "is not supported... Available commands: none".

This was latent for a while; pre-Skills the registry-free `send_available_commands_update` ran fast enough that the response often won the race, and/or Zed has hardened its unknown-session handling since then. Either way, the source-level ordering was always the latent bug.

## Fix

Invert the order in all three handlers:

```rust
let result = responder.respond(response);
send_available_commands_update(&cx, &session.id, &session.skills);
result
```

Comment at the `session/new` site documents the FIFO invariant for future readers (one comment is enough; the other two sites are straightforward symmetry).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bins` (234 passed; the only failure is `bifrost_client::tests::handshake_and_call_search_tools` which needs to download a fixture from `github.com` -- blocked by my local network sandbox, unrelated to this change)
- [ ] After release: install via `brokk install --rust`, start a new Zed session against Brokk Code (Rust), type `/codex-login` -> should now appear in autocomplete and execute.
- [ ] Tail `~/Library/Logs/Zed/Zed.log` during the new session and confirm no new `Received session notification for unknown session` warnings tied to that session_id.

Diff size: 3 files, 16 insertions, 11 deletions.

Generated with [Claude Code](https://claude.com/claude-code)
