### PR TITLE
brokk-acp-rust: add /openrouter-login for runtime credentials

### DIFF
--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -439,6 +439,10 @@ fn builtin_commands() -> Vec<AvailableCommand> {
             "Sign in with ChatGPT (or `status` / `disconnect`)",
         ),
         AvailableCommand::new(
+            "openrouter-login",
+            "Save an OpenRouter API key (or `status` / `disconnect`)",
+        ),
+        AvailableCommand::new(
             "idle-timeout",
             "Show or set the LLM SSE idle timeout for this session (e.g. `/idle-timeout 600`)",
         ),
@@ -454,9 +458,15 @@ fn builtin_commands() -> Vec<AvailableCommand> {
 /// filtered skills entirely" guidance: don't expose a slash that won't
 /// actually dispatch to the skill).
 fn builtin_command_names() -> std::collections::HashSet<&'static str> {
-    ["context", "codex-login", "idle-timeout", "configure"]
-        .into_iter()
-        .collect()
+    [
+        "context",
+        "codex-login",
+        "openrouter-login",
+        "idle-timeout",
+        "configure",
+    ]
+    .into_iter()
+    .collect()
 }
 
 /// Build the full command list advertised to the client: built-ins plus
@@ -854,6 +864,18 @@ pub async fn run_agent(
 
                 if is_slash_command(&prompt_text, "codex-login") {
                     let report = handle_codex_login(
+                        &prompt_text,
+                        &llm_login,
+                        &sessions_login,
+                        &refresh_lock_login,
+                    )
+                    .await;
+                    send_message(&cx, &session_id, &report);
+                    return responder.respond(PromptResponse::new(StopReason::EndTurn));
+                }
+
+                if is_slash_command(&prompt_text, "openrouter-login") {
+                    let report = handle_openrouter_login(
                         &prompt_text,
                         &llm_login,
                         &sessions_login,
@@ -1646,6 +1668,160 @@ async fn handle_codex_login(
     }
 }
 
+/// Handle the `/openrouter-login` slash command and its subcommands.
+/// Subcommands: bare = help text (no OAuth flow), `<key>` = save key and
+/// install backend, `status` = report what's stored and where it came
+/// from, `disconnect` = wipe the local credentials.
+///
+/// Unlike Codex, OpenRouter has no browser flow -- the user pastes a
+/// static `sk-or-...` key inline. That key lands in the session
+/// transcript, so the help text and the success message both warn the
+/// user to rotate the key if the transcript is shared. The
+/// `OPENROUTER_API_KEY` env var still takes precedence when set; this
+/// matches `build_openrouter_backend`'s startup precedence and keeps
+/// `status` honest about which source is actually in use.
+async fn handle_openrouter_login(
+    prompt_text: &str,
+    llm: &Arc<MultiBackend>,
+    sessions: &SessionStore,
+    refresh_lock: &Arc<tokio::sync::Mutex<()>>,
+) -> String {
+    // Take the entire argument tail (everything after the command), not
+    // just the first whitespace-delimited token: OpenRouter keys are
+    // ASCII with no spaces in practice, but we trim defensively so a
+    // user who pasted with trailing spaces doesn't see a "key was empty"
+    // bounce. `status` and `disconnect` are case-insensitive to match
+    // the `/codex-login` ergonomics.
+    let after_cmd = prompt_text
+        .trim()
+        .strip_prefix('/')
+        .unwrap_or("")
+        .split_once(char::is_whitespace)
+        .map(|(_, tail)| tail)
+        .unwrap_or("")
+        .trim();
+
+    let lowered = after_cmd.to_ascii_lowercase();
+    match lowered.as_str() {
+        "" => format!(
+            "Usage: `/openrouter-login <key>` | `/openrouter-login status` | \
+             `/openrouter-login disconnect`. Get a key at \
+             https://openrouter.ai/keys. Note: the key appears in this session's \
+             transcript, so rotate it at openrouter.ai if you share the log. \
+             Credentials are persisted to {}.",
+            crate::openrouter_auth::auth_path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "the OS config directory".to_string())
+        ),
+        "status" => {
+            let env_key = std::env::var(crate::discovery::OPENROUTER_API_KEY_ENV)
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            let file_key = match crate::openrouter_auth::read() {
+                Ok(Some(auth)) => Some(auth.api_key.trim().to_string()).filter(|s| !s.is_empty()),
+                Ok(None) => None,
+                Err(e) => {
+                    return format!("Failed to read OpenRouter credential file: {e:#}");
+                }
+            };
+            let active_source = match (&env_key, &file_key) {
+                (Some(_), _) => "env (OPENROUTER_API_KEY takes precedence)",
+                (None, Some(_)) => "file",
+                (None, None) => "none",
+            };
+            let active_len = env_key
+                .as_deref()
+                .or(file_key.as_deref())
+                .map(str::len)
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "n/a".to_string());
+            let path = crate::openrouter_auth::auth_path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "<unresolved>".to_string());
+            format!(
+                "OpenRouter login status:\n  active_source: {active_source}\n  \
+                 active_key_length: {active_len}\n  base_url: {}\n  \
+                 credential_file: {path}\n  file_present: {}\n  env_set: {}",
+                crate::discovery::OPENROUTER_BASE_URL,
+                file_key.is_some(),
+                env_key.is_some(),
+            )
+        }
+        "disconnect" => match crate::openrouter_auth::logout() {
+            Ok(()) => {
+                llm.uninstall_openrouter();
+                spawn_throttled_refresh(refresh_lock.clone(), llm.clone(), sessions.clone());
+                let env_still_set = std::env::var(crate::discovery::OPENROUTER_API_KEY_ENV)
+                    .ok()
+                    .map(|s| !s.trim().is_empty())
+                    .unwrap_or(false);
+                if env_still_set {
+                    "OpenRouter credentials file removed and the in-memory backend was unloaded. \
+                     OPENROUTER_API_KEY is still set in this server's environment, so the \
+                     backend will be rebuilt from the env var on the next server restart -- \
+                     unset the env var if you want OpenRouter fully disabled."
+                        .to_string()
+                } else {
+                    "OpenRouter credentials cleared and the in-memory backend was unloaded; \
+                     the picker will only show models from other configured backends until \
+                     you re-run `/openrouter-login <key>`."
+                        .to_string()
+                }
+            }
+            Err(e) => format!("Failed to remove OpenRouter credential file: {e:#}"),
+        },
+        _ => {
+            // Anything else is treated as a candidate API key. Reject
+            // obvious junk (whitespace-only after trim is handled above;
+            // empty is the "" arm); accept everything else and let the
+            // first request 401 if the key is malformed. We don't gate
+            // on the `sk-or-` prefix because OpenRouter has historically
+            // issued keys with other shapes and we'd rather not hardcode
+            // a check that ages out.
+            let key = after_cmd.to_string();
+            match crate::openrouter_auth::write(&crate::openrouter_auth::OpenRouterAuth {
+                api_key: key.clone(),
+            }) {
+                Ok(()) => match crate::openrouter_backend_from_key(&key) {
+                    Some(backend) => {
+                        llm.install_openrouter(backend);
+                        spawn_throttled_refresh(
+                            refresh_lock.clone(),
+                            llm.clone(),
+                            sessions.clone(),
+                        );
+                        let path = crate::openrouter_auth::auth_path()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_else(|_| "<unresolved>".to_string());
+                        format!(
+                            "OpenRouter login complete (key length: {}). \
+                             Credentials saved to {} (chmod 0600). The picker will \
+                             show `openrouter::*` models after the next discovery \
+                             refresh; create a new session or wait briefly. \
+                             Reminder: the key was sent inline and is recorded in \
+                             this session's transcript -- rotate it at \
+                             https://openrouter.ai/keys if the transcript is shared.",
+                            key.len(),
+                            path,
+                        )
+                    }
+                    None => {
+                        // Defensive: write() rejects empty input upstream
+                        // via the "" arm, so reaching None here means the
+                        // key became empty after trim somewhere -- still
+                        // surface a clear error rather than installing a
+                        // broken backend.
+                        let _ = crate::openrouter_auth::logout();
+                        "OpenRouter login failed: provided key was empty after trimming".to_string()
+                    }
+                },
+                Err(e) => format!("OpenRouter login failed: could not save key: {e:#}"),
+            }
+        }
+    }
+}
+
 /// Pure parser for `/idle-timeout` arguments. Returns either a successful
 /// action to apply, or a user-facing error string. Factored out from
 /// `handle_idle_timeout` so it can be unit-tested without standing up a
@@ -2430,6 +2606,7 @@ mod tests {
             vec![
                 "context",
                 "codex-login",
+                "openrouter-login",
                 "idle-timeout",
                 "configure",
                 "apple",

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -432,25 +432,38 @@ async fn apply_config_option(
 /// shows up in editor autocomplete (Zed, JetBrains ACP) -- without this
 /// the slash command works when typed but is invisible to discovery.
 fn builtin_commands() -> Vec<AvailableCommand> {
-    vec![
+    let mut commands = vec![
         AvailableCommand::new("context", "Show current session context snapshot"),
         AvailableCommand::new(
             "codex-login",
             "Sign in with ChatGPT (or `status` / `disconnect`)",
         ),
-        AvailableCommand::new(
+    ];
+    // `/openrouter-login` is advertised only when the env var does not
+    // own the credential lifecycle. When `OPENROUTER_API_KEY` is set
+    // in the process environment, the key cannot be mutated from a
+    // session (the server reads env once at startup and a `disconnect`
+    // can't undo that), so showing the slash would be misleading. The
+    // slash is still kept in `builtin_command_names()` unconditionally
+    // so a skill can't claim the name -- typing it manually dispatches
+    // to the handler, which then explains why the command is disabled.
+    // `/configure` exposes the credential status either way so users
+    // can still see where the active key comes from.
+    if !crate::openrouter_auth::CredentialState::snapshot().env_owns() {
+        commands.push(AvailableCommand::new(
             "openrouter-login",
             "Save an OpenRouter API key (or `status` / `disconnect`)",
-        ),
-        AvailableCommand::new(
-            "idle-timeout",
-            "Show or set the LLM SSE idle timeout for this session (e.g. `/idle-timeout 600`)",
-        ),
-        AvailableCommand::new(
-            "configure",
-            "Show or change session settings (e.g. `/configure model_selection gpt-5`)",
-        ),
-    ]
+        ));
+    }
+    commands.push(AvailableCommand::new(
+        "idle-timeout",
+        "Show or set the LLM SSE idle timeout for this session (e.g. `/idle-timeout 600`)",
+    ));
+    commands.push(AvailableCommand::new(
+        "configure",
+        "Show or change session settings (e.g. `/configure model_selection gpt-5`)",
+    ));
+    commands
 }
 
 /// Set of built-in slash command names, used to detect collisions with
@@ -1668,6 +1681,20 @@ async fn handle_codex_login(
     }
 }
 
+/// User-facing explanation returned when `OPENROUTER_API_KEY` is set
+/// in the process environment. Single source of truth for the message
+/// so the slash handler, future status surfaces, and any test stay in
+/// agreement on the wording (and on the pointer to `/configure` for
+/// the actual state dump).
+fn openrouter_env_owned_explanation() -> String {
+    "OpenRouter credentials are owned by the OPENROUTER_API_KEY environment \
+     variable, so /openrouter-login is disabled. The server reads \
+     OPENROUTER_API_KEY once at startup; unset it (and restart the server) if \
+     you want to manage credentials via /openrouter-login. Run /configure to \
+     see the current credential state (env_set / file_present / active_source)."
+        .to_string()
+}
+
 /// Handle the `/openrouter-login` slash command and its subcommands.
 /// Subcommands: bare = help text (no OAuth flow), `<key>` = save key and
 /// install backend, `status` = report what's stored and where it came
@@ -1676,16 +1703,25 @@ async fn handle_codex_login(
 /// Unlike Codex, OpenRouter has no browser flow -- the user pastes a
 /// static `sk-or-...` key inline. That key lands in the session
 /// transcript, so the help text and the success message both warn the
-/// user to rotate the key if the transcript is shared. The
-/// `OPENROUTER_API_KEY` env var still takes precedence when set; this
-/// matches `build_openrouter_backend`'s startup precedence and keeps
-/// `status` honest about which source is actually in use.
+/// user to rotate the key if the transcript is shared.
+///
+/// **Credential-ownership contract**: when `OPENROUTER_API_KEY` is set
+/// in the process environment, the env owns the credential lifecycle
+/// and this handler short-circuits with an explanation for every
+/// subcommand. The slash is hidden from autocomplete in that mode too
+/// (see `builtin_commands`), but the handler still runs when typed
+/// manually so users can't get "command not found" with no hint.
+/// Diagnostic state (env_set, file_present, active_source) stays
+/// available via `/configure` regardless of which mode is active.
 async fn handle_openrouter_login(
     prompt_text: &str,
     llm: &Arc<MultiBackend>,
     sessions: &SessionStore,
     refresh_lock: &Arc<tokio::sync::Mutex<()>>,
 ) -> String {
+    if crate::openrouter_auth::CredentialState::snapshot().env_owns() {
+        return openrouter_env_owned_explanation();
+    }
     // Take the entire argument tail (everything after the command), not
     // just the first whitespace-delimited token: OpenRouter keys are
     // ASCII with no spaces in practice, but we trim defensively so a
@@ -1714,10 +1750,13 @@ async fn handle_openrouter_login(
                 .unwrap_or_else(|_| "the OS config directory".to_string())
         ),
         "status" => {
-            let env_key = std::env::var(crate::discovery::OPENROUTER_API_KEY_ENV)
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty());
+            // env_owns short-circuits the whole handler at the top, so
+            // we only reach this arm when the env var is unset. The
+            // snapshot's env_set is therefore always false here -- we
+            // include it in the output anyway for self-contained
+            // diagnostics so users don't have to cross-reference
+            // /configure to confirm the env is clear.
+            let state = crate::openrouter_auth::CredentialState::snapshot();
             let file_key = match crate::openrouter_auth::read() {
                 Ok(Some(auth)) => Some(auth.api_key.trim().to_string()).filter(|s| !s.is_empty()),
                 Ok(None) => None,
@@ -1725,14 +1764,8 @@ async fn handle_openrouter_login(
                     return format!("Failed to read OpenRouter credential file: {e:#}");
                 }
             };
-            let active_source = match (&env_key, &file_key) {
-                (Some(_), _) => "env (OPENROUTER_API_KEY takes precedence)",
-                (None, Some(_)) => "file",
-                (None, None) => "none",
-            };
-            let active_len = env_key
+            let active_len = file_key
                 .as_deref()
-                .or(file_key.as_deref())
                 .map(str::len)
                 .map(|n| n.to_string())
                 .unwrap_or_else(|| "n/a".to_string());
@@ -1740,34 +1773,23 @@ async fn handle_openrouter_login(
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|_| "<unresolved>".to_string());
             format!(
-                "OpenRouter login status:\n  active_source: {active_source}\n  \
+                "OpenRouter login status:\n  active_source: {}\n  \
                  active_key_length: {active_len}\n  base_url: {}\n  \
                  credential_file: {path}\n  file_present: {}\n  env_set: {}",
+                state.active_source(),
                 crate::discovery::OPENROUTER_BASE_URL,
-                file_key.is_some(),
-                env_key.is_some(),
+                state.file_present,
+                state.env_set,
             )
         }
         "disconnect" => match crate::openrouter_auth::logout() {
             Ok(()) => {
                 llm.uninstall_openrouter();
                 spawn_throttled_refresh(refresh_lock.clone(), llm.clone(), sessions.clone());
-                let env_still_set = std::env::var(crate::discovery::OPENROUTER_API_KEY_ENV)
-                    .ok()
-                    .map(|s| !s.trim().is_empty())
-                    .unwrap_or(false);
-                if env_still_set {
-                    "OpenRouter credentials file removed and the in-memory backend was unloaded. \
-                     OPENROUTER_API_KEY is still set in this server's environment, so the \
-                     backend will be rebuilt from the env var on the next server restart -- \
-                     unset the env var if you want OpenRouter fully disabled."
-                        .to_string()
-                } else {
-                    "OpenRouter credentials cleared and the in-memory backend was unloaded; \
-                     the picker will only show models from other configured backends until \
-                     you re-run `/openrouter-login <key>`."
-                        .to_string()
-                }
+                "OpenRouter credentials cleared and the in-memory backend was unloaded; \
+                 the picker will only show models from other configured backends until \
+                 you re-run `/openrouter-login <key>`."
+                    .to_string()
             }
             Err(e) => format!("Failed to remove OpenRouter credential file: {e:#}"),
         },
@@ -1990,11 +2012,22 @@ async fn handle_configure(
 /// Render the `/configure` dump of all four session knobs as a single
 /// readable block. Mirrors `all_config_options` field-for-field so the
 /// text view never drifts from the structured view.
+///
+/// The OpenRouter credential block at the bottom is **read-only** -- it
+/// reports where the active key comes from (env / file / none) and
+/// whether `/openrouter-login` is available, so users can see the
+/// credential state even when the env owns the lifecycle and the slash
+/// is hidden from autocomplete. Setting credentials is intentionally
+/// not routed through `/configure`: a global secret has a different
+/// lifecycle than per-session knobs, and the dedicated
+/// `/openrouter-login` keeps that distinction sharp.
 fn render_configure_dump(session: &Session) -> String {
     let effort = session
         .selected_reasoning_effort
         .clone()
         .unwrap_or_else(|| REASONING_EFFORT_DEFAULT_VALUE.to_string());
+    let or_state = crate::openrouter_auth::CredentialState::snapshot();
+    let login_available = !or_state.env_owns();
     format!(
         "**Configuration**\n\n\
          - `{BEHAVIOR_CONFIG_ID}`: `{behavior}`\n\
@@ -2002,11 +2035,28 @@ fn render_configure_dump(session: &Session) -> String {
          - `{MODEL_CONFIG_ID}`: `{model}`\n\
          - `{REASONING_EFFORT_CONFIG_ID}`: `{effort}`\n\n\
          Set a value with `/configure <key> <value>`. \
-         Supported keys: {keys}.",
+         Supported keys: {keys}.\n\n\
+         **OpenRouter credentials** (read-only)\n\n\
+         - `active_source`: `{active_source}`\n\
+         - `env_set`: `{env_set}`\n\
+         - `file_present`: `{file_present}`\n\
+         - `login_command_available`: `{login_available}`\n\n\
+         {login_hint}",
         behavior = session.mode.as_str(),
         permission = session.permission_mode.as_str(),
         model = session.model,
         keys = CONFIGURE_KNOWN_KEYS.join(", "),
+        active_source = or_state.active_source(),
+        env_set = or_state.env_set,
+        file_present = or_state.file_present,
+        login_available = login_available,
+        login_hint = if login_available {
+            "Manage the key with `/openrouter-login <key>` | `status` | `disconnect`."
+        } else {
+            "`/openrouter-login` is disabled because `OPENROUTER_API_KEY` owns \
+             the credential lifecycle. Unset the env var and restart the server \
+             to manage the key from a session."
+        },
     )
 }
 
@@ -2596,6 +2646,13 @@ mod tests {
 
     #[test]
     fn available_commands_merges_builtins_and_skills() {
+        use crate::openrouter_auth::test_support::{ENV_GUARD, EnvScope};
+        // The expected ordering includes /openrouter-login, which is
+        // gated on OPENROUTER_API_KEY being unset; without this guard
+        // the test would fail on dev machines that happen to have the
+        // env var exported.
+        let _lock = ENV_GUARD.blocking_lock();
+        let _env = EnvScope::remove("OPENROUTER_API_KEY");
         let registry = make_registry(vec![("zebra", "Z skill"), ("apple", "A skill")]);
         let cmds = available_commands(&registry);
         let names: Vec<&str> = cmds.iter().map(|c| c.name.as_str()).collect();
@@ -2631,6 +2688,192 @@ mod tests {
         assert_eq!(names.iter().filter(|n| **n == "context").count(), 1);
         // Non-colliding skill still appears.
         assert!(names.contains(&"ok-skill"));
+    }
+
+    /// When `OPENROUTER_API_KEY` is set, the env owns the credential
+    /// lifecycle and `/openrouter-login` must not appear in
+    /// autocomplete -- it would be misleading because the server can't
+    /// swap the env-sourced backend at runtime. The slash is still
+    /// reserved in `builtin_command_names()` so a skill can't capture
+    /// it; typing it manually still dispatches to the handler, which
+    /// short-circuits with an explanation.
+    #[test]
+    fn available_commands_omits_openrouter_login_when_env_set() {
+        use crate::openrouter_auth::test_support::{ENV_GUARD, EnvScope};
+        let _lock = ENV_GUARD.blocking_lock();
+        let _env = EnvScope::set("OPENROUTER_API_KEY", "sk-or-from-env");
+
+        let registry = make_registry(vec![]);
+        let cmds = available_commands(&registry);
+        let names: Vec<&str> = cmds.iter().map(|c| c.name.as_str()).collect();
+
+        assert!(
+            !names.contains(&"openrouter-login"),
+            "openrouter-login must be hidden when env owns credentials; got {names:?}"
+        );
+        // The other built-ins are unaffected.
+        assert!(names.contains(&"context"));
+        assert!(names.contains(&"codex-login"));
+        assert!(names.contains(&"idle-timeout"));
+        assert!(names.contains(&"configure"));
+    }
+
+    /// Sanity check the inverse: with the env unset, the slash IS
+    /// advertised. Pairs with the env-set test so a future refactor
+    /// can't accidentally hide the command unconditionally.
+    #[test]
+    fn available_commands_includes_openrouter_login_when_env_unset() {
+        use crate::openrouter_auth::test_support::{ENV_GUARD, EnvScope};
+        let _lock = ENV_GUARD.blocking_lock();
+        let _env = EnvScope::remove("OPENROUTER_API_KEY");
+
+        let registry = make_registry(vec![]);
+        let cmds = available_commands(&registry);
+        let names: Vec<&str> = cmds.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            names.contains(&"openrouter-login"),
+            "openrouter-login must be advertised when env is unset; got {names:?}"
+        );
+    }
+
+    /// The `/configure` dump surfaces OpenRouter credential state as a
+    /// read-only block so it stays discoverable even when
+    /// `/openrouter-login` is hidden. Env-owned case: env_set=true,
+    /// login_command_available=false, hint mentions the env var.
+    #[tokio::test]
+    async fn render_configure_dump_reports_env_owned_credentials() {
+        use crate::openrouter_auth::test_support::{ENV_GUARD, EnvScope};
+        let _lock = ENV_GUARD.lock().await;
+        let tmp_cfg = tempfile::tempdir().unwrap();
+        let _brokk = EnvScope::set("BROKK_CONFIG_HOME", tmp_cfg.path());
+        let _env = EnvScope::set("OPENROUTER_API_KEY", "sk-or-from-env");
+
+        let (store, id) = make_store_with_session("m").await;
+        let session = store
+            .get_session(&id, &std::env::temp_dir())
+            .await
+            .expect("session present");
+        let dump = render_configure_dump(&session);
+
+        assert!(
+            dump.contains("`active_source`: `env`"),
+            "dump must report env as active source; got:\n{dump}"
+        );
+        assert!(dump.contains("`env_set`: `true`"), "dump:\n{dump}");
+        assert!(dump.contains("`file_present`: `false`"), "dump:\n{dump}");
+        assert!(
+            dump.contains("`login_command_available`: `false`"),
+            "dump:\n{dump}"
+        );
+        assert!(
+            dump.contains("OPENROUTER_API_KEY"),
+            "hint must point at the env var when env owns: {dump}"
+        );
+    }
+
+    /// File-owned case: env unset, file has a key. active_source=file,
+    /// login_command_available=true, hint points at `/openrouter-login`.
+    #[tokio::test]
+    async fn render_configure_dump_reports_file_owned_credentials() {
+        use crate::openrouter_auth::test_support::{ENV_GUARD, EnvScope};
+        let _lock = ENV_GUARD.lock().await;
+        let tmp_cfg = tempfile::tempdir().unwrap();
+        let _brokk = EnvScope::set("BROKK_CONFIG_HOME", tmp_cfg.path());
+        let _env = EnvScope::remove("OPENROUTER_API_KEY");
+        crate::openrouter_auth::write(&crate::openrouter_auth::OpenRouterAuth {
+            api_key: "sk-or-on-disk".to_string(),
+        })
+        .unwrap();
+
+        let (store, id) = make_store_with_session("m").await;
+        let session = store
+            .get_session(&id, &std::env::temp_dir())
+            .await
+            .expect("session present");
+        let dump = render_configure_dump(&session);
+
+        assert!(
+            dump.contains("`active_source`: `file`"),
+            "dump must report file as active source; got:\n{dump}"
+        );
+        assert!(dump.contains("`env_set`: `false`"), "dump:\n{dump}");
+        assert!(dump.contains("`file_present`: `true`"), "dump:\n{dump}");
+        assert!(
+            dump.contains("`login_command_available`: `true`"),
+            "dump:\n{dump}"
+        );
+        assert!(
+            dump.contains("/openrouter-login"),
+            "hint must mention the slash when login is available: {dump}"
+        );
+    }
+
+    /// No credentials at all: dump still renders, reports
+    /// active_source=none, login is still available (so the user knows
+    /// they CAN add a key via the slash).
+    #[tokio::test]
+    async fn render_configure_dump_reports_no_credentials() {
+        use crate::openrouter_auth::test_support::{ENV_GUARD, EnvScope};
+        let _lock = ENV_GUARD.lock().await;
+        let tmp_cfg = tempfile::tempdir().unwrap();
+        let _brokk = EnvScope::set("BROKK_CONFIG_HOME", tmp_cfg.path());
+        let _env = EnvScope::remove("OPENROUTER_API_KEY");
+
+        let (store, id) = make_store_with_session("m").await;
+        let session = store
+            .get_session(&id, &std::env::temp_dir())
+            .await
+            .expect("session present");
+        let dump = render_configure_dump(&session);
+
+        assert!(dump.contains("`active_source`: `none`"), "dump:\n{dump}");
+        assert!(dump.contains("`env_set`: `false`"), "dump:\n{dump}");
+        assert!(dump.contains("`file_present`: `false`"), "dump:\n{dump}");
+        // Login is still possible, just no key registered yet.
+        assert!(
+            dump.contains("`login_command_available`: `true`"),
+            "dump:\n{dump}"
+        );
+    }
+
+    /// The handler short-circuits with the env-owned explanation for
+    /// every subcommand when `OPENROUTER_API_KEY` is set. We assert the
+    /// bare and `<key>` paths -- they're the ones that would mutate
+    /// state if the early-return ever regressed. Status/disconnect are
+    /// covered transitively by the same short-circuit.
+    #[tokio::test]
+    async fn handle_openrouter_login_short_circuits_when_env_owns() {
+        use crate::openrouter_auth::test_support::{ENV_GUARD, EnvScope};
+        let _lock = ENV_GUARD.lock().await;
+        let tmp_cfg = tempfile::tempdir().unwrap();
+        let _brokk = EnvScope::set("BROKK_CONFIG_HOME", tmp_cfg.path());
+        let _env = EnvScope::set("OPENROUTER_API_KEY", "sk-or-from-env");
+
+        let store = SessionStore::new("m".into());
+        let llm = std::sync::Arc::new(crate::multi_backend::MultiBackend::new(None, None, None));
+        let refresh = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+
+        let bare = handle_openrouter_login("/openrouter-login", &llm, &store, &refresh).await;
+        let with_key =
+            handle_openrouter_login("/openrouter-login sk-or-rotated", &llm, &store, &refresh)
+                .await;
+
+        for (label, msg) in [("bare", bare), ("with key", with_key)] {
+            assert!(
+                msg.contains("OPENROUTER_API_KEY"),
+                "{label} response must explain env ownership: {msg}"
+            );
+            assert!(
+                msg.contains("/configure"),
+                "{label} response must point at /configure for diagnostics: {msg}"
+            );
+        }
+        // And critically: no file was written despite the candidate key.
+        let path = crate::openrouter_auth::auth_path().unwrap();
+        assert!(
+            !path.exists(),
+            "env-owned mode must not persist a key on disk; file at {path:?} should not exist"
+        );
     }
 
     #[test]

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -13,6 +13,7 @@ mod codex_client;
 mod discovery;
 mod llm_client;
 mod multi_backend;
+mod openrouter_auth;
 mod session;
 mod skills;
 mod tool_loop;
@@ -204,25 +205,20 @@ fn build_ollama_backend() -> Arc<dyn LlmBackend> {
     Arc::new(llm_client::OpenAiClient::new(chat_url, None))
 }
 
-/// Build the OpenRouter chat backend if `OPENROUTER_API_KEY` is set.
-/// OpenRouter speaks the OpenAI Chat Completions wire format verbatim,
-/// so we reuse `OpenAiClient` with the OpenRouter base URL and attach
-/// the optional `HTTP-Referer` / `X-Title` attribution headers (these
-/// drive the openrouter.ai leaderboard rankings; both are documented as
-/// optional but we always set them so the app shows up consistently).
+/// Build an OpenRouter chat backend from a raw API key. OpenRouter speaks
+/// the OpenAI Chat Completions wire format verbatim, so we reuse
+/// `OpenAiClient` with the OpenRouter base URL and attach the optional
+/// `HTTP-Referer` / `X-Title` attribution headers (these drive the
+/// openrouter.ai leaderboard rankings; both are documented as optional
+/// but we always set them so the app shows up consistently).
 ///
-/// Auth posture mirrors Codex: zero-config -- if the env var is absent
-/// the backend is skipped silently, no CLI flag, no warning. Whitespace
-/// is trimmed so accidental shell quoting (`export OPENROUTER_API_KEY=" sk-..."`)
-/// doesn't 401 every request.
-fn build_openrouter_backend() -> Option<Arc<dyn LlmBackend>> {
-    let raw = std::env::var(discovery::OPENROUTER_API_KEY_ENV).ok()?;
+/// Whitespace is trimmed so accidental shell quoting
+/// (`export OPENROUTER_API_KEY=" sk-..."`) doesn't 401 every request.
+/// Returns `None` for an empty key so callers can distinguish "not
+/// configured" from "configured but broken".
+pub fn openrouter_backend_from_key(raw: &str) -> Option<Arc<dyn LlmBackend>> {
     let key = raw.trim();
     if key.is_empty() {
-        tracing::info!(
-            "{} is set but empty; OpenRouter backend skipped",
-            discovery::OPENROUTER_API_KEY_ENV
-        );
         return None;
     }
 
@@ -240,16 +236,68 @@ fn build_openrouter_backend() -> Option<Arc<dyn LlmBackend>> {
         reqwest::header::HeaderValue::from_static("brokk-acp-rust"),
     );
 
-    tracing::info!(
-        "OpenRouter backend wired at {} (chat + discovery); key length={}",
-        discovery::OPENROUTER_BASE_URL,
-        key.len()
-    );
     Some(Arc::new(llm_client::OpenAiClient::with_default_headers(
         discovery::OPENROUTER_BASE_URL.to_string(),
         Some(key.to_string()),
         headers,
     )))
+}
+
+/// Build the OpenRouter chat backend from the first available credential
+/// source. Auth posture mirrors Codex: zero-config -- if neither the env
+/// var nor the on-disk file holds a usable key the backend is skipped
+/// silently, no CLI flag required.
+///
+/// Precedence is env > file: an explicit `OPENROUTER_API_KEY=...` in the
+/// shell that launched the server overrides a stale on-disk key, so a
+/// user rotating their key in a shell session doesn't have to remember
+/// to `/openrouter-login` first. The on-disk file (written by
+/// `/openrouter-login <key>` mid-session) is the persistent fallback for
+/// the common case of starting the server without env vars.
+fn build_openrouter_backend() -> Option<Arc<dyn LlmBackend>> {
+    if let Ok(raw) = std::env::var(discovery::OPENROUTER_API_KEY_ENV) {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            tracing::info!(
+                "{} is set but empty; falling back to {}",
+                discovery::OPENROUTER_API_KEY_ENV,
+                openrouter_auth::auth_path()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|_| "on-disk credential file".to_string())
+            );
+        } else {
+            tracing::info!(
+                "OpenRouter backend wired from {} at {} (chat + discovery); key length={}",
+                discovery::OPENROUTER_API_KEY_ENV,
+                discovery::OPENROUTER_BASE_URL,
+                trimmed.len()
+            );
+            return openrouter_backend_from_key(trimmed);
+        }
+    }
+
+    match openrouter_auth::read() {
+        Ok(Some(auth)) => {
+            let trimmed = auth.api_key.trim();
+            if trimmed.is_empty() {
+                tracing::info!(
+                    "OpenRouter credential file exists but contains an empty key; backend skipped"
+                );
+                return None;
+            }
+            tracing::info!(
+                "OpenRouter backend wired from on-disk credentials at {} (chat + discovery); key length={}",
+                discovery::OPENROUTER_BASE_URL,
+                trimmed.len()
+            );
+            openrouter_backend_from_key(trimmed)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!("failed to read OpenRouter credential file: {e:#}");
+            None
+        }
+    }
 }
 
 #[tokio::main]
@@ -299,7 +347,8 @@ async fn main() -> Result<()> {
     }
     if openrouter_backend.is_none() {
         tracing::info!(
-            "OpenRouter backend not available; set {} to enable it.",
+            "OpenRouter backend not available; set {} or run `/openrouter-login <key>` \
+             from a session to enable it.",
             discovery::OPENROUTER_API_KEY_ENV
         );
     }

--- a/brokk-acp-rust/src/multi_backend.rs
+++ b/brokk-acp-rust/src/multi_backend.rs
@@ -34,19 +34,18 @@ use crate::llm_client::{ChatMessage, LlmBackend, LlmResponse, ModelMetadata, Too
 /// Ollama on the default port); calls for a source whose backend isn't
 /// configured return a clear error rather than silently falling through.
 ///
-/// The Codex slot is held behind a `RwLock` so a successful
-/// `/codex-login` mid-session can install a backend without a server
-/// restart. The lock is only ever held for the duration of a synchronous
-/// `Option<Arc<...>>` clone -- we never hold it across an `.await`.
+/// The Codex and OpenRouter slots are held behind `RwLock`s so a
+/// successful `/codex-login` or `/openrouter-login` mid-session can
+/// install a backend without a server restart. The lock is only ever
+/// held for the duration of a synchronous `Option<Arc<...>>` clone --
+/// we never hold it across an `.await`.
 ///
-/// OpenRouter is held as a plain `Option<Arc<...>>` (no lock): there's no
-/// runtime install flow for it today -- the API key is read once at
-/// startup from the env var, and we never need to mutate the slot after
-/// construction. Adding a lock later if a `/openrouter-login` slash
-/// command lands would be mechanical.
+/// Ollama stays a plain `Option<Arc<...>>`: there's no login flow for
+/// it (the daemon either listens on the default port or it doesn't),
+/// so the slot is set once at construction and never mutated.
 pub struct MultiBackend {
     codex: RwLock<Option<Arc<dyn LlmBackend>>>,
-    openrouter: Option<Arc<dyn LlmBackend>>,
+    openrouter: RwLock<Option<Arc<dyn LlmBackend>>>,
     ollama: Option<Arc<dyn LlmBackend>>,
 }
 
@@ -58,7 +57,7 @@ impl MultiBackend {
     ) -> Self {
         Self {
             codex: RwLock::new(codex),
-            openrouter,
+            openrouter: RwLock::new(openrouter),
             ollama,
         }
     }
@@ -92,6 +91,22 @@ impl MultiBackend {
         *self.codex.write().unwrap() = None;
     }
 
+    /// Install (or replace) the OpenRouter backend at runtime. Called
+    /// from `/openrouter-login <key>` so a session that started without
+    /// `OPENROUTER_API_KEY` or an on-disk credential file picks up the
+    /// new key on the next discovery refresh.
+    pub fn install_openrouter(&self, backend: Arc<dyn LlmBackend>) {
+        *self.openrouter.write().unwrap() = Some(backend);
+    }
+
+    /// Drop the currently-installed OpenRouter backend, if any. Called
+    /// from `/openrouter-login disconnect` after the on-disk credential
+    /// file is wiped so a subsequent `openrouter::*` request fails with
+    /// "backend not configured" instead of firing 401-bound requests.
+    pub fn uninstall_openrouter(&self) {
+        *self.openrouter.write().unwrap() = None;
+    }
+
     /// Snapshot the current Codex backend, if any. Cloning the inner Arc
     /// lets callers release the read lock immediately; they can then
     /// `.await` the backend without holding a guard.
@@ -99,10 +114,16 @@ impl MultiBackend {
         self.codex.read().unwrap().clone()
     }
 
+    /// Snapshot the current OpenRouter backend, if any. Same shape as
+    /// `codex_snapshot` -- callers release the read lock before awaiting.
+    fn openrouter_snapshot(&self) -> Option<Arc<dyn LlmBackend>> {
+        self.openrouter.read().unwrap().clone()
+    }
+
     fn pick(&self, source: ModelSource) -> Option<Arc<dyn LlmBackend>> {
         match source {
             ModelSource::Codex => self.codex_snapshot(),
-            ModelSource::OpenRouter => self.openrouter.clone(),
+            ModelSource::OpenRouter => self.openrouter_snapshot(),
             ModelSource::Ollama => self.ollama.clone(),
         }
     }
@@ -121,7 +142,8 @@ impl MultiBackend {
         if codex_present {
             return Some(ModelSource::Codex);
         }
-        if self.openrouter.is_some() {
+        let openrouter_present = self.openrouter.read().unwrap().is_some();
+        if openrouter_present {
             return Some(ModelSource::OpenRouter);
         }
         if self.ollama.is_some() {
@@ -197,7 +219,7 @@ impl LlmBackend for MultiBackend {
             // the backend isn't configured (no `OPENROUTER_API_KEY`),
             // the closure returns an empty list and `discover_all`
             // logs/skips it like any other absent source.
-            let openrouter_backend = self.openrouter.clone();
+            let openrouter_backend = self.openrouter_snapshot();
             let openrouter_lookup = move || async move {
                 match openrouter_backend {
                     Some(or) => or.list_models().await,

--- a/brokk-acp-rust/src/openrouter_auth.rs
+++ b/brokk-acp-rust/src/openrouter_auth.rs
@@ -1,0 +1,183 @@
+//! On-disk credential store for OpenRouter.
+//!
+//! Unlike Codex, OpenRouter has no OAuth flow -- the user pastes a static
+//! `sk-or-...` key once and we reuse it forever (until they rotate or
+//! disconnect). Persistence is opt-in: users who export
+//! `OPENROUTER_API_KEY` in their shell get the existing zero-config
+//! behaviour, and this file is only created when `/openrouter-login
+//! <key>` is invoked from a session.
+//!
+//! Storage location follows OS conventions via `dirs::config_dir()`:
+//! `~/.config/brokk/openrouter.json` on Linux (or `$XDG_CONFIG_HOME`),
+//! `~/Library/Application Support/brokk/openrouter.json` on macOS,
+//! `%APPDATA%\brokk\openrouter.json` on Windows. The file is written
+//! atomically (stage `.tmp` then rename) and chmod'd to 0600 on Unix so
+//! other local users can't read the key.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+
+/// Flat one-field record. OpenRouter keys are static (no refresh, no
+/// expiry, no auth_mode) so there's nothing more to persist.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenRouterAuth {
+    pub api_key: String,
+}
+
+/// Resolve `<config>/brokk/openrouter.json`. Honours `$BROKK_CONFIG_HOME`
+/// if set so tests (and power users) can redirect the credential file
+/// without touching the real one.
+pub fn auth_path() -> Result<PathBuf> {
+    if let Ok(custom) = std::env::var("BROKK_CONFIG_HOME") {
+        return Ok(PathBuf::from(custom).join("openrouter.json"));
+    }
+    let base = dirs::config_dir().ok_or_else(|| {
+        anyhow!("could not resolve OS config directory for OpenRouter credentials")
+    })?;
+    Ok(base.join("brokk").join("openrouter.json"))
+}
+
+pub fn read() -> Result<Option<OpenRouterAuth>> {
+    let path = auth_path()?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+    let parsed = serde_json::from_slice::<OpenRouterAuth>(&bytes)
+        .with_context(|| format!("parsing {}", path.display()))?;
+    Ok(Some(parsed))
+}
+
+/// Atomic write: stage to `openrouter.json.tmp` in the same directory,
+/// chmod to 0600, then rename. Mirrors `codex_auth::write_auth_dot_json`
+/// so a crash mid-write never leaves a half-written credential file.
+pub fn write(auth: &OpenRouterAuth) -> Result<()> {
+    let path = auth_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(auth).context("serializing OpenRouterAuth")?;
+    std::fs::write(&tmp, &bytes).with_context(|| format!("writing {}", tmp.display()))?;
+    set_user_only_perms(&tmp)?;
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Best-effort logout: delete the stored credentials. Missing file is
+/// not an error -- `/openrouter-login disconnect` is idempotent.
+pub fn logout() -> Result<()> {
+    let path = auth_path()?;
+    if path.exists() {
+        std::fs::remove_file(&path).with_context(|| format!("removing {}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_user_only_perms(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 600 {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_user_only_perms(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // BROKK_CONFIG_HOME is process-global; serialise tests that mutate it
+    // so they don't race when cargo schedules them on different threads.
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    struct EnvScope {
+        prev: Option<String>,
+    }
+
+    impl EnvScope {
+        fn new(path: &Path) -> Self {
+            let prev = std::env::var("BROKK_CONFIG_HOME").ok();
+            // SAFETY: tests are serialised on ENV_GUARD; no other thread
+            // is reading or writing this env var concurrently.
+            unsafe {
+                std::env::set_var("BROKK_CONFIG_HOME", path);
+            }
+            Self { prev }
+        }
+    }
+
+    impl Drop for EnvScope {
+        fn drop(&mut self) {
+            // SAFETY: see EnvScope::new.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("BROKK_CONFIG_HOME", v),
+                    None => std::env::remove_var("BROKK_CONFIG_HOME"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_writes_then_reads_same_key() {
+        let _lock = ENV_GUARD.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _scope = EnvScope::new(tmp.path());
+
+        assert!(read().unwrap().is_none(), "no key before write");
+        write(&OpenRouterAuth {
+            api_key: "sk-or-test-key".to_string(),
+        })
+        .unwrap();
+        let got = read().unwrap().expect("key present after write");
+        assert_eq!(got.api_key, "sk-or-test-key");
+    }
+
+    #[test]
+    fn logout_removes_file_and_is_idempotent() {
+        let _lock = ENV_GUARD.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _scope = EnvScope::new(tmp.path());
+
+        write(&OpenRouterAuth {
+            api_key: "sk-or-test".to_string(),
+        })
+        .unwrap();
+        assert!(auth_path().unwrap().exists());
+        logout().unwrap();
+        assert!(!auth_path().unwrap().exists());
+        // second call must not error
+        logout().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_sets_user_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = ENV_GUARD.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _scope = EnvScope::new(tmp.path());
+
+        write(&OpenRouterAuth {
+            api_key: "sk-or-test".to_string(),
+        })
+        .unwrap();
+        let perms = std::fs::metadata(auth_path().unwrap())
+            .unwrap()
+            .permissions();
+        assert_eq!(
+            perms.mode() & 0o777,
+            0o600,
+            "credential file must be readable only by the owner"
+        );
+    }
+}

--- a/brokk-acp-rust/src/openrouter_auth.rs
+++ b/brokk-acp-rust/src/openrouter_auth.rs
@@ -19,11 +19,71 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 
+use crate::discovery::OPENROUTER_API_KEY_ENV;
+
 /// Flat one-field record. OpenRouter keys are static (no refresh, no
 /// expiry, no auth_mode) so there's nothing more to persist.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenRouterAuth {
     pub api_key: String,
+}
+
+/// Snapshot of where OpenRouter credentials currently come from.
+/// Single source of truth for the "env owns" contract: whenever
+/// `OPENROUTER_API_KEY` is non-empty the environment owns the
+/// credential lifecycle, `/openrouter-login` is hidden from
+/// autocomplete, and the slash command returns an explanation rather
+/// than mutating state.
+///
+/// Both reads (`env_set`, `file_present`) treat any failure as
+/// "absent" so callers can render a consistent UI even when the file
+/// is malformed or the env var is unset -- diagnostic output should
+/// never panic, and a broken on-disk file is functionally equivalent
+/// to no file at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CredentialState {
+    pub env_set: bool,
+    pub file_present: bool,
+}
+
+impl CredentialState {
+    /// Read the current env+file state. Cheap: a single env lookup and
+    /// (when needed) a small disk read; safe to call from
+    /// `available_commands_update` paths and per-request handlers.
+    pub fn snapshot() -> Self {
+        let env_set = std::env::var(OPENROUTER_API_KEY_ENV)
+            .ok()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        let file_present = match read() {
+            Ok(Some(auth)) => !auth.api_key.trim().is_empty(),
+            _ => false,
+        };
+        Self {
+            env_set,
+            file_present,
+        }
+    }
+
+    /// Where the active credential, if any, is being read from.
+    /// Mirrors the precedence in `build_openrouter_backend`: env wins
+    /// over file, file wins over nothing.
+    pub fn active_source(&self) -> &'static str {
+        if self.env_set {
+            "env"
+        } else if self.file_present {
+            "file"
+        } else {
+            "none"
+        }
+    }
+
+    /// True when the environment owns the credential lifecycle.
+    /// Callers should hide `/openrouter-login` from autocomplete and
+    /// have the handler explain rather than mutate state.
+    pub fn env_owns(&self) -> bool {
+        self.env_set
+    }
 }
 
 /// Resolve `<config>/brokk/openrouter.json`. Honours `$BROKK_CONFIG_HOME`
@@ -90,48 +150,81 @@ fn set_user_only_perms(_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Test-only helpers shared with sibling modules so any test that
+/// mutates `OPENROUTER_API_KEY` or `BROKK_CONFIG_HOME` serialises on a
+/// single process-wide mutex. Env mutation in multi-threaded Rust is
+/// `unsafe` (POSIX `getenv` is not atomic), so one guard for all
+/// env-touching tests is the minimum-friction safe pattern.
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Mutex;
+pub(crate) mod test_support {
+    use std::ffi::OsStr;
+    use tokio::sync::Mutex;
 
-    // BROKK_CONFIG_HOME is process-global; serialise tests that mutate it
-    // so they don't race when cargo schedules them on different threads.
-    static ENV_GUARD: Mutex<()> = Mutex::new(());
+    /// Acquire this before mutating any env var read by either
+    /// `openrouter_auth` or any caller of `CredentialState::snapshot`.
+    /// Holding it during the whole test (until `EnvScope` drops) keeps
+    /// concurrent tests from observing partial state.
+    ///
+    /// Uses `tokio::sync::Mutex` instead of `std::sync::Mutex` so the
+    /// guard can be held across `.await` points in `#[tokio::test]`
+    /// cases without tripping `clippy::await_holding_lock`. Sync
+    /// `#[test]` cases acquire it via `blocking_lock()`; async cases
+    /// use `.lock().await`. The mutex is constructed via `const_new`
+    /// so it fits in a plain `static`.
+    pub(crate) static ENV_GUARD: Mutex<()> = Mutex::const_new(());
 
-    struct EnvScope {
+    /// RAII guard that sets (or removes) an env var on construction and
+    /// restores the previous value on drop. Pair with a held lock on
+    /// `ENV_GUARD` for cross-test safety.
+    pub(crate) struct EnvScope {
+        var: &'static str,
         prev: Option<String>,
     }
 
     impl EnvScope {
-        fn new(path: &Path) -> Self {
-            let prev = std::env::var("BROKK_CONFIG_HOME").ok();
-            // SAFETY: tests are serialised on ENV_GUARD; no other thread
-            // is reading or writing this env var concurrently.
+        pub(crate) fn set(var: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let prev = std::env::var(var).ok();
+            // SAFETY: callers hold `ENV_GUARD` so no concurrent thread
+            // is reading or writing this process's env table.
             unsafe {
-                std::env::set_var("BROKK_CONFIG_HOME", path);
+                std::env::set_var(var, value);
             }
-            Self { prev }
+            Self { var, prev }
+        }
+
+        pub(crate) fn remove(var: &'static str) -> Self {
+            let prev = std::env::var(var).ok();
+            // SAFETY: see `set`.
+            unsafe {
+                std::env::remove_var(var);
+            }
+            Self { var, prev }
         }
     }
 
     impl Drop for EnvScope {
         fn drop(&mut self) {
-            // SAFETY: see EnvScope::new.
+            // SAFETY: see `EnvScope::set`.
             unsafe {
                 match &self.prev {
-                    Some(v) => std::env::set_var("BROKK_CONFIG_HOME", v),
-                    None => std::env::remove_var("BROKK_CONFIG_HOME"),
+                    Some(v) => std::env::set_var(self.var, v),
+                    None => std::env::remove_var(self.var),
                 }
             }
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openrouter_auth::test_support::{ENV_GUARD, EnvScope};
 
     #[test]
     fn round_trip_writes_then_reads_same_key() {
-        let _lock = ENV_GUARD.lock().unwrap();
+        let _lock = ENV_GUARD.blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        let _scope = EnvScope::new(tmp.path());
+        let _scope = EnvScope::set("BROKK_CONFIG_HOME", tmp.path());
 
         assert!(read().unwrap().is_none(), "no key before write");
         write(&OpenRouterAuth {
@@ -144,9 +237,9 @@ mod tests {
 
     #[test]
     fn logout_removes_file_and_is_idempotent() {
-        let _lock = ENV_GUARD.lock().unwrap();
+        let _lock = ENV_GUARD.blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        let _scope = EnvScope::new(tmp.path());
+        let _scope = EnvScope::set("BROKK_CONFIG_HOME", tmp.path());
 
         write(&OpenRouterAuth {
             api_key: "sk-or-test".to_string(),
@@ -163,9 +256,9 @@ mod tests {
     #[test]
     fn write_sets_user_only_permissions() {
         use std::os::unix::fs::PermissionsExt;
-        let _lock = ENV_GUARD.lock().unwrap();
+        let _lock = ENV_GUARD.blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
-        let _scope = EnvScope::new(tmp.path());
+        let _scope = EnvScope::set("BROKK_CONFIG_HOME", tmp.path());
 
         write(&OpenRouterAuth {
             api_key: "sk-or-test".to_string(),
@@ -179,5 +272,66 @@ mod tests {
             0o600,
             "credential file must be readable only by the owner"
         );
+    }
+
+    #[test]
+    fn credential_state_reports_env_when_env_set() {
+        let _lock = ENV_GUARD.blocking_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _brokk = EnvScope::set("BROKK_CONFIG_HOME", tmp.path());
+        let _env = EnvScope::set("OPENROUTER_API_KEY", "sk-or-from-env");
+
+        let state = CredentialState::snapshot();
+        assert!(state.env_set);
+        assert!(!state.file_present);
+        assert!(state.env_owns());
+        assert_eq!(state.active_source(), "env");
+    }
+
+    #[test]
+    fn credential_state_reports_file_when_only_file_set() {
+        let _lock = ENV_GUARD.blocking_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _brokk = EnvScope::set("BROKK_CONFIG_HOME", tmp.path());
+        let _env = EnvScope::remove("OPENROUTER_API_KEY");
+        write(&OpenRouterAuth {
+            api_key: "sk-or-from-file".to_string(),
+        })
+        .unwrap();
+
+        let state = CredentialState::snapshot();
+        assert!(!state.env_set);
+        assert!(state.file_present);
+        assert!(!state.env_owns());
+        assert_eq!(state.active_source(), "file");
+    }
+
+    #[test]
+    fn credential_state_reports_none_when_nothing_set() {
+        let _lock = ENV_GUARD.blocking_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _brokk = EnvScope::set("BROKK_CONFIG_HOME", tmp.path());
+        let _env = EnvScope::remove("OPENROUTER_API_KEY");
+
+        let state = CredentialState::snapshot();
+        assert!(!state.env_set);
+        assert!(!state.file_present);
+        assert!(!state.env_owns());
+        assert_eq!(state.active_source(), "none");
+    }
+
+    #[test]
+    fn credential_state_treats_blank_env_as_unset() {
+        let _lock = ENV_GUARD.blocking_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _brokk = EnvScope::set("BROKK_CONFIG_HOME", tmp.path());
+        let _env = EnvScope::set("OPENROUTER_API_KEY", "   ");
+
+        let state = CredentialState::snapshot();
+        // Trim-empty env var must NOT take ownership: matches the
+        // startup parser in `build_openrouter_backend`, which falls
+        // through to the file when the env is whitespace-only.
+        assert!(!state.env_set);
+        assert!(!state.env_owns());
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `/openrouter-login` slash command to `brokk-acp-rust` so users can register an OpenRouter API key from inside a session, without restarting the ACP server. Also establishes an explicit credential-owner contract: when `OPENROUTER_API_KEY` is set in the process environment, the env owns the credential lifecycle and the slash command is hidden from autocomplete -- but `/configure` always surfaces the current credential state so users can see where the active key comes from.

Mirrors the existing `/codex-login` surface for muscle-memory parity.

## Credential-owner contract

Single source of truth: `openrouter_auth::CredentialState::snapshot()` reads env + file together so every consumer agrees on precedence.

| Env (`OPENROUTER_API_KEY`) | File (`<config>/brokk/openrouter.json`) | `active_source` | `/openrouter-login` advertised? | Slash behaviour when typed manually |
|---|---|---|---|---|
| set, non-empty           | any   | `env`  | no  | every subcommand short-circuits with an explanation pointing at `/configure` |
| unset (or blank-trimmed) | set   | `file` | yes | `bare`/`status`/`disconnect`/`<key>` as usual |
| unset                    | unset | `none` | yes | help text invites the user to add a key |

`/configure` always emits a read-only OpenRouter block (active_source, env_set, file_present, login_command_available) so the state stays discoverable even when the slash is hidden.

## Surface

- `/openrouter-login` -- prints help (no OAuth flow, key required as arg).
- `/openrouter-login <key>` -- saves the key and installs the backend.
- `/openrouter-login status` -- reports source (`env` / `file` / `none`), key length, base URL, and whether the file is present.
- `/openrouter-login disconnect` -- wipes the credential file and uninstalls the in-memory backend.
- `/configure` -- existing four session knobs, plus a new **OpenRouter credentials** (read-only) block.

## Why

The doc comment at `multi_backend.rs:42-46` already anticipated this: *"Adding a lock later if a `/openrouter-login` slash command lands would be mechanical."* Now it has landed.

The recent `/configure` command (#3609) covers session knobs (mode, permission, model, reasoning_effort) but deliberately leaves credentials out of that surface -- a global secret has a different lifecycle than per-session settings. So `/openrouter-login` lives as a peer slash command, not a `/configure` key. `/configure` only **displays** OpenRouter credential state; it does not allow setting it.

## Implementation notes

- **Persistence:** new `openrouter_auth` module owns `<OS config dir>/brokk/openrouter.json`. Atomic write (stage `.tmp`, chmod 0600 on Unix, rename) -- the same pattern as `codex_auth::write_auth_dot_json`. Storage location uses `dirs::config_dir()`, so it lands at `~/.config/brokk/...` on Linux, `~/Library/Application Support/brokk/...` on macOS, `%APPDATA%\brokk\...` on Windows.
- **Precedence:** env > file. If `OPENROUTER_API_KEY` is set in the shell that launched the server, it wins over any on-disk key. The status output and `/configure` dump both report this explicitly so a user who rotated their key via env doesn't get confused by stale file contents.
- **Live swap:** `MultiBackend::openrouter` moves from `Option<Arc<dyn LlmBackend>>` to `RwLock<Option<Arc<dyn LlmBackend>>>`. New helpers `install_openrouter` / `uninstall_openrouter` / `openrouter_snapshot` mirror the existing Codex trio. The lock is only ever held for synchronous `Option<Arc>` clones -- never across an `.await`.
- **No OAuth:** unlike `/codex-login`, OpenRouter has no browser flow. The user pastes a static `sk-or-...` key inline. The success message and help text both warn that the key lands in the session transcript and suggest rotating at `https://openrouter.ai/keys` if shared.
- **`build_openrouter_backend` refactor:** the header-construction logic was extracted into `openrouter_backend_from_key(&str)` (now `pub`) so the startup path and the runtime install path can't drift. Startup tries env first, falls back to the on-disk file.
- **Single source of truth:** `CredentialState::snapshot()` is the only place env + file are read together. `builtin_commands`, `handle_openrouter_login` (status arm), and `render_configure_dump` all consume it. A blank-trimmed env var counts as unset, matching the startup parser.
- **Test serialisation:** `openrouter_auth::test_support` exports `ENV_GUARD` (a `tokio::sync::Mutex<()>`) and a parameterised `EnvScope` RAII guard. Async tests use `.lock().await`, sync tests use `.blocking_lock()`. This keeps the guard Send across await points (avoids `clippy::await_holding_lock`) and lets cross-module env-mutating tests share one process-wide critical section.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` -- 257 tests pass; one pre-existing failure (`bifrost_client::tests::handshake_and_call_search_tools`) is a network-blocked GitHub-release download, unrelated to this change.
- [x] New unit tests covering the contract:
  - `openrouter_auth::tests::round_trip_writes_then_reads_same_key`
  - `openrouter_auth::tests::logout_removes_file_and_is_idempotent`
  - `openrouter_auth::tests::write_sets_user_only_permissions` (`#[cfg(unix)]`)
  - `openrouter_auth::tests::credential_state_reports_env_when_env_set`
  - `openrouter_auth::tests::credential_state_reports_file_when_only_file_set`
  - `openrouter_auth::tests::credential_state_reports_none_when_nothing_set`
  - `openrouter_auth::tests::credential_state_treats_blank_env_as_unset`
  - `agent::tests::available_commands_omits_openrouter_login_when_env_set`
  - `agent::tests::available_commands_includes_openrouter_login_when_env_unset`
  - `agent::tests::render_configure_dump_reports_env_owned_credentials`
  - `agent::tests::render_configure_dump_reports_file_owned_credentials`
  - `agent::tests::render_configure_dump_reports_no_credentials`
  - `agent::tests::handle_openrouter_login_short_circuits_when_env_owns`
- [x] Updated `available_commands_merges_builtins_and_skills` to guard `OPENROUTER_API_KEY` and include `openrouter-login` in the expected ordering.

Manual end-to-end verification (reviewers welcome to repeat):

1. Launch the server with `OPENROUTER_API_KEY` unset. Startup log should read `OpenRouter backend not available; set OPENROUTER_API_KEY or run /openrouter-login <key> from a session to enable it.`
2. From an ACP client (Zed / JetBrains): `/openrouter-login sk-or-v1-...real-key...`. Expect the success message; the credential file exists at the platform-appropriate path with mode `-rw-------` and content `{"api_key": "..."}`.
3. After a `session/new` (or the auto-spawned discovery refresh), the model picker lists `openrouter::*` entries.
4. `/configure` (no args) -- dump reports `active_source: file`, `env_set: false`, `file_present: true`, `login_command_available: true`.
5. `/openrouter-login disconnect` -- file removed, subsequent `openrouter::*` request returns "backend not configured".
6. Set `OPENROUTER_API_KEY=...` in the shell and restart. Expected:
   - Autocomplete: `/openrouter-login` is **absent** from the list (`/configure` still listed).
   - `/configure` dump: `active_source: env`, `env_set: true`, `login_command_available: false`, hint mentions unsetting the env var.
   - Manually typing `/openrouter-login` (any subcommand): handler returns the explanation pointing at `/configure`; no file is written or backend swapped.

## Out of scope

- No UI side changes (Java executor / Settings panel) -- this is purely the Rust ACP server.
- No revocation: `disconnect` deletes the local file only, it does not hit OpenRouter's API to invalidate the key. Rotation via the OpenRouter dashboard is the recommended path if a key was exposed in a transcript.
