### PR TITLE
Memoize GitDistance related-file relevance

### DIFF
--- a/app/src/test/java/ai/brokk/analyzer/ranking/GitDistanceRelatedFilesTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/ranking/GitDistanceRelatedFilesTest.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.AfterAll;
@@ -117,6 +118,32 @@ public class GitDistanceRelatedFilesTest {
 
         var results = GitDistance.getRelatedFiles((GitRepo) testProject.getRepo(), seedWeights, 10);
         assertFalse(results.isEmpty(), "PMI should return results");
+    }
+
+    @Test
+    public void repeatedRelatedFileRequestsReuseSnapshotCache() throws Exception {
+        assertNotNull(testPath, "Test path should not be null");
+        var userService = new ProjectFile(testProject.getRoot(), "UserService.java");
+        var user = new ProjectFile(testProject.getRoot(), "User.java");
+
+        GitDistance.clearRelatedFilesCache();
+        long baselineHits = GitDistance.relatedFilesCacheHitCount();
+
+        var firstSeeds = new HashMap<ProjectFile, Double>();
+        firstSeeds.put(userService, 1.0);
+        firstSeeds.put(user, 0.5);
+        var firstResults = GitDistance.getRelatedFiles((GitRepo) testProject.getRepo(), firstSeeds, 10);
+
+        var sameSeedsDifferentOrder = new HashMap<ProjectFile, Double>();
+        sameSeedsDifferentOrder.put(user, 0.5);
+        sameSeedsDifferentOrder.put(userService, 1.0);
+        var secondResults = GitDistance.getRelatedFiles((GitRepo) testProject.getRepo(), sameSeedsDifferentOrder, 10);
+
+        assertEquals(firstResults, secondResults, "Cached GitDistance results should preserve ordering and scores");
+        assertEquals(
+                baselineHits + 1,
+                GitDistance.relatedFilesCacheHitCount(),
+                "Repeated requests for the same snapshot, seeds, and topK should hit the cache");
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/analyzer/ranking/GitDistanceRelatedFilesTest.java
+++ b/app/src/test/java/ai/brokk/analyzer/ranking/GitDistanceRelatedFilesTest.java
@@ -147,6 +147,36 @@ public class GitDistanceRelatedFilesTest {
     }
 
     @Test
+    public void cachedRelatedFileRequestsFilterDeletedWorkingTreeFiles() throws Exception {
+        assertNotNull(testPath, "Test path should not be null");
+        var userService = new ProjectFile(testProject.getRoot(), "UserService.java");
+        var user = new ProjectFile(testProject.getRoot(), "User.java");
+
+        GitDistance.clearRelatedFilesCache();
+        var seeds = Map.of(userService, 1.0);
+        var firstResults = GitDistance.getRelatedFiles((GitRepo) testProject.getRepo(), seeds, 10);
+        assertTrue(firstResults.stream().anyMatch(result -> result.file().equals(user)), firstResults.toString());
+
+        var originalContent = Files.readString(user.absPath());
+        try {
+            Files.delete(user.absPath());
+            long baselineHits = GitDistance.relatedFilesCacheHitCount();
+            var secondResults = GitDistance.getRelatedFiles((GitRepo) testProject.getRepo(), seeds, 10);
+
+            assertFalse(
+                    secondResults.stream().anyMatch(result -> result.file().equals(user)),
+                    "Cached GitDistance results should not return files deleted from the working tree");
+            assertEquals(
+                    baselineHits + 1,
+                    GitDistance.relatedFilesCacheHitCount(),
+                    "Deleted-file filtering should run on the cache-hit path");
+        } finally {
+            Files.writeString(user.absPath(), originalContent);
+            GitDistance.clearRelatedFilesCache();
+        }
+    }
+
+    @Test
     public void pmiCanonicalizesRenames() throws Exception {
         var tempDir = Files.createTempDirectory("brokk-pmi-rename-test-");
         try {

--- a/brokk-shared/src/main/java/ai/brokk/git/GitDistance.java
+++ b/brokk-shared/src/main/java/ai/brokk/git/GitDistance.java
@@ -2,11 +2,15 @@ package ai.brokk.git;
 
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -21,6 +25,14 @@ public final class GitDistance {
     private static final Logger logger = LogManager.getLogger(GitDistance.class);
     private static final int COMMITS_TO_PROCESS = 1_000;
     private static final int LARGE_SEED_THRESHOLD = 100;
+    private static final Cache<RelatedFilesCacheKey, List<IAnalyzer.FileRelevance>> RELATED_FILES_CACHE =
+            Caffeine.newBuilder().maximumSize(256).recordStats().build();
+
+    private record SeedWeight(ProjectFile file, double weight) {}
+
+    private record GitSnapshot(String branch, String currentCommitId) {}
+
+    private record RelatedFilesCacheKey(GitSnapshot snapshot, List<SeedWeight> seedWeights, int topK) {}
 
     /** Represents an edge between two files in the co-occurrence graph. */
     public record FileEdge(ProjectFile src, ProjectFile dst) {}
@@ -42,7 +54,20 @@ public final class GitDistance {
         }
 
         try {
-            return computeConditionalScores(repo, seedWeights, k);
+            var snapshot = currentSnapshot(repo);
+            if (snapshot.isEmpty()) {
+                return computeConditionalScores(repo, repo.getCurrentBranch(), seedWeights, k);
+            }
+
+            var key = new RelatedFilesCacheKey(snapshot.get(), normalizedSeedWeights(seedWeights), k);
+            var cached = RELATED_FILES_CACHE.getIfPresent(key);
+            if (cached != null) {
+                return cached;
+            }
+
+            var computed = computeConditionalScores(repo, snapshot.get().branch(), seedWeights, k);
+            RELATED_FILES_CACHE.put(key, computed);
+            return computed;
         } catch (UnsupportedOperationException e) {
             return List.of();
         } catch (GitAPIException e) {
@@ -50,9 +75,29 @@ public final class GitDistance {
         }
     }
 
+    private static Optional<GitSnapshot> currentSnapshot(IGitRepo repo) {
+        try {
+            return Optional.of(new GitSnapshot(repo.getCurrentBranch(), repo.getCurrentCommitId()));
+        } catch (UnsupportedOperationException e) {
+            logger.debug("GitDistance related-file cache disabled because repo snapshot is unavailable", e);
+            return Optional.empty();
+        } catch (GitAPIException e) {
+            logger.debug("GitDistance related-file cache disabled because repo snapshot failed to resolve", e);
+            return Optional.empty();
+        }
+    }
+
+    private static List<SeedWeight> normalizedSeedWeights(Map<ProjectFile, Double> seedWeights) {
+        return seedWeights.entrySet().stream()
+                .map(entry -> new SeedWeight(entry.getKey(), entry.getValue()))
+                .sorted(Comparator.comparing(SeedWeight::file).thenComparingDouble(SeedWeight::weight))
+                .toList();
+    }
+
     private static List<IAnalyzer.FileRelevance> computeConditionalScores(
-            IGitRepo repo, Map<ProjectFile, Double> seedWeights, int k) throws GitAPIException, InterruptedException {
-        var baselineCommits = repo.listCommitsDetailed(repo.getCurrentBranch(), COMMITS_TO_PROCESS);
+            IGitRepo repo, String branch, Map<ProjectFile, Double> seedWeights, int k)
+            throws GitAPIException, InterruptedException {
+        var baselineCommits = repo.listCommitsDetailed(branch, COMMITS_TO_PROCESS);
         final int n = baselineCommits.size();
         if (n == 0) {
             return List.of();
@@ -244,5 +289,16 @@ public final class GitDistance {
         }
 
         return scores;
+    }
+
+    @VisibleForTesting
+    public static void clearRelatedFilesCache() {
+        RELATED_FILES_CACHE.invalidateAll();
+        RELATED_FILES_CACHE.cleanUp();
+    }
+
+    @VisibleForTesting
+    public static long relatedFilesCacheHitCount() {
+        return RELATED_FILES_CACHE.stats().hitCount();
     }
 }

--- a/brokk-shared/src/main/java/ai/brokk/git/GitDistance.java
+++ b/brokk-shared/src/main/java/ai/brokk/git/GitDistance.java
@@ -62,7 +62,7 @@ public final class GitDistance {
             var key = new RelatedFilesCacheKey(snapshot.get(), normalizedSeedWeights(seedWeights), k);
             var cached = RELATED_FILES_CACHE.getIfPresent(key);
             if (cached != null) {
-                return cached;
+                return existingFiles(cached);
             }
 
             var computed = computeConditionalScores(repo, snapshot.get().branch(), seedWeights, k);
@@ -92,6 +92,10 @@ public final class GitDistance {
                 .map(entry -> new SeedWeight(entry.getKey(), entry.getValue()))
                 .sorted(Comparator.comparing(SeedWeight::file).thenComparingDouble(SeedWeight::weight))
                 .toList();
+    }
+
+    private static List<IAnalyzer.FileRelevance> existingFiles(List<IAnalyzer.FileRelevance> results) {
+        return results.stream().filter(result -> result.file().exists()).toList();
     }
 
     private static List<IAnalyzer.FileRelevance> computeConditionalScores(


### PR DESCRIPTION
### Description
Adds bounded, snapshot-scoped memoization for GitDistance related-file relevance calculations so repeated headless executor/search relevance calls avoid recomputing the same recent-history scores. Cache hits are filtered against current working-tree file existence to avoid returning stale deleted paths.

**Key Changes**:
- Adds a bounded Caffeine cache keyed by branch, current commit, normalized seed weights, and topK for GitDistance related-file scoring.
- Filters cached relevance results to existing files before returning them and adds regression coverage for equivalent seed ordering and deleted working-tree files.

**Touch Points**:
- brokk-shared/src/main/java/ai/brokk/git/GitDistance.java
- app/src/test/java/ai/brokk/analyzer/ranking/GitDistanceRelatedFilesTest.java