### PR TITLE
Cache JS/TS import specifier parsing

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
@@ -1134,7 +1134,7 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
     @Override
     protected Set<CodeUnit> resolveImports(ProjectFile file, List<String> importStatements) {
         var resolved = importStatements.stream()
-                .map(JsTsAnalyzer::extractModulePathFromImport)
+                .map(this::cachedModulePathFromImport)
                 .flatMap(Optional::stream)
                 .flatMap(path -> resolveImportModule(file, path).stream())
                 .flatMap(resolvedFile -> {
@@ -1159,7 +1159,7 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
     @Override
     public boolean couldImportFile(ProjectFile sourceFile, List<ImportInfo> imports, ProjectFile target) {
         for (ImportInfo imp : imports) {
-            Optional<String> modulePathOpt = extractModulePathFromImport(imp.rawSnippet());
+            Optional<String> modulePathOpt = cachedModulePathFromImport(imp.rawSnippet());
             if (modulePathOpt.isEmpty()) {
                 continue;
             }
@@ -1203,7 +1203,7 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
     public boolean couldImportFile(List<ImportInfo> imports, ProjectFile target) {
         // Prefer the 3-arg variant so we can use TSConfig context; keep this as a conservative fallback.
         for (ImportInfo imp : imports) {
-            Optional<String> modulePathOpt = extractModulePathFromImport(imp.rawSnippet());
+            Optional<String> modulePathOpt = cachedModulePathFromImport(imp.rawSnippet());
             if (modulePathOpt.isEmpty()) {
                 continue;
             }
@@ -1301,6 +1301,10 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
         if (cjsMatcher.find()) return Optional.of(cjsMatcher.group(1));
 
         return Optional.empty();
+    }
+
+    private Optional<String> cachedModulePathFromImport(String importStatement) {
+        return jsTsCache().importModuleSpecifierCache().get(importStatement, JsTsAnalyzer::extractModulePathFromImport);
     }
 
     protected static @Nullable ProjectFile resolveJavaScriptLikeModulePath(

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/cache/JsTsAnalyzerCache.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/cache/JsTsAnalyzerCache.java
@@ -12,11 +12,14 @@ import java.util.stream.Collectors;
 
 /** JS/TS-specific analyzer caches for module and path resolution. */
 public final class JsTsAnalyzerCache extends AnalyzerCache {
+    private final Cache<String, Optional<String>> importModuleSpecifierCache;
     private final Cache<ModulePathKey, JsTsAnalyzer.ResolutionOutcome> moduleResolutionCache;
     private final Cache<ModulePathFromBaseKey, Optional<ProjectFile>> moduleResolutionFromBaseCache;
 
     public JsTsAnalyzerCache() {
         super();
+        this.importModuleSpecifierCache =
+                Caffeine.newBuilder().maximumSize(20_000).build();
         this.moduleResolutionCache = Caffeine.newBuilder().maximumSize(10_000).build();
         this.moduleResolutionFromBaseCache =
                 Caffeine.newBuilder().maximumSize(20_000).build();
@@ -24,10 +27,13 @@ public final class JsTsAnalyzerCache extends AnalyzerCache {
 
     public JsTsAnalyzerCache(JsTsAnalyzerCache previous, Set<ProjectFile> changedFiles) {
         super(previous, changedFiles);
+        this.importModuleSpecifierCache =
+                Caffeine.newBuilder().maximumSize(20_000).build();
         this.moduleResolutionCache = Caffeine.newBuilder().maximumSize(10_000).build();
         this.moduleResolutionFromBaseCache =
                 Caffeine.newBuilder().maximumSize(20_000).build();
 
+        previous.importModuleSpecifierCache.asMap().forEach(this.importModuleSpecifierCache::put);
         if (changedFiles.isEmpty()) {
             previous.moduleResolutionCache.asMap().forEach(this.moduleResolutionCache::put);
             previous.moduleResolutionFromBaseCache.asMap().forEach(this.moduleResolutionFromBaseCache::put);
@@ -59,6 +65,10 @@ public final class JsTsAnalyzerCache extends AnalyzerCache {
             }
             this.moduleResolutionCache.put(key, outcome);
         });
+    }
+
+    public Cache<String, Optional<String>> importModuleSpecifierCache() {
+        return importModuleSpecifierCache;
     }
 
     public Cache<ModulePathKey, JsTsAnalyzer.ResolutionOutcome> moduleResolutionCache() {


### PR DESCRIPTION
### Description
Cache parsed JS/TS import module specifiers so repeated reference checks do not regex-parse the same raw import snippets.

**Key Changes**:
- Adds a bounded Caffeine cache to `JsTsAnalyzerCache` for parsed import module specifiers.
- Routes analyzer reference-check/import-resolution paths through the analyzer-owned cache while keeping `JsTsAnalyzer.extractModulePathFromImport` as the pure parser.

**Touch Points**:
- `brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/cache/JsTsAnalyzerCache.java`

Tests:
- `git diff --check`
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.imports.JavaScriptImportTest --tests ai.brokk.analyzer.usages.JsTsExportUsageReferenceGraphTest`
- Guided review against `master`: no findings
