### PR TITLE
brokk-core: expose reportDeadCodeAndUnusedAbstractionSmells MCP tool

### DIFF
--- a/brokk-core/README.md
+++ b/brokk-core/README.md
@@ -190,9 +190,26 @@ Detects low-value or brittle test assertion smells using language-aware weighted
 | `meaningfulAssertionCreditCap` | int | no | (internal default) | Maximum meaningful assertions that earn credit |
 | `largeLiteralLengthThreshold` | int | no | (internal default) | String literal length considered oversized |
 
+#### `reportDeadCodeAndUnusedAbstractionSmells`
+
+Reports likely generated-code residue: unused declarations and one-call abstractions. Uses analyzer declarations plus symbol/reference usage analysis -- not text-only matching. Java uses JDT analysis; JavaScript/TypeScript/Python/Rust route through export-graph strategies with regex fallback. No LLM disambiguation, so language coverage is best-effort outside of Java.
+
+Pass `fqNames` to target specific symbols; leave it empty to scan declarations in the bounded files.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `filePaths` | string[] | yes | -- | File paths relative to project root |
+| `fqNames` | string[] | no | `[]` | Optional fully qualified symbol names to analyze; empty means discover candidates from `filePaths` |
+| `minScore` | int | no | 8 | Minimum score to include a finding |
+| `maxFindings` | int | no | 40 | Maximum findings to emit |
+| `maxInputFiles` | int | no | 25 | Maximum existing files to scan for candidate declarations |
+| `maxCandidateSymbols` | int | no | 200 | Maximum candidate symbols to analyze |
+| `maxUsageCandidateFiles` | int | no | (usage finder default) | Maximum usage-candidate files to inspect |
+| `maxUsagesPerSymbol` | int | no | 100 | Maximum usage hits per symbol before usage lookup returns a guardrail result |
+
 ## Note on MCP servers
 
 The Brokk codebase has two MCP servers:
 
-1. **`BrokkCoreMcpServer`** (this module, `brokk-core/`) -- Standalone, no LLM dependencies, pure tree-sitter analysis. This is what the Claude Code plugin connects to. Exposes 28 tools.
+1. **`BrokkCoreMcpServer`** (this module, `brokk-core/`) -- Standalone, no LLM dependencies, pure tree-sitter analysis. This is what the Claude Code plugin connects to. Exposes 29 tools.
 2. **`BrokkExternalMcpServer`** (in `app/`) -- Full server with LLM agent capabilities. Not used by the Claude Code plugin.

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -854,6 +854,54 @@ public class BrokkCoreMcpServer {
                             intArg(request, "largeLiteralLengthThreshold", -1)));
                 })));
 
+        specs.add(tool(
+                "reportDeadCodeAndUnusedAbstractionSmells",
+                "Reports likely generated-code residue: unused declarations and one-call abstractions in the given files. "
+                        + "Uses analyzer declarations plus symbol/reference usage analysis where available, not text-only matching. "
+                        + "Pass fqNames to target specific symbols; leave fqNames empty to scan declarations in the bounded files. "
+                        + "Java uses JDT analysis; JavaScript/TypeScript/Python/Rust route through export-graph strategies with regex fallback. "
+                        + "No LLM disambiguation.",
+                schema(
+                        Map.ofEntries(
+                                entry("filePaths", arrayProp("File paths relative to the project root.")),
+                                entry(
+                                        "fqNames",
+                                        arrayProp(
+                                                "Optional fully qualified symbol names to analyze. Empty means discover candidates from filePaths.")),
+                                entry(
+                                        "minScore",
+                                        intProp("Minimum score to include a finding; values <= 0 default to 8.")),
+                                entry("maxFindings", intProp("Maximum findings to emit; values <= 0 default to 40.")),
+                                entry(
+                                        "maxInputFiles",
+                                        intProp(
+                                                "Maximum existing files to scan for candidate declarations; values <= 0 default to 25.")),
+                                entry(
+                                        "maxCandidateSymbols",
+                                        intProp("Maximum candidate symbols to analyze; values <= 0 default to 200.")),
+                                entry(
+                                        "maxUsageCandidateFiles",
+                                        intProp(
+                                                "Maximum usage-candidate files to inspect; values <= 0 default to the usage finder default.")),
+                                entry(
+                                        "maxUsagesPerSymbol",
+                                        intProp(
+                                                "Maximum usage hits per symbol before usage lookup returns a guardrail result; values <= 0 default to 100."))),
+                        List.of("filePaths")),
+                (exchange, request) -> withReadLock(() -> {
+                    var filePaths = stringListArg(request, "filePaths");
+                    var fqNames = stringListArgOrEmpty(request, "fqNames");
+                    return textResult(codeQualityTools.reportDeadCodeAndUnusedAbstractionSmells(
+                            filePaths,
+                            fqNames,
+                            intArg(request, "minScore", 0),
+                            intArg(request, "maxFindings", 0),
+                            intArg(request, "maxInputFiles", 0),
+                            intArg(request, "maxCandidateSymbols", 0),
+                            intArg(request, "maxUsageCandidateFiles", 0),
+                            intArg(request, "maxUsagesPerSymbol", 0)));
+                })));
+
         // NOTE: analyzeGitHotspots is not exposed here because GitHotspotAnalyzer
         // lives in the app module with dependencies not available in brokk-core.
 
@@ -1013,6 +1061,18 @@ public class BrokkCoreMcpServer {
         var value = args.get(name);
         if (value == null) {
             throw new IllegalArgumentException("Missing required argument: " + name);
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(Object::toString).toList();
+        }
+        throw new IllegalArgumentException("Argument " + name + " must be an array");
+    }
+
+    private static List<String> stringListArgOrEmpty(McpSchema.CallToolRequest request, String name) {
+        var args = request.arguments() != null ? request.arguments() : Map.<String, Object>of();
+        var value = args.get(name);
+        if (value == null) {
+            return List.of();
         }
         if (value instanceof List<?> list) {
             return list.stream().map(Object::toString).toList();

--- a/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
@@ -4,13 +4,26 @@ import ai.brokk.ICodeIntelligence;
 import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.CommentDensityStats;
 import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.analyzer.usages.CandidateFileProvider;
+import ai.brokk.analyzer.usages.FuzzyResult;
+import ai.brokk.analyzer.usages.RegexUsageAnalyzer;
+import ai.brokk.analyzer.usages.UsageAnalyzer;
+import ai.brokk.analyzer.usages.UsageAnalyzerSelector;
+import ai.brokk.analyzer.usages.UsageFinder;
+import ai.brokk.analyzer.usages.UsageHit;
+import ai.brokk.project.ICoreProject;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Read-only static analysis helpers for code quality, adapted for the MCP server.
@@ -523,6 +536,294 @@ public class CodeQualityToolsMcp {
         }
         return String.join("\n", lines);
     }
+
+    // -- reportDeadCodeAndUnusedAbstractionSmells --
+
+    public String reportDeadCodeAndUnusedAbstractionSmells(
+            List<String> filePaths,
+            List<String> fqNames,
+            int minScore,
+            int maxFindings,
+            int maxInputFiles,
+            int maxCandidateSymbols,
+            int maxUsageCandidateFiles,
+            int maxUsagesPerSymbol) {
+
+        int threshold = minScore > 0 ? minScore : 8;
+        int findingsCap = maxFindings > 0 ? maxFindings : 40;
+        int inputFileCap = maxInputFiles > 0 ? maxInputFiles : 25;
+        int candidateCap = maxCandidateSymbols > 0 ? maxCandidateSymbols : 200;
+        int usageFileCap = maxUsageCandidateFiles > 0 ? maxUsageCandidateFiles : UsageFinder.DEFAULT_MAX_FILES;
+        int usageCap = maxUsagesPerSymbol > 0 ? maxUsagesPerSymbol : 100;
+
+        IAnalyzer analyzer = intelligence.getAnalyzer();
+        ICoreProject project = intelligence.getProject();
+        var files = filePaths.stream()
+                .map(intelligence::toFile)
+                .filter(ProjectFile::exists)
+                .limit(inputFileCap)
+                .toList();
+        var selectedFiles = Set.copyOf(files);
+        var findings = new ArrayList<DeadCodeFinding>();
+        var skipped = new ArrayList<String>();
+        CandidateFileProvider batchCandidateProvider = (target, analysis) -> analysis.getProject()
+                .getAnalyzableFiles(Languages.fromExtension(target.source().extension()));
+        UsageAnalyzer multiLangAnalyzer = (overloads, candidates, maxUsages) -> {
+            if (overloads.isEmpty()) {
+                return new FuzzyResult.Success(Map.of());
+            }
+            var strategy = UsageAnalyzerSelector.forTarget(overloads.getFirst(), analyzer, project);
+            var result = strategy.findUsages(overloads, candidates, maxUsages);
+            if (UsageAnalyzerSelector.shouldFallbackToRegex(result, strategy)) {
+                return new RegexUsageAnalyzer(analyzer).findUsages(overloads, candidates, maxUsages);
+            }
+            return result;
+        };
+        var usageFinder = new UsageFinder(project, analyzer, batchCandidateProvider, multiLangAnalyzer, null);
+        var candidateSelection = deadCodeCandidates(analyzer, files, fqNames, selectedFiles, candidateCap, skipped);
+
+        for (CodeUnit candidate : candidateSelection.candidates()) {
+            Optional<DeadCodeFinding> finding = analyzeDeadCodeCandidate(
+                    analyzer, usageFinder, batchCandidateProvider, candidate, usageFileCap, usageCap, skipped);
+            finding.filter(f -> f.score() >= threshold).ifPresent(findings::add);
+        }
+
+        var filtered = findings.stream()
+                .sorted(Comparator.comparingInt(DeadCodeFinding::totalUsageCount)
+                        .thenComparing(
+                                Comparator.comparingInt(DeadCodeFinding::score).reversed())
+                        .thenComparing(f -> displayPath(f.file()), String.CASE_INSENSITIVE_ORDER)
+                        .thenComparing(DeadCodeFinding::symbol, String.CASE_INSENSITIVE_ORDER))
+                .limit(findingsCap)
+                .toList();
+
+        var lines = new ArrayList<String>();
+        lines.add("## Dead code and unused abstraction smells");
+        lines.add("");
+        lines.add("- Min score: %d".formatted(threshold));
+        lines.add("- Input files analyzed cap: %d".formatted(inputFileCap));
+        lines.add("- Candidate symbol cap: %d%s"
+                .formatted(candidateCap, candidateSelection.truncated() ? " (truncated)" : ""));
+        lines.add("- Usage candidate file cap: %d".formatted(usageFileCap));
+        lines.add("- Usage cap per symbol: %d".formatted(usageCap));
+        lines.add("- Candidate symbols analyzed: %d"
+                .formatted(candidateSelection.candidates().size()));
+        lines.add("- Findings shown: %d of %d".formatted(filtered.size(), findings.size()));
+        if (!skipped.isEmpty()) {
+            lines.add("- Skipped symbols: %d".formatted(skipped.size()));
+        }
+        lines.add("");
+
+        if (filtered.isEmpty()) {
+            lines.add("No dead code or unused abstraction smells met minScore " + threshold + ".");
+            if (!skipped.isEmpty()) {
+                lines.add("");
+                lines.add("Skipped evidence:");
+                skipped.stream().limit(10).forEach(skip -> lines.add("- " + skip));
+            }
+            return String.join("\n", lines);
+        }
+
+        lines.add(
+                "| Score | Confidence | Kind | Symbol | File | Total Usages | External Usages | Evidence | Rationale |");
+        lines.add(
+                "|------:|-----------:|------|--------|------|-------------:|----------------:|----------|-----------|");
+        for (DeadCodeFinding finding : filtered) {
+            String location = "%s:%d-%d".formatted(displayPath(finding.file()), finding.startLine(), finding.endLine());
+            lines.add("| %d | %.2f | `%s` | `%s` | `%s` | %d | %d | `%s` | `%s` |"
+                    .formatted(
+                            finding.score(),
+                            finding.confidence(),
+                            finding.kind(),
+                            sanitizeTableCell(finding.symbol()),
+                            sanitizeTableCell(location),
+                            finding.totalUsageCount(),
+                            finding.externalUsageCount(),
+                            sanitizeTableCell(finding.evidence()),
+                            sanitizeTableCell(finding.rationale())));
+        }
+        if (findings.size() > filtered.size()) {
+            lines.add("");
+            lines.add("- Note: output truncated; increase maxFindings to see more.");
+        }
+        if (!skipped.isEmpty()) {
+            lines.add("");
+            lines.add("Skipped evidence:");
+            skipped.stream().limit(10).forEach(skip -> lines.add("- " + skip));
+            if (skipped.size() > 10) {
+                lines.add("- ... " + (skipped.size() - 10) + " more skipped symbols");
+            }
+        }
+        return String.join("\n", lines);
+    }
+
+    private CandidateSelection deadCodeCandidates(
+            IAnalyzer analyzer,
+            List<ProjectFile> files,
+            List<String> fqNames,
+            Set<ProjectFile> selectedFiles,
+            int candidateCap,
+            List<String> skipped) {
+        var candidates = new LinkedHashSet<CodeUnit>();
+        var targets =
+                fqNames.stream().map(String::strip).filter(s -> !s.isBlank()).toList();
+        if (!targets.isEmpty()) {
+            for (String fqName : targets) {
+                var definitions = analyzer.getDefinitions(fqName);
+                if (definitions.isEmpty()) {
+                    skipped.add("`%s`: no definition found".formatted(fqName));
+                    continue;
+                }
+                definitions.stream()
+                        .filter(cu -> selectedFiles.isEmpty() || selectedFiles.contains(cu.source()))
+                        .filter(CodeQualityToolsMcp::isDeadCodeCandidate)
+                        .forEach(candidates::add);
+            }
+            return capCandidates(candidates, candidateCap, skipped);
+        }
+
+        for (ProjectFile file : files) {
+            analyzer.getDeclarations(file).stream()
+                    .filter(CodeQualityToolsMcp::isDeadCodeCandidate)
+                    .forEach(candidates::add);
+        }
+        return capCandidates(candidates, candidateCap, skipped);
+    }
+
+    private static CandidateSelection capCandidates(Set<CodeUnit> candidates, int candidateCap, List<String> skipped) {
+        boolean truncated = candidates.size() > candidateCap;
+        if (truncated) {
+            skipped.add("candidate symbol cap reached: analyzed first %d of %d candidates"
+                    .formatted(candidateCap, candidates.size()));
+        }
+        return new CandidateSelection(candidates.stream().limit(candidateCap).toList(), truncated);
+    }
+
+    private static boolean isDeadCodeCandidate(CodeUnit cu) {
+        return !cu.isSynthetic() && !cu.isAnonymous() && (cu.isFunction() || cu.isClass() || cu.isField());
+    }
+
+    private Optional<DeadCodeFinding> analyzeDeadCodeCandidate(
+            IAnalyzer analyzer,
+            UsageFinder usageFinder,
+            CandidateFileProvider candidateProvider,
+            CodeUnit candidate,
+            int usageFileCap,
+            int usageCap,
+            List<String> skipped) {
+        var rangeOpt = analyzer.rangesOf(candidate).stream()
+                .filter(range -> !range.isEmpty())
+                .max(Comparator.comparingInt(CodeQualityToolsMcp::spanLines));
+        if (rangeOpt.isEmpty()) {
+            skipped.add("`%s`: no declaration range available".formatted(candidate.fqName()));
+            return Optional.empty();
+        }
+
+        FuzzyResult usageResult;
+        UsageFinder.QueryResult queryResult;
+        try {
+            queryResult = usageFinder.query(List.of(candidate), candidateProvider, usageFileCap, usageCap);
+            usageResult = queryResult.result();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            skipped.add("`%s`: usage analysis interrupted".formatted(candidate.fqName()));
+            return Optional.empty();
+        }
+
+        if (queryResult.candidateFilesTruncated()) {
+            skipped.add("`%s`: usage candidate files exceeded cap %d; evidence is inconclusive"
+                    .formatted(candidate.fqName(), usageFileCap));
+            return Optional.empty();
+        }
+
+        var either = usageResult.toEither();
+        if (either.hasErrorMessage()) {
+            skipped.add("`%s`: %s".formatted(candidate.fqName(), either.getErrorMessage()));
+            return Optional.empty();
+        }
+
+        Optional<CodeUnit> definingOwner = analyzer.parentOf(candidate).or(() -> Optional.of(candidate));
+        var usageHits = either.getUsages().stream()
+                .filter(hit -> !hit.enclosing().equals(candidate))
+                .sorted(Comparator.comparing((UsageHit h) -> displayPath(h.file()))
+                        .thenComparingInt(UsageHit::line)
+                        .thenComparingInt(UsageHit::startOffset))
+                .toList();
+        var externalHits = either.getUsages().stream()
+                .filter(hit -> !hit.enclosing().equals(candidate))
+                .filter(hit -> isExternalUsage(analyzer, definingOwner, hit))
+                .sorted(Comparator.comparing((UsageHit h) -> displayPath(h.file()))
+                        .thenComparingInt(UsageHit::line)
+                        .thenComparingInt(UsageHit::startOffset))
+                .toList();
+        int usageCount = usageHits.size();
+        if (usageCount > 1) {
+            return Optional.empty();
+        }
+
+        var range = rangeOpt.orElseThrow();
+        int declarationLines = spanLines(range);
+        int score = usageCount == 0 ? 30 + Math.min(20, declarationLines / 4) : 12 + Math.min(12, declarationLines / 8);
+        double confidence = usageCount == 0 ? 0.95 : 0.75;
+        String evidence = usageCount == 0
+                ? "no non-self usages found"
+                : "only usage: %s:%d in %s%s"
+                        .formatted(
+                                displayPath(usageHits.getFirst().file()),
+                                usageHits.getFirst().line(),
+                                usageHits.getFirst().enclosing().fqName(),
+                                externalHits.isEmpty() ? " (same owner)" : "");
+        String rationale = usageCount == 0
+                ? "symbol has no usage evidence and may be generated residue"
+                : "symbol has only one caller and may be a low-value abstraction";
+
+        return Optional.of(new DeadCodeFinding(
+                score,
+                confidence,
+                candidate.kind().name().toLowerCase(Locale.ROOT),
+                candidate.fqName(),
+                candidate.source(),
+                range.startLine() + 1,
+                range.endLine() + 1,
+                usageCount,
+                externalHits.size(),
+                evidence,
+                rationale));
+    }
+
+    private static boolean isExternalUsage(IAnalyzer analyzer, Optional<CodeUnit> definingOwner, UsageHit hit) {
+        if (definingOwner.isEmpty()) {
+            return true;
+        }
+        CodeUnit hitOwner = analyzer.parentOf(hit.enclosing()).orElse(hit.enclosing());
+        return !hitOwner.equals(definingOwner.get());
+    }
+
+    private static String displayPath(ProjectFile file) {
+        return file.toString().replace('\\', '/');
+    }
+
+    private static int spanLines(IAnalyzer.Range range) {
+        if (range.isEmpty()) {
+            return 0;
+        }
+        return Math.max(1, range.endLine() - range.startLine() + 1);
+    }
+
+    private record CandidateSelection(List<CodeUnit> candidates, boolean truncated) {}
+
+    private record DeadCodeFinding(
+            int score,
+            double confidence,
+            String kind,
+            String symbol,
+            ProjectFile file,
+            int startLine,
+            int endLine,
+            int totalUsageCount,
+            int externalUsageCount,
+            String evidence,
+            String rationale) {}
 
     // NOTE: analyzeGitHotspots is not available in brokk-core because GitHotspotAnalyzer
     // lives in the app module with dependencies (ai.brokk.concurrent.*) not available here.

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -95,7 +95,8 @@ class BrokkCoreMcpServerTest {
                 "reportLongMethodAndGodObjectSmells",
                 "reportExceptionHandlingSmells",
                 "reportStructuralCloneSmells",
-                "reportTestAssertionSmells");
+                "reportTestAssertionSmells",
+                "reportDeadCodeAndUnusedAbstractionSmells");
 
         for (var expected : expectedTools) {
             assertTrue(toolNames.contains(expected), "Missing tool: " + expected);
@@ -308,6 +309,24 @@ class BrokkCoreMcpServerTest {
     @Test
     void reportTestAssertionSmellsRunsWithoutError() {
         var result = callTool("reportTestAssertionSmells", Map.of("filePaths", List.of("README.md")));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportDeadCodeAndUnusedAbstractionSmellsRunsWithoutError() {
+        var result = callTool(
+                "reportDeadCodeAndUnusedAbstractionSmells",
+                Map.of("filePaths", List.of("README.md"), "fqNames", List.of()));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportDeadCodeAndUnusedAbstractionSmellsAcceptsMissingFqNames() {
+        var result = callTool("reportDeadCodeAndUnusedAbstractionSmells", Map.of("filePaths", List.of("README.md")));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -6,17 +6,22 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.analyzer.DisabledAnalyzer;
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.Languages;
 import ai.brokk.project.CoreProject;
 import ai.brokk.tools.SearchTools;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.PersonIdent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -315,20 +320,194 @@ class BrokkCoreMcpServerTest {
     }
 
     @Test
-    void reportDeadCodeAndUnusedAbstractionSmellsRunsWithoutError() {
-        var result = callTool(
-                "reportDeadCodeAndUnusedAbstractionSmells",
-                Map.of("filePaths", List.of("README.md"), "fqNames", List.of()));
+    void reportDeadCodeAndUnusedAbstractionSmellsAcceptsMissingFqNames() {
+        var result = callTool("reportDeadCodeAndUnusedAbstractionSmells", Map.of("filePaths", List.of("README.md")));
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());
     }
 
     @Test
-    void reportDeadCodeAndUnusedAbstractionSmellsAcceptsMissingFqNames() {
-        var result = callTool("reportDeadCodeAndUnusedAbstractionSmells", Map.of("filePaths", List.of("README.md")));
-        assertNotNull(result);
+    void reportDeadCodeReportsUnusedSymbolWithEvidence() throws Exception {
+        rebuildServerWithJavaSources(Map.of(
+                "src/main/java/com/example/Sample.java",
+                """
+                package com.example;
+                public class Sample {
+                    public int used(int value) {
+                        return value + 1;
+                    }
+
+                    private int unusedHelper(int value) {
+                        return value * 2;
+                    }
+                }
+                """
+                        .stripIndent()));
+
+        var result = callTool(
+                "reportDeadCodeAndUnusedAbstractionSmells",
+                Map.of(
+                        "filePaths",
+                        List.of("src/main/java/com/example/Sample.java"),
+                        "fqNames",
+                        List.of("com.example.Sample.unusedHelper")));
         assertFalse(result.isError() != null && result.isError());
-        assertFalse(result.content().isEmpty());
+        String text = textOf(result);
+        assertTrue(text.contains("com.example.Sample.unusedHelper"), text);
+        assertTrue(text.contains("no non-self usages found"), text);
+        assertTrue(text.contains("may be generated residue"), text);
+    }
+
+    @Test
+    void reportDeadCodeFlagsOneCallAbstraction() throws Exception {
+        rebuildServerWithJavaSources(Map.of(
+                "src/main/java/com/example/Target.java",
+                """
+                package com.example;
+                public class Target {
+                    public int oneCallWrapper(int value) {
+                        return value + 1;
+                    }
+                }
+                """
+                        .stripIndent(),
+                "src/main/java/com/example/Caller.java",
+                """
+                package com.example;
+                public class Caller {
+                    public int call(Target target) {
+                        return target.oneCallWrapper(41);
+                    }
+                }
+                """
+                        .stripIndent()));
+
+        var result = callTool(
+                "reportDeadCodeAndUnusedAbstractionSmells",
+                Map.of(
+                        "filePaths",
+                        List.of("src/main/java/com/example/Target.java"),
+                        "fqNames",
+                        List.of("com.example.Target.oneCallWrapper")));
+        assertFalse(result.isError() != null && result.isError());
+        String text = textOf(result);
+        assertTrue(text.contains("com.example.Target.oneCallWrapper"), text);
+        assertTrue(text.contains("only usage"), text);
+        assertTrue(text.contains("low-value abstraction"), text);
+    }
+
+    @Test
+    void reportDeadCodeSuppressesSymbolsWithMultipleCallers() throws Exception {
+        rebuildServerWithJavaSources(Map.of(
+                "src/main/java/com/example/Target.java",
+                """
+                package com.example;
+                public class Target {
+                    public int usedByMany(int value) {
+                        return value + 1;
+                    }
+                }
+                """
+                        .stripIndent(),
+                "src/main/java/com/example/First.java",
+                """
+                package com.example;
+                public class First {
+                    public int call(Target target) {
+                        return target.usedByMany(1);
+                    }
+                }
+                """
+                        .stripIndent(),
+                "src/main/java/com/example/Second.java",
+                """
+                package com.example;
+                public class Second {
+                    public int call(Target target) {
+                        return target.usedByMany(2);
+                    }
+                }
+                """
+                        .stripIndent()));
+
+        var result = callTool(
+                "reportDeadCodeAndUnusedAbstractionSmells",
+                Map.of(
+                        "filePaths",
+                        List.of("src/main/java/com/example/Target.java"),
+                        "fqNames",
+                        List.of("com.example.Target.usedByMany")));
+        assertFalse(result.isError() != null && result.isError());
+        String text = textOf(result);
+        assertTrue(text.contains("No dead code or unused abstraction smells met minScore"), text);
+        assertFalse(text.contains("| `com.example.Target.usedByMany` |"), text);
+    }
+
+    @Test
+    void reportDeadCodeDiscoversCandidatesWhenFqNamesEmpty() throws Exception {
+        rebuildServerWithJavaSources(Map.of(
+                "src/main/java/com/example/Discovery.java",
+                """
+                package com.example;
+                public class Discovery {
+                    private int unusedDeclaration(int value) {
+                        return value * 3;
+                    }
+                }
+                """
+                        .stripIndent()));
+
+        var result = callTool(
+                "reportDeadCodeAndUnusedAbstractionSmells",
+                Map.of(
+                        "filePaths", List.of("src/main/java/com/example/Discovery.java"),
+                        "fqNames", List.of()));
+        assertFalse(result.isError() != null && result.isError());
+        String text = textOf(result);
+        assertTrue(text.contains("unusedDeclaration"), text);
+        assertTrue(text.contains("no non-self usages found"), text);
+    }
+
+    // -- Helpers --
+
+    private String textOf(McpSchema.CallToolResult result) {
+        return result.content().stream()
+                .filter(McpSchema.TextContent.class::isInstance)
+                .map(McpSchema.TextContent.class::cast)
+                .map(McpSchema.TextContent::text)
+                .collect(Collectors.joining("\n"));
+    }
+
+    private void rebuildServerWithJavaSources(Map<String, String> sources) throws Exception {
+        commitTrackedFiles(projectRoot, sources, Instant.parse("2025-01-01T00:00:00Z"), "Add Java sources");
+        project.close();
+        project = new CoreProject(projectRoot);
+        IAnalyzer analyzer = Languages.JAVA.createAnalyzer(project);
+        var intel = new StandaloneCodeIntelligence(project, analyzer);
+        var searchTools = new SearchTools(intel);
+        server = new BrokkCoreMcpServer(project, intel, searchTools);
+    }
+
+    private static void commitTrackedFiles(
+            Path projectRoot, Map<String, String> filesByPath, Instant instant, String message) throws Exception {
+        try (Git git = Git.open(projectRoot.toFile())) {
+            var ident = new PersonIdent("Test User", "test@example.com", instant, ZoneId.of("UTC"));
+            for (var entry : filesByPath.entrySet()) {
+                Path file = projectRoot.resolve(entry.getKey());
+                Path parent = file.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+                Files.writeString(file, entry.getValue());
+                git.add().addFilepattern(entry.getKey().replace('\\', '/')).call();
+            }
+            git.commit()
+                    .setMessage(message)
+                    .setAuthor(ident)
+                    .setCommitter(ident)
+                    .setSign(false)
+                    .call();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Wires the existing `reportDeadCodeAndUnusedAbstractionSmells` through the brokk-core MCP server. This was the most complex of the seven brokk-core MCP gap issues — it depends on `UsageFinder` for symbol/reference analysis. The wrapper preserves the brokk-core invariant (no LLM, no subprocess, no network) by routing through brokk-shared's `UsageAnalyzerSelector` instead of the app-layer LLM-bound `UsageFinder`.

Brings the brokk-core MCP server from 28 to 29 advertised tools.

| Tool | Issue | App-layer reference |
|------|-------|---------------------|
| `reportDeadCodeAndUnusedAbstractionSmells` | #3603 | `app/src/main/java/ai/brokk/tools/CodeQualityTools.java:228-506` |

## What changed

### `brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java`
- New `reportDeadCodeAndUnusedAbstractionSmells(...)` method mirroring the app-layer eight-parameter signature.
- A `UsageAnalyzer` lambda that delegates to `UsageAnalyzerSelector.forTarget(target, analyzer, project)` per candidate and falls back to `RegexUsageAnalyzer` when `UsageAnalyzerSelector.shouldFallbackToRegex(...)` is true.
- Helpers ported alongside: `deadCodeCandidates`, `capCandidates`, `isDeadCodeCandidate`, `analyzeDeadCodeCandidate`, `isExternalUsage`, `displayPath`, `spanLines`.
- Records: `CandidateSelection`, `DeadCodeFinding`.

### `brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java`
- New `specs.add(tool("reportDeadCodeAndUnusedAbstractionSmells", ...))` registration wrapped in `withReadLock` with the eight-parameter schema mirroring the app-layer `@P` annotations.
- New `stringListArgOrEmpty(...)` helper alongside `stringListArg(...)` so the optional `fqNames` parameter can be absent from the request.

### `brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java`
- New tool name added to `expectedTools` in `registersAllExpectedTools`.
- Two smoke tests: one passes `fqNames: []` explicitly, the other omits it (covers the `stringListArgOrEmpty` path).

### `brokk-core/README.md`
- New documentation section for `reportDeadCodeAndUnusedAbstractionSmells` with the parameter table.
- Tool count bumped from 28 to 29.

## Why

`reportDeadCodeAndUnusedAbstractionSmells` is the slop-scan dead-code specialist lane's backbone — it identifies likely generated-code residue and one-call abstractions by combining analyzer declarations with reference analysis. Required by the WASM-sandboxed scan runtime that replaces the brokk headless executor.

## Architectural note: which `UsageFinder`?

There are two `UsageFinder` classes in this repo:
- `app/src/main/java/ai/brokk/usages/UsageFinder.java` — takes an `IAppContextManager`, uses `LlmUsageAnalyzer` as fallback. LLM-bound.
- `brokk-shared/src/main/java/ai/brokk/analyzer/usages/UsageFinder.java` — pure, takes an `ICoreProject` + injected `UsageAnalyzer`. No LLM.

The MCP wrapper uses **brokk-shared's** `UsageFinder` to preserve the no-LLM invariant. For per-language strategy selection it delegates to `UsageAnalyzerSelector.forTarget(...)` (already declared as "shared by context fragments and MCP tools") and uses `RegexUsageAnalyzer` as the deterministic fallback via `UsageAnalyzerSelector.shouldFallbackToRegex(...)`.

Net effect: Java uses JDT; JS/TS/Python/Rust use export-graph strategies with regex fallback; no per-language routing is duplicated, and no LLM is invoked.

## Verification

```bash
./gradlew :brokk-core:check
```

passes locally: spotless, errorprone/NullAway, compile, tests.

## Out of scope

The remaining three brokk-core MCP gap issues:
- #3605 (`reportSecretLikeCode`) — depends on `GitSecretScanner` which lives in `app/`
- #3606 (`analyzeGitHotspots`) — depends on `GitHotspotAnalyzer` with the same module-location problem
- #3607 (`getCommitDiff`) — a new deterministic tool, not a wrapper of existing app-layer code
