### PR TITLE
Reduce custom-agent tool allocation churn

### DIFF
--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -135,13 +135,16 @@ public class CustomAgentExecutor {
             }
 
             var additionsThisTurn = new ArrayList<ContextFragment>();
+            var executionRegistry = registryForContext(toolRegistry, context);
 
             // Parallel execution for safe tools
             var parallelPartition =
                     ToolRegistry.partitionByNames(ai.toolExecutionRequests(), PARALLEL_SAFE_SEARCH_TOOL_NAMES);
             var parallelRequests = parallelPartition.matchingRequests();
-            Map<ToolExecutionRequest, CompletableFuture<ToolExecutionResult>> parallelFutures = new LinkedHashMap<>();
+            Map<ToolExecutionRequest, CompletableFuture<ToolExecutionResult>> parallelFutures =
+                    new LinkedHashMap<>(parallelRequests.size());
             if (parallelRequests.size() > 1) {
+                var parallelExecutionRegistry = executionRegistry;
                 for (var request : parallelRequests) {
                     boolean destructive = toolRegistry.isToolAnnotated(request.name(), Destructive.class);
                     var approval = io.beforeToolCall(request, destructive);
@@ -152,12 +155,10 @@ public class CustomAgentExecutor {
                                         request, "Tool call '%s' was denied by user.".formatted(request.name()))));
                     } else {
                         io.toolCallInProgress(request);
-                        Context snapshotContext = context;
                         parallelFutures.put(
-                                request, LoggingFuture.supplyCallableVirtual(() -> ToolRegistry.fromBase(toolRegistry)
-                                        .register(new WorkspaceTools(snapshotContext))
-                                        .build()
-                                        .executeTool(request)));
+                                request,
+                                LoggingFuture.supplyCallableVirtual(
+                                        () -> parallelExecutionRegistry.executeTool(request)));
                     }
                 }
             }
@@ -187,9 +188,6 @@ public class CustomAgentExecutor {
                         io.afterToolOutput(toolResult);
                     } else {
                         io.toolCallInProgress(request);
-                        var executionRegistry = ToolRegistry.fromBase(toolRegistry)
-                                .register(new WorkspaceTools(context))
-                                .build();
                         toolResult = executionRegistry.executeTool(request);
                         io.afterToolOutput(toolResult);
                     }
@@ -199,9 +197,11 @@ public class CustomAgentExecutor {
 
                 if (toolResult.result() instanceof WorkspaceTools.WorkspaceMutationOutput output) {
                     context = output.context();
+                    executionRegistry = registryForContext(toolRegistry, context);
                     additionsThisTurn.addAll(output.addedFragments());
                 } else if (toolResult.result() instanceof WorkspaceTools.DropWorkspaceOutput output) {
                     context = output.context();
+                    executionRegistry = registryForContext(toolRegistry, context);
                     additionsThisTurn.addAll(output.addedFragments());
                 }
 
@@ -221,6 +221,12 @@ public class CustomAgentExecutor {
         }
 
         return errorResult("Turn limit reached (%d turns).".formatted(maxTurns));
+    }
+
+    private static ToolRegistry registryForContext(ToolRegistry baseRegistry, Context context) {
+        return ToolRegistry.fromBase(baseRegistry)
+                .register(new WorkspaceTools(context))
+                .build();
     }
 
     private String buildTurnDirective(

--- a/app/src/main/java/ai/brokk/tools/ToolExecutionResult.java
+++ b/app/src/main/java/ai/brokk/tools/ToolExecutionResult.java
@@ -15,6 +15,7 @@ public final class ToolExecutionResult {
     private final Status status;
     private final ToolOutput result;
     private final long elapsedMs;
+    private @Nullable ToolExecutionResultMessage message;
 
     private ToolExecutionResult(ToolExecutionRequest request, Status status, ToolOutput result, long elapsedMs) {
         this.request = request;
@@ -120,6 +121,10 @@ public final class ToolExecutionResult {
      * @return A ToolExecutionResultMessage.
      */
     public ToolExecutionResultMessage toMessage() {
+        var cached = message;
+        if (cached != null) {
+            return cached;
+        }
         String text =
                 switch (status) {
                     case SUCCESS -> result.llmText();
@@ -127,7 +132,9 @@ public final class ToolExecutionResult {
                     case INTERNAL_ERROR -> "Internal error: " + result.llmText();
                     case FATAL -> "Fatal error: " + result.llmText();
                 };
-        return new ToolExecutionResultMessage(toolId(), toolName(), text);
+        var resultMessage = new ToolExecutionResultMessage(toolId(), toolName(), text);
+        message = resultMessage;
+        return resultMessage;
     }
 
     public ToolExecutionRequest request() {


### PR DESCRIPTION
### Description
Reduces avoidable allocations in custom-agent tool loops by reusing context-specific tool registries within a turn and caching tool-result message conversion.

**Key Changes**:
- Reuses a workspace-aware tool registry until the custom-agent context changes, then refreshes it after workspace mutation outputs.
- Caches `ToolExecutionResultMessage` creation inside `ToolExecutionResult.toMessage()` for repeated conversions.

**Touch Points**:
- `CustomAgentExecutor.java`
- `ToolExecutionResult.java`

Validation:
- `git fetch && git rebase`
- `./gradlew :app:spotlessJavaApply`
- Guided review against `master`: no findings

Blocked validation:
- `./gradlew fix tidy` and focused compile/test were blocked by unrelated dirty `brokk-shared` Error Prone/internal compile state in this worktree.
