### PR TITLE
Add literal fast path for definition searches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ with try/catch is unnecessary and futile; don't do that.
 ## Project-specific guidelines
 
 1. **Use ProjectFile to represent files**. String and File and Path all have issues that ProjectFile resolves. If you're dealing with files but you don't have the ProjectFile API available, stop and ask the user to provide it. DO NOT write code that reads from a File or Path unless explicitly instructed to do so.
+1. **Reuse shared text/regex utilities**. Before adding local ASCII, literal matching, or regex-shape parsing helpers, check `brokk-shared/src/main/java/ai/brokk/util`. In particular, use `AsciiUtil` for ASCII-only matching/case operations and `RegexLiteralSet` for parsing safe literal/quoted-literal contains patterns.
 
 ## Concurrency
 

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1389,6 +1389,10 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
     private Set<CodeUnit> searchDefinitionsInternal(Pattern compiledPattern, @Nullable String substringFilter) {
         checkStale("searchDefinitionsInternal");
+        var literalSearch = LiteralDefinitionSearch.from(compiledPattern, substringFilter);
+        if (literalSearch.isPresent()) {
+            return searchDefinitionsByLiterals(literalSearch.get());
+        }
         var threadLocalMatcher = ThreadLocal.withInitial(() -> compiledPattern.matcher(""));
         return this.state.codeUnitState.keySet().parallelStream()
                 .filter(cu -> !cu.isSynthetic())
@@ -1397,6 +1401,89 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 .filter(cu -> threadLocalMatcher.get().reset(cu.fqName()).find())
                 .filter(cu -> !isAnonymousStructure(cu.fqName()))
                 .collect(Collectors.toSet());
+    }
+
+    private Set<CodeUnit> searchDefinitionsByLiterals(LiteralDefinitionSearch search) {
+        var literals = search.literals();
+        return this.state.codeUnitState.keySet().parallelStream()
+                .filter(cu -> !cu.isSynthetic())
+                .filter(cu -> {
+                    String fqName = search.caseInsensitive() ? cu.fqName().toLowerCase(Locale.ROOT) : cu.fqName();
+                    return literals.stream().anyMatch(fqName::contains);
+                })
+                .filter(cu -> !isAnonymousStructure(cu.fqName()))
+                .collect(Collectors.toSet());
+    }
+
+    private record LiteralDefinitionSearch(List<String> literals, boolean caseInsensitive) {
+        private static Optional<LiteralDefinitionSearch> from(Pattern pattern, @Nullable String substringFilter) {
+            String regex = pattern.pattern();
+            if (regex.startsWith("(?i)")) {
+                return fromLiteralPattern(regex.substring("(?i)".length()), true);
+            }
+
+            if ((pattern.flags() & Pattern.CASE_INSENSITIVE) != 0) {
+                return fromLiteralPattern(regex, true);
+            }
+            if (substringFilter != null) {
+                return Optional.of(new LiteralDefinitionSearch(List.of(substringFilter), true));
+            }
+            return fromLiteralPattern(regex, false);
+        }
+
+        private static Optional<LiteralDefinitionSearch> fromLiteralPattern(String regex, boolean caseInsensitive) {
+            String body = stripContainsWrapper(regex);
+            body = stripGroup(body);
+            if (body.isEmpty()) {
+                return Optional.empty();
+            }
+
+            var literals = new ArrayList<String>();
+            for (String quoted : body.split("\\|", -1)) {
+                var literal = unquoteLiteral(quoted);
+                if (literal.isEmpty()) {
+                    return Optional.empty();
+                }
+                literals.add(caseInsensitive ? literal.get().toLowerCase(Locale.ROOT) : literal.get());
+            }
+            return Optional.of(new LiteralDefinitionSearch(List.copyOf(literals), caseInsensitive));
+        }
+
+        private static String stripContainsWrapper(String regex) {
+            String body = regex;
+            if (body.startsWith(".*?")) {
+                body = body.substring(".*?".length());
+            } else if (body.startsWith(".*")) {
+                body = body.substring(".*".length());
+            }
+
+            if (body.endsWith(".*?")) {
+                body = body.substring(0, body.length() - ".*?".length());
+            } else if (body.endsWith(".*")) {
+                body = body.substring(0, body.length() - ".*".length());
+            }
+            return body;
+        }
+
+        private static String stripGroup(String body) {
+            if (body.startsWith("(?:") && body.endsWith(")")) {
+                return body.substring(3, body.length() - 1);
+            }
+            if (body.startsWith("(") && body.endsWith(")")) {
+                return body.substring(1, body.length() - 1);
+            }
+            return body;
+        }
+
+        private static Optional<String> unquoteLiteral(String regex) {
+            if (regex.startsWith("\\Q") && regex.endsWith("\\E")) {
+                return Optional.of(regex.substring(2, regex.length() - 2));
+            }
+            if (regex.chars().noneMatch(ch -> ".^$*+?{}[]\\|()".indexOf(ch) >= 0)) {
+                return Optional.of(regex);
+            }
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -3,6 +3,7 @@ package ai.brokk.analyzer;
 import ai.brokk.analyzer.cache.AnalyzerCache;
 import ai.brokk.concurrent.ExecutorsUtil;
 import ai.brokk.project.ICoreProject;
+import ai.brokk.util.AsciiUtil;
 import ai.brokk.util.ConcurrencyUtil;
 import ai.brokk.util.TextCanonicalizer;
 import com.github.benmanes.caffeine.cache.Cache;
@@ -1412,40 +1413,13 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                     if (!search.caseInsensitive()) {
                         return literals.stream().anyMatch(fqName::contains);
                     }
-                    if (!isAscii(fqName)) {
+                    if (!AsciiUtil.isAscii(fqName)) {
                         return compiledPattern.matcher(fqName).find();
                     }
-                    return literals.stream().anyMatch(literal -> containsAsciiIgnoreCase(fqName, literal));
+                    return literals.stream().anyMatch(literal -> AsciiUtil.containsIgnoreCase(fqName, literal));
                 })
                 .filter(cu -> !isAnonymousStructure(cu.fqName()))
                 .collect(Collectors.toSet());
-    }
-
-    private static boolean containsAsciiIgnoreCase(String haystack, String needle) {
-        int maxStart = haystack.length() - needle.length();
-        for (int start = 0; start <= maxStart; start++) {
-            if (regionMatchesAsciiIgnoreCase(haystack, start, needle)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean regionMatchesAsciiIgnoreCase(String haystack, int start, String needle) {
-        for (int i = 0; i < needle.length(); i++) {
-            if (toAsciiLower(haystack.charAt(start + i)) != toAsciiLower(needle.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static char toAsciiLower(char ch) {
-        return ch >= 'A' && ch <= 'Z' ? (char) (ch + ('a' - 'A')) : ch;
-    }
-
-    private static boolean isAscii(String text) {
-        return text.chars().allMatch(ch -> ch < 128);
     }
 
     private record LiteralDefinitionSearch(List<String> literals, boolean caseInsensitive) {
@@ -1459,7 +1433,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 return fromLiteralPattern(regex, true);
             }
             if (substringFilter != null) {
-                if (!isAscii(substringFilter)) {
+                if (!AsciiUtil.isAscii(substringFilter)) {
                     return Optional.empty();
                 }
                 return Optional.of(new LiteralDefinitionSearch(List.of(substringFilter), true));
@@ -1480,7 +1454,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 if (literal.isEmpty()) {
                     return Optional.empty();
                 }
-                if (caseInsensitive && !isAscii(literal.get())) {
+                if (caseInsensitive && !AsciiUtil.isAscii(literal.get())) {
                     return Optional.empty();
                 }
                 literals.add(literal.get());

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -5,6 +5,7 @@ import ai.brokk.concurrent.ExecutorsUtil;
 import ai.brokk.project.ICoreProject;
 import ai.brokk.util.AsciiUtil;
 import ai.brokk.util.ConcurrencyUtil;
+import ai.brokk.util.RegexLiteralSet;
 import ai.brokk.util.TextCanonicalizer;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -1390,7 +1391,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
     private Set<CodeUnit> searchDefinitionsInternal(Pattern compiledPattern, @Nullable String substringFilter) {
         checkStale("searchDefinitionsInternal");
-        var literalSearch = LiteralDefinitionSearch.from(compiledPattern, substringFilter);
+        var literalSearch = RegexLiteralSet.fromContainsPattern(compiledPattern, substringFilter);
         if (literalSearch.isPresent()) {
             return searchDefinitionsByLiterals(literalSearch.get(), compiledPattern);
         }
@@ -1404,7 +1405,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 .collect(Collectors.toSet());
     }
 
-    private Set<CodeUnit> searchDefinitionsByLiterals(LiteralDefinitionSearch search, Pattern compiledPattern) {
+    private Set<CodeUnit> searchDefinitionsByLiterals(RegexLiteralSet search, Pattern compiledPattern) {
         var literals = search.literals();
         return this.state.codeUnitState.keySet().parallelStream()
                 .filter(cu -> !cu.isSynthetic())
@@ -1420,83 +1421,6 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 })
                 .filter(cu -> !isAnonymousStructure(cu.fqName()))
                 .collect(Collectors.toSet());
-    }
-
-    private record LiteralDefinitionSearch(List<String> literals, boolean caseInsensitive) {
-        private static Optional<LiteralDefinitionSearch> from(Pattern pattern, @Nullable String substringFilter) {
-            String regex = pattern.pattern();
-            if (regex.startsWith("(?i)")) {
-                return fromLiteralPattern(regex.substring("(?i)".length()), true);
-            }
-
-            if ((pattern.flags() & Pattern.CASE_INSENSITIVE) != 0) {
-                return fromLiteralPattern(regex, true);
-            }
-            if (substringFilter != null) {
-                if (!AsciiUtil.isAscii(substringFilter)) {
-                    return Optional.empty();
-                }
-                return Optional.of(new LiteralDefinitionSearch(List.of(substringFilter), true));
-            }
-            return fromLiteralPattern(regex, false);
-        }
-
-        private static Optional<LiteralDefinitionSearch> fromLiteralPattern(String regex, boolean caseInsensitive) {
-            String body = stripContainsWrapper(regex);
-            body = stripGroup(body);
-            if (body.isEmpty()) {
-                return Optional.empty();
-            }
-
-            var literals = new ArrayList<String>();
-            for (String quoted : body.split("\\|", -1)) {
-                var literal = unquoteLiteral(quoted);
-                if (literal.isEmpty()) {
-                    return Optional.empty();
-                }
-                if (caseInsensitive && !AsciiUtil.isAscii(literal.get())) {
-                    return Optional.empty();
-                }
-                literals.add(literal.get());
-            }
-            return Optional.of(new LiteralDefinitionSearch(List.copyOf(literals), caseInsensitive));
-        }
-
-        private static String stripContainsWrapper(String regex) {
-            String body = regex;
-            if (body.startsWith(".*?")) {
-                body = body.substring(".*?".length());
-            } else if (body.startsWith(".*")) {
-                body = body.substring(".*".length());
-            }
-
-            if (body.endsWith(".*?")) {
-                body = body.substring(0, body.length() - ".*?".length());
-            } else if (body.endsWith(".*")) {
-                body = body.substring(0, body.length() - ".*".length());
-            }
-            return body;
-        }
-
-        private static String stripGroup(String body) {
-            if (body.startsWith("(?:") && body.endsWith(")")) {
-                return body.substring(3, body.length() - 1);
-            }
-            if (body.startsWith("(") && body.endsWith(")")) {
-                return body.substring(1, body.length() - 1);
-            }
-            return body;
-        }
-
-        private static Optional<String> unquoteLiteral(String regex) {
-            if (regex.startsWith("\\Q") && regex.endsWith("\\E")) {
-                return Optional.of(regex.substring(2, regex.length() - 2));
-            }
-            if (regex.chars().noneMatch(ch -> ".^$*+?{}[]\\|()".indexOf(ch) >= 0)) {
-                return Optional.of(regex);
-            }
-            return Optional.empty();
-        }
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1391,7 +1391,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         checkStale("searchDefinitionsInternal");
         var literalSearch = LiteralDefinitionSearch.from(compiledPattern, substringFilter);
         if (literalSearch.isPresent()) {
-            return searchDefinitionsByLiterals(literalSearch.get());
+            return searchDefinitionsByLiterals(literalSearch.get(), compiledPattern);
         }
         var threadLocalMatcher = ThreadLocal.withInitial(() -> compiledPattern.matcher(""));
         return this.state.codeUnitState.keySet().parallelStream()
@@ -1403,16 +1403,49 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 .collect(Collectors.toSet());
     }
 
-    private Set<CodeUnit> searchDefinitionsByLiterals(LiteralDefinitionSearch search) {
+    private Set<CodeUnit> searchDefinitionsByLiterals(LiteralDefinitionSearch search, Pattern compiledPattern) {
         var literals = search.literals();
         return this.state.codeUnitState.keySet().parallelStream()
                 .filter(cu -> !cu.isSynthetic())
                 .filter(cu -> {
-                    String fqName = search.caseInsensitive() ? cu.fqName().toLowerCase(Locale.ROOT) : cu.fqName();
-                    return literals.stream().anyMatch(fqName::contains);
+                    String fqName = cu.fqName();
+                    if (!search.caseInsensitive()) {
+                        return literals.stream().anyMatch(fqName::contains);
+                    }
+                    if (!isAscii(fqName)) {
+                        return compiledPattern.matcher(fqName).find();
+                    }
+                    return literals.stream().anyMatch(literal -> containsAsciiIgnoreCase(fqName, literal));
                 })
                 .filter(cu -> !isAnonymousStructure(cu.fqName()))
                 .collect(Collectors.toSet());
+    }
+
+    private static boolean containsAsciiIgnoreCase(String haystack, String needle) {
+        int maxStart = haystack.length() - needle.length();
+        for (int start = 0; start <= maxStart; start++) {
+            if (regionMatchesAsciiIgnoreCase(haystack, start, needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean regionMatchesAsciiIgnoreCase(String haystack, int start, String needle) {
+        for (int i = 0; i < needle.length(); i++) {
+            if (toAsciiLower(haystack.charAt(start + i)) != toAsciiLower(needle.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static char toAsciiLower(char ch) {
+        return ch >= 'A' && ch <= 'Z' ? (char) (ch + ('a' - 'A')) : ch;
+    }
+
+    private static boolean isAscii(String text) {
+        return text.chars().allMatch(ch -> ch < 128);
     }
 
     private record LiteralDefinitionSearch(List<String> literals, boolean caseInsensitive) {
@@ -1426,6 +1459,9 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 return fromLiteralPattern(regex, true);
             }
             if (substringFilter != null) {
+                if (!isAscii(substringFilter)) {
+                    return Optional.empty();
+                }
                 return Optional.of(new LiteralDefinitionSearch(List.of(substringFilter), true));
             }
             return fromLiteralPattern(regex, false);
@@ -1444,7 +1480,10 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 if (literal.isEmpty()) {
                     return Optional.empty();
                 }
-                literals.add(caseInsensitive ? literal.get().toLowerCase(Locale.ROOT) : literal.get());
+                if (caseInsensitive && !isAscii(literal.get())) {
+                    return Optional.empty();
+                }
+                literals.add(literal.get());
             }
             return Optional.of(new LiteralDefinitionSearch(List.copyOf(literals), caseInsensitive));
         }

--- a/brokk-shared/src/main/java/ai/brokk/util/AsciiUtil.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/AsciiUtil.java
@@ -1,0 +1,41 @@
+package ai.brokk.util;
+
+public final class AsciiUtil {
+    private AsciiUtil() {}
+
+    public static boolean isAscii(CharSequence text) {
+        for (int i = 0; i < text.length(); i++) {
+            if (!isAscii(text.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean containsIgnoreCase(String haystack, String needle) {
+        int maxStart = haystack.length() - needle.length();
+        for (int start = 0; start <= maxStart; start++) {
+            if (regionMatchesIgnoreCase(haystack, start, needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isAscii(char ch) {
+        return ch < 128;
+    }
+
+    private static boolean regionMatchesIgnoreCase(String haystack, int start, String needle) {
+        for (int i = 0; i < needle.length(); i++) {
+            if (toLower(haystack.charAt(start + i)) != toLower(needle.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static char toLower(char ch) {
+        return ch >= 'A' && ch <= 'Z' ? (char) (ch + ('a' - 'A')) : ch;
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/util/RegexLiteralSet.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/RegexLiteralSet.java
@@ -1,0 +1,84 @@
+package ai.brokk.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.Nullable;
+
+public record RegexLiteralSet(List<String> literals, boolean caseInsensitive) {
+    public static Optional<RegexLiteralSet> fromContainsPattern(Pattern pattern, @Nullable String substringFilter) {
+        String regex = pattern.pattern();
+        if (regex.startsWith("(?i)")) {
+            return fromLiteralPattern(regex.substring("(?i)".length()), true);
+        }
+
+        if ((pattern.flags() & Pattern.CASE_INSENSITIVE) != 0) {
+            return fromLiteralPattern(regex, true);
+        }
+        if (substringFilter != null) {
+            if (!AsciiUtil.isAscii(substringFilter)) {
+                return Optional.empty();
+            }
+            return Optional.of(new RegexLiteralSet(List.of(substringFilter), true));
+        }
+        return fromLiteralPattern(regex, false);
+    }
+
+    private static Optional<RegexLiteralSet> fromLiteralPattern(String regex, boolean caseInsensitive) {
+        String body = stripContainsWrapper(regex);
+        body = stripGroup(body);
+        if (body.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var literals = new ArrayList<String>();
+        for (String quoted : body.split("\\|", -1)) {
+            var literal = unquoteLiteral(quoted);
+            if (literal.isEmpty()) {
+                return Optional.empty();
+            }
+            if (caseInsensitive && !AsciiUtil.isAscii(literal.get())) {
+                return Optional.empty();
+            }
+            literals.add(literal.get());
+        }
+        return Optional.of(new RegexLiteralSet(List.copyOf(literals), caseInsensitive));
+    }
+
+    private static String stripContainsWrapper(String regex) {
+        String body = regex;
+        if (body.startsWith(".*?")) {
+            body = body.substring(".*?".length());
+        } else if (body.startsWith(".*")) {
+            body = body.substring(".*".length());
+        }
+
+        if (body.endsWith(".*?")) {
+            body = body.substring(0, body.length() - ".*?".length());
+        } else if (body.endsWith(".*")) {
+            body = body.substring(0, body.length() - ".*".length());
+        }
+        return body;
+    }
+
+    private static String stripGroup(String body) {
+        if (body.startsWith("(?:") && body.endsWith(")")) {
+            return body.substring(3, body.length() - 1);
+        }
+        if (body.startsWith("(") && body.endsWith(")")) {
+            return body.substring(1, body.length() - 1);
+        }
+        return body;
+    }
+
+    private static Optional<String> unquoteLiteral(String regex) {
+        if (regex.startsWith("\\Q") && regex.endsWith("\\E")) {
+            return Optional.of(regex.substring(2, regex.length() - 2));
+        }
+        if (TextMatcher.isLiteralPattern(regex)) {
+            return Optional.of(regex);
+        }
+        return Optional.empty();
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/util/RegexLiteralSet.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/RegexLiteralSet.java
@@ -6,6 +6,14 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Narrow recognizer for generated regex shapes that are safe to evaluate as literal contains checks.
+ *
+ * <p>This is intentionally not a general regex parser. Its job is to recognize the simple definition-search patterns
+ * produced by Brokk callers, for example {@code (?i).*?\QFoo\E.*?} or
+ * {@code (?i).*?(?:\QFoo\E|\QBar\E).*?}. Any pattern outside that small grammar must return {@link Optional#empty()}
+ * so the caller keeps using normal regex matching.
+ */
 public record RegexLiteralSet(List<String> literals, boolean caseInsensitive) {
     public static Optional<RegexLiteralSet> fromContainsPattern(Pattern pattern, @Nullable String substringFilter) {
         String regex = pattern.pattern();
@@ -26,6 +34,9 @@ public record RegexLiteralSet(List<String> literals, boolean caseInsensitive) {
     }
 
     private static Optional<RegexLiteralSet> fromLiteralPattern(String regex, boolean caseInsensitive) {
+        // Keep this recognizer conservative: optional contains wrappers, one optional grouping layer, and literal terms
+        // separated by '|'. If any term is not a plain or \Q...\E literal, callers fall back to the compiled regex
+        // path.
         String body = stripContainsWrapper(regex);
         body = stripGroup(body);
         if (body.isEmpty()) {

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/JavaAnalyzerSearchTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/JavaAnalyzerSearchTest.java
@@ -6,6 +6,7 @@ import ai.brokk.testutil.CoreTestProject;
 import ai.brokk.testutil.TestCodeProject;
 import java.io.IOException;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -173,6 +174,26 @@ public class JavaAnalyzerSearchTest {
 
         assertEquals(method2Names1, method2Names2, "Auto-wrapped pattern should match explicit pattern");
         assertTrue(method2Names1.contains("A.method2"), "Should find 'A.method2'");
+    }
+
+    @Test
+    public void testSearchDefinitions_LiteralAlternationPattern() {
+        var symbols = analyzer.searchDefinitions(Pattern.compile("(?i).*?(?:\\Qmethod1\\E|\\Qfield2\\E).*?"));
+        var names = symbols.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
+
+        assertTrue(names.contains("A.method1"), "Should find quoted literal method alternation");
+        assertTrue(names.contains("D.field2"), "Should find quoted literal field alternation");
+        assertFalse(names.contains("A.method2"), "Should not match literals outside the alternation");
+    }
+
+    @Test
+    public void testSearchDefinitions_LiteralAlternationFallbackForRegexTerms() {
+        var symbols = analyzer.searchDefinitions(Pattern.compile("(?i).*?(?:method[12]|\\Qfield2\\E).*?"));
+        var names = symbols.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
+
+        assertTrue(names.contains("A.method1"), "Regex fallback should preserve character class behavior");
+        assertTrue(names.contains("A.method2"), "Regex fallback should preserve character class behavior");
+        assertTrue(names.contains("D.field2"), "Regex fallback should preserve quoted alternation behavior");
     }
 
     @Test

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/JavaAnalyzerSearchTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/JavaAnalyzerSearchTest.java
@@ -3,6 +3,7 @@ package ai.brokk.analyzer;
 import static org.junit.jupiter.api.Assertions.*;
 
 import ai.brokk.testutil.CoreTestProject;
+import ai.brokk.testutil.InlineTestProjectCreator;
 import ai.brokk.testutil.TestCodeProject;
 import java.io.IOException;
 import java.util.Set;
@@ -194,6 +195,22 @@ public class JavaAnalyzerSearchTest {
         assertTrue(names.contains("A.method1"), "Regex fallback should preserve character class behavior");
         assertTrue(names.contains("A.method2"), "Regex fallback should preserve character class behavior");
         assertTrue(names.contains("D.field2"), "Regex fallback should preserve quoted alternation behavior");
+    }
+
+    @Test
+    public void testSearchDefinitions_LiteralFastPathPreservesUnicodeRegexCaseSemantics() throws IOException {
+        var dottedCapitalI = Character.toString(0x0130);
+        var className = dottedCapitalI + "ndex";
+        var code = "class " + className + " {}";
+        try (var project =
+                InlineTestProjectCreator.code(code, "UnicodeCase.java").build()) {
+            var unicodeAnalyzer = new JavaAnalyzer(project);
+
+            var symbols = unicodeAnalyzer.searchDefinitions(Pattern.compile("(?i).*?\\Qi\\E.*?"));
+            var names = symbols.stream().map(CodeUnit::fqName).collect(Collectors.toSet());
+
+            assertFalse(names.contains(className), "Fast path must not widen Java regex CASE_INSENSITIVE semantics");
+        }
     }
 
     @Test


### PR DESCRIPTION
### Description
Adds a low-risk literal fast path for TreeSitterAnalyzer definition searches so generated literal and literal-alternation patterns can avoid per-symbol regex matching while preserving fallback regex behavior.

**Key Changes**:
- Detects safe literal and quoted literal-alternation search patterns, using direct contains checks instead of regex matching for ASCII-safe candidates.
- Preserves Java regex case-insensitive semantics by falling back to the compiled regex for non-ASCII candidates and non-ASCII case-insensitive literals.
- Adds regression coverage for literal alternation, regex fallback, and Unicode case-semantics preservation.

**Touch Points**:
- brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
- brokk-shared/src/test/java/ai/brokk/analyzer/JavaAnalyzerSearchTest.java

Validation:
- ./gradlew :brokk-shared:test --tests ai.brokk.analyzer.JavaAnalyzerSearchTest
- ./gradlew fix tidy

Closes #3623