### PR TITLE
Optimize headless job event polling

### DIFF
--- a/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -223,19 +224,21 @@ public final class JobStore {
         }
 
         var result = new ArrayList<JobEvent>();
-        var lines = Files.readAllLines(eventsFile, StandardCharsets.UTF_8);
-
-        for (var line : lines) {
-            if (line.isBlank()) {
-                continue;
-            }
-            try {
-                var event = objectMapper.readValue(line, JobEvent.class);
-                if (event.seq() > afterSeq) {
-                    result.add(event);
+        try (Stream<String> lines = Files.lines(eventsFile, StandardCharsets.UTF_8)) {
+            var iterator = lines.iterator();
+            while (iterator.hasNext()) {
+                var line = iterator.next();
+                if (line.isBlank()) {
+                    continue;
                 }
-            } catch (JsonProcessingException e) {
-                logger.debug("Skipping malformed event line (likely partial write): {}", e.getMessage());
+                try {
+                    var event = objectMapper.readValue(line, JobEvent.class);
+                    if (event.seq() > afterSeq) {
+                        result.add(event);
+                    }
+                } catch (JsonProcessingException e) {
+                    logger.debug("Skipping malformed event line (likely partial write): {}", e.getMessage());
+                }
             }
         }
 

--- a/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
@@ -187,6 +187,36 @@ class JobStoreTest {
     }
 
     @Test
+    void testReadEvents_streamsLinesPreservingFilterSortAndLimitSemantics(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var spec = JobSpec.of("test task", DEFAULT_PLANNER_MODEL);
+        var result = store.createOrGetJob("idem-key-1", spec);
+        var jobId = result.jobId();
+
+        var eventsFile = store.getJobDir(jobId).resolve("events.jsonl");
+        Files.writeString(
+                eventsFile,
+                """
+                {"seq":4,"timestamp":400,"type":"event4","data":"data4"}
+                {"seq":2,"timestamp":200,"type":"event2","data":"data2"}
+                {"seq":3,"timestamp":300,"type":"event3","data":"data3"}
+                {"seq":5,"timestamp":500,"type":"TRUNC
+                {"seq":1,"timestamp":100,"type":"event1","data":"data1"}
+                """,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE);
+
+        var events = store.readEvents(jobId, 1, 2);
+
+        assertEquals(2, events.size());
+        assertEquals(2L, events.get(0).seq());
+        assertEquals("event2", events.get(0).type());
+        assertEquals(3L, events.get(1).seq());
+        assertEquals("event3", events.get(1).type());
+    }
+
+    @Test
     void testSequenceCounter_skipsTruncatedTrailingLine(@TempDir Path tempDir) throws Exception {
         var store = new JobStore(tempDir);
         var spec = JobSpec.of("test task", DEFAULT_PLANNER_MODEL);


### PR DESCRIPTION
### Description
Optimize headless job event polling by streaming events.jsonl reads instead of loading the whole file into memory on every poll.

**Key Changes**:
- Replace readAllLines in JobStore.readEvents with a try-with-resources Files.lines stream while preserving malformed partial-line tolerance, afterSeq filtering, limit handling, and sequence ordering.
- Add JobStore coverage for malformed-line skipping combined with filter, sort, and limit semantics.

**Touch Points**:
- app/src/main/java/ai/brokk/executor/jobs/JobStore.java
- app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java

Issue: #3622

Verification:
- ./gradlew :app:test --tests ai.brokk.executor.jobs.JobStoreTest (blocked by unrelated compileTestJava missing-symbol failures)
- ./gradlew fix tidy (blocked by unrelated Error Prone crash in brokk-shared/src/main/java/ai/brokk/git/GitDistance.java)
- ./gradlew :app:compileJava (blocked by unrelated broad missing-symbol failures)