### PR TITLE
Validate reasoning effort for models without presets

### DIFF
--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -377,23 +377,32 @@ async fn apply_config_option(
                 let catalog = sessions.available_model_metadata().await;
                 if let Some(model_id) = active_model
                     && let Some(meta) = catalog.iter().find(|m| m.id == model_id)
-                    && !meta.supported_reasoning_levels.is_empty()
-                    && !meta
+                {
+                    if meta.supported_reasoning_levels.is_empty() {
+                        return Err(ConfigApplyError::InvalidValue {
+                            reason: format!(
+                                "model '{model_id}' does not support configurable reasoning effort"
+                            ),
+                            supported: Vec::new(),
+                        });
+                    }
+                    if !meta
                         .supported_reasoning_levels
                         .iter()
                         .any(|p| &p.effort == eff)
-                {
-                    let supported: Vec<String> = meta
-                        .supported_reasoning_levels
-                        .iter()
-                        .map(|p| p.effort.clone())
-                        .collect();
-                    return Err(ConfigApplyError::InvalidValue {
-                        reason: format!(
-                            "reasoning effort '{eff}' is not supported by model '{model_id}'"
-                        ),
-                        supported,
-                    });
+                    {
+                        let supported: Vec<String> = meta
+                            .supported_reasoning_levels
+                            .iter()
+                            .map(|p| p.effort.clone())
+                            .collect();
+                        return Err(ConfigApplyError::InvalidValue {
+                            reason: format!(
+                                "reasoning effort '{eff}' is not supported by model '{model_id}'"
+                            ),
+                            supported,
+                        });
+                    }
                 }
             }
             if !sessions.set_reasoning_effort(session_id, effort).await {
@@ -2610,6 +2619,26 @@ mod tests {
             .await
             .expect("swap model");
         assert_eq!(outcome.cleared_reasoning.as_deref(), Some("high"));
+    }
+
+    #[tokio::test]
+    async fn apply_config_option_rejects_reasoning_effort_for_model_without_presets() {
+        let (store, id) = make_store_with_session("plain-model").await;
+        store
+            .set_available_models(vec![ModelMetadata::id_only("plain-model")])
+            .await;
+
+        let err = apply_config_option(&store, &id, REASONING_EFFORT_CONFIG_ID, "high")
+            .await
+            .expect_err("known model without presets cannot accept reasoning effort");
+
+        match err {
+            ConfigApplyError::InvalidValue { reason, supported } => {
+                assert!(reason.contains("plain-model"));
+                assert!(supported.is_empty());
+            }
+            other => panic!("expected InvalidValue, got {other:?}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #3609 that missed the squash-merge. Adds an explicit error when
`/configure reasoning_effort` is set on a model whose `supported_reasoning_levels`
is empty, instead of silently accepting any value.

- Splits the previous chained `&& && &&` condition in `apply_config_option` into
  two `if` branches so the empty-presets case can return a dedicated
  `ConfigApplyError::InvalidValue { reason: "model '<id>' does not support
  configurable reasoning effort", supported: [] }`.
- Keeps the existing error path for "preset list non-empty but effort not in it".
- Adds `apply_config_option_rejects_reasoning_effort_for_model_without_presets`
  in `brokk-acp-rust/src/agent.rs` covering the new branch with
  `ModelMetadata::id_only("plain-model")`.

## Why this is a separate PR

The commit was pushed to `codex/review-3609` three minutes before #3609 was
squash-merged. GitHub's squash captured the branch state from before the push,
so the change never landed on master.

## Test plan

- [x] `cargo fmt --check` in `brokk-acp-rust/`
- [x] `cargo clippy --all-targets -- -D warnings` in `brokk-acp-rust/`
- [x] `cargo test apply_config_option_rejects_reasoning_effort_for_model_without_presets` passes
- [x] `cargo test -- --skip bifrost_client` — 245 passed, 0 failed
  (the skipped `bifrost_client::tests::handshake_and_call_search_tools` needs
  network access to download a release fixture, blocked by the local sandbox;
  CI will exercise it)
