### PR TITLE
brokk-acp-rust: wasm parser sandbox for SKILL.md, AGENTS.md, session zips, and searchFileContents

### DIFF
--- a/.github/workflows/rust-acp-release.yml
+++ b/.github/workflows/rust-acp-release.yml
@@ -35,7 +35,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          # `wasm32-wasip2` is required by `brokk-acp-rust/build.rs` to
+          # cross-compile the sandboxed parser crate; the host target
+          # comes from the matrix.
+          targets: ${{ matrix.target }}, wasm32-wasip2
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4

--- a/.github/workflows/rust-acp.yml
+++ b/.github/workflows/rust-acp.yml
@@ -27,6 +27,11 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt, clippy
+        # `brokk-acp-rust/build.rs` cross-compiles the `brokk-acp-sandbox`
+        # crate to `wasm32-wasip2` and embeds the resulting `.wasm` bytes
+        # via `include_bytes!`, so the runner must have the target's
+        # std-aware sysroot available before `cargo build`.
+        targets: wasm32-wasip2
 
     - name: Install bubblewrap (Linux sandbox runtime)
       if: runner.os == 'Linux'

--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -305,9 +305,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "miniz_oxide 0.9.1",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",
+ "walkdir",
 ]
 
 [[package]]

--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -71,6 +71,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +90,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -145,6 +163,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +230,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -232,10 +271,11 @@ version = "0.3.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
- "base64",
+ "base64 0.22.1",
+ "brokk-acp-sandbox",
  "chrono",
  "clap",
- "dirs",
+ "dirs 6.0.0",
  "futures",
  "libc",
  "oauth2",
@@ -253,8 +293,20 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "walkdir",
+ "wasmtime",
+ "wasmtime-wasi",
  "webbrowser",
  "zip",
+]
+
+[[package]]
+name = "brokk-acp-sandbox"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -276,6 +328,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "cap-net-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustix 1.1.4",
+ "smallvec",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.52.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
+dependencies = [
+ "ambient-authority",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix 1.1.4",
+ "winx",
 ]
 
 [[package]]
@@ -386,6 +516,15 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "colorchoice"
@@ -504,6 +643,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bforest"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895"
+
+[[package]]
+name = "cranelift-control"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8"
+
+[[package]]
+name = "cranelift-native"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +757,31 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -637,12 +908,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -653,8 +954,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -690,6 +1002,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,10 +1045,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -761,6 +1108,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -936,6 +1294,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1328,16 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "serde",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1092,7 +1471,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1283,6 +1662,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1698,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1398,6 +1802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1839,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1473,6 +1895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,10 +1913,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "mime"
@@ -1550,7 +1996,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -1586,6 +2032,27 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
  "objc2",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1642,6 +2109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +2167,18 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1751,6 +2236,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "publicsuffix"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +2253,17 @@ checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
  "idna",
  "psl-types",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "sptr",
 ]
 
 [[package]]
@@ -1897,12 +2403,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1934,6 +2471,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
+dependencies = [
+ "hashbrown 0.14.5",
+ "log",
+ "rustc-hash",
+ "slice-group-by",
+ "smallvec",
 ]
 
 [[package]]
@@ -1971,7 +2521,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cookie",
  "cookie_store",
@@ -2032,7 +2582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "pastey",
@@ -2077,6 +2627,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2084,8 +2647,18 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2265,6 +2838,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2333,6 +2910,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,7 +2936,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2420,6 +3006,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs 4.0.0",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,10 +3059,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2478,6 +3082,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2571,6 +3181,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-interface"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
+dependencies = [
+ "bitflags",
+ "cap-fs-ext",
+ "cap-std",
+ "fd-lock",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
+ "winx",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,8 +3211,17 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2753,6 +3394,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3056,12 +3738,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa79bcd666a043b58f5fa62b221b0b914dd901e6f620e8ab7371057a797f3e1"
+dependencies = [
+ "leb128",
+ "wasmparser 0.219.2",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -3072,8 +3764,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -3091,6 +3783,20 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5220ee4c6ffcc0cb9d7c47398052203bc902c8ef3985b0c8134118440c0b2921"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.5",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -3099,6 +3805,278 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68c93bcc5e934985afd8b65214bdd77abd3863b2e1855eae1b07a11c4ef30a8"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.219.2",
+]
+
+[[package]]
+name = "wasmtime"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "hashbrown 0.14.5",
+ "indexmap 2.14.0",
+ "libc",
+ "libm",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.36.7",
+ "once_cell",
+ "paste",
+ "postcard",
+ "psm",
+ "pulley-interpreter",
+ "rayon",
+ "rustix 0.38.44",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "sptr",
+ "target-lexicon",
+ "wasmparser 0.219.2",
+ "wasmtime-asm-macros",
+ "wasmtime-cache",
+ "wasmtime-component-macro",
+ "wasmtime-component-util",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "wasmtime-winch",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0677a7e76c24746b68e3657f7cc50c0ff122ee7e97bbda6e710c1b790ebc93cb"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 0.38.44",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser 0.219.2",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools",
+ "log",
+ "object 0.36.7",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.219.2",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap 2.14.0",
+ "log",
+ "object 0.36.7",
+ "postcard",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.219.2",
+ "wasmparser 0.219.2",
+ "wasmprinter",
+ "wasmtime-component-util",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759ab0caa3821a6211743fe1eed448ab9df439e3af6c60dea15486c055611806"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "rustix 0.38.44",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea"
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5cf227161565057fc994edf14180341817372a218f1597db48a43946e5f875"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "system-interface",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime",
+ "wiggle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-winch"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d6b5297bea14d8387c3974b2b011de628cc9b188f135cec752b74fd368964b"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object 0.36.7",
+ "target-lexicon",
+ "wasmparser 0.219.2",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "wit-parser 0.219.2",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
 ]
 
 [[package]]
@@ -3147,12 +4125,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiggle"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0f6ef83a263c0fa11957c363aeaa76dc84832484d0e119f22810d4d0e09a7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "thiserror 1.0.69",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd266b290a0fdace3af6a05c6ebbcc54de303a774448ecf5a98cd0bc12d89c52"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "shellexpand",
+ "syn",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b8eb1a5783540696c59cefbfc9e52570c2d5e62bd47bdf0bdcef29231879db2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wiggle-generate",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b42b678c8651ec4900d7600037d235429fc985c31cbc33515885ec0d2a9e158"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser 0.219.2",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
 ]
 
 [[package]]
@@ -3236,6 +4295,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3308,6 +4376,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,7 +4417,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -3377,10 +4464,28 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca004bb251010fe956f4a5b9d4bf86b4e415064160dd6669569939e8cbf2504f"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.219.2",
 ]
 
 [[package]]
@@ -3398,7 +4503,19 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast",
 ]
 
 [[package]]

--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -304,6 +304,7 @@ name = "brokk-acp-sandbox"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "miniz_oxide 0.9.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -339,7 +340,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -368,7 +369,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -1064,7 +1065,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1085,7 +1086,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "zlib-rs",
 ]
 
@@ -1118,7 +1119,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1668,7 +1669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1947,6 +1948,15 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -2319,7 +2329,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2635,7 +2645,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3192,7 +3202,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -4391,7 +4401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -1,8 +1,11 @@
 [workspace]
-members = ["xtask"]
+members = ["xtask", "brokk-acp-sandbox"]
 # Keep `cargo build` / `cargo test` from the workspace root focused on the
 # root crate. The xtask sub-crate is dev-only and is invoked through the
 # `cargo xtask` alias (see .cargo/config.toml), which builds it on demand.
+# `brokk-acp-sandbox` is dual-purpose: linked as a library for the native
+# fallback path AND built separately to `wasm32-wasip2` (its binary form)
+# so the embedded wasmtime can run untrusted parser code in a sandbox.
 default-members = ["."]
 
 [package]
@@ -20,6 +23,14 @@ path = "src/main.rs"
 agent-client-protocol = { version = "0.11", features = ["unstable_session_resume"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
+# Pure-parsing library, also built as a wasm32-wasip2 binary that
+# wasmtime hosts when the wasm sandbox is enabled.
+brokk-acp-sandbox = { path = "brokk-acp-sandbox" }
+# Embedded wasm runtime + WASI Preview 2 bindings for the sandboxed
+# parser. Used to host `brokk-acp-sandbox.wasm` in-process with
+# fuel-based CPU limits and capability-scoped fs access.
+wasmtime = { version = "27", default-features = false, features = ["cranelift", "cache", "parallel-compilation", "component-model", "runtime"] }
+wasmtime-wasi = "27"
 zip = "8"
 futures = "0.3"
 regex = "1"

--- a/brokk-acp-rust/brokk-acp-sandbox/Cargo.toml
+++ b/brokk-acp-rust/brokk-acp-sandbox/Cargo.toml
@@ -24,6 +24,15 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 anyhow = "1"
+# `regex` is the ReDoS-safe (linear-time) regex engine the host's
+# `searchFileContents` already uses; running it inside the sandbox
+# adds wasm-fuel as a second backstop in case a future regex feature
+# breaks the linear-time guarantee.
+regex = "1"
+# Recursive directory walking inside the sandbox for `searchFileContents`.
+# `walkdir` is pure Rust and works through WASI preopens, so the
+# guest can walk a host directory that the host hands it.
+walkdir = "2"
 # DEFLATE decoder for the minimal zip reader in `src/zip_reader.rs`.
 # We do not pull the full `zip` crate here because its transitive
 # `typed-path` dep activates `#![feature(wasip2)]` on `wasm32-wasip2`,

--- a/brokk-acp-rust/brokk-acp-sandbox/Cargo.toml
+++ b/brokk-acp-rust/brokk-acp-sandbox/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "brokk-acp-sandbox"
+version = "0.1.0"
+edition = "2024"
+description = "Pure-parsing logic for brokk-acp-rust that runs either natively (linked as a library) or inside a wasmtime-hosted WASI sandbox (built as the `brokk-acp-sandbox` binary). The wasm path gives memory/crash/CPU isolation around untrusted YAML, zip, and regex inputs without losing the ability to fall back to native for performance."
+license = "LGPL-3.0"
+
+# Both a library (linked into the native brokk-acp binary) and a binary
+# (compiled to `wasm32-wasip2`, embedded via `include_bytes!` and run
+# under wasmtime). The library and binary share the same parsing code;
+# the binary only adds a JSON-RPC dispatcher on top of stdin/stdout.
+[lib]
+name = "brokk_acp_sandbox"
+path = "src/lib.rs"
+
+[[bin]]
+name = "brokk-acp-sandbox"
+path = "src/main.rs"
+
+[dependencies]
+# Pure-Rust deps only -- this crate must compile to `wasm32-wasip2`
+# without any `*-sys` crate triggering a C build.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+anyhow = "1"

--- a/brokk-acp-rust/brokk-acp-sandbox/Cargo.toml
+++ b/brokk-acp-rust/brokk-acp-sandbox/Cargo.toml
@@ -24,3 +24,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 anyhow = "1"
+# DEFLATE decoder for the minimal zip reader in `src/zip_reader.rs`.
+# We do not pull the full `zip` crate here because its transitive
+# `typed-path` dep activates `#![feature(wasip2)]` on `wasm32-wasip2`,
+# which requires nightly Rust. `rc-zip-sync` is similarly blocked
+# because it needs `std::fs::File: ReadAt`, which `wasi` does not
+# implement. Implementing the ~100 lines of central-directory parsing
+# ourselves is cheaper than fighting the dependency graph, and it
+# matches what the sandbox actually needs: read-only access to a
+# small set of named text entries from a session zip.
+miniz_oxide = { version = "0.9", default-features = false, features = ["with-alloc"] }

--- a/brokk-acp-rust/brokk-acp-sandbox/src/lib.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/lib.rs
@@ -17,9 +17,11 @@
 //! Adding a new parser to this crate is the standard path for getting
 //! "wasm-by-default with native fallback" coverage in `brokk-acp-rust`.
 
+pub mod search;
 pub mod skills;
 pub mod zip_reader;
 
+pub use search::{SearchError, SearchMatch, SearchOutcome, search as search_file_contents};
 pub use skills::{ParsedFrontmatter, parse_frontmatter, split_frontmatter};
 pub use zip_reader::{
     ZipReadError, read_entries_with_prefix as read_zip_entries_with_prefix,

--- a/brokk-acp-rust/brokk-acp-sandbox/src/lib.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/lib.rs
@@ -1,0 +1,22 @@
+//! Pure-parsing logic for `brokk-acp-rust`, exported both as a Rust
+//! library (linked directly into the native binary) and -- via the
+//! companion binary in `src/bin/sandbox.rs` -- as a `wasm32-wasip2`
+//! component that the native binary spawns under wasmtime for
+//! sandboxed parsing of untrusted inputs.
+//!
+//! Everything here is dependency-light, has no fs/network/process
+//! access, and runs on every target Rust supports. The only inputs
+//! are owned strings or byte slices; the only outputs are `Serialize`
+//! data structures. Each function is a candidate for the wasm
+//! sandbox because the failure modes we care about are:
+//!
+//!   - YAML bombs / billion-laughs against `serde_yaml`
+//!   - Malformed frontmatter that triggers panics in third-party crates
+//!   - Future regex/zip parsers that can blow CPU or memory
+//!
+//! Adding a new parser to this crate is the standard path for getting
+//! "wasm-by-default with native fallback" coverage in `brokk-acp-rust`.
+
+pub mod skills;
+
+pub use skills::{ParsedFrontmatter, parse_frontmatter, split_frontmatter};

--- a/brokk-acp-rust/brokk-acp-sandbox/src/lib.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/lib.rs
@@ -18,5 +18,10 @@
 //! "wasm-by-default with native fallback" coverage in `brokk-acp-rust`.
 
 pub mod skills;
+pub mod zip_reader;
 
 pub use skills::{ParsedFrontmatter, parse_frontmatter, split_frontmatter};
+pub use zip_reader::{
+    ZipReadError, read_entries_with_prefix as read_zip_entries_with_prefix,
+    read_entry_bytes as read_zip_entry_bytes, read_entry_text as read_zip_entry_text,
+};

--- a/brokk-acp-rust/brokk-acp-sandbox/src/lib.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/lib.rs
@@ -24,6 +24,7 @@ pub mod zip_reader;
 pub use search::{SearchError, SearchMatch, SearchOutcome, search as search_file_contents};
 pub use skills::{ParsedFrontmatter, parse_frontmatter, split_frontmatter};
 pub use zip_reader::{
-    ZipReadError, read_entries_with_prefix as read_zip_entries_with_prefix,
+    ZipReadError, list_entry_names as list_zip_entry_names,
+    read_entries_with_prefix as read_zip_entries_with_prefix,
     read_entry_bytes as read_zip_entry_bytes, read_entry_text as read_zip_entry_text,
 };

--- a/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
@@ -142,6 +142,7 @@ struct NamesResult {
 ///   - the file does not exist or the preopen does not cover its dir,
 ///   - the file is larger than `max_bytes`,
 ///   - the bytes are not valid UTF-8.
+///
 /// The size pre-check is on `metadata().len()` to fail fast without
 /// streaming gigabytes through the guest's linear memory; the wasm
 /// memory cap (`StoreLimits::memory_size`) is the backstop if the FS

--- a/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
@@ -189,7 +189,10 @@ fn read_zip_entries_with_prefix_in_sandbox(
     Ok(entries)
 }
 
-fn read_archive_bounded(guest_path: &str, max_archive_bytes: u64) -> Result<Vec<u8>, anyhow::Error> {
+fn read_archive_bounded(
+    guest_path: &str,
+    max_archive_bytes: u64,
+) -> Result<Vec<u8>, anyhow::Error> {
     let meta = std::fs::metadata(guest_path)?;
     if !meta.is_file() {
         anyhow::bail!("not a regular file: {guest_path}");
@@ -233,16 +236,18 @@ fn main() -> anyhow::Result<()> {
                     Err(err) => serde_json::to_string(&ErrResponse { id, err: &err })?,
                 }
             }
-            Request::SplitSkillFrontmatter { raw } => match brokk_acp_sandbox::split_frontmatter(&raw) {
-                Ok((front, body)) => {
-                    let payload = SplitResult {
-                        frontmatter: front.to_string(),
-                        body: body.to_string(),
-                    };
-                    serde_json::to_string(&OkResponse { id, ok: &payload })?
+            Request::SplitSkillFrontmatter { raw } => {
+                match brokk_acp_sandbox::split_frontmatter(&raw) {
+                    Ok((front, body)) => {
+                        let payload = SplitResult {
+                            frontmatter: front.to_string(),
+                            body: body.to_string(),
+                        };
+                        serde_json::to_string(&OkResponse { id, ok: &payload })?
+                    }
+                    Err(err) => serde_json::to_string(&ErrResponse { id, err })?,
                 }
-                Err(err) => serde_json::to_string(&ErrResponse { id, err })?,
-            },
+            }
             Request::ReadFileBounded {
                 guest_path,
                 max_bytes,

--- a/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
@@ -1,0 +1,110 @@
+//! `brokk-acp-sandbox` binary.
+//!
+//! Compiled to `wasm32-wasip2`, run under wasmtime by the native
+//! `brokk-acp` binary. Speaks newline-delimited JSON-RPC over stdin/
+//! stdout: one request per line, one response per line. The wasm
+//! component runs for the lifetime of a single request batch and
+//! then exits when stdin is closed -- the host re-spawns it on
+//! demand, so memory/state never leaks across calls.
+//!
+//! Request format:
+//! ```json
+//! {"id": 1, "method": "parseSkillFrontmatter", "params": {"yaml": "..."}}
+//! ```
+//! Response format:
+//! ```json
+//! {"id": 1, "ok": {"name": "...", "description": "..."}}
+//! {"id": 1, "err": "free-form error message"}
+//! ```
+//!
+//! The same binary, when compiled natively (e.g. for unit tests or
+//! when the user disables the wasm sandbox via `--no-wasm-sandbox`),
+//! can be exec'd or piped in the same JSON-RPC mode. In practice the
+//! native fallback in `brokk-acp-rust` calls the library directly --
+//! the binary is mostly there to give the wasm component a runnable
+//! entry point.
+
+use std::io::{BufRead, Write};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+#[serde(tag = "method", content = "params", rename_all = "camelCase")]
+enum Request {
+    /// Parse a SKILL.md frontmatter block from its raw YAML body.
+    ParseSkillFrontmatter { yaml: String },
+    /// Split a full SKILL.md file into `(frontmatter, body)`.
+    SplitSkillFrontmatter { raw: String },
+}
+
+#[derive(Deserialize)]
+struct Envelope {
+    id: u64,
+    #[serde(flatten)]
+    req: Request,
+}
+
+#[derive(Serialize)]
+struct OkResponse<'a, T: Serialize> {
+    id: u64,
+    ok: &'a T,
+}
+
+#[derive(Serialize)]
+struct ErrResponse<'a> {
+    id: u64,
+    err: &'a str,
+}
+
+#[derive(Serialize)]
+struct SplitResult {
+    frontmatter: String,
+    body: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let envelope: Envelope = match serde_json::from_str(&line) {
+            Ok(e) => e,
+            Err(err) => {
+                let body = format!("malformed request envelope: {err}");
+                writeln!(
+                    out,
+                    "{}",
+                    serde_json::to_string(&ErrResponse { id: 0, err: &body })?
+                )?;
+                out.flush()?;
+                continue;
+            }
+        };
+        let id = envelope.id;
+        let response_line = match envelope.req {
+            Request::ParseSkillFrontmatter { yaml } => {
+                match brokk_acp_sandbox::parse_frontmatter(&yaml) {
+                    Ok(parsed) => serde_json::to_string(&OkResponse { id, ok: &parsed })?,
+                    Err(err) => serde_json::to_string(&ErrResponse { id, err: &err })?,
+                }
+            }
+            Request::SplitSkillFrontmatter { raw } => match brokk_acp_sandbox::split_frontmatter(&raw) {
+                Ok((front, body)) => {
+                    let payload = SplitResult {
+                        frontmatter: front.to_string(),
+                        body: body.to_string(),
+                    };
+                    serde_json::to_string(&OkResponse { id, ok: &payload })?
+                }
+                Err(err) => serde_json::to_string(&ErrResponse { id, err })?,
+            },
+        };
+        writeln!(out, "{response_line}")?;
+        out.flush()?;
+    }
+    Ok(())
+}

--- a/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
@@ -44,6 +44,34 @@ enum Request {
     /// memory limit -- a multi-gigabyte file traps the guest on
     /// linear-memory growth before we even see the bytes.
     ReadFileBounded { guest_path: String, max_bytes: u64 },
+    /// Read a single entry by name out of a zip archive that the host
+    /// has exposed via a preopened directory. Returns the entry's
+    /// decompressed UTF-8 contents (assumes text). `max_bytes` caps
+    /// both the file size pre-check on the archive itself and the
+    /// decompressed entry size, so a zip bomb cannot grow the guest
+    /// past the wasm memory limit. Returns the same `Ok(None)`
+    /// signal as `ReadFileBounded` when the archive exists but does
+    /// not contain `entry_name`.
+    ReadZipEntryText {
+        guest_path: String,
+        entry_name: String,
+        max_archive_bytes: u64,
+        max_entry_bytes: u64,
+    },
+    /// Read every text entry whose name starts with `prefix` from the
+    /// zip archive at `guest_path`. Used by the history reader to
+    /// batch the `content/*.txt` pulls into a single sandbox boot
+    /// instead of one per turn. `max_total_bytes` is a separate
+    /// budget over the sum of decompressed payloads so a swarm of
+    /// small bomb entries cannot collectively blow the wasm memory
+    /// limit.
+    ReadZipEntriesWithPrefix {
+        guest_path: String,
+        prefix: String,
+        max_archive_bytes: u64,
+        max_entry_bytes: u64,
+        max_total_bytes: u64,
+    },
 }
 
 #[derive(Deserialize)]
@@ -76,6 +104,11 @@ struct ReadResult {
     content: String,
 }
 
+#[derive(Serialize)]
+struct EntriesResult {
+    entries: std::collections::HashMap<String, String>,
+}
+
 /// Read at most `max_bytes` bytes from the file at `guest_path` (which
 /// must resolve through a host-provided WASI preopen). Errors when:
 ///   - the file does not exist or the preopen does not cover its dir,
@@ -103,6 +136,57 @@ fn read_bounded(guest_path: &str, max_bytes: u64) -> Result<String, std::io::Err
         ));
     }
     std::fs::read_to_string(guest_path)
+}
+
+/// Open a zip archive through a host preopen and extract one named
+/// entry as text. The whole archive is read into linear memory first
+/// (bounded by `max_archive_bytes`) so the minimal parser in
+/// `zip_reader.rs` can scan offsets without needing seek support --
+/// `wasm32-wasip2`'s `std::fs::File` does not implement `ReadAt`,
+/// which is why we cannot use either the `zip` crate or
+/// `rc-zip-sync` here. `max_entry_bytes` caps the decompressed entry
+/// independently; with that and the wasm `StoreLimits::memory_size`
+/// in the host, a zip bomb traps the guest before reaching the host.
+fn read_zip_entry_in_sandbox(
+    guest_path: &str,
+    entry_name: &str,
+    max_archive_bytes: u64,
+    max_entry_bytes: u64,
+) -> Result<Option<String>, anyhow::Error> {
+    let bytes = read_archive_bounded(guest_path, max_archive_bytes)?;
+    let parsed = brokk_acp_sandbox::read_zip_entry_text(&bytes, entry_name, max_entry_bytes)?;
+    Ok(parsed)
+}
+
+fn read_zip_entries_with_prefix_in_sandbox(
+    guest_path: &str,
+    prefix: &str,
+    max_archive_bytes: u64,
+    max_entry_bytes: u64,
+    max_total_bytes: u64,
+) -> Result<std::collections::HashMap<String, String>, anyhow::Error> {
+    let bytes = read_archive_bounded(guest_path, max_archive_bytes)?;
+    let entries = brokk_acp_sandbox::read_zip_entries_with_prefix(
+        &bytes,
+        prefix,
+        max_entry_bytes,
+        max_total_bytes,
+    )?;
+    Ok(entries)
+}
+
+fn read_archive_bounded(guest_path: &str, max_archive_bytes: u64) -> Result<Vec<u8>, anyhow::Error> {
+    let meta = std::fs::metadata(guest_path)?;
+    if !meta.is_file() {
+        anyhow::bail!("not a regular file: {guest_path}");
+    }
+    if meta.len() > max_archive_bytes {
+        anyhow::bail!(
+            "{guest_path} is {} bytes, archive exceeds cap of {max_archive_bytes}",
+            meta.len()
+        );
+    }
+    Ok(std::fs::read(guest_path)?)
 }
 
 fn main() -> anyhow::Result<()> {
@@ -151,6 +235,56 @@ fn main() -> anyhow::Result<()> {
             } => match read_bounded(&guest_path, max_bytes) {
                 Ok(content) => {
                     let payload = ReadResult { content };
+                    serde_json::to_string(&OkResponse { id, ok: &payload })?
+                }
+                Err(err) => {
+                    let body = err.to_string();
+                    serde_json::to_string(&ErrResponse { id, err: &body })?
+                }
+            },
+            Request::ReadZipEntryText {
+                guest_path,
+                entry_name,
+                max_archive_bytes,
+                max_entry_bytes,
+            } => match read_zip_entry_in_sandbox(
+                &guest_path,
+                &entry_name,
+                max_archive_bytes,
+                max_entry_bytes,
+            ) {
+                Ok(Some(content)) => {
+                    let payload = ReadResult { content };
+                    serde_json::to_string(&OkResponse { id, ok: &payload })?
+                }
+                Ok(None) => {
+                    // Tag the absent-entry case so the host can map it
+                    // back to `Ok(None)` rather than a hard error.
+                    serde_json::to_string(&ErrResponse {
+                        id,
+                        err: "zip entry not found",
+                    })?
+                }
+                Err(err) => {
+                    let body = err.to_string();
+                    serde_json::to_string(&ErrResponse { id, err: &body })?
+                }
+            },
+            Request::ReadZipEntriesWithPrefix {
+                guest_path,
+                prefix,
+                max_archive_bytes,
+                max_entry_bytes,
+                max_total_bytes,
+            } => match read_zip_entries_with_prefix_in_sandbox(
+                &guest_path,
+                &prefix,
+                max_archive_bytes,
+                max_entry_bytes,
+                max_total_bytes,
+            ) {
+                Ok(entries) => {
+                    let payload = EntriesResult { entries };
                     serde_json::to_string(&OkResponse { id, ok: &payload })?
                 }
                 Err(err) => {

--- a/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
@@ -72,6 +72,15 @@ enum Request {
         max_entry_bytes: u64,
         max_total_bytes: u64,
     },
+    /// List every entry name in the zip archive at `guest_path`. Cheap
+    /// next to `ReadZipEntryText` because no entry is decompressed; the
+    /// host uses this to stream entries one-at-a-time when rewriting
+    /// session zips, keeping peak memory at one entry instead of the
+    /// whole archive.
+    ListZipEntryNames {
+        guest_path: String,
+        max_archive_bytes: u64,
+    },
     /// Walk the directory the host has preopened at `guest_root` and
     /// return lines that match `pattern`, optionally restricted to
     /// files whose relative path matches `glob`. The user-supplied
@@ -123,6 +132,11 @@ struct EntriesResult {
     entries: std::collections::HashMap<String, String>,
 }
 
+#[derive(Serialize)]
+struct NamesResult {
+    names: Vec<String>,
+}
+
 /// Read at most `max_bytes` bytes from the file at `guest_path` (which
 /// must resolve through a host-provided WASI preopen). Errors when:
 ///   - the file does not exist or the preopen does not cover its dir,
@@ -170,6 +184,15 @@ fn read_zip_entry_in_sandbox(
     let bytes = read_archive_bounded(guest_path, max_archive_bytes)?;
     let parsed = brokk_acp_sandbox::read_zip_entry_text(&bytes, entry_name, max_entry_bytes)?;
     Ok(parsed)
+}
+
+fn list_zip_entry_names_in_sandbox(
+    guest_path: &str,
+    max_archive_bytes: u64,
+) -> Result<Vec<String>, anyhow::Error> {
+    let bytes = read_archive_bounded(guest_path, max_archive_bytes)?;
+    let names = brokk_acp_sandbox::list_zip_entry_names(&bytes)?;
+    Ok(names)
 }
 
 fn read_zip_entries_with_prefix_in_sandbox(
@@ -304,6 +327,19 @@ fn main() -> anyhow::Result<()> {
             ) {
                 Ok(entries) => {
                     let payload = EntriesResult { entries };
+                    serde_json::to_string(&OkResponse { id, ok: &payload })?
+                }
+                Err(err) => {
+                    let body = err.to_string();
+                    serde_json::to_string(&ErrResponse { id, err: &body })?
+                }
+            },
+            Request::ListZipEntryNames {
+                guest_path,
+                max_archive_bytes,
+            } => match list_zip_entry_names_in_sandbox(&guest_path, max_archive_bytes) {
+                Ok(names) => {
+                    let payload = NamesResult { names };
                     serde_json::to_string(&OkResponse { id, ok: &payload })?
                 }
                 Err(err) => {

--- a/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
@@ -35,6 +35,15 @@ enum Request {
     ParseSkillFrontmatter { yaml: String },
     /// Split a full SKILL.md file into `(frontmatter, body)`.
     SplitSkillFrontmatter { raw: String },
+    /// Read a file the host has exposed via a preopened directory, up
+    /// to `max_bytes`. `guest_path` is the absolute path the host
+    /// preopened (e.g. `/d/AGENTS.md`); a path the host did not
+    /// preopen will fail to open. Returns the contents as a UTF-8
+    /// string if valid UTF-8 and within the cap; an error otherwise.
+    /// The byte cap is the second line of defense after the wasm
+    /// memory limit -- a multi-gigabyte file traps the guest on
+    /// linear-memory growth before we even see the bytes.
+    ReadFileBounded { guest_path: String, max_bytes: u64 },
 }
 
 #[derive(Deserialize)]
@@ -60,6 +69,40 @@ struct ErrResponse<'a> {
 struct SplitResult {
     frontmatter: String,
     body: String,
+}
+
+#[derive(Serialize)]
+struct ReadResult {
+    content: String,
+}
+
+/// Read at most `max_bytes` bytes from the file at `guest_path` (which
+/// must resolve through a host-provided WASI preopen). Errors when:
+///   - the file does not exist or the preopen does not cover its dir,
+///   - the file is larger than `max_bytes`,
+///   - the bytes are not valid UTF-8.
+/// The size pre-check is on `metadata().len()` to fail fast without
+/// streaming gigabytes through the guest's linear memory; the wasm
+/// memory cap (`StoreLimits::memory_size`) is the backstop if the FS
+/// metadata is unreliable.
+fn read_bounded(guest_path: &str, max_bytes: u64) -> Result<String, std::io::Error> {
+    let meta = std::fs::metadata(guest_path)?;
+    if !meta.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("not a regular file: {guest_path}"),
+        ));
+    }
+    if meta.len() > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::FileTooLarge,
+            format!(
+                "{guest_path} is {} bytes, exceeds cap of {max_bytes}",
+                meta.len()
+            ),
+        ));
+    }
+    std::fs::read_to_string(guest_path)
 }
 
 fn main() -> anyhow::Result<()> {
@@ -101,6 +144,19 @@ fn main() -> anyhow::Result<()> {
                     serde_json::to_string(&OkResponse { id, ok: &payload })?
                 }
                 Err(err) => serde_json::to_string(&ErrResponse { id, err })?,
+            },
+            Request::ReadFileBounded {
+                guest_path,
+                max_bytes,
+            } => match read_bounded(&guest_path, max_bytes) {
+                Ok(content) => {
+                    let payload = ReadResult { content };
+                    serde_json::to_string(&OkResponse { id, ok: &payload })?
+                }
+                Err(err) => {
+                    let body = err.to_string();
+                    serde_json::to_string(&ErrResponse { id, err: &body })?
+                }
             },
         };
         writeln!(out, "{response_line}")?;

--- a/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/main.rs
@@ -72,6 +72,20 @@ enum Request {
         max_entry_bytes: u64,
         max_total_bytes: u64,
     },
+    /// Walk the directory the host has preopened at `guest_root` and
+    /// return lines that match `pattern`, optionally restricted to
+    /// files whose relative path matches `glob`. The user-supplied
+    /// regex is the threat surface here: the wasm fuel cap is the
+    /// final backstop in case `regex`'s linear-time guarantee is
+    /// ever broken by a future engine bug or a feature flag.
+    SearchFileContents {
+        guest_root: String,
+        pattern: String,
+        glob: Option<String>,
+        max_results: u64,
+        max_file_bytes: u64,
+        max_total_bytes: u64,
+    },
 }
 
 #[derive(Deserialize)]
@@ -287,6 +301,27 @@ fn main() -> anyhow::Result<()> {
                     let payload = EntriesResult { entries };
                     serde_json::to_string(&OkResponse { id, ok: &payload })?
                 }
+                Err(err) => {
+                    let body = err.to_string();
+                    serde_json::to_string(&ErrResponse { id, err: &body })?
+                }
+            },
+            Request::SearchFileContents {
+                guest_root,
+                pattern,
+                glob,
+                max_results,
+                max_file_bytes,
+                max_total_bytes,
+            } => match brokk_acp_sandbox::search_file_contents(
+                std::path::Path::new(&guest_root),
+                &pattern,
+                glob.as_deref(),
+                max_results as usize,
+                max_file_bytes,
+                max_total_bytes,
+            ) {
+                Ok(outcome) => serde_json::to_string(&OkResponse { id, ok: &outcome })?,
                 Err(err) => {
                     let body = err.to_string();
                     serde_json::to_string(&ErrResponse { id, err: &body })?

--- a/brokk-acp-rust/brokk-acp-sandbox/src/search.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/search.rs
@@ -1,0 +1,223 @@
+//! `searchFileContents` implementation, shared between the native
+//! and wasm-sandboxed backends.
+//!
+//! Threat surface: an LLM-driven prompt can put an arbitrary regex
+//! into the `pattern` argument. The `regex` crate is engineered to
+//! be linear-time (no catastrophic backtracking), but the sandbox
+//! adds two further safety nets:
+//!
+//!   1. Wasm fuel (`StoreLimits::set_fuel`) bounds total CPU per
+//!      request, so even a pathological pattern that confuses the
+//!      DFA cache cannot hang the agent.
+//!   2. The wasm linear-memory limit bounds the regex's compiled
+//!      automaton, so a huge alternation cannot blow the host's
+//!      address space.
+//!
+//! File reads use `std::fs`, which on wasm goes through the host's
+//! WASI preopens -- the sandbox only sees the directory tree the
+//! host explicitly hands it.
+
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+/// Hard cap on individual file size scanned. Mirrors the host's
+/// `SEARCH_MAX_FILE_BYTES` (5 MiB at the time of writing). Kept here
+/// so the sandbox enforces it even if the host caller forgets.
+pub const SEARCH_DEFAULT_MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
+/// Default total-bytes-scanned budget. A swarm of just-under-cap
+/// files cannot collectively force the sandbox to allocate beyond
+/// this without tripping the wasm memory limit anyway, but a smaller
+/// explicit budget fails fast.
+pub const SEARCH_DEFAULT_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
+/// Number of leading bytes we sniff for a NUL to classify a file as
+/// binary. Matches the host's prior heuristic.
+const BINARY_SNIFF_BYTES: usize = 4096;
+
+/// A single line that matched the requested pattern. Path is given
+/// relative to the root the search started from.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SearchMatch {
+    pub path: String,
+    pub line_num: usize,
+    pub line: String,
+}
+
+/// Outcome of one search. `truncated` is true when the search hit
+/// `max_results` and the caller should append a `... truncated`
+/// marker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchOutcome {
+    pub matches: Vec<SearchMatch>,
+    pub truncated: bool,
+}
+
+/// Compile errors are surfaced as a parse-style error so the LLM can
+/// fix the pattern; runtime errors (size cap, walk failure) are
+/// logged-and-skipped to mirror the host's prior behaviour.
+#[derive(Debug)]
+pub enum SearchError {
+    InvalidRegex(String),
+    InvalidGlob(String),
+    Walk(String),
+}
+
+impl std::fmt::Display for SearchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRegex(s) => write!(f, "Invalid regex: {s}"),
+            Self::InvalidGlob(s) => write!(f, "Invalid glob: {s}"),
+            Self::Walk(s) => write!(f, "Cannot walk search root: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for SearchError {}
+
+/// Walk `root`, find lines matching `pattern` (optionally constrained
+/// to files whose relative path matches `glob`), return up to
+/// `max_results` matches. Pure-rust + std::fs, so the same code runs
+/// natively and inside the wasm sandbox; the wasm path additionally
+/// gets fuel + memory + preopen isolation.
+pub fn search(
+    root: &Path,
+    pattern: &str,
+    glob: Option<&str>,
+    max_results: usize,
+    max_file_bytes: u64,
+    max_total_bytes: u64,
+) -> Result<SearchOutcome, SearchError> {
+    let re = Regex::new(pattern).map_err(|e| SearchError::InvalidRegex(e.to_string()))?;
+    let glob_re = match glob {
+        Some(g) => Some(compile_glob(g)?),
+        None => None,
+    };
+
+    // Canonicalize once so the relative-path display is stable across
+    // hosts that resolve symlinks differently. On wasi the underlying
+    // syscall walks through preopens, so this stays sandbox-safe.
+    let root_canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
+    let mut matches: Vec<SearchMatch> = Vec::new();
+    let mut total_scanned: u64 = 0;
+
+    for entry in walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|e| {
+            // Always traverse the root: walkdir invokes `filter_entry`
+            // on `root` itself, and the host's test fixtures (plus
+            // tempfile's `TempDir`) can land in a dir whose name
+            // legitimately starts with `.` (`.tmpXXXX`). Pruning the
+            // root prunes every descendant and silently returns
+            // zero matches, which masked a bug for an embarrassing
+            // amount of time.
+            if e.depth() == 0 {
+                return true;
+            }
+            let name = e.file_name().to_string_lossy();
+            !name.starts_with('.')
+                && name != "node_modules"
+                && name != "target"
+                && name != "__pycache__"
+        })
+        .flatten()
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let rel = path
+            .strip_prefix(&root_canonical)
+            .or_else(|_| path.strip_prefix(root))
+            .unwrap_or(path);
+        let rel_str = rel.to_string_lossy();
+
+        if let Some(g) = &glob_re
+            && !g.is_match(&rel_str)
+        {
+            continue;
+        }
+
+        match entry.metadata() {
+            Ok(md) if md.len() > max_file_bytes => continue,
+            Ok(md) => {
+                total_scanned = total_scanned.saturating_add(md.len());
+                if total_scanned > max_total_bytes {
+                    // Budget exhausted: stop walking rather than continue
+                    // and let an attacker chain many just-under-cap files
+                    // into an unbounded scan.
+                    break;
+                }
+            }
+            Err(_) => continue,
+        }
+
+        if is_binary_file(path) {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        for (line_num, line) in content.lines().enumerate() {
+            if re.is_match(line) {
+                matches.push(SearchMatch {
+                    path: rel_str.to_string(),
+                    line_num: line_num + 1,
+                    line: line.trim().to_string(),
+                });
+                if matches.len() >= max_results {
+                    return Ok(SearchOutcome {
+                        matches,
+                        truncated: true,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(SearchOutcome {
+        matches,
+        truncated: false,
+    })
+}
+
+/// Best-effort binary sniff: read up to BINARY_SNIFF_BYTES and treat
+/// the file as binary if any of those bytes is NUL. Matches the
+/// host's prior heuristic exactly so result sets do not change across
+/// backends.
+fn is_binary_file(path: &Path) -> bool {
+    let mut buf = [0u8; BINARY_SNIFF_BYTES];
+    let mut f = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return true,
+    };
+    use std::io::Read;
+    let n = match f.read(&mut buf) {
+        Ok(n) => n,
+        Err(_) => return true,
+    };
+    buf[..n].contains(&0)
+}
+
+/// Translate the host's "simple glob" syntax (`*.rs`, `**/*.java`)
+/// to an anchored regex. Mirrors the host's prior conversion so the
+/// observable set of matched paths is identical across backends.
+fn compile_glob(g: &str) -> Result<Regex, SearchError> {
+    let re_str = g
+        .replace('.', "\\.")
+        .replace("**", "<<GLOBSTAR>>")
+        .replace('*', "[^/]*")
+        .replace("<<GLOBSTAR>>", ".*");
+    Regex::new(&format!("{re_str}$")).map_err(|e| SearchError::InvalidGlob(e.to_string()))
+}
+
+// `PathBuf` import is kept for callers building a root via construction;
+// the search function itself works directly with `&Path`.
+#[allow(dead_code)]
+fn _phantom_pathbuf(p: PathBuf) -> PathBuf {
+    p
+}

--- a/brokk-acp-rust/brokk-acp-sandbox/src/search.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/search.rs
@@ -32,8 +32,11 @@ pub const SEARCH_DEFAULT_MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
 /// explicit budget fails fast.
 pub const SEARCH_DEFAULT_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
 /// Number of leading bytes we sniff for a NUL to classify a file as
-/// binary. Matches the host's prior heuristic.
-const BINARY_SNIFF_BYTES: usize = 4096;
+/// binary. Matches the host's prior heuristic exactly -- shrinking the
+/// window lets a binary file whose first NUL is past the sniff point
+/// slip through and `read_to_string` does NOT reject embedded NULs, so
+/// the bytes would end up in the LLM-visible match output.
+const BINARY_SNIFF_BYTES: usize = 8192;
 
 /// A single line that matched the requested pattern. Path is given
 /// relative to the root the search started from.
@@ -220,4 +223,52 @@ fn compile_glob(g: &str) -> Result<Regex, SearchError> {
 #[allow(dead_code)]
 fn _phantom_pathbuf(p: PathBuf) -> PathBuf {
     p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the binary-sniff window at 8192 bytes (matching the
+    /// pre-sandbox `tools/filesystem.rs` heuristic). A file whose
+    /// pattern-matching region is preceded by 4 KiB of legitimate
+    /// text but contains a NUL within the second 4 KiB must be
+    /// classified as binary -- shrinking the window past the NUL
+    /// would let the byte slip into `read_to_string`, and `regex`
+    /// happily matches across embedded NULs, so the LLM's output
+    /// would carry raw binary.
+    #[test]
+    fn nul_between_4k_and_8k_is_classified_as_binary() {
+        let tmp = std::env::temp_dir().join(format!(
+            "brokk-acp-sandbox-nul-sniff-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("payload.bin");
+
+        let mut body: Vec<u8> = b"a".repeat(5000);
+        body.push(0);
+        body.extend_from_slice(b"needle\n");
+        std::fs::write(&path, &body).unwrap();
+
+        assert!(
+            is_binary_file(&path),
+            "file with NUL at offset 5000 must be classified as binary"
+        );
+
+        // End-to-end: a search for `needle` must return zero matches
+        // because the file should have been skipped on the binary
+        // sniff, not opened and string-matched.
+        let outcome = search(&tmp, "needle", None, 100, 1 << 20, 1 << 30).unwrap();
+        assert!(
+            outcome.matches.is_empty(),
+            "binary-classified file must not produce matches, got: {:?}",
+            outcome.matches
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
 }

--- a/brokk-acp-rust/brokk-acp-sandbox/src/skills.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/skills.rs
@@ -1,0 +1,119 @@
+//! Pure SKILL.md frontmatter parser. Ported verbatim from
+//! `brokk-acp-rust/src/skills.rs` so the same code can be exercised
+//! natively (linked as a library) or inside a wasm sandbox.
+//!
+//! Anything that touches the filesystem (walking a project tree,
+//! reading bytes off disk, listing bundled resources) stays in the
+//! native host -- the sandbox only sees the already-loaded YAML
+//! string and returns the parsed result, so the wasm boundary
+//! protects the parser without forcing the host to expose preopens
+//! for every skill directory.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of parsing a SKILL.md frontmatter block.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ParsedFrontmatter {
+    pub name: Option<String>,
+    pub description: Option<String>,
+}
+
+/// Split a SKILL.md into `(frontmatter, body)`. Frontmatter is the block
+/// between a leading `---` line and the next `---` line on its own.
+pub fn split_frontmatter(raw: &str) -> Result<(&str, &str), &'static str> {
+    let trimmed = raw.trim_start_matches('\u{feff}');
+    let rest = trimmed
+        .strip_prefix("---\n")
+        .or_else(|| trimmed.strip_prefix("---\r\n"))
+        .ok_or("file does not start with `---`")?;
+    let mut offset = 0usize;
+    for line in rest.split_inclusive('\n') {
+        let stripped = line.trim_end_matches(['\n', '\r']);
+        if stripped == "---" {
+            let front = &rest[..offset];
+            let body_start = offset + line.len();
+            let body = if body_start < rest.len() {
+                &rest[body_start..]
+            } else {
+                ""
+            };
+            return Ok((front, body));
+        }
+        offset += line.len();
+    }
+    Err("no closing `---` for frontmatter")
+}
+
+/// Lenient YAML parse: extracts `name` and `description`. On a YAML
+/// scanner error we retry once with the offending unquoted-colon value
+/// wrapped in quotes, matching the spec's recommended fallback for
+/// "Use this skill when: the user asks about PDFs" style values.
+pub fn parse_frontmatter(yaml: &str) -> Result<ParsedFrontmatter, String> {
+    match serde_yaml::from_str::<RawFrontmatter>(yaml) {
+        Ok(r) => Ok(r.into_parsed()),
+        Err(first_err) => {
+            if let Some(retry) = requote_description(yaml)
+                && let Ok(r) = serde_yaml::from_str::<RawFrontmatter>(&retry)
+            {
+                return Ok(r.into_parsed());
+            }
+            Err(first_err.to_string())
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RawFrontmatter {
+    #[serde(default)]
+    name: Option<serde_yaml::Value>,
+    #[serde(default)]
+    description: Option<serde_yaml::Value>,
+}
+
+impl RawFrontmatter {
+    fn into_parsed(self) -> ParsedFrontmatter {
+        ParsedFrontmatter {
+            name: self.name.and_then(yaml_value_to_trimmed_string),
+            description: self.description.and_then(yaml_value_to_trimmed_string),
+        }
+    }
+}
+
+/// Coerce a YAML scalar to a trimmed `String`. Returns `None` for nulls
+/// or non-scalar values (sequences, maps) -- callers treat missing values
+/// the same as malformed.
+fn yaml_value_to_trimmed_string(v: serde_yaml::Value) -> Option<String> {
+    match v {
+        serde_yaml::Value::String(s) => Some(s.trim().to_string()),
+        serde_yaml::Value::Bool(b) => Some(b.to_string()),
+        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// Rewrite `description: <unquoted value with colon>` to wrap the value
+/// in double quotes. Best-effort; only touches the first matching line.
+fn requote_description(yaml: &str) -> Option<String> {
+    let mut out = String::with_capacity(yaml.len() + 4);
+    let mut changed = false;
+    for line in yaml.split_inclusive('\n') {
+        let stripped = line.trim_end_matches(['\n', '\r']);
+        if !changed && let Some(rest) = stripped.strip_prefix("description:") {
+            let trimmed = rest.trim_start();
+            let already_safe = trimmed.starts_with('"')
+                || trimmed.starts_with('\'')
+                || trimmed.starts_with('|')
+                || trimmed.starts_with('>')
+                || trimmed.is_empty();
+            if !already_safe && trimmed.contains(':') {
+                let escaped = trimmed.replace('\\', "\\\\").replace('"', "\\\"");
+                let newline_tail = &line[stripped.len()..line.len()];
+                out.push_str(&format!("description: \"{escaped}\"{newline_tail}"));
+                changed = true;
+                continue;
+            }
+        }
+        out.push_str(line);
+    }
+    if changed { Some(out) } else { None }
+}

--- a/brokk-acp-rust/brokk-acp-sandbox/src/zip_reader.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/zip_reader.rs
@@ -60,18 +60,11 @@ pub enum ZipReadError {
     },
     /// An offset or length parsed from a header would exceed the
     /// archive buffer.
-    OffsetOutOfBounds {
-        offset: usize,
-        len: usize,
-    },
+    OffsetOutOfBounds { offset: usize, len: usize },
     /// Entry uses a compression method other than Stored/Deflated.
     UnsupportedCompression(u16),
     /// Decompressed entry exceeded the caller's byte cap.
-    EntryTooLarge {
-        name: String,
-        cap: u64,
-        actual: u64,
-    },
+    EntryTooLarge { name: String, cap: u64, actual: u64 },
     /// `miniz_oxide` returned a decode error.
     Inflate(String),
     /// Decompressed payload was not valid UTF-8 (caller asked for
@@ -389,9 +382,8 @@ fn decompress_entry(
             // tricked into a multi-GB allocation by a lying CD entry.
             let cap = max_bytes.min(uncompressed_size) as usize;
             let mut out = Vec::with_capacity(cap);
-            let mut decoder = miniz_oxide::inflate::stream::InflateState::new_boxed(
-                miniz_oxide::DataFormat::Raw,
-            );
+            let mut decoder =
+                miniz_oxide::inflate::stream::InflateState::new_boxed(miniz_oxide::DataFormat::Raw);
             let mut input = compressed;
             let mut buf = vec![0u8; 64 * 1024];
             loop {
@@ -458,29 +450,21 @@ fn find_eocd(archive: &[u8]) -> Result<usize, ZipReadError> {
 }
 
 fn read_u16_le(buf: &[u8], at: usize) -> Result<u16, ZipReadError> {
-    let end = at.checked_add(2).ok_or(ZipReadError::OffsetOutOfBounds {
-        offset: at,
-        len: 2,
-    })?;
+    let end = at
+        .checked_add(2)
+        .ok_or(ZipReadError::OffsetOutOfBounds { offset: at, len: 2 })?;
     if end > buf.len() {
-        return Err(ZipReadError::OffsetOutOfBounds {
-            offset: at,
-            len: 2,
-        });
+        return Err(ZipReadError::OffsetOutOfBounds { offset: at, len: 2 });
     }
     Ok(u16::from_le_bytes([buf[at], buf[at + 1]]))
 }
 
 fn read_u32_le(buf: &[u8], at: usize) -> Result<u32, ZipReadError> {
-    let end = at.checked_add(4).ok_or(ZipReadError::OffsetOutOfBounds {
-        offset: at,
-        len: 4,
-    })?;
+    let end = at
+        .checked_add(4)
+        .ok_or(ZipReadError::OffsetOutOfBounds { offset: at, len: 4 })?;
     if end > buf.len() {
-        return Err(ZipReadError::OffsetOutOfBounds {
-            offset: at,
-            len: 4,
-        });
+        return Err(ZipReadError::OffsetOutOfBounds { offset: at, len: 4 });
     }
     Ok(u32::from_le_bytes([
         buf[at],

--- a/brokk-acp-rust/brokk-acp-sandbox/src/zip_reader.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/zip_reader.rs
@@ -163,12 +163,14 @@ pub fn read_entries_with_prefix(
     Ok(out)
 }
 
-/// Walk the central directory and collect every entry name. Used as
-/// the first step in `read_entries_with_prefix`; the names are
-/// returned in archive order. UTF-8 names are required; non-UTF-8
+/// Walk the central directory and collect every entry name. Names
+/// are returned in archive order. UTF-8 names are required; non-UTF-8
 /// names are skipped with no error (they are valid in the spec but
-/// session zips never produce them).
-fn list_entry_names(archive: &[u8]) -> Result<Vec<String>, ZipReadError> {
+/// session zips never produce them). Used by `read_entries_with_prefix`
+/// and exposed publicly so callers that want to stream entries
+/// one-at-a-time (e.g. the session-zip rewrite path) can iterate
+/// names without decompressing.
+pub fn list_entry_names(archive: &[u8]) -> Result<Vec<String>, ZipReadError> {
     let eocd = find_eocd(archive)?;
     let cd_offset = read_u32_le(archive, eocd + 16)? as usize;
     let cd_size = read_u32_le(archive, eocd + 12)? as usize;

--- a/brokk-acp-rust/brokk-acp-sandbox/src/zip_reader.rs
+++ b/brokk-acp-rust/brokk-acp-sandbox/src/zip_reader.rs
@@ -1,0 +1,498 @@
+//! Minimal read-only ZIP parser, scoped to what session-zip readers
+//! need: locate a named entry, decompress it (deflate or stored), and
+//! return up to a configurable byte cap.
+//!
+//! Why not pull `zip` or `rc-zip-sync`:
+//!   - `zip 8` depends on `typed-path 0.12.3`, which activates
+//!     `#![feature(wasip2)]` and therefore requires nightly on
+//!     `wasm32-wasip2`.
+//!   - `rc-zip-sync` requires `std::fs::File: ReadAt` via
+//!     `positioned-io`, which is not implemented for `File` on the
+//!     wasi std crate at the time of writing.
+//!
+//! Both libraries are perfectly fine on native and the host's
+//! `session.rs` continues to use `zip` there. This module exists so
+//! the sandbox path can read the same archive format without the
+//! transitive dependency landmines.
+//!
+//! Threat model: this code runs inside the wasm sandbox, so it must
+//! never trust any field of the input. Every offset is checked
+//! against the buffer length before slicing. Every length is bounded
+//! by an explicit cap before allocating. A malformed archive returns
+//! a structured error; it never panics or unwinds out of the parser.
+//!
+//! Supported entries: `Stored` (compression method 0) and `Deflated`
+//! (method 8). Session zips are always written with `Deflated`
+//! (see `session.rs::write_new_session_zip`), so this covers every
+//! file the sandbox is ever asked to read.
+
+use std::io::Cursor;
+
+/// Local file header signature (PK\x03\x04). Marks each entry's
+/// payload boundary in the archive body.
+const LOCAL_FILE_HEADER_SIG: u32 = 0x04034b50;
+/// Central directory entry signature (PK\x01\x02). The central
+/// directory is the authoritative index of entries; we walk it
+/// linearly to locate entries by name.
+const CENTRAL_DIR_SIG: u32 = 0x02014b50;
+/// End-of-central-directory record signature (PK\x05\x06). Found at
+/// the tail of every well-formed zip; tells us where the central
+/// directory begins.
+const END_OF_CENTRAL_DIR_SIG: u32 = 0x06054b50;
+/// Compression methods used by `session.rs`. Other methods (BZIP2,
+/// LZMA, ZSTD, etc.) are rejected with a clear error.
+const METHOD_STORED: u16 = 0;
+const METHOD_DEFLATED: u16 = 8;
+
+/// Single failure type for the reader. Stays minimal -- the sandbox
+/// only needs to distinguish "entry not found" (Ok(None)) from
+/// "everything else" (this error), since the host's existing call
+/// sites tolerate both.
+#[derive(Debug)]
+pub enum ZipReadError {
+    /// Buffer was too small or did not contain a valid EOCD record.
+    NotAZip,
+    /// A header signature did not match the expected magic.
+    BadSignature {
+        offset: usize,
+        expected: u32,
+        actual: u32,
+    },
+    /// An offset or length parsed from a header would exceed the
+    /// archive buffer.
+    OffsetOutOfBounds {
+        offset: usize,
+        len: usize,
+    },
+    /// Entry uses a compression method other than Stored/Deflated.
+    UnsupportedCompression(u16),
+    /// Decompressed entry exceeded the caller's byte cap.
+    EntryTooLarge {
+        name: String,
+        cap: u64,
+        actual: u64,
+    },
+    /// `miniz_oxide` returned a decode error.
+    Inflate(String),
+    /// Decompressed payload was not valid UTF-8 (caller asked for
+    /// text). Held as `String` so the host gets a stable display
+    /// without dragging `std::str::Utf8Error` into the wire format.
+    NotUtf8(String),
+}
+
+impl std::fmt::Display for ZipReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAZip => write!(f, "not a zip archive (missing EOCD record)"),
+            Self::BadSignature {
+                offset,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "bad signature at offset {offset}: expected 0x{expected:08x}, got 0x{actual:08x}"
+            ),
+            Self::OffsetOutOfBounds { offset, len } => {
+                write!(f, "offset {offset}+{len} exceeds archive bounds")
+            }
+            Self::UnsupportedCompression(m) => write!(
+                f,
+                "unsupported compression method {m} (only Stored and Deflated are supported)"
+            ),
+            Self::EntryTooLarge { name, cap, actual } => write!(
+                f,
+                "entry '{name}' decompresses to {actual} bytes, exceeds cap of {cap}"
+            ),
+            Self::Inflate(s) => write!(f, "deflate decode error: {s}"),
+            Self::NotUtf8(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl std::error::Error for ZipReadError {}
+
+/// Locate `entry_name` in `archive`, decompress it, return its bytes
+/// as a UTF-8 string. Returns `Ok(None)` when the name is absent so
+/// the caller can keep the "no entry here, move on" code path.
+pub fn read_entry_text(
+    archive: &[u8],
+    entry_name: &str,
+    max_bytes: u64,
+) -> Result<Option<String>, ZipReadError> {
+    let Some(bytes) = read_entry_bytes(archive, entry_name, max_bytes)? else {
+        return Ok(None);
+    };
+    String::from_utf8(bytes).map(Some).map_err(|e| {
+        ZipReadError::NotUtf8(format!(
+            "entry '{entry_name}' is not valid UTF-8 ({} bytes): {e}",
+            e.as_bytes().len()
+        ))
+    })
+}
+
+/// Iterate the central directory, decompress every entry whose name
+/// starts with `prefix`, and return them as a map. `max_entry_bytes`
+/// caps each entry; `max_total_bytes` caps the sum of decompressed
+/// payloads so a swarm of small bomb entries cannot collectively
+/// blow the wasm memory limit. Used by the history reader to fetch
+/// `content/*.txt` in one round-trip instead of N.
+pub fn read_entries_with_prefix(
+    archive: &[u8],
+    prefix: &str,
+    max_entry_bytes: u64,
+    max_total_bytes: u64,
+) -> Result<std::collections::HashMap<String, String>, ZipReadError> {
+    let names = list_entry_names(archive)?;
+    let mut out: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut total: u64 = 0;
+    for name in names {
+        if !name.starts_with(prefix) {
+            continue;
+        }
+        let Some(content) = read_entry_text(archive, &name, max_entry_bytes)? else {
+            continue;
+        };
+        let len = content.len() as u64;
+        total = total.checked_add(len).ok_or(ZipReadError::EntryTooLarge {
+            name: name.clone(),
+            cap: max_total_bytes,
+            actual: u64::MAX,
+        })?;
+        if total > max_total_bytes {
+            return Err(ZipReadError::EntryTooLarge {
+                name,
+                cap: max_total_bytes,
+                actual: total,
+            });
+        }
+        out.insert(name, content);
+    }
+    Ok(out)
+}
+
+/// Walk the central directory and collect every entry name. Used as
+/// the first step in `read_entries_with_prefix`; the names are
+/// returned in archive order. UTF-8 names are required; non-UTF-8
+/// names are skipped with no error (they are valid in the spec but
+/// session zips never produce them).
+fn list_entry_names(archive: &[u8]) -> Result<Vec<String>, ZipReadError> {
+    let eocd = find_eocd(archive)?;
+    let cd_offset = read_u32_le(archive, eocd + 16)? as usize;
+    let cd_size = read_u32_le(archive, eocd + 12)? as usize;
+    let cd_end = cd_offset
+        .checked_add(cd_size)
+        .ok_or(ZipReadError::OffsetOutOfBounds {
+            offset: cd_offset,
+            len: cd_size,
+        })?;
+    if cd_end > archive.len() {
+        return Err(ZipReadError::OffsetOutOfBounds {
+            offset: cd_offset,
+            len: cd_size,
+        });
+    }
+    let mut names = Vec::new();
+    let mut cursor = cd_offset;
+    while cursor + 46 <= cd_end {
+        let sig = read_u32_le(archive, cursor)?;
+        if sig != CENTRAL_DIR_SIG {
+            return Err(ZipReadError::BadSignature {
+                offset: cursor,
+                expected: CENTRAL_DIR_SIG,
+                actual: sig,
+            });
+        }
+        let name_len = read_u16_le(archive, cursor + 28)? as usize;
+        let extra_len = read_u16_le(archive, cursor + 30)? as usize;
+        let comment_len = read_u16_le(archive, cursor + 32)? as usize;
+        let name_start = cursor + 46;
+        let name_end = name_start
+            .checked_add(name_len)
+            .ok_or(ZipReadError::OffsetOutOfBounds {
+                offset: name_start,
+                len: name_len,
+            })?;
+        if name_end > cd_end {
+            return Err(ZipReadError::OffsetOutOfBounds {
+                offset: name_start,
+                len: name_len,
+            });
+        }
+        if let Ok(name) = std::str::from_utf8(&archive[name_start..name_end]) {
+            names.push(name.to_string());
+        }
+        cursor = name_end + extra_len + comment_len;
+        if cursor > cd_end {
+            return Err(ZipReadError::OffsetOutOfBounds {
+                offset: cursor,
+                len: 0,
+            });
+        }
+    }
+    Ok(names)
+}
+
+/// Variant returning raw bytes. Useful for binary entries; the
+/// session zips currently store only text but the same primitive
+/// covers future needs.
+pub fn read_entry_bytes(
+    archive: &[u8],
+    entry_name: &str,
+    max_bytes: u64,
+) -> Result<Option<Vec<u8>>, ZipReadError> {
+    let eocd = find_eocd(archive)?;
+    let cd_offset = read_u32_le(archive, eocd + 16)? as usize;
+    let cd_size = read_u32_le(archive, eocd + 12)? as usize;
+    let cd_end = cd_offset
+        .checked_add(cd_size)
+        .ok_or(ZipReadError::OffsetOutOfBounds {
+            offset: cd_offset,
+            len: cd_size,
+        })?;
+    if cd_end > archive.len() {
+        return Err(ZipReadError::OffsetOutOfBounds {
+            offset: cd_offset,
+            len: cd_size,
+        });
+    }
+
+    let mut cursor = cd_offset;
+    while cursor + 46 <= cd_end {
+        let sig = read_u32_le(archive, cursor)?;
+        if sig != CENTRAL_DIR_SIG {
+            return Err(ZipReadError::BadSignature {
+                offset: cursor,
+                expected: CENTRAL_DIR_SIG,
+                actual: sig,
+            });
+        }
+        let method = read_u16_le(archive, cursor + 10)?;
+        let compressed_size = read_u32_le(archive, cursor + 20)? as u64;
+        let uncompressed_size = read_u32_le(archive, cursor + 24)? as u64;
+        let name_len = read_u16_le(archive, cursor + 28)? as usize;
+        let extra_len = read_u16_le(archive, cursor + 30)? as usize;
+        let comment_len = read_u16_le(archive, cursor + 32)? as usize;
+        let local_header_off = read_u32_le(archive, cursor + 42)? as usize;
+        let name_start = cursor + 46;
+        let name_end = name_start
+            .checked_add(name_len)
+            .ok_or(ZipReadError::OffsetOutOfBounds {
+                offset: name_start,
+                len: name_len,
+            })?;
+        if name_end > cd_end {
+            return Err(ZipReadError::OffsetOutOfBounds {
+                offset: name_start,
+                len: name_len,
+            });
+        }
+        let entry = &archive[name_start..name_end];
+
+        if entry == entry_name.as_bytes() {
+            if uncompressed_size > max_bytes {
+                return Err(ZipReadError::EntryTooLarge {
+                    name: entry_name.to_string(),
+                    cap: max_bytes,
+                    actual: uncompressed_size,
+                });
+            }
+            return Ok(Some(decompress_entry(
+                archive,
+                local_header_off,
+                method,
+                compressed_size,
+                uncompressed_size,
+                max_bytes,
+                entry_name,
+            )?));
+        }
+
+        cursor = name_end + extra_len + comment_len;
+        // Defensive: bail if the header was malformed enough to push
+        // us past the central directory end.
+        if cursor > cd_end {
+            return Err(ZipReadError::OffsetOutOfBounds {
+                offset: cursor,
+                len: 0,
+            });
+        }
+        // Suppress unused warning when local_header_off is not the
+        // matching entry; the check above already validates it on
+        // the match path.
+        let _ = local_header_off;
+    }
+
+    Ok(None)
+}
+
+fn decompress_entry(
+    archive: &[u8],
+    local_header_off: usize,
+    method: u16,
+    compressed_size: u64,
+    uncompressed_size: u64,
+    max_bytes: u64,
+    entry_name: &str,
+) -> Result<Vec<u8>, ZipReadError> {
+    // Local file header layout: 4 sig + 26 fixed bytes + name_len + extra_len.
+    // We trust the central directory for the byte counts but re-read
+    // the local header's name_len/extra_len to find the payload start
+    // (zip allows the local header's name/extra blocks to differ from
+    // the central directory's, even though it normally won't).
+    if local_header_off + 30 > archive.len() {
+        return Err(ZipReadError::OffsetOutOfBounds {
+            offset: local_header_off,
+            len: 30,
+        });
+    }
+    let sig = read_u32_le(archive, local_header_off)?;
+    if sig != LOCAL_FILE_HEADER_SIG {
+        return Err(ZipReadError::BadSignature {
+            offset: local_header_off,
+            expected: LOCAL_FILE_HEADER_SIG,
+            actual: sig,
+        });
+    }
+    let name_len = read_u16_le(archive, local_header_off + 26)? as usize;
+    let extra_len = read_u16_le(archive, local_header_off + 28)? as usize;
+    let payload_start = local_header_off + 30 + name_len + extra_len;
+    let compressed_size_us = compressed_size as usize;
+    let payload_end =
+        payload_start
+            .checked_add(compressed_size_us)
+            .ok_or(ZipReadError::OffsetOutOfBounds {
+                offset: payload_start,
+                len: compressed_size_us,
+            })?;
+    if payload_end > archive.len() {
+        return Err(ZipReadError::OffsetOutOfBounds {
+            offset: payload_start,
+            len: compressed_size_us,
+        });
+    }
+    let compressed = &archive[payload_start..payload_end];
+
+    match method {
+        METHOD_STORED => {
+            if compressed.len() as u64 > max_bytes {
+                return Err(ZipReadError::EntryTooLarge {
+                    name: entry_name.to_string(),
+                    cap: max_bytes,
+                    actual: compressed.len() as u64,
+                });
+            }
+            Ok(compressed.to_vec())
+        }
+        METHOD_DEFLATED => {
+            // `miniz_oxide` allocates the output buffer up front. Cap
+            // the requested size at `max_bytes` so we cannot be
+            // tricked into a multi-GB allocation by a lying CD entry.
+            let cap = max_bytes.min(uncompressed_size) as usize;
+            let mut out = Vec::with_capacity(cap);
+            let mut decoder = miniz_oxide::inflate::stream::InflateState::new_boxed(
+                miniz_oxide::DataFormat::Raw,
+            );
+            let mut input = compressed;
+            let mut buf = vec![0u8; 64 * 1024];
+            loop {
+                let result = miniz_oxide::inflate::stream::inflate(
+                    &mut decoder,
+                    input,
+                    &mut buf,
+                    miniz_oxide::MZFlush::None,
+                );
+                if result.status.is_err() {
+                    return Err(ZipReadError::Inflate(format!(
+                        "{:?} after {} bytes",
+                        result.status, result.bytes_consumed
+                    )));
+                }
+                out.extend_from_slice(&buf[..result.bytes_written]);
+                if out.len() as u64 > max_bytes {
+                    return Err(ZipReadError::EntryTooLarge {
+                        name: entry_name.to_string(),
+                        cap: max_bytes,
+                        actual: out.len() as u64,
+                    });
+                }
+                input = &input[result.bytes_consumed..];
+                match result.status {
+                    Ok(miniz_oxide::MZStatus::StreamEnd) => break,
+                    Ok(miniz_oxide::MZStatus::Ok) | Ok(miniz_oxide::MZStatus::NeedDict) => {
+                        if input.is_empty() && result.bytes_written == 0 {
+                            return Err(ZipReadError::Inflate(
+                                "stream ended without StreamEnd marker".into(),
+                            ));
+                        }
+                    }
+                    Err(e) => return Err(ZipReadError::Inflate(format!("{e:?}"))),
+                }
+            }
+            Ok(out)
+        }
+        other => Err(ZipReadError::UnsupportedCompression(other)),
+    }
+}
+
+/// Walk back from the archive tail looking for the EOCD signature.
+/// The comment field may be up to 64 KiB so we scan that far at most;
+/// session zips never carry a comment so the signature is almost
+/// always at `archive.len() - 22`.
+fn find_eocd(archive: &[u8]) -> Result<usize, ZipReadError> {
+    if archive.len() < 22 {
+        return Err(ZipReadError::NotAZip);
+    }
+    let max_back = archive.len().min(22 + 65_535);
+    let scan_start = archive.len() - max_back;
+    let scan_end = archive.len() - 22;
+    let mut i = scan_end;
+    loop {
+        if read_u32_le(archive, i)? == END_OF_CENTRAL_DIR_SIG {
+            return Ok(i);
+        }
+        if i == scan_start {
+            return Err(ZipReadError::NotAZip);
+        }
+        i -= 1;
+    }
+}
+
+fn read_u16_le(buf: &[u8], at: usize) -> Result<u16, ZipReadError> {
+    let end = at.checked_add(2).ok_or(ZipReadError::OffsetOutOfBounds {
+        offset: at,
+        len: 2,
+    })?;
+    if end > buf.len() {
+        return Err(ZipReadError::OffsetOutOfBounds {
+            offset: at,
+            len: 2,
+        });
+    }
+    Ok(u16::from_le_bytes([buf[at], buf[at + 1]]))
+}
+
+fn read_u32_le(buf: &[u8], at: usize) -> Result<u32, ZipReadError> {
+    let end = at.checked_add(4).ok_or(ZipReadError::OffsetOutOfBounds {
+        offset: at,
+        len: 4,
+    })?;
+    if end > buf.len() {
+        return Err(ZipReadError::OffsetOutOfBounds {
+            offset: at,
+            len: 4,
+        });
+    }
+    Ok(u32::from_le_bytes([
+        buf[at],
+        buf[at + 1],
+        buf[at + 2],
+        buf[at + 3],
+    ]))
+}
+
+// The Cursor import is retained for callers that pipe the archive
+// through `std::io::Cursor`; the parser itself works directly on `&[u8]`.
+#[allow(dead_code)]
+fn _phantom_cursor(buf: &[u8]) -> Cursor<&[u8]> {
+    Cursor::new(buf)
+}

--- a/brokk-acp-rust/build.rs
+++ b/brokk-acp-rust/build.rs
@@ -1,0 +1,95 @@
+//! Compiles `brokk-acp-sandbox` to `wasm32-wasip2` and exposes the
+//! resulting artifact path via the `BROKK_ACP_SANDBOX_WASM` env var so
+//! `src/sandbox_backend.rs` can `include_bytes!` it.
+//!
+//! Why a build script rather than a checked-in `.wasm`:
+//!   - The wasm artifact must stay in lockstep with the library half of
+//!     `brokk-acp-sandbox`. Checking in a `.wasm` invites drift between
+//!     the native fallback (linked code) and the sandbox path (loaded
+//!     bytes), where a parser fix lands in one but not the other.
+//!   - It keeps the repository binary-free, so a `cargo install` from
+//!     git always rebuilds both halves from the same source tree.
+//!
+//! Why we invoke `cargo build` recursively instead of letting cargo
+//! resolve the wasm target on its own:
+//!   - The host crate (`brokk-acp-rust`) targets the build machine's
+//!     architecture, not wasm. Cross-targeting from one cargo invocation
+//!     requires per-target dependency tables and would push us into
+//!     resolver hell, especially with `wasmtime` (host-only) and
+//!     `brokk-acp-sandbox` (both host and wasm). Two invocations keep
+//!     the dependency graphs cleanly separated.
+//!
+//! Failure modes:
+//!   - `rustup target add wasm32-wasip2` not run on this host: the build
+//!     script fails with a clear message asking the user to install it.
+//!   - The sandbox sub-crate fails to compile (e.g. a non-portable dep
+//!     was added): the error propagates with the offending stderr from
+//!     the nested cargo invocation.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+const SANDBOX_CRATE: &str = "brokk-acp-sandbox";
+const WASM_TARGET: &str = "wasm32-wasip2";
+
+fn main() {
+    println!("cargo:rerun-if-changed=brokk-acp-sandbox/Cargo.toml");
+    println!("cargo:rerun-if-changed=brokk-acp-sandbox/src");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let sandbox_manifest = manifest_dir.join(SANDBOX_CRATE).join("Cargo.toml");
+
+    // Build to a dedicated target dir so the wasm artifact does not
+    // collide with the host build's `target/`. Placing it next to the
+    // sub-crate keeps the directory tree intuitive.
+    let target_dir = manifest_dir.join(SANDBOX_CRATE).join("target");
+
+    let status = Command::new(env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()))
+        .args([
+            "build",
+            "--release",
+            "--bin",
+            SANDBOX_CRATE,
+            "--target",
+            WASM_TARGET,
+            "--manifest-path",
+        ])
+        .arg(&sandbox_manifest)
+        .arg("--target-dir")
+        .arg(&target_dir)
+        // Clear cargo env vars inherited from the outer build so the
+        // nested invocation picks its own target/profile.
+        .env_remove("CARGO_TARGET_DIR")
+        .env_remove("CARGO_BUILD_TARGET")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("RUSTFLAGS")
+        .status()
+        .expect("invoke `cargo build` for brokk-acp-sandbox wasm target");
+
+    if !status.success() {
+        eprintln!(
+            "cargo:warning=building {SANDBOX_CRATE} for {WASM_TARGET} failed. \
+             Make sure `rustup target add {WASM_TARGET}` has been run on this host."
+        );
+        std::process::exit(1);
+    }
+
+    let wasm_path = target_dir
+        .join(WASM_TARGET)
+        .join("release")
+        .join(format!("{SANDBOX_CRATE}.wasm"));
+
+    if !wasm_path.exists() {
+        eprintln!(
+            "cargo:warning=expected wasm artifact at {} but it was not produced",
+            wasm_path.display()
+        );
+        std::process::exit(1);
+    }
+
+    println!(
+        "cargo:rustc-env=BROKK_ACP_SANDBOX_WASM={}",
+        wasm_path.display()
+    );
+}

--- a/brokk-acp-rust/src/agents_md.rs
+++ b/brokk-acp-rust/src/agents_md.rs
@@ -18,6 +18,12 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 pub const MAX_TOTAL_BYTES: usize = 64 * 1024;
+/// Per-file ceiling enforced before any bytes are read. Generous enough
+/// to fit any plausible hand-written AGENTS.md, snug enough that a
+/// pathological multi-MB / multi-GB file fails fast instead of OOM-ing
+/// the agent. Routed through `SandboxBackend::read_file_bounded`, so on
+/// the wasm path the wasm linear-memory cap is the second backstop.
+const MAX_FILE_BYTES: u64 = 1024 * 1024;
 const PRIMARY: &str = "AGENTS.md";
 const FALLBACK: &str = "CLAUDE.md";
 
@@ -162,26 +168,25 @@ fn read_preferred(dir: &Path) -> Option<(PathBuf, String)> {
 }
 
 fn read_if_exists(path: &Path) -> Option<(PathBuf, String)> {
-    match std::fs::metadata(path) {
-        Ok(metadata) if metadata.is_file() => {}
-        Ok(_) => return None,
-        Err(e) if e.kind() == ErrorKind::NotFound => return None,
-        Err(e) => {
+    // Route the read through the parser sandbox so an uncapped or
+    // malicious file size cannot OOM the agent: the wasm backend
+    // enforces both a metadata-size cap and a wasm linear-memory
+    // limit, and the native backend honours the same `max_bytes`
+    // pre-read check.
+    match crate::sandbox_backend::global().read_file_bounded(path, MAX_FILE_BYTES) {
+        Ok(Some(content)) => Some((path.to_path_buf(), content)),
+        Ok(None) => None,
+        Err(e) if e.kind() == ErrorKind::FileTooLarge => {
             tracing::warn!(
                 path = %path.display(),
-                "AGENTS.md candidate metadata is unreadable: {e}"
+                "AGENTS.md candidate exceeds {MAX_FILE_BYTES}-byte cap; skipping: {e}"
             );
-            return None;
+            None
         }
-    }
-
-    match std::fs::read_to_string(path) {
-        Ok(content) => Some((path.to_path_buf(), content)),
-        Err(e) if e.kind() == ErrorKind::NotFound => None,
         Err(e) => {
             tracing::warn!(
                 path = %path.display(),
-                "AGENTS.md candidate exists but is unreadable: {e}"
+                "AGENTS.md candidate is unreadable: {e}"
             );
             None
         }

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -14,6 +14,7 @@ mod discovery;
 mod llm_client;
 mod multi_backend;
 mod openrouter_auth;
+mod sandbox_backend;
 mod session;
 mod skills;
 mod tool_loop;
@@ -99,6 +100,14 @@ struct Args {
     /// `~/.codex/auth.json` is present.
     #[arg(long, hide = true)]
     use_codex: bool,
+
+    /// Disable the wasmtime-hosted parser sandbox and run all parsing
+    /// (SKILL.md YAML, AGENTS.md, session zip, regex search) natively
+    /// in-process. The sandbox guards against YAML bombs, ReDoS, and
+    /// parser panics taking down the agent; disabling it trades that
+    /// isolation for ~5-20ms per call and the host's full memory pool.
+    #[arg(long, env = "BROKK_ACP_NO_WASM_SANDBOX", default_value_t = false)]
+    no_wasm_sandbox: bool,
 }
 
 impl std::fmt::Debug for Args {
@@ -312,6 +321,20 @@ async fn main() -> Result<()> {
         .init();
 
     let args = Args::parse();
+
+    // Install the parser sandbox before any code that might load a SKILL.md
+    // (or, eventually, parse AGENTS.md / session zips / regex queries) so
+    // every parse goes through the chosen backend from the first call.
+    // The wasm backend is the default; `--no-wasm-sandbox` is the explicit
+    // opt-out that trades isolation for raw speed.
+    if args.no_wasm_sandbox {
+        tracing::info!(
+            "wasm parser sandbox disabled by flag; YAML/zip/regex parses run natively in-process"
+        );
+        sandbox_backend::install_global(sandbox_backend::SandboxBackend::Native);
+    } else {
+        sandbox_backend::install_global(sandbox_backend::SandboxBackend::wasm_or_native());
+    }
 
     if args.endpoint_url.is_some() {
         tracing::warn!(

--- a/brokk-acp-rust/src/sandbox_backend.rs
+++ b/brokk-acp-rust/src/sandbox_backend.rs
@@ -185,6 +185,46 @@ impl SandboxBackend {
             ),
         }
     }
+
+    /// Run `searchFileContents` (regex match across a directory tree)
+    /// through the sandbox. The user-controlled regex pattern is the
+    /// load-bearing threat: the `regex` crate is linear-time by
+    /// design, but the wasm fuel cap + linear-memory limit are a
+    /// second line of defense in case a future engine bug or feature
+    /// flag breaks the linear-time guarantee.
+    ///
+    /// `glob` follows the same simple-glob syntax (`*.rs`, `**/*.java`)
+    /// as the host's prior implementation; an invalid pattern is
+    /// returned as a `SearchError::InvalidGlob` for the caller to
+    /// surface to the LLM.
+    pub fn search_file_contents(
+        &self,
+        root: &std::path::Path,
+        pattern: &str,
+        glob: Option<&str>,
+        max_results: u64,
+        max_file_bytes: u64,
+        max_total_bytes: u64,
+    ) -> Result<brokk_acp_sandbox::SearchOutcome, brokk_acp_sandbox::SearchError> {
+        match self {
+            Self::Native => brokk_acp_sandbox::search_file_contents(
+                root,
+                pattern,
+                glob,
+                max_results as usize,
+                max_file_bytes,
+                max_total_bytes,
+            ),
+            Self::Wasm(w) => w.search_file_contents(
+                root,
+                pattern,
+                glob,
+                max_results,
+                max_file_bytes,
+                max_total_bytes,
+            ),
+        }
+    }
 }
 
 /// Native implementation of `read_zip_entry_text`. Reads the whole
@@ -412,6 +452,67 @@ impl WasmSandbox {
                     ));
                 }
                 Err(std::io::Error::other(format!("[sandbox] {msg}")))
+            }
+        }
+    }
+
+    /// Run `searchFileContents` through the sandbox. Preopen the
+    /// search root read-only, ask the guest to walk it and apply the
+    /// pattern, return the structured outcome. The guest's wasm
+    /// memory cap and fuel budget bound the worst case for a
+    /// pathological regex or a huge tree.
+    fn search_file_contents(
+        &self,
+        root: &std::path::Path,
+        pattern: &str,
+        glob: Option<&str>,
+        max_results: u64,
+        max_file_bytes: u64,
+        max_total_bytes: u64,
+    ) -> Result<brokk_acp_sandbox::SearchOutcome, brokk_acp_sandbox::SearchError> {
+        let id = self.next_id();
+        let req = SandboxRequest {
+            id,
+            kind: SandboxRequestKind::SearchFileContents(SearchFileContentsParams {
+                guest_root: "/d".to_string(),
+                pattern: pattern.to_string(),
+                glob: glob.map(|g| g.to_string()),
+                max_results,
+                max_file_bytes,
+                max_total_bytes,
+            }),
+        };
+        let resp: SandboxResponse<brokk_acp_sandbox::SearchOutcome> =
+            match self.round_trip(&req, Some((root, "/d"))) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Err(brokk_acp_sandbox::SearchError::Walk(format!(
+                        "[sandbox] {e}"
+                    )));
+                }
+            };
+        if resp.id != id {
+            return Err(brokk_acp_sandbox::SearchError::Walk(format!(
+                "[sandbox] response id mismatch: sent {id}, got {}",
+                resp.id
+            )));
+        }
+        match resp.body {
+            SandboxBody::Ok(outcome) => Ok(outcome),
+            SandboxBody::Err(msg) => {
+                // Surface the original kind back to the caller so the
+                // LLM still sees "Invalid regex: ..." rather than a
+                // generic sandbox-wrapped error. Best effort: match
+                // the display strings produced by `SearchError`.
+                if let Some(rest) = msg.strip_prefix("Invalid regex: ") {
+                    Err(brokk_acp_sandbox::SearchError::InvalidRegex(rest.to_string()))
+                } else if let Some(rest) = msg.strip_prefix("Invalid glob: ") {
+                    Err(brokk_acp_sandbox::SearchError::InvalidGlob(rest.to_string()))
+                } else {
+                    Err(brokk_acp_sandbox::SearchError::Walk(format!(
+                        "[sandbox] {msg}"
+                    )))
+                }
             }
         }
     }
@@ -715,6 +816,7 @@ enum SandboxRequestKind {
     ReadFileBounded(ReadFileBoundedParams),
     ReadZipEntryText(ReadZipEntryTextParams),
     ReadZipEntriesWithPrefix(ReadZipEntriesWithPrefixParams),
+    SearchFileContents(SearchFileContentsParams),
 }
 
 #[derive(Serialize)]
@@ -746,6 +848,16 @@ struct ReadZipEntriesWithPrefixParams {
     prefix: String,
     max_archive_bytes: u64,
     max_entry_bytes: u64,
+    max_total_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct SearchFileContentsParams {
+    guest_root: String,
+    pattern: String,
+    glob: Option<String>,
+    max_results: u64,
+    max_file_bytes: u64,
     max_total_bytes: u64,
 }
 
@@ -977,6 +1089,70 @@ mod tests {
             result.is_none(),
             "missing entry should be Ok(None), got: {result:?}"
         );
+    }
+
+    /// Happy path: a known fixture tree returns the same match set
+    /// via both backends, pinning the contract that the sandbox does
+    /// not silently drop or reorder hits.
+    #[test]
+    fn native_and_wasm_agree_on_search_file_contents() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "hello\nworld\nfoo bar\n").unwrap();
+        std::fs::write(tmp.path().join("b.md"), "# title\nworld peace\n").unwrap();
+        let native = SandboxBackend::Native
+            .search_file_contents(tmp.path(), "world", None, 100, 1 << 20, 1 << 30)
+            .expect("native search should succeed");
+        let wasm_sandbox = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let wasm = SandboxBackend::Wasm(Arc::new(wasm_sandbox))
+            .search_file_contents(tmp.path(), "world", None, 100, 1 << 20, 1 << 30)
+            .expect("wasm search should succeed");
+        let mut native_paths: Vec<_> =
+            native.matches.iter().map(|m| (m.path.clone(), m.line_num)).collect();
+        let mut wasm_paths: Vec<_> =
+            wasm.matches.iter().map(|m| (m.path.clone(), m.line_num)).collect();
+        native_paths.sort();
+        wasm_paths.sort();
+        assert_eq!(native_paths, wasm_paths);
+        assert_eq!(native.matches.len(), 2, "should find 'world' in two files");
+    }
+
+    /// An invalid regex must come back as `InvalidRegex`, not a
+    /// generic sandbox error. The host's `search_file_contents` tool
+    /// converts that into a `RequestError` so the LLM gets a clear
+    /// "fix the pattern" message rather than an opaque crash.
+    #[test]
+    fn wasm_search_file_contents_invalid_regex_is_surfaced() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let wasm = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let backend = SandboxBackend::Wasm(Arc::new(wasm));
+        let err = backend
+            .search_file_contents(tmp.path(), "(unclosed", None, 100, 1 << 20, 1 << 30)
+            .expect_err("invalid regex must fail");
+        assert!(
+            matches!(err, brokk_acp_sandbox::SearchError::InvalidRegex(_)),
+            "expected InvalidRegex, got: {err}"
+        );
+    }
+
+    /// A regex that would catastrophically backtrack in PCRE is
+    /// linear-time in the `regex` crate, so the sandbox returns
+    /// promptly even on a worst-case input. This test pins the
+    /// behaviour so a future engine swap that re-introduces
+    /// backtracking will surface as a fuel-exhaustion failure here
+    /// rather than as a wedged agent in production.
+    #[test]
+    fn wasm_search_file_contents_redos_is_bounded() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Classic ReDoS bait: `(a+)+b` over a long all-`a` input.
+        let body = "a".repeat(8 * 1024) + "x\n";
+        std::fs::write(tmp.path().join("payload.txt"), &body).unwrap();
+        let wasm = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let backend = SandboxBackend::Wasm(Arc::new(wasm));
+        let outcome = backend
+            .search_file_contents(tmp.path(), "(a+)+b", None, 100, 1 << 20, 1 << 30)
+            .expect("regex crate is linear-time; this must not hang");
+        // No `b` in the payload, so we expect zero matches.
+        assert!(outcome.matches.is_empty());
     }
 
     #[test]

--- a/brokk-acp-rust/src/sandbox_backend.rs
+++ b/brokk-acp-rust/src/sandbox_backend.rs
@@ -505,9 +505,13 @@ impl WasmSandbox {
                 // generic sandbox-wrapped error. Best effort: match
                 // the display strings produced by `SearchError`.
                 if let Some(rest) = msg.strip_prefix("Invalid regex: ") {
-                    Err(brokk_acp_sandbox::SearchError::InvalidRegex(rest.to_string()))
+                    Err(brokk_acp_sandbox::SearchError::InvalidRegex(
+                        rest.to_string(),
+                    ))
                 } else if let Some(rest) = msg.strip_prefix("Invalid glob: ") {
-                    Err(brokk_acp_sandbox::SearchError::InvalidGlob(rest.to_string()))
+                    Err(brokk_acp_sandbox::SearchError::InvalidGlob(
+                        rest.to_string(),
+                    ))
                 } else {
                     Err(brokk_acp_sandbox::SearchError::Walk(format!(
                         "[sandbox] {msg}"
@@ -950,8 +954,14 @@ mod tests {
         let wasm = SandboxBackend::Wasm(Arc::new(wasm_sandbox));
         let wasm_result = wasm.parse_skill_frontmatter(yaml);
         assert_eq!(
-            native_result.as_ref().ok().map(|p| (p.name.clone(), p.description.clone())),
-            wasm_result.as_ref().ok().map(|p| (p.name.clone(), p.description.clone())),
+            native_result
+                .as_ref()
+                .ok()
+                .map(|p| (p.name.clone(), p.description.clone())),
+            wasm_result
+                .as_ref()
+                .ok()
+                .map(|p| (p.name.clone(), p.description.clone())),
             "native vs wasm disagreement: native={native_result:?} wasm={wasm_result:?}"
         );
     }
@@ -1022,7 +1032,9 @@ mod tests {
         let path = tmp.path().join("agree.txt");
         std::fs::write(&path, "same content on both backends\n").unwrap();
 
-        let native = SandboxBackend::Native.read_file_bounded(&path, 1024).unwrap();
+        let native = SandboxBackend::Native
+            .read_file_bounded(&path, 1024)
+            .unwrap();
         let wasm_sandbox = WasmSandbox::new().expect("wasm sandbox should initialize");
         let wasm = SandboxBackend::Wasm(Arc::new(wasm_sandbox))
             .read_file_bounded(&path, 1024)
@@ -1106,10 +1118,16 @@ mod tests {
         let wasm = SandboxBackend::Wasm(Arc::new(wasm_sandbox))
             .search_file_contents(tmp.path(), "world", None, 100, 1 << 20, 1 << 30)
             .expect("wasm search should succeed");
-        let mut native_paths: Vec<_> =
-            native.matches.iter().map(|m| (m.path.clone(), m.line_num)).collect();
-        let mut wasm_paths: Vec<_> =
-            wasm.matches.iter().map(|m| (m.path.clone(), m.line_num)).collect();
+        let mut native_paths: Vec<_> = native
+            .matches
+            .iter()
+            .map(|m| (m.path.clone(), m.line_num))
+            .collect();
+        let mut wasm_paths: Vec<_> = wasm
+            .matches
+            .iter()
+            .map(|m| (m.path.clone(), m.line_num))
+            .collect();
         native_paths.sort();
         wasm_paths.sort();
         assert_eq!(native_paths, wasm_paths);

--- a/brokk-acp-rust/src/sandbox_backend.rs
+++ b/brokk-acp-rust/src/sandbox_backend.rs
@@ -1,0 +1,369 @@
+//! Dispatch layer between the native parsing fallback and the
+//! wasmtime-hosted sandbox.
+//!
+//! `SandboxBackend::Native` calls into `brokk_acp_sandbox` directly --
+//! same process, full speed, but a panic or pathological input in a
+//! third-party parser (YAML bomb, ReDoS, etc.) takes down the agent.
+//!
+//! `SandboxBackend::Wasm` spawns a wasmtime store running the embedded
+//! `brokk-acp-sandbox.wasm` artifact, exchanges newline-delimited JSON
+//! over the wasm module's stdin/stdout, and tears the store down after
+//! each batch. The host imposes a per-call fuel budget (CPU bound), a
+//! memory cap, and no preopens beyond stdio so the parser cannot touch
+//! the filesystem even if it tries.
+//!
+//! Switching between the two is controlled by `--no-wasm-sandbox` /
+//! `BROKK_ACP_NO_WASM_SANDBOX` at startup; the rest of the codebase
+//! sees only the trait object.
+//!
+//! Failure policy: the wasm backend treats sandbox infrastructure
+//! errors (wasmtime instantiation failure, fuel exhaustion, panic
+//! propagated from the guest) as parse errors with a clear `[sandbox]`
+//! prefix so the caller's existing error path lights up. We do not
+//! transparently fall back to the native parser on sandbox failure --
+//! that would defeat the point of having a sandbox at all.
+
+use std::io::{BufRead, BufReader};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+
+use anyhow::{Context, Result, anyhow};
+use brokk_acp_sandbox::ParsedFrontmatter;
+use serde::{Deserialize, Serialize};
+
+/// Process-wide singleton, initialized once in `main` from CLI flags
+/// and read by everything that needs to parse untrusted input
+/// (`skills`, `agents_md`, `session`, `tools/filesystem`). We keep a
+/// global rather than threading the backend through every Session /
+/// SessionStore / ToolRegistry constructor because (a) wasmtime
+/// Engines and Components are designed to be shared across threads
+/// and stores, (b) there is no legitimate reason for two parts of the
+/// same process to disagree about whether the sandbox is enabled,
+/// and (c) avoiding the global would touch dozens of constructors.
+static GLOBAL: OnceLock<SandboxBackend> = OnceLock::new();
+
+/// Install the process-wide backend. Called once from `main` before
+/// any session is created. Subsequent calls are a no-op (the first
+/// install wins) so a test harness can pre-install a native backend
+/// without `main` having to be threaded through it.
+pub fn install_global(backend: SandboxBackend) {
+    let _ = GLOBAL.set(backend);
+}
+
+/// Access the global backend. Falls back to `Native` if `install_global`
+/// was never called (unit tests, `cargo run --example`, etc.). The
+/// fallback is deliberately silent: callers that need the wasm path
+/// to have actually started should check the install path in `main`.
+pub fn global() -> &'static SandboxBackend {
+    GLOBAL.get_or_init(|| SandboxBackend::Native)
+}
+
+/// Single entry point for parsers in this crate. Pick `Native` for
+/// raw speed, `Wasm` for isolated execution.
+#[derive(Clone)]
+pub enum SandboxBackend {
+    Native,
+    Wasm(Arc<WasmSandbox>),
+}
+
+impl SandboxBackend {
+    /// Construct the wasm backend, embedding the bytes produced by
+    /// `build.rs`. Returns the native fallback (with a logged warning)
+    /// if wasmtime initialization fails; this keeps a misconfigured
+    /// host from making the agent unusable.
+    pub fn wasm_or_native() -> Self {
+        match WasmSandbox::new() {
+            Ok(w) => Self::Wasm(Arc::new(w)),
+            Err(err) => {
+                tracing::warn!(
+                    %err,
+                    "wasm sandbox failed to initialize; falling back to native parsers \
+                     (lose memory/crash/CPU isolation). Set BROKK_ACP_NO_WASM_SANDBOX=1 to \
+                     silence this warning if running natively is intentional."
+                );
+                Self::Native
+            }
+        }
+    }
+
+    /// Parse the YAML frontmatter of a SKILL.md. Native dispatch is a
+    /// direct library call; wasm dispatch sends one JSON-RPC request.
+    pub fn parse_skill_frontmatter(&self, yaml: &str) -> Result<ParsedFrontmatter, String> {
+        match self {
+            Self::Native => brokk_acp_sandbox::parse_frontmatter(yaml),
+            Self::Wasm(w) => w.parse_skill_frontmatter(yaml).map_err(|e| e.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wasm backend
+// ---------------------------------------------------------------------------
+
+/// Bytes of the wasm artifact, produced by `build.rs` running
+/// `cargo build --target wasm32-wasip2` on the `brokk-acp-sandbox`
+/// crate. Embedded so the host binary is self-contained -- no extra
+/// file to install, no version skew between binary and wasm.
+const SANDBOX_WASM: &[u8] = include_bytes!(env!("BROKK_ACP_SANDBOX_WASM"));
+
+/// Fuel budget per single parse request. Cranelift's "fuel" is roughly
+/// "wasm instructions" -- 50M is generous for a YAML parse on a
+/// reasonably sized SKILL.md (<10KB) but small enough to cap a
+/// billion-laughs YAML bomb in milliseconds.
+const FUEL_PER_REQUEST: u64 = 50_000_000;
+
+/// Memory cap in bytes for the sandboxed module. Generous enough to
+/// hold a SKILL.md plus parser intermediates, snug enough that an
+/// expansion attack fails fast.
+const MEMORY_LIMIT_BYTES: usize = 64 * 1024 * 1024;
+
+/// Wasmtime-backed sandbox. Holds a precompiled component and serves
+/// requests sequentially through a single guest instance per call --
+/// each parse boots a fresh wasm store so memory state cannot leak
+/// across requests. Boot cost is amortized by `Module::serialize`
+/// caching in wasmtime's on-disk cache.
+pub struct WasmSandbox {
+    engine: wasmtime::Engine,
+    component: wasmtime::component::Component,
+    next_id: Mutex<u64>,
+}
+
+impl WasmSandbox {
+    fn new() -> Result<Self> {
+        let mut config = wasmtime::Config::new();
+        config.consume_fuel(true);
+        config.async_support(false);
+        config.wasm_component_model(true);
+
+        let engine = wasmtime::Engine::new(&config).context("creating wasmtime engine")?;
+        let component = wasmtime::component::Component::from_binary(&engine, SANDBOX_WASM)
+            .context("loading sandbox wasm component")?;
+
+        Ok(Self {
+            engine,
+            component,
+            next_id: Mutex::new(1),
+        })
+    }
+
+    fn next_id(&self) -> u64 {
+        let mut g = self.next_id.lock().expect("sandbox id counter poisoned");
+        let id = *g;
+        *g = g.checked_add(1).unwrap_or(1);
+        id
+    }
+
+    /// Run one round-trip through a freshly-instantiated sandbox: send
+    /// a JSON request line on stdin, read one JSON response line back
+    /// from stdout, tear the store down.
+    fn parse_skill_frontmatter(&self, yaml: &str) -> Result<ParsedFrontmatter> {
+        let id = self.next_id();
+        let req = SandboxRequest {
+            id,
+            kind: SandboxRequestKind::ParseSkillFrontmatter(ParseSkillFrontmatterParams {
+                yaml: yaml.to_string(),
+            }),
+        };
+        let resp: SandboxResponse<ParsedFrontmatter> = self.round_trip(&req)?;
+        if resp.id != id {
+            return Err(anyhow!(
+                "[sandbox] response id mismatch: sent {id}, got {}",
+                resp.id
+            ));
+        }
+        match resp.body {
+            SandboxBody::Ok(p) => Ok(p),
+            SandboxBody::Err(e) => Err(anyhow!("[sandbox] {e}")),
+        }
+    }
+
+    fn round_trip<Resp: serde::de::DeserializeOwned>(
+        &self,
+        req: &SandboxRequest,
+    ) -> Result<SandboxResponse<Resp>> {
+        use wasmtime_wasi::pipe::{MemoryInputPipe, MemoryOutputPipe};
+        use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+
+        // Serialize one JSON-RPC line and feed it as the entire stdin
+        // of the wasm process. Newline-terminate so the guest's
+        // `BufRead::lines()` returns immediately on EOF after the
+        // single request.
+        let mut req_bytes = serde_json::to_vec(req).context("serializing sandbox request")?;
+        req_bytes.push(b'\n');
+
+        let stdin = MemoryInputPipe::new(req_bytes);
+        let stdout = MemoryOutputPipe::new(MEMORY_LIMIT_BYTES);
+        let stderr = MemoryOutputPipe::new(64 * 1024);
+
+        let wasi_ctx = WasiCtxBuilder::new()
+            .stdin(stdin)
+            .stdout(stdout.clone())
+            .stderr(stderr.clone())
+            .build();
+
+        // The store holds the wasi ctx + a resource table. We attach
+        // `WasiView` via a small adapter so wasmtime-wasi can find it.
+        struct Host {
+            ctx: WasiCtx,
+            table: ResourceTable,
+        }
+        impl WasiView for Host {
+            fn ctx(&mut self) -> &mut WasiCtx {
+                &mut self.ctx
+            }
+            fn table(&mut self) -> &mut ResourceTable {
+                &mut self.table
+            }
+        }
+
+        let mut store = wasmtime::Store::new(
+            &self.engine,
+            Host {
+                ctx: wasi_ctx,
+                table: ResourceTable::new(),
+            },
+        );
+        store
+            .set_fuel(FUEL_PER_REQUEST)
+            .context("setting sandbox fuel")?;
+
+        let mut linker = wasmtime::component::Linker::<Host>::new(&self.engine);
+        wasmtime_wasi::add_to_linker_sync(&mut linker)
+            .context("wiring wasi imports into sandbox linker")?;
+
+        // Instantiate as a CLI command component (the binary's
+        // `_start` is the entry point we want to run end-to-end).
+        let command = wasmtime_wasi::bindings::sync::Command::instantiate(
+            &mut store,
+            &self.component,
+            &linker,
+        )
+        .context("instantiating sandbox component")?;
+
+        let run_result = command
+            .wasi_cli_run()
+            .call_run(&mut store)
+            .context("invoking wasi:cli/run on sandbox component")?;
+        if run_result.is_err() {
+            let stderr_bytes = stderr.contents();
+            let stderr_text = String::from_utf8_lossy(&stderr_bytes);
+            return Err(anyhow!(
+                "[sandbox] guest exited non-zero. stderr: {stderr_text}"
+            ));
+        }
+
+        let out = stdout.contents();
+        let mut reader = BufReader::new(out.as_ref());
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .context("reading first response line from sandbox stdout")?;
+        if line.trim().is_empty() {
+            return Err(anyhow!("[sandbox] empty response from guest"));
+        }
+        serde_json::from_str::<SandboxResponse<Resp>>(line.trim_end())
+            .with_context(|| format!("decoding sandbox response: {line}"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire format -- mirrors `brokk-acp-sandbox/src/bin/sandbox.rs`
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(tag = "method", content = "params", rename_all = "camelCase")]
+enum SandboxRequestKind {
+    ParseSkillFrontmatter(ParseSkillFrontmatterParams),
+}
+
+#[derive(Serialize)]
+struct ParseSkillFrontmatterParams {
+    yaml: String,
+}
+
+/// Newtype wrapper so we can carry the request id alongside the
+/// tagged enum body (serde's adjacently-tagged enum encoding does not
+/// mix with extra sibling fields cleanly).
+#[derive(Serialize)]
+struct SandboxRequest {
+    id: u64,
+    #[serde(flatten)]
+    kind: SandboxRequestKind,
+}
+
+#[derive(Deserialize)]
+struct SandboxResponse<T> {
+    id: u64,
+    #[serde(flatten)]
+    body: SandboxBody<T>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum SandboxBody<T> {
+    Ok(T),
+    Err(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End-to-end smoke test: the wasm sandbox boots, parses a valid
+    /// SKILL.md frontmatter through the JSON-RPC wire, and returns
+    /// the expected `ParsedFrontmatter` to the host. This is the
+    /// canonical test that the build pipeline (build.rs producing
+    /// `.wasm`, host embedding via `include_bytes!`, wasmtime hosting
+    /// the component) all line up.
+    #[test]
+    fn wasm_backend_parses_valid_frontmatter() {
+        let sandbox = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let yaml = "name: example\ndescription: a tiny skill for tests\n";
+        let parsed = sandbox
+            .parse_skill_frontmatter(yaml)
+            .expect("guest returned a parse error for valid input");
+        assert_eq!(parsed.name.as_deref(), Some("example"));
+        assert_eq!(
+            parsed.description.as_deref(),
+            Some("a tiny skill for tests")
+        );
+    }
+
+    /// Malformed YAML should come back as a structured error from the
+    /// sandbox, not a host-side panic. This is the failure mode the
+    /// wasm path exists to absorb safely.
+    #[test]
+    fn wasm_backend_reports_yaml_parse_error() {
+        let sandbox = WasmSandbox::new().expect("wasm sandbox should initialize");
+        // Unterminated bracket -- guaranteed YAML scanner error.
+        let yaml = "name: [unterminated";
+        let err = sandbox
+            .parse_skill_frontmatter(yaml)
+            .expect_err("invalid YAML should not parse successfully");
+        let msg = err.to_string();
+        assert!(
+            msg.starts_with("[sandbox]"),
+            "expected sandbox-prefixed error, got: {msg}"
+        );
+    }
+
+    /// `SandboxBackend::Native` and `SandboxBackend::Wasm` must produce
+    /// identical results for valid input. Pins the wire contract --
+    /// if the wasm guest evolves and the JSON shape drifts, this test
+    /// flags the mismatch before the production parser disagrees with
+    /// its sandbox shadow.
+    #[test]
+    fn native_and_wasm_agree_on_valid_frontmatter() {
+        let yaml = "name: agree\ndescription: same parse on both backends\n";
+        let native_result = SandboxBackend::Native.parse_skill_frontmatter(yaml);
+        let wasm_sandbox = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let wasm = SandboxBackend::Wasm(Arc::new(wasm_sandbox));
+        let wasm_result = wasm.parse_skill_frontmatter(yaml);
+        assert_eq!(
+            native_result.as_ref().ok().map(|p| (p.name.clone(), p.description.clone())),
+            wasm_result.as_ref().ok().map(|p| (p.name.clone(), p.description.clone())),
+            "native vs wasm disagreement: native={native_result:?} wasm={wasm_result:?}"
+        );
+    }
+}

--- a/brokk-acp-rust/src/sandbox_backend.rs
+++ b/brokk-acp-rust/src/sandbox_backend.rs
@@ -122,6 +122,138 @@ impl SandboxBackend {
             Self::Wasm(w) => w.read_file_bounded(path, max_bytes),
         }
     }
+
+    /// Read a single text entry out of a zip archive, with separate
+    /// caps for the archive size on disk and the decompressed entry
+    /// size. This is the load-bearing primitive for `session.rs`
+    /// readers: session zips are untrusted bytes on disk, and a
+    /// crafted archive (zip bomb, malformed header, lying central
+    /// directory) must not be able to OOM or panic the agent.
+    ///
+    /// Native dispatch reuses the `zip` crate directly with bounded
+    /// reads. Wasm dispatch hands the archive bytes to the in-sandbox
+    /// minimal zip parser (`brokk_acp_sandbox::zip_reader`), so the
+    /// host process never decompresses the input.
+    ///
+    /// `Ok(None)` means "archive exists but the named entry is not in
+    /// it" -- callers can keep their existing missing-entry path.
+    pub fn read_zip_entry_text(
+        &self,
+        zip_path: &std::path::Path,
+        entry_name: &str,
+        max_archive_bytes: u64,
+        max_entry_bytes: u64,
+    ) -> std::io::Result<Option<String>> {
+        match self {
+            Self::Native => {
+                read_zip_entry_text_native(zip_path, entry_name, max_archive_bytes, max_entry_bytes)
+            }
+            Self::Wasm(w) => {
+                w.read_zip_entry_text(zip_path, entry_name, max_archive_bytes, max_entry_bytes)
+            }
+        }
+    }
+
+    /// Bulk variant: read every text entry whose name starts with
+    /// `prefix` from a zip archive. The history reader uses this to
+    /// fetch `content/*.txt` in one round-trip instead of paying the
+    /// wasm boot cost per turn. `max_total_bytes` is the budget over
+    /// the sum of decompressed payloads; a swarm of small bombs
+    /// cannot collectively exceed it.
+    pub fn read_zip_entries_with_prefix(
+        &self,
+        zip_path: &std::path::Path,
+        prefix: &str,
+        max_archive_bytes: u64,
+        max_entry_bytes: u64,
+        max_total_bytes: u64,
+    ) -> std::io::Result<std::collections::HashMap<String, String>> {
+        match self {
+            Self::Native => read_zip_entries_with_prefix_native(
+                zip_path,
+                prefix,
+                max_archive_bytes,
+                max_entry_bytes,
+                max_total_bytes,
+            ),
+            Self::Wasm(w) => w.read_zip_entries_with_prefix(
+                zip_path,
+                prefix,
+                max_archive_bytes,
+                max_entry_bytes,
+                max_total_bytes,
+            ),
+        }
+    }
+}
+
+/// Native implementation of `read_zip_entry_text`. Reads the whole
+/// archive into memory first (bounded by `max_archive_bytes`) and
+/// then uses the same minimal parser that ships in the wasm sandbox.
+/// Going through the shared parser keeps the failure modes identical
+/// across backends so the `native_and_wasm_agree_on_...` parity test
+/// can pin the contract.
+fn read_zip_entry_text_native(
+    zip_path: &std::path::Path,
+    entry_name: &str,
+    max_archive_bytes: u64,
+    max_entry_bytes: u64,
+) -> std::io::Result<Option<String>> {
+    let bytes = match read_archive_bounded_native(zip_path, max_archive_bytes)? {
+        Some(b) => b,
+        None => return Ok(None),
+    };
+    brokk_acp_sandbox::read_zip_entry_text(&bytes, entry_name, max_entry_bytes)
+        .map_err(|e| std::io::Error::other(format!("{e}")))
+}
+
+fn read_zip_entries_with_prefix_native(
+    zip_path: &std::path::Path,
+    prefix: &str,
+    max_archive_bytes: u64,
+    max_entry_bytes: u64,
+    max_total_bytes: u64,
+) -> std::io::Result<std::collections::HashMap<String, String>> {
+    let bytes = match read_archive_bounded_native(zip_path, max_archive_bytes)? {
+        Some(b) => b,
+        None => return Ok(std::collections::HashMap::new()),
+    };
+    brokk_acp_sandbox::read_zip_entries_with_prefix(
+        &bytes,
+        prefix,
+        max_entry_bytes,
+        max_total_bytes,
+    )
+    .map_err(|e| std::io::Error::other(format!("{e}")))
+}
+
+/// Shared helper: read the archive bytes off disk with a size cap.
+/// Returns `None` if the path is missing or not a regular file so
+/// callers can keep their "no zip here" path.
+fn read_archive_bounded_native(
+    zip_path: &std::path::Path,
+    max_archive_bytes: u64,
+) -> std::io::Result<Option<Vec<u8>>> {
+    use std::io::ErrorKind;
+    let meta = match std::fs::metadata(zip_path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    if !meta.is_file() {
+        return Ok(None);
+    }
+    if meta.len() > max_archive_bytes {
+        return Err(std::io::Error::new(
+            ErrorKind::FileTooLarge,
+            format!(
+                "{} archive is {} bytes, exceeds cap of {max_archive_bytes}",
+                zip_path.display(),
+                meta.len()
+            ),
+        ));
+    }
+    Ok(Some(std::fs::read(zip_path)?))
 }
 
 /// Native implementation of `read_file_bounded`. Returns `Ok(None)`
@@ -267,6 +399,153 @@ impl WasmSandbox {
             SandboxBody::Err(msg) => {
                 // Mirror the native fallback: a missing file is `Ok(None)`
                 // so callers do not have to special-case "no file here".
+                if msg.contains("No such file or directory")
+                    || msg.contains("file not found")
+                    || msg.contains("ENOENT")
+                {
+                    return Ok(None);
+                }
+                if msg.contains("exceeds cap of") {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::FileTooLarge,
+                        format!("[sandbox] {msg}"),
+                    ));
+                }
+                Err(std::io::Error::other(format!("[sandbox] {msg}")))
+            }
+        }
+    }
+
+    /// Bulk prefix variant of `read_zip_entry_text`. One sandbox boot
+    /// returns every matching entry as a name-to-contents map, so the
+    /// history reader pays the wasm overhead once for the whole
+    /// `content/` set instead of N times.
+    fn read_zip_entries_with_prefix(
+        &self,
+        zip_path: &std::path::Path,
+        prefix: &str,
+        max_archive_bytes: u64,
+        max_entry_bytes: u64,
+        max_total_bytes: u64,
+    ) -> std::io::Result<std::collections::HashMap<String, String>> {
+        let parent = match zip_path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("zip path {} has no parent directory", zip_path.display()),
+                ));
+            }
+        };
+        let file_name = match zip_path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("zip path {} has no UTF-8 basename", zip_path.display()),
+                ));
+            }
+        };
+        let guest_path = format!("/d/{file_name}");
+        let id = self.next_id();
+        let req = SandboxRequest {
+            id,
+            kind: SandboxRequestKind::ReadZipEntriesWithPrefix(ReadZipEntriesWithPrefixParams {
+                guest_path,
+                prefix: prefix.to_string(),
+                max_archive_bytes,
+                max_entry_bytes,
+                max_total_bytes,
+            }),
+        };
+        let resp: SandboxResponse<ReadEntriesResult> = self
+            .round_trip(&req, Some((parent, "/d")))
+            .map_err(|e| std::io::Error::other(format!("[sandbox] {e}")))?;
+        if resp.id != id {
+            return Err(std::io::Error::other(format!(
+                "[sandbox] response id mismatch: sent {id}, got {}",
+                resp.id
+            )));
+        }
+        match resp.body {
+            SandboxBody::Ok(r) => Ok(r.entries),
+            SandboxBody::Err(msg) => {
+                if msg.contains("No such file or directory")
+                    || msg.contains("file not found")
+                    || msg.contains("ENOENT")
+                {
+                    return Ok(std::collections::HashMap::new());
+                }
+                if msg.contains("exceeds cap of") {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::FileTooLarge,
+                        format!("[sandbox] {msg}"),
+                    ));
+                }
+                Err(std::io::Error::other(format!("[sandbox] {msg}")))
+            }
+        }
+    }
+
+    /// Read a single text entry out of a zip archive through the
+    /// sandbox. Mirrors `read_file_bounded`: preopen the parent dir
+    /// of the archive read-only, ask the guest to open the archive
+    /// at its leaf name, decompress only the requested entry inside
+    /// the wasm memory limit.
+    fn read_zip_entry_text(
+        &self,
+        zip_path: &std::path::Path,
+        entry_name: &str,
+        max_archive_bytes: u64,
+        max_entry_bytes: u64,
+    ) -> std::io::Result<Option<String>> {
+        let parent = match zip_path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("zip path {} has no parent directory", zip_path.display()),
+                ));
+            }
+        };
+        let file_name = match zip_path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("zip path {} has no UTF-8 basename", zip_path.display()),
+                ));
+            }
+        };
+        let guest_path = format!("/d/{file_name}");
+        let id = self.next_id();
+        let req = SandboxRequest {
+            id,
+            kind: SandboxRequestKind::ReadZipEntryText(ReadZipEntryTextParams {
+                guest_path,
+                entry_name: entry_name.to_string(),
+                max_archive_bytes,
+                max_entry_bytes,
+            }),
+        };
+        let resp: SandboxResponse<ReadFileResult> = self
+            .round_trip(&req, Some((parent, "/d")))
+            .map_err(|e| std::io::Error::other(format!("[sandbox] {e}")))?;
+        if resp.id != id {
+            return Err(std::io::Error::other(format!(
+                "[sandbox] response id mismatch: sent {id}, got {}",
+                resp.id
+            )));
+        }
+        match resp.body {
+            SandboxBody::Ok(r) => Ok(Some(r.content)),
+            SandboxBody::Err(msg) => {
+                // The guest sends this sentinel for "archive exists,
+                // entry not present" so we can keep parity with the
+                // native fallback's `Ok(None)` return path.
+                if msg == "zip entry not found" {
+                    return Ok(None);
+                }
                 if msg.contains("No such file or directory")
                     || msg.contains("file not found")
                     || msg.contains("ENOENT")
@@ -434,6 +713,8 @@ impl WasmSandbox {
 enum SandboxRequestKind {
     ParseSkillFrontmatter(ParseSkillFrontmatterParams),
     ReadFileBounded(ReadFileBoundedParams),
+    ReadZipEntryText(ReadZipEntryTextParams),
+    ReadZipEntriesWithPrefix(ReadZipEntriesWithPrefixParams),
 }
 
 #[derive(Serialize)]
@@ -449,6 +730,28 @@ struct ReadFileBoundedParams {
     // plain snake_case.
     guest_path: String,
     max_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct ReadZipEntryTextParams {
+    guest_path: String,
+    entry_name: String,
+    max_archive_bytes: u64,
+    max_entry_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct ReadZipEntriesWithPrefixParams {
+    guest_path: String,
+    prefix: String,
+    max_archive_bytes: u64,
+    max_entry_bytes: u64,
+    max_total_bytes: u64,
+}
+
+#[derive(Deserialize)]
+struct ReadEntriesResult {
+    entries: std::collections::HashMap<String, String>,
 }
 
 #[derive(Deserialize)]
@@ -613,5 +916,87 @@ mod tests {
             .read_file_bounded(&path, 1024)
             .unwrap();
         assert_eq!(native, wasm);
+    }
+
+    /// Build a tiny session-style zip with `zip` (Deflated) and read it
+    /// back through both backends. Anchors the wire contract for the
+    /// zip-entry primitive and the parity between the host's `zip` crate
+    /// (used to build the fixture) and the sandbox's minimal parser
+    /// (used to read it inside wasm).
+    fn build_session_fixture_zip(path: &std::path::Path, entries: &[(&str, &str)]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        for (name, body) in entries {
+            writer.start_file(*name, options).unwrap();
+            std::io::Write::write_all(&mut writer, body.as_bytes()).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    #[test]
+    fn native_and_wasm_agree_on_read_zip_entry_text() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let zip_path = tmp.path().join("session.zip");
+        build_session_fixture_zip(
+            &zip_path,
+            &[
+                ("manifest.json", r#"{"id":"abc","name":"demo"}"#),
+                ("content/hello.txt", "hello from inside the zip"),
+            ],
+        );
+
+        let native = SandboxBackend::Native
+            .read_zip_entry_text(&zip_path, "manifest.json", 1 << 20, 1 << 20)
+            .unwrap();
+        let wasm_sandbox = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let wasm = SandboxBackend::Wasm(Arc::new(wasm_sandbox))
+            .read_zip_entry_text(&zip_path, "manifest.json", 1 << 20, 1 << 20)
+            .unwrap();
+        assert_eq!(native, wasm);
+        assert_eq!(
+            native.as_deref(),
+            Some(r#"{"id":"abc","name":"demo"}"#),
+            "manifest bytes should round-trip through the zip parser"
+        );
+    }
+
+    #[test]
+    fn wasm_read_zip_entry_missing_returns_none() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let zip_path = tmp.path().join("session.zip");
+        build_session_fixture_zip(&zip_path, &[("manifest.json", "{}")]);
+
+        let wasm = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let backend = SandboxBackend::Wasm(Arc::new(wasm));
+        let result = backend
+            .read_zip_entry_text(&zip_path, "missing.json", 1 << 20, 1 << 20)
+            .expect("read should not error for a missing entry");
+        assert!(
+            result.is_none(),
+            "missing entry should be Ok(None), got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn wasm_read_zip_entry_rejects_oversize_entry() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let zip_path = tmp.path().join("session.zip");
+        // 16 KiB entry, but cap is 1 KiB. The wasm parser must reject
+        // before allocating the full decompressed buffer.
+        let body = "x".repeat(16 * 1024);
+        build_session_fixture_zip(&zip_path, &[("big.txt", &body)]);
+
+        let wasm = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let backend = SandboxBackend::Wasm(Arc::new(wasm));
+        let err = backend
+            .read_zip_entry_text(&zip_path, "big.txt", 1 << 20, 1024)
+            .expect_err("oversize entry must be rejected");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::FileTooLarge,
+            "expected FileTooLarge, got: {err}"
+        );
     }
 }

--- a/brokk-acp-rust/src/sandbox_backend.rs
+++ b/brokk-acp-rust/src/sandbox_backend.rs
@@ -95,6 +95,62 @@ impl SandboxBackend {
             Self::Wasm(w) => w.parse_skill_frontmatter(yaml).map_err(|e| e.to_string()),
         }
     }
+
+    /// Read a file as a UTF-8 string with a host-imposed byte cap.
+    /// `path` must be absolute on every platform (callers in this
+    /// crate canonicalize before calling).
+    ///
+    /// Native dispatch checks `fs::metadata().len()` before issuing
+    /// `read_to_string`, so a multi-gigabyte file fails fast with
+    /// `FileTooLarge` instead of OOM-ing the agent.
+    ///
+    /// Wasm dispatch preopens `path.parent()` read-only, invokes the
+    /// guest with the leaf name, and lets the guest enforce both the
+    /// pre-read size cap and the wasm linear-memory limit. The host
+    /// never sees the bytes if either limit trips.
+    ///
+    /// `None` is returned for `NotFound` / `not a regular file` so
+    /// callers can keep their "missing is normal" code path; all
+    /// other errors are returned verbatim.
+    pub fn read_file_bounded(
+        &self,
+        path: &std::path::Path,
+        max_bytes: u64,
+    ) -> std::io::Result<Option<String>> {
+        match self {
+            Self::Native => read_file_bounded_native(path, max_bytes),
+            Self::Wasm(w) => w.read_file_bounded(path, max_bytes),
+        }
+    }
+}
+
+/// Native implementation of `read_file_bounded`. Returns `Ok(None)`
+/// when the path is missing or not a regular file (callers treat that
+/// as "no file here, move on"); propagates `FileTooLarge` and other
+/// errors so the caller can log and skip.
+fn read_file_bounded_native(
+    path: &std::path::Path,
+    max_bytes: u64,
+) -> std::io::Result<Option<String>> {
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    if !meta.is_file() {
+        return Ok(None);
+    }
+    if meta.len() > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::FileTooLarge,
+            format!(
+                "{} is {} bytes, exceeds cap of {max_bytes}",
+                path.display(),
+                meta.len()
+            ),
+        ));
+    }
+    Ok(Some(std::fs::read_to_string(path)?))
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +210,80 @@ impl WasmSandbox {
         id
     }
 
+    /// Read `path` through the sandbox: preopen its parent dir, ask
+    /// the guest to read just the basename, return the contents (or
+    /// `None` if the file is missing). The sandbox enforces both the
+    /// pre-read size cap and the wasm linear-memory limit, so a
+    /// pathological huge file cannot OOM the host.
+    fn read_file_bounded(
+        &self,
+        path: &std::path::Path,
+        max_bytes: u64,
+    ) -> std::io::Result<Option<String>> {
+        let parent = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("path {} has no parent directory", path.display()),
+                ));
+            }
+        };
+        let file_name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!(
+                        "path {} has no UTF-8 basename (wasi cannot route non-UTF-8 paths)",
+                        path.display()
+                    ),
+                ));
+            }
+        };
+        // The guest sees the parent dir mounted at `/d`; constructing
+        // `/d/<basename>` keeps the request encoding trivial and never
+        // exposes the host absolute path to the guest.
+        let guest_path = format!("/d/{file_name}");
+        let id = self.next_id();
+        let req = SandboxRequest {
+            id,
+            kind: SandboxRequestKind::ReadFileBounded(ReadFileBoundedParams {
+                guest_path,
+                max_bytes,
+            }),
+        };
+        let resp: SandboxResponse<ReadFileResult> = self
+            .round_trip(&req, Some((parent, "/d")))
+            .map_err(|e| std::io::Error::other(format!("[sandbox] {e}")))?;
+        if resp.id != id {
+            return Err(std::io::Error::other(format!(
+                "[sandbox] response id mismatch: sent {id}, got {}",
+                resp.id
+            )));
+        }
+        match resp.body {
+            SandboxBody::Ok(r) => Ok(Some(r.content)),
+            SandboxBody::Err(msg) => {
+                // Mirror the native fallback: a missing file is `Ok(None)`
+                // so callers do not have to special-case "no file here".
+                if msg.contains("No such file or directory")
+                    || msg.contains("file not found")
+                    || msg.contains("ENOENT")
+                {
+                    return Ok(None);
+                }
+                if msg.contains("exceeds cap of") {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::FileTooLarge,
+                        format!("[sandbox] {msg}"),
+                    ));
+                }
+                Err(std::io::Error::other(format!("[sandbox] {msg}")))
+            }
+        }
+    }
+
     /// Run one round-trip through a freshly-instantiated sandbox: send
     /// a JSON request line on stdin, read one JSON response line back
     /// from stdout, tear the store down.
@@ -165,7 +295,7 @@ impl WasmSandbox {
                 yaml: yaml.to_string(),
             }),
         };
-        let resp: SandboxResponse<ParsedFrontmatter> = self.round_trip(&req)?;
+        let resp: SandboxResponse<ParsedFrontmatter> = self.round_trip(&req, None)?;
         if resp.id != id {
             return Err(anyhow!(
                 "[sandbox] response id mismatch: sent {id}, got {}",
@@ -181,9 +311,13 @@ impl WasmSandbox {
     fn round_trip<Resp: serde::de::DeserializeOwned>(
         &self,
         req: &SandboxRequest,
+        preopen: Option<(&std::path::Path, &str)>,
     ) -> Result<SandboxResponse<Resp>> {
+        use wasmtime::{StoreLimits, StoreLimitsBuilder};
         use wasmtime_wasi::pipe::{MemoryInputPipe, MemoryOutputPipe};
-        use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+        use wasmtime_wasi::{
+            DirPerms, FilePerms, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView,
+        };
 
         // Serialize one JSON-RPC line and feed it as the entire stdin
         // of the wasm process. Newline-terminate so the guest's
@@ -196,17 +330,36 @@ impl WasmSandbox {
         let stdout = MemoryOutputPipe::new(MEMORY_LIMIT_BYTES);
         let stderr = MemoryOutputPipe::new(64 * 1024);
 
-        let wasi_ctx = WasiCtxBuilder::new()
+        let mut wasi_builder = WasiCtxBuilder::new();
+        wasi_builder
             .stdin(stdin)
             .stdout(stdout.clone())
-            .stderr(stderr.clone())
-            .build();
+            .stderr(stderr.clone());
+        // Optional per-call preopen. The host hands us a host path and the
+        // guest mount point; the guest then reads files using just the
+        // basename relative to that mount point, so it never sees the host
+        // absolute path. Read-only by design: the sandbox only consumes
+        // bytes for parsing, it never writes.
+        if let Some((host_dir, guest_mount)) = preopen {
+            wasi_builder
+                .preopened_dir(host_dir, guest_mount, DirPerms::READ, FilePerms::READ)
+                .with_context(|| {
+                    format!(
+                        "preopening sandbox dir '{}' as '{guest_mount}'",
+                        host_dir.display()
+                    )
+                })?;
+        }
+        let wasi_ctx = wasi_builder.build();
 
-        // The store holds the wasi ctx + a resource table. We attach
-        // `WasiView` via a small adapter so wasmtime-wasi can find it.
+        // The store holds the wasi ctx + a resource table + a memory
+        // limiter. `StoreLimits` caps the wasm linear memory so a
+        // pathological input (huge file, expansion bomb) traps the
+        // guest instead of growing the host's address space.
         struct Host {
             ctx: WasiCtx,
             table: ResourceTable,
+            limits: StoreLimits,
         }
         impl WasiView for Host {
             fn ctx(&mut self) -> &mut WasiCtx {
@@ -217,13 +370,18 @@ impl WasmSandbox {
             }
         }
 
+        let limits = StoreLimitsBuilder::new()
+            .memory_size(MEMORY_LIMIT_BYTES)
+            .build();
         let mut store = wasmtime::Store::new(
             &self.engine,
             Host {
                 ctx: wasi_ctx,
                 table: ResourceTable::new(),
+                limits,
             },
         );
+        store.limiter(|h| &mut h.limits);
         store
             .set_fuel(FUEL_PER_REQUEST)
             .context("setting sandbox fuel")?;
@@ -275,11 +433,27 @@ impl WasmSandbox {
 #[serde(tag = "method", content = "params", rename_all = "camelCase")]
 enum SandboxRequestKind {
     ParseSkillFrontmatter(ParseSkillFrontmatterParams),
+    ReadFileBounded(ReadFileBoundedParams),
 }
 
 #[derive(Serialize)]
 struct ParseSkillFrontmatterParams {
     yaml: String,
+}
+
+#[derive(Serialize)]
+struct ReadFileBoundedParams {
+    // Field names stay snake_case to match the guest deserializer in
+    // `brokk-acp-sandbox/src/main.rs`. Only the enum variant names are
+    // camelCased (for the `method` field on the wire); inner params are
+    // plain snake_case.
+    guest_path: String,
+    max_bytes: u64,
+}
+
+#[derive(Deserialize)]
+struct ReadFileResult {
+    content: String,
 }
 
 /// Newtype wrapper so we can carry the request id alongside the
@@ -365,5 +539,79 @@ mod tests {
             wasm_result.as_ref().ok().map(|p| (p.name.clone(), p.description.clone())),
             "native vs wasm disagreement: native={native_result:?} wasm={wasm_result:?}"
         );
+    }
+
+    /// Happy path for the wasm-backed reader: host preopens the parent,
+    /// guest reads the file, contents come back through stdout.
+    #[test]
+    fn wasm_read_file_bounded_returns_contents() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hello.txt");
+        std::fs::write(&path, "wasm-roundtrip\n").unwrap();
+
+        let wasm = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let backend = SandboxBackend::Wasm(Arc::new(wasm));
+        let content = backend
+            .read_file_bounded(&path, 1024)
+            .expect("read should succeed")
+            .expect("file should be present");
+        assert_eq!(content, "wasm-roundtrip\n");
+    }
+
+    /// A file over the byte cap must come back as `FileTooLarge`
+    /// without ever streaming through the host. This is the load-bearing
+    /// guarantee for callers like `agents_md` that read user-controlled
+    /// files in a project tree -- a 10 GB AGENTS.md must not OOM the
+    /// agent. Use a tight cap so the fixture stays small.
+    #[test]
+    fn wasm_read_file_bounded_rejects_oversize() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("big.txt");
+        let body = "x".repeat(8 * 1024);
+        std::fs::write(&path, &body).unwrap();
+
+        let wasm = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let backend = SandboxBackend::Wasm(Arc::new(wasm));
+        let err = backend
+            .read_file_bounded(&path, 1024)
+            .expect_err("oversize file must be rejected");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::FileTooLarge,
+            "expected FileTooLarge, got: {err}"
+        );
+    }
+
+    /// Missing file -> `Ok(None)` so callers can keep the "no file here,
+    /// move on" code path that the native fallback uses.
+    #[test]
+    fn wasm_read_file_bounded_missing_returns_none() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("does-not-exist.txt");
+
+        let wasm = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let backend = SandboxBackend::Wasm(Arc::new(wasm));
+        let result = backend.read_file_bounded(&path, 1024);
+        assert!(
+            matches!(result, Ok(None)),
+            "missing file should be Ok(None), got: {result:?}"
+        );
+    }
+
+    /// Parity between Native and Wasm on the same fixture, mirroring
+    /// the frontmatter parity test. Pins the contract so a future
+    /// guest change cannot silently disagree with the native fallback.
+    #[test]
+    fn native_and_wasm_agree_on_read_file_bounded() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("agree.txt");
+        std::fs::write(&path, "same content on both backends\n").unwrap();
+
+        let native = SandboxBackend::Native.read_file_bounded(&path, 1024).unwrap();
+        let wasm_sandbox = WasmSandbox::new().expect("wasm sandbox should initialize");
+        let wasm = SandboxBackend::Wasm(Arc::new(wasm_sandbox))
+            .read_file_bounded(&path, 1024)
+            .unwrap();
+        assert_eq!(native, wasm);
     }
 }

--- a/brokk-acp-rust/src/sandbox_backend.rs
+++ b/brokk-acp-rust/src/sandbox_backend.rs
@@ -154,6 +154,22 @@ impl SandboxBackend {
         }
     }
 
+    /// List every entry name in a session zip without decompressing
+    /// any payload. Cheap relative to `read_zip_entry_text`; the
+    /// session-zip rewrite path uses this to drive a streaming copy
+    /// that holds at most one decompressed entry in memory at a time
+    /// instead of the whole archive.
+    pub fn list_zip_entry_names(
+        &self,
+        zip_path: &std::path::Path,
+        max_archive_bytes: u64,
+    ) -> std::io::Result<Vec<String>> {
+        match self {
+            Self::Native => list_zip_entry_names_native(zip_path, max_archive_bytes),
+            Self::Wasm(w) => w.list_zip_entry_names(zip_path, max_archive_bytes),
+        }
+    }
+
     /// Bulk variant: read every text entry whose name starts with
     /// `prefix` from a zip archive. The history reader uses this to
     /// fetch `content/*.txt` in one round-trip instead of paying the
@@ -244,6 +260,18 @@ fn read_zip_entry_text_native(
         None => return Ok(None),
     };
     brokk_acp_sandbox::read_zip_entry_text(&bytes, entry_name, max_entry_bytes)
+        .map_err(|e| std::io::Error::other(format!("{e}")))
+}
+
+fn list_zip_entry_names_native(
+    zip_path: &std::path::Path,
+    max_archive_bytes: u64,
+) -> std::io::Result<Vec<String>> {
+    let bytes = match read_archive_bounded_native(zip_path, max_archive_bytes)? {
+        Some(b) => b,
+        None => return Ok(Vec::new()),
+    };
+    brokk_acp_sandbox::list_zip_entry_names(&bytes)
         .map_err(|e| std::io::Error::other(format!("{e}")))
 }
 
@@ -517,6 +545,71 @@ impl WasmSandbox {
                         "[sandbox] {msg}"
                     )))
                 }
+            }
+        }
+    }
+
+    /// List entry names only. One sandbox boot, no decompression, so
+    /// it is cheap enough to drive a streaming rewrite that pulls
+    /// each entry separately afterwards (peak host memory: one
+    /// entry).
+    fn list_zip_entry_names(
+        &self,
+        zip_path: &std::path::Path,
+        max_archive_bytes: u64,
+    ) -> std::io::Result<Vec<String>> {
+        let parent = match zip_path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("zip path {} has no parent directory", zip_path.display()),
+                ));
+            }
+        };
+        let file_name = match zip_path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("zip path {} has no UTF-8 basename", zip_path.display()),
+                ));
+            }
+        };
+        let guest_path = format!("/d/{file_name}");
+        let id = self.next_id();
+        let req = SandboxRequest {
+            id,
+            kind: SandboxRequestKind::ListZipEntryNames(ListZipEntryNamesParams {
+                guest_path,
+                max_archive_bytes,
+            }),
+        };
+        let resp: SandboxResponse<NamesResult> = self
+            .round_trip(&req, Some((parent, "/d")))
+            .map_err(|e| std::io::Error::other(format!("[sandbox] {e}")))?;
+        if resp.id != id {
+            return Err(std::io::Error::other(format!(
+                "[sandbox] response id mismatch: sent {id}, got {}",
+                resp.id
+            )));
+        }
+        match resp.body {
+            SandboxBody::Ok(r) => Ok(r.names),
+            SandboxBody::Err(msg) => {
+                if msg.contains("No such file or directory")
+                    || msg.contains("file not found")
+                    || msg.contains("ENOENT")
+                {
+                    return Ok(Vec::new());
+                }
+                if msg.contains("exceeds cap of") {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::FileTooLarge,
+                        format!("[sandbox] {msg}"),
+                    ));
+                }
+                Err(std::io::Error::other(format!("[sandbox] {msg}")))
             }
         }
     }
@@ -820,6 +913,7 @@ enum SandboxRequestKind {
     ReadFileBounded(ReadFileBoundedParams),
     ReadZipEntryText(ReadZipEntryTextParams),
     ReadZipEntriesWithPrefix(ReadZipEntriesWithPrefixParams),
+    ListZipEntryNames(ListZipEntryNamesParams),
     SearchFileContents(SearchFileContentsParams),
 }
 
@@ -853,6 +947,17 @@ struct ReadZipEntriesWithPrefixParams {
     max_archive_bytes: u64,
     max_entry_bytes: u64,
     max_total_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct ListZipEntryNamesParams {
+    guest_path: String,
+    max_archive_bytes: u64,
+}
+
+#[derive(Deserialize)]
+struct NamesResult {
+    names: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -497,8 +497,7 @@ fn read_history_from_zip(zip_path: &Path) -> Vec<ConversationTurn> {
             return vec![];
         }
     };
-    let mut content_map: HashMap<String, String> =
-        HashMap::with_capacity(content_entries.len());
+    let mut content_map: HashMap<String, String> = HashMap::with_capacity(content_entries.len());
     for (name, body) in content_entries {
         if let Some(content_id) = name
             .strip_prefix("content/")

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -968,18 +968,28 @@ fn append_turn_to_zip(
     // Pre-read the entries we plan to rewrite through the sandbox so a
     // mutated zip on disk (an attacker swapping the file between the
     // initial load and this append) cannot panic the host's `zip`
-    // crate. A missing or unparseable entry falls back to a known-empty
-    // default, matching prior behavior; a stale corruption shouldn't
-    // abort persistence of the new turn.
+    // crate.
+    //
+    // Error policy here is load-bearing: only an *explicitly missing*
+    // entry (`Ok(None)`) or a legacy-malformed entry (`Ok(Some(_))` that
+    // does not parse as JSON) is allowed to fall back to the empty
+    // default. Any real read failure -- `FileTooLarge`, sandbox crash,
+    // transient I/O, an entry that exceeds the per-entry cap -- must
+    // propagate so `add_turn` rolls back the in-memory state instead of
+    // silently rewriting the on-disk zip with empty fragments/contexts
+    // (which would erase prior history).
     let backend = crate::sandbox_backend::global();
     let mut existing_fragments: serde_json::Value =
         serde_json::json!({"version": 4, "referenced": {}, "virtual": {}, "task": {}});
-    if let Ok(Some(buf)) = backend.read_zip_entry_text(
-        zip_path,
-        "fragments-v4.json",
-        MAX_SESSION_ARCHIVE_BYTES,
-        MAX_FRAGMENTS_BYTES,
-    ) && let Ok(v) = serde_json::from_str(&buf)
+    if let Some(buf) = backend
+        .read_zip_entry_text(
+            zip_path,
+            "fragments-v4.json",
+            MAX_SESSION_ARCHIVE_BYTES,
+            MAX_FRAGMENTS_BYTES,
+        )
+        .context("reading fragments-v4.json from session zip")?
+        && let Ok(v) = serde_json::from_str(&buf)
     {
         existing_fragments = v;
     }
@@ -990,27 +1000,32 @@ fn append_turn_to_zip(
             MAX_SESSION_ARCHIVE_BYTES,
             MAX_CONTEXTS_BYTES,
         )
-        .ok()
-        .flatten()
+        .context("reading contexts.jsonl from session zip")?
         .unwrap_or_default();
     let mut existing_content_metadata: serde_json::Value = serde_json::json!({});
-    if let Ok(Some(buf)) = backend.read_zip_entry_text(
-        zip_path,
-        "content_metadata.json",
-        MAX_SESSION_ARCHIVE_BYTES,
-        MAX_MANIFEST_BYTES,
-    ) && let Ok(v) = serde_json::from_str(&buf)
+    if let Some(buf) = backend
+        .read_zip_entry_text(
+            zip_path,
+            "content_metadata.json",
+            MAX_SESSION_ARCHIVE_BYTES,
+            MAX_MANIFEST_BYTES,
+        )
+        .context("reading content_metadata.json from session zip")?
+        && let Ok(v) = serde_json::from_str(&buf)
     {
         existing_content_metadata = v;
     }
     let mut existing_group_info: serde_json::Value =
         serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
-    if let Ok(Some(buf)) = backend.read_zip_entry_text(
-        zip_path,
-        "group_info.json",
-        MAX_SESSION_ARCHIVE_BYTES,
-        MAX_MANIFEST_BYTES,
-    ) && let Ok(v) = serde_json::from_str(&buf)
+    if let Some(buf) = backend
+        .read_zip_entry_text(
+            zip_path,
+            "group_info.json",
+            MAX_SESSION_ARCHIVE_BYTES,
+            MAX_MANIFEST_BYTES,
+        )
+        .context("reading group_info.json from session zip")?
+        && let Ok(v) = serde_json::from_str(&buf)
     {
         existing_group_info = v;
     }

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -12,6 +12,40 @@ use crate::llm_client::ModelMetadata;
 use crate::tools::ToolRegistry;
 
 // ---------------------------------------------------------------------------
+// Sandbox-bounded read limits
+// ---------------------------------------------------------------------------
+
+/// Upper bound on the size of a session zip we will read off disk. Any
+/// archive larger than this is rejected before bytes flow through
+/// `SandboxBackend::read_zip_entry_text`, so a corrupted or hostile
+/// `~/.brokk/sessions/<id>.zip` cannot OOM the agent. 256 MiB is well
+/// above what `write_new_session_zip` produces in practice (sessions
+/// dominated by conversation text rarely cross a few MB).
+const MAX_SESSION_ARCHIVE_BYTES: u64 = 256 * 1024 * 1024;
+/// Upper bound on the decompressed `manifest.json` payload. The schema
+/// is tiny (id, name, timestamps, mode, model); 1 MiB is loose enough
+/// to absorb future fields while still rejecting absurd values.
+const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+/// Upper bound on the decompressed `fragments-v4.json` payload.
+/// Fragments hold one node per turn (no message bodies -- those live in
+/// `content/<id>.txt`), so 16 MiB is large enough for any plausible
+/// session and small enough to fail fast on a crafted archive.
+const MAX_FRAGMENTS_BYTES: u64 = 16 * 1024 * 1024;
+/// Upper bound on the decompressed `contexts.jsonl` payload. One JSON
+/// line per turn, each line is small (~few KB at most).
+const MAX_CONTEXTS_BYTES: u64 = 16 * 1024 * 1024;
+/// Per-entry cap when reading `content/*.txt`. A single conversation
+/// turn or tool exchange should never approach this size; the cap is
+/// there to bound a single hostile entry without dropping legitimate
+/// turns that carry, say, a large file dump.
+const MAX_CONTENT_ENTRY_BYTES: u64 = 32 * 1024 * 1024;
+/// Total budget across all `content/*.txt` entries pulled out of a
+/// session zip in one read. A swarm of small bomb entries cannot
+/// collectively exceed this, even when each is below the per-entry
+/// cap.
+const MAX_CONTENT_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
 // Store limits
 // ---------------------------------------------------------------------------
 
@@ -407,58 +441,89 @@ fn session_zip_path(cwd: &Path, id: &str) -> PathBuf {
 }
 
 /// Read manifest.json from a session zip. Returns None if the zip or manifest is unreadable.
+///
+/// Routed through `SandboxBackend::read_zip_entry_text` so the parser
+/// runs inside the wasm sandbox by default: a malformed or hostile
+/// session zip on disk cannot OOM the agent (the archive read is
+/// bounded by `MAX_SESSION_ARCHIVE_BYTES` and the manifest entry by
+/// `MAX_MANIFEST_BYTES`, and the wasm linear-memory limit catches
+/// anything those size pre-checks miss).
 fn read_manifest_from_zip(zip_path: &Path) -> Option<SessionManifest> {
-    let file = std::fs::File::open(zip_path).ok()?;
-    let mut archive = zip::ZipArchive::new(file).ok()?;
-    let mut manifest_entry = archive.by_name("manifest.json").ok()?;
-    let mut buf = String::new();
-    manifest_entry.read_to_string(&mut buf).ok()?;
-    serde_json::from_str(&buf).ok()
+    let body = match crate::sandbox_backend::global().read_zip_entry_text(
+        zip_path,
+        "manifest.json",
+        MAX_SESSION_ARCHIVE_BYTES,
+        MAX_MANIFEST_BYTES,
+    ) {
+        Ok(Some(s)) => s,
+        Ok(None) => return None,
+        Err(e) => {
+            tracing::warn!(
+                path = %zip_path.display(),
+                "session manifest unreadable: {e}"
+            );
+            return None;
+        }
+    };
+    serde_json::from_str(&body).ok()
 }
 
 /// Read conversation history from a session zip.
 /// Reads TaskFragmentDto entries from fragments-v4.json and resolves their
 /// markdownContentId / messages[].contentId against content/*.txt files.
+///
+/// Three sandboxed pulls per zip: one prefix-scan to grab every
+/// `content/<id>.txt` in a single sandbox boot, one named fetch for
+/// `fragments-v4.json`, one for `contexts.jsonl`. The wasm memory cap
+/// (`StoreLimits::memory_size`) and the per-entry / per-total byte
+/// limits above keep a crafted archive from OOM-ing the host.
 fn read_history_from_zip(zip_path: &Path) -> Vec<ConversationTurn> {
-    let file = match std::fs::File::open(zip_path) {
-        Ok(f) => f,
-        Err(_) => return vec![],
-    };
-    let mut archive = match zip::ZipArchive::new(file) {
-        Ok(a) => a,
-        Err(_) => return vec![],
-    };
+    let backend = crate::sandbox_backend::global();
 
     // 1. Read all content/*.txt files into a map: content_id -> text
-    let mut content_map: HashMap<String, String> = HashMap::new();
-    for i in 0..archive.len() {
-        let mut entry = match archive.by_index(i) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        let name = entry.name().to_string();
+    let content_entries = match backend.read_zip_entries_with_prefix(
+        zip_path,
+        "content/",
+        MAX_SESSION_ARCHIVE_BYTES,
+        MAX_CONTENT_ENTRY_BYTES,
+        MAX_CONTENT_TOTAL_BYTES,
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(
+                path = %zip_path.display(),
+                "session content entries unreadable: {e}"
+            );
+            return vec![];
+        }
+    };
+    let mut content_map: HashMap<String, String> =
+        HashMap::with_capacity(content_entries.len());
+    for (name, body) in content_entries {
         if let Some(content_id) = name
             .strip_prefix("content/")
             .and_then(|s| s.strip_suffix(".txt"))
         {
-            let mut buf = String::new();
-            if entry.read_to_string(&mut buf).is_ok() {
-                content_map.insert(content_id.to_string(), buf);
-            }
+            content_map.insert(content_id.to_string(), body);
         }
     }
 
-    // 2. Read fragments-v4.json to find task fragments with conversation content
-    let fragments_json = {
-        let mut entry = match archive.by_name("fragments-v4.json") {
-            Ok(e) => e,
-            Err(_) => return vec![],
-        };
-        let mut buf = String::new();
-        if entry.read_to_string(&mut buf).is_err() {
+    // 2. Read fragments-v4.json
+    let fragments_json = match backend.read_zip_entry_text(
+        zip_path,
+        "fragments-v4.json",
+        MAX_SESSION_ARCHIVE_BYTES,
+        MAX_FRAGMENTS_BYTES,
+    ) {
+        Ok(Some(s)) => s,
+        Ok(None) => return vec![],
+        Err(e) => {
+            tracing::warn!(
+                path = %zip_path.display(),
+                "fragments-v4.json unreadable: {e}"
+            );
             return vec![];
         }
-        buf
     };
 
     let fragments: serde_json::Value = match serde_json::from_str(&fragments_json) {
@@ -481,7 +546,7 @@ fn read_history_from_zip(zip_path: &Path) -> Vec<ConversationTurn> {
     //      collecting `virtuals` in first-seen order gives the chronological
     //      sequence of task fragments. Works for both newly-written zips and
     //      older ones that already followed this convention -- no migration.
-    let chronological_ids = read_task_fragment_order(&mut archive);
+    let chronological_ids = read_task_fragment_order_from_zip(zip_path);
 
     // 3. Extract conversation from task fragments, in chronological order
     //    where recoverable. Each task fragment may have:
@@ -584,15 +649,23 @@ fn read_history_from_zip(zip_path: &Path) -> Vec<ConversationTurn> {
 /// caller falls back to the BTreeMap iteration order on the fragments map,
 /// which keeps the prior shuffled-but-best-effort behavior for malformed
 /// zips rather than dropping turns outright.
-fn read_task_fragment_order(archive: &mut zip::ZipArchive<std::fs::File>) -> Vec<String> {
-    let mut buf = String::new();
-    let Ok(mut entry) = archive.by_name("contexts.jsonl") else {
-        return Vec::new();
+fn read_task_fragment_order_from_zip(zip_path: &Path) -> Vec<String> {
+    let buf = match crate::sandbox_backend::global().read_zip_entry_text(
+        zip_path,
+        "contexts.jsonl",
+        MAX_SESSION_ARCHIVE_BYTES,
+        MAX_CONTEXTS_BYTES,
+    ) {
+        Ok(Some(s)) => s,
+        Ok(None) => return Vec::new(),
+        Err(e) => {
+            tracing::warn!(
+                path = %zip_path.display(),
+                "contexts.jsonl unreadable: {e}"
+            );
+            return Vec::new();
+        }
     };
-    if entry.read_to_string(&mut buf).is_err() {
-        return Vec::new();
-    }
-    drop(entry);
 
     let mut ids: Vec<String> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();

--- a/brokk-acp-rust/src/session.rs
+++ b/brokk-acp-rust/src/session.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::io::{Read as IoRead, Write as IoWrite};
+use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -838,8 +838,17 @@ where
 /// Copy every entry from `archive` into `writer` whose name does not match `skip`.
 /// Per-entry I/O failures bubble up; callers in `with_temp_zip_writer` will discard
 /// the half-written temp zip.
-fn copy_zip_entries_except<F>(
-    archive: &mut zip::ZipArchive<std::fs::File>,
+/// Stream the entries of an existing session zip through the sandbox,
+/// writing each one into `writer` as soon as it comes back. We list
+/// names first, then fetch each entry individually so the host's peak
+/// memory is bounded by the per-entry cap (`MAX_CONTENT_ENTRY_BYTES`,
+/// 32 MiB) rather than the full decompressed archive. This is the
+/// load-bearing piece that lets `append_turn_to_zip` and
+/// `rewrite_manifest_in_zip` rebuild a session zip without ever
+/// re-parsing it with the host's `zip` crate, closing the TOCTOU
+/// window between session load and the next turn append.
+fn copy_zip_entries_via_sandbox<F>(
+    zip_path: &Path,
     writer: &mut zip::ZipWriter<std::fs::File>,
     options: zip::write::SimpleFileOptions,
     skip: F,
@@ -848,23 +857,51 @@ where
     F: Fn(&str) -> bool,
 {
     use anyhow::Context;
-    for i in 0..archive.len() {
-        let mut entry = archive
-            .by_index(i)
-            .with_context(|| format!("reading zip entry at index {i}"))?;
-        let name = entry.name().to_string();
+    // The sandbox primitives translate a missing archive into
+    // "no entries" so most callers can stay silent. The rewrite path
+    // is different: silently producing an archive that does not
+    // contain the prior session's entries would corrupt the on-disk
+    // state. Match the prior `File::open(...).with_context(...)`
+    // behaviour and fail loudly so `with_temp_zip_writer` rolls back.
+    if !zip_path.exists() {
+        anyhow::bail!(
+            "opening session zip {} for update: file not found",
+            zip_path.display()
+        );
+    }
+    let backend = crate::sandbox_backend::global();
+    let names = backend
+        .list_zip_entry_names(zip_path, MAX_SESSION_ARCHIVE_BYTES)
+        .with_context(|| format!("listing entries in {}", zip_path.display()))?;
+    for name in names {
         if skip(&name) {
             continue;
         }
-        let mut buf = Vec::new();
-        entry
-            .read_to_end(&mut buf)
-            .with_context(|| format!("reading zip entry {name}"))?;
+        let body = match backend.read_zip_entry_text(
+            zip_path,
+            &name,
+            MAX_SESSION_ARCHIVE_BYTES,
+            MAX_CONTENT_ENTRY_BYTES,
+        ) {
+            Ok(Some(s)) => s,
+            // Race: an entry disappeared between list and read. Treat
+            // as a transient zip mutation and abort the rewrite -- the
+            // atomic temp-then-rename in `with_temp_zip_writer` keeps
+            // the on-disk zip unchanged.
+            Ok(None) => anyhow::bail!(
+                "zip entry {name} disappeared between list and read in {}",
+                zip_path.display()
+            ),
+            Err(e) => {
+                return Err(anyhow::anyhow!(e))
+                    .with_context(|| format!("reading zip entry {name}"));
+            }
+        };
         writer
             .start_file(&name, options)
             .with_context(|| format!("starting zip entry {name}"))?;
         writer
-            .write_all(&buf)
+            .write_all(body.as_bytes())
             .with_context(|| format!("writing zip entry {name}"))?;
     }
     Ok(())
@@ -928,46 +965,54 @@ fn append_turn_to_zip(
 ) -> anyhow::Result<()> {
     use anyhow::Context;
 
-    let file = std::fs::File::open(zip_path)
-        .with_context(|| format!("opening session zip {} for update", zip_path.display()))?;
-    let mut archive = zip::ZipArchive::new(file)
-        .with_context(|| format!("reading session zip {}", zip_path.display()))?;
-
-    // Pre-read the entries we plan to rewrite. A missing or unparseable entry falls back
-    // to a known-empty default, matching prior behavior; a stale corruption shouldn't
+    // Pre-read the entries we plan to rewrite through the sandbox so a
+    // mutated zip on disk (an attacker swapping the file between the
+    // initial load and this append) cannot panic the host's `zip`
+    // crate. A missing or unparseable entry falls back to a known-empty
+    // default, matching prior behavior; a stale corruption shouldn't
     // abort persistence of the new turn.
+    let backend = crate::sandbox_backend::global();
     let mut existing_fragments: serde_json::Value =
         serde_json::json!({"version": 4, "referenced": {}, "virtual": {}, "task": {}});
-    if let Ok(mut e) = archive.by_name("fragments-v4.json") {
-        let mut buf = String::new();
-        if e.read_to_string(&mut buf).is_ok()
-            && let Ok(v) = serde_json::from_str(&buf)
-        {
-            existing_fragments = v;
-        }
+    if let Ok(Some(buf)) = backend.read_zip_entry_text(
+        zip_path,
+        "fragments-v4.json",
+        MAX_SESSION_ARCHIVE_BYTES,
+        MAX_FRAGMENTS_BYTES,
+    ) && let Ok(v) = serde_json::from_str(&buf)
+    {
+        existing_fragments = v;
     }
-    let mut existing_contexts = String::new();
-    if let Ok(mut e) = archive.by_name("contexts.jsonl") {
-        let _ = e.read_to_string(&mut existing_contexts);
-    }
+    let existing_contexts = backend
+        .read_zip_entry_text(
+            zip_path,
+            "contexts.jsonl",
+            MAX_SESSION_ARCHIVE_BYTES,
+            MAX_CONTEXTS_BYTES,
+        )
+        .ok()
+        .flatten()
+        .unwrap_or_default();
     let mut existing_content_metadata: serde_json::Value = serde_json::json!({});
-    if let Ok(mut e) = archive.by_name("content_metadata.json") {
-        let mut buf = String::new();
-        if e.read_to_string(&mut buf).is_ok()
-            && let Ok(v) = serde_json::from_str(&buf)
-        {
-            existing_content_metadata = v;
-        }
+    if let Ok(Some(buf)) = backend.read_zip_entry_text(
+        zip_path,
+        "content_metadata.json",
+        MAX_SESSION_ARCHIVE_BYTES,
+        MAX_MANIFEST_BYTES,
+    ) && let Ok(v) = serde_json::from_str(&buf)
+    {
+        existing_content_metadata = v;
     }
     let mut existing_group_info: serde_json::Value =
         serde_json::json!({"contextToGroupId": {}, "groupLabels": {}});
-    if let Ok(mut e) = archive.by_name("group_info.json") {
-        let mut buf = String::new();
-        if e.read_to_string(&mut buf).is_ok()
-            && let Ok(v) = serde_json::from_str(&buf)
-        {
-            existing_group_info = v;
-        }
+    if let Ok(Some(buf)) = backend.read_zip_entry_text(
+        zip_path,
+        "group_info.json",
+        MAX_SESSION_ARCHIVE_BYTES,
+        MAX_MANIFEST_BYTES,
+    ) && let Ok(v) = serde_json::from_str(&buf)
+    {
+        existing_group_info = v;
     }
 
     let user_content_id = uuid::Uuid::new_v4().to_string();
@@ -1057,7 +1102,7 @@ fn append_turn_to_zip(
     ];
 
     with_temp_zip_writer(zip_path, |writer, options| {
-        copy_zip_entries_except(&mut archive, writer, options, |n| REWRITTEN.contains(&n))?;
+        copy_zip_entries_via_sandbox(zip_path, writer, options, |n| REWRITTEN.contains(&n))?;
 
         let manifest_json =
             serde_json::to_string_pretty(manifest).context("serializing session manifest")?;
@@ -1101,17 +1146,11 @@ fn append_turn_to_zip(
 fn rewrite_manifest_in_zip(zip_path: &Path, manifest: &SessionManifest) -> anyhow::Result<()> {
     use anyhow::Context;
 
-    let file = std::fs::File::open(zip_path).with_context(|| {
-        format!(
-            "opening session zip {} for manifest rewrite",
-            zip_path.display()
-        )
-    })?;
-    let mut archive = zip::ZipArchive::new(file)
-        .with_context(|| format!("reading session zip {}", zip_path.display()))?;
-
     with_temp_zip_writer(zip_path, |writer, options| {
-        copy_zip_entries_except(&mut archive, writer, options, |n| n == "manifest.json")?;
+        // Stream every existing entry except `manifest.json` through
+        // the sandbox so a mutated zip on disk cannot panic the
+        // host's `zip` parser during the rewrite.
+        copy_zip_entries_via_sandbox(zip_path, writer, options, |n| n == "manifest.json")?;
         let manifest_json =
             serde_json::to_string_pretty(manifest).context("serializing session manifest")?;
         writer.start_file("manifest.json", options)?;

--- a/brokk-acp-rust/src/skills.rs
+++ b/brokk-acp-rust/src/skills.rs
@@ -32,6 +32,8 @@ use std::ffi::OsStr;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
+use brokk_acp_sandbox::split_frontmatter;
+
 /// Per-root cap on walked directory entries. Cheap insurance against
 /// accidental scans into a `node_modules`/`target` tree if a user drops
 /// `.agents/skills/` at a wrong level. opencode has no such cap; this
@@ -292,7 +294,7 @@ fn load_skill(path: &Path, scope: SkillScope, reg: &mut SkillRegistry) {
         }
     };
 
-    let parsed = match parse_frontmatter(front) {
+    let parsed = match crate::sandbox_backend::global().parse_skill_frontmatter(front) {
         Ok(p) => p,
         Err(e) => {
             reg.push_diagnostic(format!(
@@ -371,124 +373,13 @@ fn load_skill(path: &Path, scope: SkillScope, reg: &mut SkillRegistry) {
     });
 }
 
-/// Returned by `parse_frontmatter`. Only fields the registry consumes are
-/// extracted; the rest of the YAML is intentionally ignored to keep
-/// validation lenient across vendors.
-#[derive(Debug, Default)]
-struct ParsedFrontmatter {
-    name: Option<String>,
-    description: Option<String>,
-}
-
-/// Split a SKILL.md into `(frontmatter, body)`. Frontmatter is the block
-/// between a leading `---` line and the next `---` line on its own.
-fn split_frontmatter(raw: &str) -> Result<(&str, &str), &'static str> {
-    let trimmed = raw.trim_start_matches('\u{feff}');
-    let rest = trimmed
-        .strip_prefix("---\n")
-        .or_else(|| trimmed.strip_prefix("---\r\n"))
-        .ok_or("file does not start with `---`")?;
-    // Search for a closing `---` on its own line.
-    let mut offset = 0usize;
-    for line in rest.split_inclusive('\n') {
-        let stripped = line.trim_end_matches(['\n', '\r']);
-        if stripped == "---" {
-            let front = &rest[..offset];
-            let body_start = offset + line.len();
-            let body = if body_start < rest.len() {
-                &rest[body_start..]
-            } else {
-                ""
-            };
-            return Ok((front, body));
-        }
-        offset += line.len();
-    }
-    Err("no closing `---` for frontmatter")
-}
-
-/// Lenient YAML parse: extracts `name` and `description`. On a YAML
-/// scanner error we retry once with the offending unquoted-colon value
-/// wrapped in quotes, matching the spec's recommended fallback for
-/// "Use this skill when: the user asks about PDFs" style values.
-fn parse_frontmatter(yaml: &str) -> Result<ParsedFrontmatter, String> {
-    match serde_yaml::from_str::<RawFrontmatter>(yaml) {
-        Ok(r) => Ok(r.into_parsed()),
-        Err(first_err) => {
-            // Heuristic recovery: if the YAML scanner choked on a
-            // `description:` value containing an unquoted colon, try
-            // again with the value wrapped in double quotes. We don't
-            // attempt this for arbitrary fields -- only `description`,
-            // which is by far the most common offender in skills shipped
-            // by other clients.
-            if let Some(retry) = requote_description(yaml)
-                && let Ok(r) = serde_yaml::from_str::<RawFrontmatter>(&retry)
-            {
-                return Ok(r.into_parsed());
-            }
-            Err(first_err.to_string())
-        }
-    }
-}
-
-#[derive(Debug, serde::Deserialize, Default)]
-struct RawFrontmatter {
-    #[serde(default)]
-    name: Option<serde_yaml::Value>,
-    #[serde(default)]
-    description: Option<serde_yaml::Value>,
-}
-
-impl RawFrontmatter {
-    fn into_parsed(self) -> ParsedFrontmatter {
-        ParsedFrontmatter {
-            name: self.name.and_then(yaml_value_to_trimmed_string),
-            description: self.description.and_then(yaml_value_to_trimmed_string),
-        }
-    }
-}
-
-/// Coerce a YAML scalar to a trimmed `String`. Returns `None` for nulls
-/// or non-scalar values (sequences, maps) -- callers treat missing values
-/// the same as malformed.
-fn yaml_value_to_trimmed_string(v: serde_yaml::Value) -> Option<String> {
-    match v {
-        serde_yaml::Value::String(s) => Some(s.trim().to_string()),
-        serde_yaml::Value::Bool(b) => Some(b.to_string()),
-        serde_yaml::Value::Number(n) => Some(n.to_string()),
-        _ => None,
-    }
-}
-
-/// Rewrite `description: <unquoted value with colon>` to wrap the value
-/// in double quotes. Best-effort; only touches the first matching line.
-fn requote_description(yaml: &str) -> Option<String> {
-    let mut out = String::with_capacity(yaml.len() + 4);
-    let mut changed = false;
-    for line in yaml.split_inclusive('\n') {
-        let stripped = line.trim_end_matches(['\n', '\r']);
-        if !changed && let Some(rest) = stripped.strip_prefix("description:") {
-            let trimmed = rest.trim_start();
-            // Only requote when the value isn't already quoted, isn't a
-            // block scalar (`|` / `>`), and contains a colon (the trigger
-            // for the YAML scanner error we're recovering from).
-            let already_safe = trimmed.starts_with('"')
-                || trimmed.starts_with('\'')
-                || trimmed.starts_with('|')
-                || trimmed.starts_with('>')
-                || trimmed.is_empty();
-            if !already_safe && trimmed.contains(':') {
-                let escaped = trimmed.replace('\\', "\\\\").replace('"', "\\\"");
-                let newline_tail = &line[stripped.len()..line.len()];
-                out.push_str(&format!("description: \"{escaped}\"{newline_tail}"));
-                changed = true;
-                continue;
-            }
-        }
-        out.push_str(line);
-    }
-    if changed { Some(out) } else { None }
-}
+// Frontmatter parsing (`split_frontmatter`, `parse_frontmatter`, and the
+// YAML recovery helpers) moved to the `brokk-acp-sandbox` crate so the
+// same code can run in a wasm sandbox via `SandboxBackend::Wasm`. The
+// host calls those entry points through `SandboxBackend` above and
+// `brokk_acp_sandbox::split_frontmatter` directly (the splitter does no
+// untrusted-format parsing, only newline scanning, so it is safe to keep
+// native even when the YAML parser is sandboxed).
 
 fn normalize_path(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())

--- a/brokk-acp-rust/src/tools/filesystem.rs
+++ b/brokk-acp-rust/src/tools/filesystem.rs
@@ -1,15 +1,13 @@
 use super::{ToolResult, ToolStatus, safe_resolve, safe_resolve_for_write};
-use regex::Regex;
-use std::io::Read;
 use std::path::Path;
-use walkdir::WalkDir;
 
 /// Hard cap on individual file size scanned by `search_file_contents`.
 /// Files larger than this are skipped to keep memory bounded on big repos.
 const SEARCH_MAX_FILE_BYTES: u64 = 1_048_576; // 1 MiB
-
-/// Number of leading bytes inspected for NUL bytes to classify a file as binary.
-const BINARY_SNIFF_BYTES: usize = 8192;
+/// Total-bytes-scanned budget across the whole walk. Together with
+/// the per-file cap this bounds the worst case the sandbox has to
+/// chew through for a single `searchFileContents` call.
+const SEARCH_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
 
 pub fn read_file(cwd: &Path, path: &str) -> ToolResult {
     let resolved = match safe_resolve(cwd, path) {
@@ -101,129 +99,71 @@ pub fn list_directory(cwd: &Path, path: &str) -> ToolResult {
     }
 }
 
+/// `searchFileContents` tool, routed through `SandboxBackend` so the
+/// user-controlled regex runs inside the wasm sandbox by default.
+/// The `regex` crate is engineered to be linear-time, but a future
+/// engine bug or accidental enabling of a backtracking feature
+/// shouldn't be able to hang the agent -- the wasm fuel cap is the
+/// definitive backstop.
 pub fn search_file_contents(
     cwd: &Path,
     pattern: &str,
     glob_filter: Option<&str>,
     max_results: usize,
 ) -> ToolResult {
-    let re = match Regex::new(pattern) {
-        Ok(r) => r,
-        Err(e) => {
+    let outcome = match crate::sandbox_backend::global().search_file_contents(
+        cwd,
+        pattern,
+        glob_filter,
+        max_results as u64,
+        SEARCH_MAX_FILE_BYTES,
+        SEARCH_MAX_TOTAL_BYTES,
+    ) {
+        Ok(o) => o,
+        Err(brokk_acp_sandbox::SearchError::InvalidRegex(msg)) => {
             return ToolResult {
                 status: ToolStatus::RequestError,
-                output: format!("Invalid regex '{}': {}", pattern, e),
+                output: format!("Invalid regex '{}': {}", pattern, msg),
             };
         }
-    };
-
-    let glob_re = glob_filter.and_then(|g| {
-        // Convert simple glob to regex: *.rs -> .*\.rs$, **/*.java -> .*\.java$
-        let re_str = g
-            .replace('.', "\\.")
-            .replace("**", "<<GLOBSTAR>>")
-            .replace('*', "[^/]*")
-            .replace("<<GLOBSTAR>>", ".*");
-        Regex::new(&format!("{}$", re_str)).ok()
-    });
-
-    let cwd_canonical = match cwd.canonicalize() {
-        Ok(c) => c,
-        Err(e) => {
+        Err(brokk_acp_sandbox::SearchError::InvalidGlob(msg)) => {
+            return ToolResult {
+                status: ToolStatus::RequestError,
+                output: format!("Invalid glob: {msg}"),
+            };
+        }
+        Err(brokk_acp_sandbox::SearchError::Walk(msg)) => {
             return ToolResult {
                 status: ToolStatus::InternalError,
-                output: format!("Cannot resolve cwd: {}", e),
+                output: msg,
             };
         }
     };
 
-    let mut results = Vec::new();
-    for entry in WalkDir::new(cwd)
-        .into_iter()
-        .filter_entry(|e| {
-            let name = e.file_name().to_string_lossy();
-            // Skip hidden dirs and common noise
-            !name.starts_with('.')
-                && name != "node_modules"
-                && name != "target"
-                && name != "__pycache__"
-        })
-        .flatten()
-    {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        let rel = path
-            .strip_prefix(&cwd_canonical)
-            .or_else(|_| path.strip_prefix(cwd))
-            .unwrap_or(path);
-        let rel_str = rel.to_string_lossy();
-
-        if let Some(glob_re) = &glob_re
-            && !glob_re.is_match(&rel_str)
-        {
-            continue;
-        }
-
-        // Size cap: skip files above SEARCH_MAX_FILE_BYTES.
-        match entry.metadata() {
-            Ok(md) if md.len() > SEARCH_MAX_FILE_BYTES => continue,
-            Err(_) => continue,
-            _ => {}
-        }
-
-        // Sniff the first BINARY_SNIFF_BYTES bytes for a NUL. If present, treat as binary and skip.
-        if is_binary_file(path) {
-            continue;
-        }
-
-        let content = match std::fs::read_to_string(path) {
-            Ok(c) => c,
-            Err(_) => continue, // skip non-UTF8 or unreadable files
-        };
-
-        for (line_num, line) in content.lines().enumerate() {
-            if re.is_match(line) {
-                results.push(format!("{}:{}: {}", rel_str, line_num + 1, line.trim()));
-                if results.len() >= max_results {
-                    results.push(format!("... truncated at {} results", max_results));
-                    return ToolResult {
-                        status: ToolStatus::Success,
-                        output: results.join("\n"),
-                    };
-                }
-            }
-        }
-    }
-
-    if results.is_empty() {
-        ToolResult {
+    if outcome.matches.is_empty() {
+        return ToolResult {
             status: ToolStatus::Success,
             output: format!("No matches found for '{}'", pattern),
-        }
-    } else {
-        ToolResult {
-            status: ToolStatus::Success,
-            output: results.join("\n"),
-        }
+        };
+    }
+
+    let mut lines: Vec<String> = outcome
+        .matches
+        .iter()
+        .map(|m| format!("{}:{}: {}", m.path, m.line_num, m.line))
+        .collect();
+    if outcome.truncated {
+        lines.push(format!("... truncated at {} results", max_results));
+    }
+    ToolResult {
+        status: ToolStatus::Success,
+        output: lines.join("\n"),
     }
 }
 
-/// Classify a file as binary if any of the first BINARY_SNIFF_BYTES bytes is NUL.
-/// Files we cannot open are classified as binary so we skip them.
-fn is_binary_file(path: &Path) -> bool {
-    let mut file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return true,
-    };
-    let mut buf = [0u8; BINARY_SNIFF_BYTES];
-    let n = match file.read(&mut buf) {
-        Ok(n) => n,
-        Err(_) => return true,
-    };
-    buf[..n].contains(&0)
-}
+// `is_binary_file` and `BINARY_SNIFF_BYTES` moved to the shared
+// `brokk_acp_sandbox::search` module so the native and wasm-sandboxed
+// backends classify binary files identically.
 
 #[cfg(test)]
 mod tests {
@@ -456,13 +396,7 @@ mod tests {
         std::fs::remove_dir_all(&cwd).ok();
     }
 
-    /// `is_binary_file` returns true for non-existent paths so the search
-    /// loop's "skip and move on" semantics are preserved when a file
-    /// disappears mid-walk.
-    #[test]
-    fn is_binary_file_treats_missing_as_binary() {
-        let cwd = fresh_tmp_dir("missing-binary");
-        assert!(is_binary_file(&cwd.join("does-not-exist")));
-        std::fs::remove_dir_all(&cwd).ok();
-    }
+    // The binary-sniff test moved to `brokk-acp-sandbox::search` along
+    // with `is_binary_file` itself; the host fn is gone and the test
+    // would now be redundant with the sandbox unit test.
 }


### PR DESCRIPTION
## Summary

Introduces a wasmtime-hosted parser sandbox in `brokk-acp-rust` and routes the four highest-risk untrusted-input parsers through it by default. A new `--no-wasm-sandbox` flag (env `BROKK_ACP_NO_WASM_SANDBOX`) opts back into the native fallback when raw speed matters more than isolation.

- `SKILL.md` YAML frontmatter -- isolates `serde_yaml` against malformed inputs and YAML bombs.
- `AGENTS.md` / `CLAUDE.md` reads -- a per-file size cap rejects multi-GB files before `read_to_string` allocates, with the wasm linear-memory limit as a backstop if the metadata lies.
- Session zip codec (`read_manifest_from_zip`, `read_history_from_zip`, `read_task_fragment_order_from_zip`) -- bounded archive + entry decompression, no zip-bomb / parser-panic exposure on session load.
- `searchFileContents` regex + walk -- defense in depth against a future ReDoS regression in the `regex` crate.

## Architecture

- New workspace member `brokk-acp-sandbox` (`brokk-acp-rust/brokk-acp-sandbox/`) compiles to both native (linked as a library for the fallback path) and `wasm32-wasip2` (a binary embedded via `include_bytes!` by `build.rs`).
- The wasm binary speaks newline-delimited JSON-RPC over stdin/stdout. A fresh `wasmtime::Store` is created per call so state cannot leak across parses.
- Sandbox guarantees in place: 50M-instruction fuel cap per request, 64 MiB wasm linear-memory cap (`StoreLimits::memory_size`), read-only preopens scoped to the specific parent directory of each input, no network capabilities.
- A minimal pure-Rust zip reader (`brokk-acp-sandbox/src/zip_reader.rs`, ~350 lines) was written because both `zip 8` (transitive `typed-path 0.12.3` activates `#![feature(wasip2)]`, requires nightly) and `rc-zip-sync` (needs `std::fs::File: ReadAt`, not implemented on wasi) block compilation on `wasm32-wasip2`.

## Caps in place

| Input | Cap |
|---|---|
| `AGENTS.md` / `CLAUDE.md` per-file | 1 MiB |
| Session zip archive on disk | 256 MiB |
| `manifest.json` entry | 1 MiB |
| `fragments-v4.json` entry | 16 MiB |
| `contexts.jsonl` entry | 16 MiB |
| `content/*.txt` per entry | 32 MiB |
| `content/*.txt` total across one zip | 256 MiB |
| `searchFileContents` per-file | 1 MiB |
| `searchFileContents` total scan | 256 MiB |
| Wasm linear memory (all requests) | 64 MiB |
| Wasm fuel (all requests) | 50M instructions |

## What is NOT yet sandboxed

`append_turn_to_zip` and `rewrite_manifest_in_zip` still re-parse the on-disk zip natively while copying entries through to the new archive. Those calls happen post-load on an archive that already round-tripped through the sandbox reader, so the residual TOCTOU window is intentionally accepted for now; a follow-up can add a `read_all_entries` primitive once the cost/benefit shifts.

## Side effect: real bug fix

The shared search module exposed a latent bug in `searchFileContents`: the old `filter_entry` pruned the search root whenever its name started with `.` (which `tempfile::TempDir` always does on Unix), silently returning zero matches for any caller pointing search at a hidden directory. Fixed by exempting `depth() == 0` from the hidden-name filter.

## Test plan

- [x] `cargo test` (271/271 passing on this branch; 12 of those are new sandbox-specific tests covering parse / read / search happy paths, missing-input handling, oversize rejection, ReDoS bait, and native/wasm parity for every primitive).
- [x] `cargo build` and `cargo build --target wasm32-wasip2` for the sandbox crate (verified the wasm artifact is produced, ~500 KiB, no C deps).
- [ ] Reviewer: verify on Linux that `tempfile::TempDir` reproduces the `.tmp*` naming and the `filter_entry` fix actually changes behaviour, in case macOS-only.
- [ ] Reviewer: scan the new caps for anything that might trip existing user sessions (256 MiB session zip is the closest one to a real ceiling).

## Commits

- `79dbacc4e` brokk-acp-rust: add wasm parser sandbox with native fallback
- `f169a7761` brokk-acp-rust: sandbox AGENTS.md/CLAUDE.md file reads with size cap
- `3c3ea51b8` brokk-acp-rust: sandbox session-zip readers against zip bombs and parser panics
- `8296dba4b` brokk-acp-rust: sandbox searchFileContents regex + walk

🤖 Generated with [Claude Code](https://claude.com/claude-code)