### PR TITLE
Add headless debug log path override

### DIFF
--- a/app/src/main/java/ai/brokk/Service.java
+++ b/app/src/main/java/ai/brokk/Service.java
@@ -1,8 +1,8 @@
 package ai.brokk;
 
-import ai.brokk.project.AbstractProject;
 import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
+import ai.brokk.util.DebugLogPath;
 import ai.brokk.util.Environment;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -618,8 +618,7 @@ public class Service extends AbstractService implements ExceptionReporter.Report
                 .addFormDataPart("environment", environment);
 
         if (includeDebugLog) {
-            var debugLogPath =
-                    Path.of(System.getProperty("user.home"), AbstractProject.BROKK_DIR, AbstractProject.DEBUG_LOG_FILE);
+            var debugLogPath = DebugLogPath.currentPath();
             var debugFile = debugLogPath.toFile();
             if (debugFile.exists()) {
                 try {

--- a/app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java
+++ b/app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java
@@ -28,6 +28,7 @@ import ai.brokk.executor.routers.SessionsRouter;
 import ai.brokk.executor.routers.SettingsRouter;
 import ai.brokk.executor.routers.StaticAnalysisRouter;
 import ai.brokk.project.MainProject;
+import ai.brokk.util.DebugLogPath;
 import com.google.common.base.Splitter;
 import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
@@ -50,8 +51,6 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 public final class HeadlessExecutorMain {
-    private static final Logger logger = LogManager.getLogger(HeadlessExecutorMain.class);
-
     // Valid argument keys that the application accepts
     private static final Set<String> VALID_ARGS = Set.of(
             "exec-id",
@@ -61,8 +60,17 @@ public final class HeadlessExecutorMain {
             "brokk-api-key",
             "proxy-setting",
             "vendor",
+            DebugLogPath.ARG,
             "exit-on-stdin-eof",
             "help");
+
+    private static Logger logger() {
+        return LoggerHolder.LOGGER;
+    }
+
+    private static final class LoggerHolder {
+        private static final Logger LOGGER = LogManager.getLogger(HeadlessExecutorMain.class);
+    }
 
     private final UUID execId;
     private final SimpleHttpServer server;
@@ -137,13 +145,14 @@ public final class HeadlessExecutorMain {
         System.out.println("  --proxy-setting <setting>  LLM proxy: BROKK, LOCALHOST, STAGING (optional)");
         System.out.println(
                 "  --vendor <vendor>          Other-models vendor: Default, Anthropic, Gemini, OpenAI, OpenAI - Codex (optional)");
+        System.out.println("  --debug-log-path <path>    Debug log file path (optional; env BROKK_DEBUG_LOG_PATH)");
         System.out.println(
                 "  --exit-on-stdin-eof[=bool] Exit when stdin closes/errors (default: false; env EXIT_ON_STDIN_EOF)");
         System.out.println("  --help                     Show this help message");
         System.out.println();
         System.out.println("Arguments can also be provided via environment variables:");
         System.out.println(
-                "  EXEC_ID, LISTEN_ADDR, AUTH_TOKEN, WORKSPACE_DIR, BROKK_API_KEY, PROXY_SETTING, EXIT_ON_STDIN_EOF");
+                "  EXEC_ID, LISTEN_ADDR, AUTH_TOKEN, WORKSPACE_DIR, BROKK_API_KEY, PROXY_SETTING, BROKK_DEBUG_LOG_PATH, EXIT_ON_STDIN_EOF");
         System.out.println();
 
         System.exit(invalidArgs.isEmpty() ? 0 : 1);
@@ -174,12 +183,12 @@ public final class HeadlessExecutorMain {
         var workspaceDir = contextManager.getProject().getRoot();
         var sessionsDir = contextManager.getProject().getSessionManager().getSessionsDir();
 
-        logger.info(
-                "Initializing HeadlessExecutorMain: execId={}, listen={}:{}, workspace={}",
-                execId,
-                host,
-                port,
-                workspaceDir);
+        logger().info(
+                        "Initializing HeadlessExecutorMain: execId={}, listen={}:{}, workspace={}",
+                        execId,
+                        host,
+                        port,
+                        workspaceDir);
 
         // Ensure sessions directory exists
         Files.createDirectories(sessionsDir);
@@ -195,10 +204,10 @@ public final class HeadlessExecutorMain {
                     try {
                         this.contextManager.createHeadless(false, new HeadlessConsole());
                         headlessInit.complete(null);
-                        logger.info("ContextManager headless initialization complete");
+                        logger().info("ContextManager headless initialization complete");
                     } catch (Exception e) {
                         headlessInit.completeExceptionally(e);
-                        logger.warn("ContextManager headless initialization failed", e);
+                        logger().warn("ContextManager headless initialization failed", e);
                     }
                 },
                 "ContextManager-Init");
@@ -271,16 +280,19 @@ public final class HeadlessExecutorMain {
         var settingsRouter = new SettingsRouter(this.contextManager);
         this.server.registerAuthenticatedContext("/v1/settings", settingsRouter);
 
-        logger.info("HeadlessExecutorMain initialized successfully");
+        logger().info("HeadlessExecutorMain initialized successfully");
     }
 
     private void logAgentStoreLoadSnapshot(AgentStore.LoadSnapshot snapshot) {
         var loadedNames = snapshot.agents().stream().map(AgentDefinition::name).toList();
-        logger.info("Loaded {} custom agents from layered store: {}", loadedNames.size(), loadedNames);
+        logger().info("Loaded {} custom agents from layered store: {}", loadedNames.size(), loadedNames);
         List<String> skipped =
                 snapshot.skippedInvalidFiles().stream().map(Path::toString).toList();
         if (!skipped.isEmpty()) {
-            logger.warn("Skipped {} invalid custom agent files while loading agent store: {}", skipped.size(), skipped);
+            logger().warn(
+                            "Skipped {} invalid custom agent files while loading agent store: {}",
+                            skipped.size(),
+                            skipped);
         }
     }
 
@@ -311,7 +323,7 @@ public final class HeadlessExecutorMain {
         response.put("execId", this.execId.toString());
         response.put("version", BuildInfo.version);
         response.put("protocolVersion", 1);
-        logger.info("/health/ready served as deprecated liveness alias");
+        logger().info("/health/ready served as deprecated liveness alias");
         SimpleHttpServer.sendJsonResponse(exchange, response);
     }
 
@@ -333,7 +345,7 @@ public final class HeadlessExecutorMain {
             // already exists on disk. Report the newest known session instead of a transient null.
             return sessions.getFirst().id().toString();
         } catch (Exception e) {
-            logger.warn("Failed to resolve sessionId for /health/ready payload", e);
+            logger().warn("Failed to resolve sessionId for /health/ready payload", e);
             return null;
         }
     }
@@ -347,9 +359,9 @@ public final class HeadlessExecutorMain {
 
     public void start() {
         this.server.start();
-        logger.info(
-                "HeadlessExecutorMain HTTP server started on endpoints: /health/live, /v1/sessions, /v1/jobs, etc.; cmSession={}",
-                contextManager.getCurrentSessionId());
+        logger().info(
+                        "HeadlessExecutorMain HTTP server started on endpoints: /health/live, /v1/sessions, /v1/jobs, etc.; cmSession={}",
+                        contextManager.getCurrentSessionId());
     }
 
     public void stop(int delaySeconds) {
@@ -366,10 +378,10 @@ public final class HeadlessExecutorMain {
         try {
             this.contextManager.close();
         } catch (Exception e) {
-            logger.warn("Error closing ContextManager", e);
+            logger().warn("Error closing ContextManager", e);
         }
         this.server.stop(delaySeconds);
-        logger.info("HeadlessExecutorMain stopped");
+        logger().info("HeadlessExecutorMain stopped");
     }
 
     /**
@@ -431,7 +443,10 @@ public final class HeadlessExecutorMain {
         try {
             // Must be set before any Swing/AWT code paths are touched.
             System.setProperty("java.awt.headless", "true");
-            // Parse command-line arguments and validate them
+            // Configure debug logging before the first application log event.
+            var debugLogPath = DebugLogPath.configureHeadless(args);
+
+            // Parse command-line arguments and validate them.
             var parseResult = parseArgs(args);
             var parsedArgs = parseResult.args();
             var invalidKeys = parseResult.invalidKeys();
@@ -439,7 +454,7 @@ public final class HeadlessExecutorMain {
             // Log parsed arguments (with sensitive values redacted) early for debugging
             var redactedArgs = redactSensitiveArgs(parsedArgs);
             var argsDisplay = CliArgParser.formatForLogging(redactedArgs);
-            logger.info("Parsed arguments: {}", argsDisplay);
+            logger().info("Parsed arguments: {}", argsDisplay);
             System.out.println("Parsed arguments: {" + argsDisplay + "}");
 
             // Check for help flag or invalid arguments
@@ -491,12 +506,12 @@ public final class HeadlessExecutorMain {
 
             var derivedSessionsDir = workspaceDir.resolve(".brokk").resolve("sessions");
 
-            logger.info(
-                    "Starting HeadlessExecutorMain with config: execId={}, listenAddr={}, workspaceDir={}, sessionsDir={}",
-                    execId,
-                    listenAddr,
-                    workspaceDir,
-                    derivedSessionsDir);
+            logger().info(
+                            "Starting HeadlessExecutorMain with config: execId={}, listenAddr={}, workspaceDir={}, sessionsDir={}",
+                            execId,
+                            listenAddr,
+                            workspaceDir,
+                            derivedSessionsDir);
 
             // Print startup banner and config summary to console
             System.out.println();
@@ -504,6 +519,7 @@ public final class HeadlessExecutorMain {
             System.out.println("  execId:      " + execId);
             System.out.println("  listenAddr:  " + listenAddr);
             System.out.println("  workspaceDir: " + workspaceDir);
+            System.out.println("  debugLogPath: " + debugLogPath);
             var brokkApiKeyArg = getConfigValue(parsedArgs, "brokk-api-key", "BROKK_API_KEY");
             System.out.println("  brokkApiKey:  " + (brokkApiKeyArg != null ? "(provided)" : "(using global config)"));
             var proxySettingArg = getConfigValue(parsedArgs, "proxy-setting", "PROXY_SETTING");
@@ -590,19 +606,21 @@ public final class HeadlessExecutorMain {
                                     // Consume bytes without processing. If stdin is a terminal, this will
                                     // block until user input / EOF and thus not interfere with normal usage.
                                 }
-                                logger.info("System.in closed (EOF detected). Initiating controlled shutdown.");
+                                logger().info("System.in closed (EOF detected). Initiating controlled shutdown.");
                             } catch (IOException e) {
-                                logger.info(
-                                        "IOException while monitoring System.in; initiating controlled shutdown.", e);
+                                logger().info(
+                                                "IOException while monitoring System.in; initiating controlled shutdown.",
+                                                e);
                             } catch (Throwable t) {
-                                logger.warn(
-                                        "Unexpected error in System.in monitor; initiating controlled shutdown.", t);
+                                logger().warn(
+                                                "Unexpected error in System.in monitor; initiating controlled shutdown.",
+                                                t);
                             } finally {
                                 try {
                                     // Try to stop executor gracefully; use a short delay to speed shutdown.
                                     executor.stop(5);
                                 } catch (Exception e) {
-                                    logger.warn("Error while stopping executor from stdin monitor", e);
+                                    logger().warn("Error while stopping executor from stdin monitor", e);
                                 } finally {
                                     // Ensure process exits even if shutdown hook doesn't run immediately.
                                     System.exit(0);
@@ -612,9 +630,9 @@ public final class HeadlessExecutorMain {
                         "HeadlessExecutor-StdInMonitor");
                 stdinMonitor.setDaemon(true);
                 stdinMonitor.start();
-                logger.info("System.in EOF monitor enabled; process will exit when stdin closes or errors.");
+                logger().info("System.in EOF monitor enabled; process will exit when stdin closes or errors.");
             } else {
-                logger.info("System.in EOF monitor disabled; executor will ignore stdin closure.");
+                logger().info("System.in EOF monitor disabled; executor will ignore stdin closure.");
             }
 
             // Add shutdown hook
@@ -623,22 +641,22 @@ public final class HeadlessExecutorMain {
                             () -> {
                                 System.out.println();
                                 System.out.println("Shutting down Brokk Headless Executor...");
-                                logger.info("Shutdown signal received, stopping executor");
+                                logger().info("Shutdown signal received, stopping executor");
                                 executor.stop(5);
                                 System.out.println("Executor stopped.");
                             },
                             "HeadlessExecutor-ShutdownHook"));
-            logger.info("HeadlessExecutorMain is running");
+            logger().info("HeadlessExecutorMain is running");
             Thread.currentThread().join(); // Keep the main thread alive
         } catch (InterruptedException e) {
             System.out.println("HeadlessExecutorMain interrupted: " + e.getMessage());
-            logger.info("HeadlessExecutorMain interrupted", e);
+            logger().info("HeadlessExecutorMain interrupted", e);
             Thread.currentThread().interrupt();
         } catch (Exception e) {
             var formattedError = formatFatalStartupError(e);
             System.err.println(formattedError);
             System.out.println(formattedError);
-            logger.error("Fatal error in HeadlessExecutorMain", e);
+            logger().error("Fatal error in HeadlessExecutorMain", e);
             System.exit(1);
         }
     }

--- a/app/src/main/java/ai/brokk/util/DebugLogPath.java
+++ b/app/src/main/java/ai/brokk/util/DebugLogPath.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
@@ -14,9 +15,10 @@ public final class DebugLogPath {
     public static final String SYSTEM_PROPERTY = "brokk.debugLogPath";
     public static final String FILE_PATTERN_PROPERTY = "brokk.debugLogFilePattern";
     public static final String DELETE_BASE_PATH_PROPERTY = "brokk.debugLogDeleteBasePath";
-    public static final String DELETE_GLOB_PROPERTY = "brokk.debugLogDeleteGlob";
+    public static final String DELETE_REGEX_PROPERTY = "brokk.debugLogDeleteRegex";
 
     private static final String ROLLOVER_DATE_PATTERN = ".%d{yyyy-MM-dd}";
+    private static final String ROLLOVER_DATE_REGEX = "\\.\\d{4}-\\d{2}-\\d{2}";
 
     private DebugLogPath() {}
 
@@ -123,6 +125,6 @@ public final class DebugLogPath {
         System.setProperty(SYSTEM_PROPERTY, debugLogPath.toString());
         System.setProperty(FILE_PATTERN_PROPERTY, debugLogPath + ROLLOVER_DATE_PATTERN);
         System.setProperty(DELETE_BASE_PATH_PROPERTY, parent.toString());
-        System.setProperty(DELETE_GLOB_PROPERTY, fileName + ".*");
+        System.setProperty(DELETE_REGEX_PROPERTY, Pattern.quote(fileName.toString()) + ROLLOVER_DATE_REGEX);
     }
 }

--- a/app/src/main/java/ai/brokk/util/DebugLogPath.java
+++ b/app/src/main/java/ai/brokk/util/DebugLogPath.java
@@ -1,0 +1,128 @@
+package ai.brokk.util;
+
+import ai.brokk.project.AbstractProject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
+
+public final class DebugLogPath {
+    public static final String ARG = "debug-log-path";
+    public static final String ENV_VAR = "BROKK_DEBUG_LOG_PATH";
+    public static final String SYSTEM_PROPERTY = "brokk.debugLogPath";
+    public static final String FILE_PATTERN_PROPERTY = "brokk.debugLogFilePattern";
+    public static final String DELETE_BASE_PATH_PROPERTY = "brokk.debugLogDeleteBasePath";
+    public static final String DELETE_GLOB_PROPERTY = "brokk.debugLogDeleteGlob";
+
+    private static final String ROLLOVER_DATE_PATTERN = ".%d{yyyy-MM-dd}";
+
+    private DebugLogPath() {}
+
+    public static Path defaultPath() {
+        return Path.of(System.getProperty("user.home"), AbstractProject.BROKK_DIR, AbstractProject.DEBUG_LOG_FILE);
+    }
+
+    public static Path currentPath() {
+        var configured = System.getProperty(SYSTEM_PROPERTY);
+        if (configured != null && !configured.isBlank()) {
+            return Path.of(configured);
+        }
+        return defaultPath();
+    }
+
+    public static Path configureHeadless(Map<String, String> parsedArgs) throws IOException {
+        var configuredPath = resolveHeadlessPath(parsedArgs);
+        return configureHeadless(configuredPath);
+    }
+
+    public static Path configureHeadless(String[] args) throws IOException {
+        var configuredPath = resolveHeadlessPath(args);
+        return configureHeadless(configuredPath);
+    }
+
+    private static Path configureHeadless(@Nullable Path configuredPath) throws IOException {
+        var debugLogPath = configuredPath != null ? configuredPath : defaultPath();
+        configureLog4jProperties(debugLogPath);
+        return debugLogPath;
+    }
+
+    @Nullable
+    public static Path resolveHeadlessPath(Map<String, String> parsedArgs) {
+        return resolveHeadlessPath(parsedArgs, System.getenv());
+    }
+
+    @TestOnly
+    static @Nullable Path resolveHeadlessPath(Map<String, String> parsedArgs, Map<String, String> env) {
+        var argValue = parsedArgs.get(ARG);
+        if (argValue != null && !argValue.isBlank()) {
+            return normalizePath(argValue);
+        }
+
+        var envValue = env.get(ENV_VAR);
+        return resolveEnvOrProperty(envValue);
+    }
+
+    @Nullable
+    private static Path resolveHeadlessPath(String[] args) {
+        return resolveHeadlessPath(args, System.getenv());
+    }
+
+    @TestOnly
+    static @Nullable Path resolveHeadlessPath(String[] args, Map<String, String> env) {
+        var prefix = "--" + ARG;
+        for (int i = 0; i < args.length; i++) {
+            var arg = args[i];
+            if (arg.equals(prefix) && i + 1 < args.length && !args[i + 1].startsWith("--")) {
+                var value = args[i + 1];
+                if (!value.isBlank()) {
+                    return normalizePath(value);
+                }
+            } else if (arg.startsWith(prefix + "=")) {
+                var value = arg.substring(prefix.length() + 1);
+                if (!value.isBlank()) {
+                    return normalizePath(value);
+                }
+            }
+        }
+
+        return resolveEnvOrProperty(env.get(ENV_VAR));
+    }
+
+    private static @Nullable Path resolveEnvOrProperty(@Nullable String envValue) {
+        if (envValue != null && !envValue.isBlank()) {
+            return normalizePath(envValue);
+        }
+
+        var propertyValue = System.getProperty(SYSTEM_PROPERTY);
+        if (propertyValue != null && !propertyValue.isBlank()) {
+            return normalizePath(propertyValue);
+        }
+
+        return null;
+    }
+
+    private static Path normalizePath(String rawPath) {
+        return Path.of(rawPath).toAbsolutePath().normalize();
+    }
+
+    private static void configureLog4jProperties(Path rawDebugLogPath) throws IOException {
+        var debugLogPath = rawDebugLogPath.toAbsolutePath().normalize();
+        var fileName = debugLogPath.getFileName();
+        if (fileName == null) {
+            throw new IllegalArgumentException("Debug log path must include a file name: " + debugLogPath);
+        }
+
+        var parent = debugLogPath.getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException("Debug log path must include a parent directory: " + debugLogPath);
+        }
+
+        Files.createDirectories(parent);
+        System.setProperty(SYSTEM_PROPERTY, debugLogPath.toString());
+        System.setProperty(FILE_PATTERN_PROPERTY, debugLogPath + ROLLOVER_DATE_PATTERN);
+        System.setProperty(DELETE_BASE_PATH_PROPERTY, parent.toString());
+        System.setProperty(DELETE_GLOB_PROPERTY, fileName + ".*");
+    }
+}

--- a/app/src/main/resources/log4j2.xml
+++ b/app/src/main/resources/log4j2.xml
@@ -4,7 +4,7 @@
     <Property name="logFile">${sys:brokk.debugLogPath:-${sys:user.home}/.brokk/debug.log}</Property>
     <Property name="logFilePattern">${sys:brokk.debugLogFilePattern:-${sys:user.home}/.brokk/debug.log.%d{yyyy-MM-dd}}</Property>
     <Property name="logFileDeleteBasePath">${sys:brokk.debugLogDeleteBasePath:-${sys:user.home}/.brokk}</Property>
-    <Property name="logFileDeleteGlob">${sys:brokk.debugLogDeleteGlob:-debug.log.*}</Property>
+    <Property name="logFileDeleteRegex">${sys:brokk.debugLogDeleteRegex:-\Qdebug.log\E\.\d{4}-\d{2}-\d{2}}</Property>
     <Property name="pattern">%d [%t] %-5level %C{1}.%M:%L - %msg%n</Property>
   </Properties>
 
@@ -19,7 +19,7 @@
       <!-- Keep only the 7 most recent rolled files -->
       <DefaultRolloverStrategy>
         <Delete basePath="${logFileDeleteBasePath}" maxDepth="1">
-          <IfFileName glob="${logFileDeleteGlob}"/>
+          <IfFileName regex="${logFileDeleteRegex}"/>
           <IfAccumulatedFileCount exceeds="7"/>
         </Delete>
       </DefaultRolloverStrategy>

--- a/app/src/main/resources/log4j2.xml
+++ b/app/src/main/resources/log4j2.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="ERROR">
   <Properties>
-    <!-- Define the log file location using the user's home directory -->
-    <Property name="logFile">${sys:user.home}/.brokk/debug.log</Property>
+    <Property name="logFile">${sys:brokk.debugLogPath:-${sys:user.home}/.brokk/debug.log}</Property>
+    <Property name="logFilePattern">${sys:brokk.debugLogFilePattern:-${sys:user.home}/.brokk/debug.log.%d{yyyy-MM-dd}}</Property>
+    <Property name="logFileDeleteBasePath">${sys:brokk.debugLogDeleteBasePath:-${sys:user.home}/.brokk}</Property>
+    <Property name="logFileDeleteGlob">${sys:brokk.debugLogDeleteGlob:-debug.log.*}</Property>
     <Property name="pattern">%d [%t] %-5level %C{1}.%M:%L - %msg%n</Property>
   </Properties>
 
   <Appenders>
     <RollingFile name="RollingFileLogger" fileName="${logFile}"
-                 filePattern="${sys:user.home}/.brokk/debug.log.%d{yyyy-MM-dd}">
+                 filePattern="${logFilePattern}">
       <PatternLayout pattern="${pattern}"/>
       <Policies>
         <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
@@ -16,8 +18,8 @@
 
       <!-- Keep only the 7 most recent rolled files -->
       <DefaultRolloverStrategy>
-        <Delete basePath="${sys:user.home}/.brokk" maxDepth="1">
-          <IfFileName glob="debug.log.*"/>
+        <Delete basePath="${logFileDeleteBasePath}" maxDepth="1">
+          <IfFileName glob="${logFileDeleteGlob}"/>
           <IfAccumulatedFileCount exceeds="7"/>
         </Delete>
       </DefaultRolloverStrategy>

--- a/app/src/test/java/ai/brokk/util/DebugLogPathTest.java
+++ b/app/src/test/java/ai/brokk/util/DebugLogPathTest.java
@@ -1,6 +1,7 @@
 package ai.brokk.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -8,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,14 +19,14 @@ class DebugLogPathTest {
     private String originalDebugLogPath;
     private String originalFilePattern;
     private String originalDeleteBasePath;
-    private String originalDeleteGlob;
+    private String originalDeleteRegex;
 
     @BeforeEach
     void saveProperties() {
         originalDebugLogPath = System.getProperty(DebugLogPath.SYSTEM_PROPERTY);
         originalFilePattern = System.getProperty(DebugLogPath.FILE_PATTERN_PROPERTY);
         originalDeleteBasePath = System.getProperty(DebugLogPath.DELETE_BASE_PATH_PROPERTY);
-        originalDeleteGlob = System.getProperty(DebugLogPath.DELETE_GLOB_PROPERTY);
+        originalDeleteRegex = System.getProperty(DebugLogPath.DELETE_REGEX_PROPERTY);
     }
 
     @AfterEach
@@ -32,7 +34,7 @@ class DebugLogPathTest {
         restoreProperty(DebugLogPath.SYSTEM_PROPERTY, originalDebugLogPath);
         restoreProperty(DebugLogPath.FILE_PATTERN_PROPERTY, originalFilePattern);
         restoreProperty(DebugLogPath.DELETE_BASE_PATH_PROPERTY, originalDeleteBasePath);
-        restoreProperty(DebugLogPath.DELETE_GLOB_PROPERTY, originalDeleteGlob);
+        restoreProperty(DebugLogPath.DELETE_REGEX_PROPERTY, originalDeleteRegex);
     }
 
     @Test
@@ -95,7 +97,23 @@ class DebugLogPathTest {
         assertEquals(debugLogPath.toString(), System.getProperty(DebugLogPath.SYSTEM_PROPERTY));
         assertEquals(debugLogPath + ".%d{yyyy-MM-dd}", System.getProperty(DebugLogPath.FILE_PATTERN_PROPERTY));
         assertEquals(parent.toString(), System.getProperty(DebugLogPath.DELETE_BASE_PATH_PROPERTY));
-        assertEquals("debug.log.*", System.getProperty(DebugLogPath.DELETE_GLOB_PROPERTY));
+        assertEquals(
+                Pattern.quote(debugLogPath.getFileName().toString()) + "\\.\\d{4}-\\d{2}-\\d{2}",
+                System.getProperty(DebugLogPath.DELETE_REGEX_PROPERTY));
+    }
+
+    @Test
+    void deleteRegexQuotesConfiguredFileName(@TempDir Path tempDir) throws IOException {
+        var debugLogPath = tempDir.resolve("scan-123").resolve("*.log");
+
+        DebugLogPath.configureHeadless(Map.of(DebugLogPath.ARG, debugLogPath.toString()));
+
+        var deleteRegex = System.getProperty(DebugLogPath.DELETE_REGEX_PROPERTY);
+        assertEquals(Pattern.quote("*.log") + "\\.\\d{4}-\\d{2}-\\d{2}", deleteRegex);
+        var pattern = Pattern.compile(deleteRegex);
+        assertTrue(pattern.matcher("*.log.2026-05-13").matches());
+        assertFalse(pattern.matcher("executor.log.2026-05-13").matches());
+        assertFalse(pattern.matcher("debug.log.backup").matches());
     }
 
     private static void restoreProperty(String key, String value) {

--- a/app/src/test/java/ai/brokk/util/DebugLogPathTest.java
+++ b/app/src/test/java/ai/brokk/util/DebugLogPathTest.java
@@ -1,0 +1,108 @@
+package ai.brokk.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DebugLogPathTest {
+    private String originalDebugLogPath;
+    private String originalFilePattern;
+    private String originalDeleteBasePath;
+    private String originalDeleteGlob;
+
+    @BeforeEach
+    void saveProperties() {
+        originalDebugLogPath = System.getProperty(DebugLogPath.SYSTEM_PROPERTY);
+        originalFilePattern = System.getProperty(DebugLogPath.FILE_PATTERN_PROPERTY);
+        originalDeleteBasePath = System.getProperty(DebugLogPath.DELETE_BASE_PATH_PROPERTY);
+        originalDeleteGlob = System.getProperty(DebugLogPath.DELETE_GLOB_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreProperties() {
+        restoreProperty(DebugLogPath.SYSTEM_PROPERTY, originalDebugLogPath);
+        restoreProperty(DebugLogPath.FILE_PATTERN_PROPERTY, originalFilePattern);
+        restoreProperty(DebugLogPath.DELETE_BASE_PATH_PROPERTY, originalDeleteBasePath);
+        restoreProperty(DebugLogPath.DELETE_GLOB_PROPERTY, originalDeleteGlob);
+    }
+
+    @Test
+    void resolvesArgumentBeforeEnvAndSystemProperty(@TempDir Path tempDir) {
+        var argPath = tempDir.resolve("arg").resolve("debug.log");
+        var envPath = tempDir.resolve("env").resolve("debug.log");
+        var propertyPath = tempDir.resolve("property").resolve("debug.log");
+        System.setProperty(DebugLogPath.SYSTEM_PROPERTY, propertyPath.toString());
+
+        var result = DebugLogPath.resolveHeadlessPath(
+                Map.of(DebugLogPath.ARG, argPath.toString()), Map.of(DebugLogPath.ENV_VAR, envPath.toString()));
+
+        assertEquals(argPath.toAbsolutePath().normalize(), result);
+    }
+
+    @Test
+    void resolvesEqualsArgumentBeforeEnvAndSystemProperty(@TempDir Path tempDir) {
+        var argPath = tempDir.resolve("arg").resolve("debug.log");
+        var envPath = tempDir.resolve("env").resolve("debug.log");
+        var propertyPath = tempDir.resolve("property").resolve("debug.log");
+        System.setProperty(DebugLogPath.SYSTEM_PROPERTY, propertyPath.toString());
+
+        var result = DebugLogPath.resolveHeadlessPath(
+                new String[] {"--" + DebugLogPath.ARG + "=" + argPath},
+                Map.of(DebugLogPath.ENV_VAR, envPath.toString()));
+
+        assertEquals(argPath.toAbsolutePath().normalize(), result);
+    }
+
+    @Test
+    void resolvesEnvBeforeSystemProperty(@TempDir Path tempDir) {
+        var envPath = tempDir.resolve("env").resolve("debug.log");
+        var propertyPath = tempDir.resolve("property").resolve("debug.log");
+        System.setProperty(DebugLogPath.SYSTEM_PROPERTY, propertyPath.toString());
+
+        var result = DebugLogPath.resolveHeadlessPath(Map.of(), Map.of(DebugLogPath.ENV_VAR, envPath.toString()));
+
+        assertEquals(envPath.toAbsolutePath().normalize(), result);
+    }
+
+    @Test
+    void resolvesSystemPropertyWhenNoArgumentOrEnv(@TempDir Path tempDir) {
+        var propertyPath = tempDir.resolve("property").resolve("debug.log");
+        System.setProperty(DebugLogPath.SYSTEM_PROPERTY, propertyPath.toString());
+
+        var result = DebugLogPath.resolveHeadlessPath(Map.of(), Map.of());
+
+        assertEquals(propertyPath.toAbsolutePath().normalize(), result);
+    }
+
+    @Test
+    void configureHeadlessCreatesParentAndSetsLog4jProperties(@TempDir Path tempDir) throws IOException {
+        var debugLogPath = tempDir.resolve("scan-123").resolve("debug.log");
+
+        var result = DebugLogPath.configureHeadless(Map.of(DebugLogPath.ARG, debugLogPath.toString()));
+
+        assertEquals(debugLogPath.toAbsolutePath().normalize(), result);
+        var parent = Objects.requireNonNull(debugLogPath.getParent());
+        assertTrue(Files.isDirectory(parent));
+        assertEquals(debugLogPath.toString(), System.getProperty(DebugLogPath.SYSTEM_PROPERTY));
+        assertEquals(debugLogPath + ".%d{yyyy-MM-dd}", System.getProperty(DebugLogPath.FILE_PATTERN_PROPERTY));
+        assertEquals(parent.toString(), System.getProperty(DebugLogPath.DELETE_BASE_PATH_PROPERTY));
+        assertEquals("debug.log.*", System.getProperty(DebugLogPath.DELETE_GLOB_PROPERTY));
+    }
+
+    private static void restoreProperty(String key, String value) {
+        if (value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+}

--- a/app/src/test/java/ai/brokk/util/DebugLogPathTest.java
+++ b/app/src/test/java/ai/brokk/util/DebugLogPathTest.java
@@ -104,15 +104,15 @@ class DebugLogPathTest {
 
     @Test
     void deleteRegexQuotesConfiguredFileName(@TempDir Path tempDir) throws IOException {
-        var debugLogPath = tempDir.resolve("scan-123").resolve("*.log");
+        var debugLogPath = tempDir.resolve("scan-123").resolve("debug(1).log");
 
         DebugLogPath.configureHeadless(Map.of(DebugLogPath.ARG, debugLogPath.toString()));
 
         var deleteRegex = System.getProperty(DebugLogPath.DELETE_REGEX_PROPERTY);
-        assertEquals(Pattern.quote("*.log") + "\\.\\d{4}-\\d{2}-\\d{2}", deleteRegex);
+        assertEquals(Pattern.quote("debug(1).log") + "\\.\\d{4}-\\d{2}-\\d{2}", deleteRegex);
         var pattern = Pattern.compile(deleteRegex);
-        assertTrue(pattern.matcher("*.log.2026-05-13").matches());
-        assertFalse(pattern.matcher("executor.log.2026-05-13").matches());
+        assertTrue(pattern.matcher("debug(1).log.2026-05-13").matches());
+        assertFalse(pattern.matcher("debug1.log.2026-05-13").matches());
         assertFalse(pattern.matcher("debug.log.backup").matches());
     }
 


### PR DESCRIPTION
Closes #3614.\n\nSummary:\n- Add supported --debug-log-path, BROKK_DEBUG_LOG_PATH, and brokk.debugLogPath handling for headless startup.\n- Derive Log4j rollover and retention paths from the configured debug log file.\n- Use the configured debug log path for feedback uploads.\n\nTests:\n- ./gradlew :app:test --tests ai.brokk.util.DebugLogPathTest --tests ai.brokk.executor.HeadlessExecutorMainTest\n- ./gradlew :app:spotlessCheck