### PR TITLE
Fixes #3605: Expose reportSecretLikeCode in brokk-core MCP server

### DIFF
--- a/app/src/main/java/ai/brokk/git/GitRepo.java
+++ b/app/src/main/java/ai/brokk/git/GitRepo.java
@@ -135,8 +135,8 @@ public class GitRepo implements Closeable, IGitRepo {
         return repository;
     }
 
-    // package-private accessor for projectRoot for the extracted worktrees helper
-    Path getProjectRoot() {
+    @Override
+    public Path getProjectRoot() {
         return projectRoot;
     }
 
@@ -666,6 +666,7 @@ public class GitRepo implements Closeable, IGitRepo {
      * Returns an abbreviated (short) hash for the given revision. Attempts to abbreviate via JGit to a unique short id;
      * falls back to the first 7 chars on error.
      */
+    @Override
     public String shortHash(String rev) {
         try {
             var id = resolveToObject(rev);

--- a/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
+++ b/app/src/main/java/ai/brokk/tools/CodeQualityTools.java
@@ -822,7 +822,8 @@ public class CodeQualityTools {
             return "Secret-like code scan requires a JGit-backed repository.";
         }
 
-        var report = new GitSecretScanner(gitRepo).scan(commitCap, includeHistoryOnly, includeLowConfidence);
+        var report = new GitSecretScanner(gitRepo, gitRepo.getGit().getRepository())
+                .scan(commitCap, includeHistoryOnly, includeLowConfidence);
         return formatSecretScanReport(report, findingsCap);
     }
 

--- a/app/src/test/java/ai/brokk/git/GitSecretScannerTest.java
+++ b/app/src/test/java/ai/brokk/git/GitSecretScannerTest.java
@@ -36,7 +36,7 @@ class GitSecretScannerTest {
     void matcherDetectsProviderTokensAndPrivateKeys() {
         String text =
                 """
-                aws = "AKIAABCDEFGHIJKLMNOP"
+                aws = "AKIAIOSFODNN7EXAMPLE"
                 token = "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"
                 key = "-----BEGIN RSA PRIVATE KEY-----"
                 """
@@ -53,7 +53,7 @@ class GitSecretScannerTest {
     void matcherDetectsProviderTokensWithoutCredentialKeywords() {
         String text =
                 """
-                value = "AKIAABCDEFGHIJKLMNOP"
+                value = "AKIAIOSFODNN7EXAMPLE"
                 value = "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"
                 value = "xoxb-1234567890-abcedfghij"
                 value = "AIza12345678901234567890123456789012345"
@@ -234,7 +234,7 @@ class GitSecretScannerTest {
             repo.getGit().commit().setSign(false).setMessage("add late secret").call();
 
             repo.invalidateCaches();
-            var report = new GitSecretScanner(repo).scan(20, true, false, 2);
+            var report = new GitSecretScanner(repo, repo.getGit().getRepository()).scan(20, true, false, 2);
             Set<String> paths = report.findings().stream()
                     .map(GitSecretScanner.SecretFinding::path)
                     .collect(Collectors.toSet());

--- a/brokk-core/README.md
+++ b/brokk-core/README.md
@@ -207,6 +207,17 @@ Pass `fqNames` to target specific symbols; leave it empty to scan declarations i
 | `maxUsageCandidateFiles` | int | no | (usage finder default) | Maximum usage-candidate files to inspect |
 | `maxUsagesPerSymbol` | int | no | 100 | Maximum usage hits per symbol before usage lookup returns a guardrail result |
 
+#### `reportSecretLikeCode`
+
+Scans non-test text files for secret-looking strings, including current/default-branch files and full git history. Findings are heuristic (regex rules + entropy) and redacted for downstream LLM triage. Requires a JGit-backed workspace; non-Git workspaces receive a notice instead of a report. May be slow on large histories -- use `maxFindings` and `maxCommits` to bound work.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `maxFindings` | int | no | 100 | Maximum findings to emit |
+| `maxCommits` | int | no | 2000 | Maximum commits to walk from `HEAD` |
+| `includeHistoryOnly` | bool | no | `false` | Include findings that only appear in history and are not present in the current/default branch |
+| `includeLowConfidence` | bool | no | `false` | Include lower-confidence short credential-like assignments |
+
 ## Note on MCP servers
 
 The Brokk codebase has two MCP servers:

--- a/brokk-core/src/main/java/ai/brokk/git/GitRepo.java
+++ b/brokk-core/src/main/java/ai/brokk/git/GitRepo.java
@@ -133,8 +133,8 @@ public class GitRepo implements Closeable, IGitRepo {
         return repository;
     }
 
-    // package-private accessor for projectRoot for the extracted worktrees helper
-    Path getProjectRoot() {
+    @Override
+    public Path getProjectRoot() {
         return projectRoot;
     }
 
@@ -662,6 +662,7 @@ public class GitRepo implements Closeable, IGitRepo {
      * Returns an abbreviated (short) hash for the given revision. Attempts to abbreviate via JGit to a unique short id;
      * falls back to the first 7 chars on error.
      */
+    @Override
     public String shortHash(String rev) {
         try {
             var id = resolveToObject(rev);

--- a/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
+++ b/brokk-core/src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java
@@ -1009,6 +1009,33 @@ public class BrokkCoreMcpServer {
                             intArg(request, "maxUsagesPerSymbol", 0)));
                 })));
 
+        specs.add(tool(
+                "reportSecretLikeCode",
+                "Scans non-test text files for secret-looking strings, including current/default-branch files and "
+                        + "git history. Findings are heuristic and redacted for LLM triage. "
+                        + "Requires a JGit-backed repository; returns a notice otherwise. "
+                        + "Use maxFindings/maxCommits to bound output and work. "
+                        + "May be slow on large histories.",
+                schema(
+                        Map.ofEntries(
+                                entry("maxFindings", intProp("Maximum findings to emit; values <= 0 default to 100.")),
+                                entry(
+                                        "maxCommits",
+                                        intProp("Maximum commits to walk from HEAD; values <= 0 default to 2000.")),
+                                entry(
+                                        "includeHistoryOnly",
+                                        boolProp(
+                                                "Include findings that only appear in history and are not present in the current/default branch.")),
+                                entry(
+                                        "includeLowConfidence",
+                                        boolProp("Include lower-confidence short credential-like assignments."))),
+                        List.of()),
+                (exchange, request) -> withReadLock(() -> textResult(codeQualityTools.reportSecretLikeCode(
+                        intArg(request, "maxFindings", 0),
+                        intArg(request, "maxCommits", 0),
+                        boolArg(request, "includeHistoryOnly", false),
+                        boolArg(request, "includeLowConfidence", false))))));
+
         // NOTE: analyzeGitHotspots is not exposed here because GitHotspotAnalyzer
         // lives in the app module with dependencies not available in brokk-core.
 

--- a/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
@@ -878,8 +878,8 @@ public class CodeQualityToolsMcp {
         var lines = new ArrayList<String>();
         lines.add("## brokk-secret-scan");
         lines.add("");
-        lines.add("- Repository: `%s`".formatted(report.repository()));
-        lines.add("- Current/default ref scanned: `%s`".formatted(report.defaultRefDisplayName()));
+        lines.add("- Repository: `%s`".formatted(sanitizeTableCell(report.repository())));
+        lines.add("- Current/default ref scanned: `%s`".formatted(sanitizeTableCell(report.defaultRefDisplayName())));
         if (report.defaultRefFallback()) {
             lines.add("- Note: default branch could not be determined; fell back to `HEAD`.");
         }
@@ -931,7 +931,8 @@ public class CodeQualityToolsMcp {
         return candidate > 0 ? candidate : fallback;
     }
 
-    private static String sanitizeTableCell(String value) {
+    // Package-private for unit testing.
+    static String sanitizeTableCell(String value) {
         // Backticks would let attacker-controlled text (e.g. committed file paths or scanned secret excerpts)
         // escape from an inline code span and inject Markdown for downstream LLM consumers.
         // Control characters (newlines, tabs, etc.) would break the single-line table-row format.

--- a/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
+++ b/brokk-core/src/main/java/ai/brokk/tools/CodeQualityToolsMcp.java
@@ -13,7 +13,11 @@ import ai.brokk.analyzer.usages.UsageAnalyzer;
 import ai.brokk.analyzer.usages.UsageAnalyzerSelector;
 import ai.brokk.analyzer.usages.UsageFinder;
 import ai.brokk.analyzer.usages.UsageHit;
+import ai.brokk.git.GitRepo;
+import ai.brokk.git.GitSecretScanner;
+import ai.brokk.git.IGitRepo;
 import ai.brokk.project.ICoreProject;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -24,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.eclipse.jgit.api.errors.GitAPIException;
 
 /**
  * Read-only static analysis helpers for code quality, adapted for the MCP server.
@@ -32,6 +37,9 @@ import java.util.Set;
 public class CodeQualityToolsMcp {
     private static final String COMMENT_DENSITY_JAVA_ONLY =
             "Comment density is only available for Java symbols in this analyzer snapshot.";
+
+    private static final int DEFAULT_SECRET_MAX_FINDINGS = 100;
+    private static final int DEFAULT_SECRET_MAX_COMMITS = 2000;
 
     private final ICodeIntelligence intelligence;
 
@@ -825,6 +833,25 @@ public class CodeQualityToolsMcp {
             String evidence,
             String rationale) {}
 
+    // -- reportSecretLikeCode --
+
+    public String reportSecretLikeCode(
+            int maxFindings, int maxCommits, boolean includeHistoryOnly, boolean includeLowConfidence)
+            throws GitAPIException, IOException {
+
+        int findingsCap = maxFindings > 0 ? maxFindings : DEFAULT_SECRET_MAX_FINDINGS;
+        int commitCap = maxCommits > 0 ? maxCommits : DEFAULT_SECRET_MAX_COMMITS;
+        IGitRepo repo = intelligence.getRepo();
+
+        if (!(repo instanceof GitRepo gitRepo)) {
+            return "Secret-like code scan requires a JGit-backed repository.";
+        }
+
+        var report = new GitSecretScanner(gitRepo, gitRepo.getGit().getRepository())
+                .scan(commitCap, includeHistoryOnly, includeLowConfidence);
+        return formatSecretScanReport(report, findingsCap);
+    }
+
     // NOTE: analyzeGitHotspots is not available in brokk-core because GitHotspotAnalyzer
     // lives in the app module with dependencies (ai.brokk.concurrent.*) not available here.
     // It could be added if GitHotspotAnalyzer is moved to brokk-core or brokk-shared.
@@ -841,6 +868,49 @@ public class CodeQualityToolsMcp {
                 .formatted(s.headerCommentLines(), s.inlineCommentLines(), s.spanLines()));
         lines.add("- Rolled-up: header %d, inline %d, span %d"
                 .formatted(s.rolledUpHeaderCommentLines(), s.rolledUpInlineCommentLines(), s.rolledUpSpanLines()));
+        return String.join("\n", lines);
+    }
+
+    private static String formatSecretScanReport(GitSecretScanner.SecretScanReport report, int maxFindings) {
+        var shown = report.findings()
+                .subList(0, Math.min(maxFindings, report.findings().size()));
+        boolean truncated = report.findings().size() > shown.size();
+        var lines = new ArrayList<String>();
+        lines.add("## brokk-secret-scan");
+        lines.add("");
+        lines.add("- Repository: `%s`".formatted(report.repository()));
+        lines.add("- Current/default ref scanned: `%s`".formatted(report.defaultRefDisplayName()));
+        if (report.defaultRefFallback()) {
+            lines.add("- Note: default branch could not be determined; fell back to `HEAD`.");
+        }
+        lines.add("- History commits scanned: %d (cap %d)".formatted(report.commitsScanned(), report.maxCommits()));
+        lines.add("- Missing git entries skipped: %d".formatted(report.missingEntriesSkipped()));
+        lines.add("- Non-text or oversized blobs skipped: %d".formatted(report.nonTextEntriesSkipped()));
+        lines.add("- Findings shown: %d of %d%s"
+                .formatted(shown.size(), report.findings().size(), truncated ? " (truncated)" : ""));
+        lines.add("");
+
+        if (shown.isEmpty()) {
+            lines.add("No secret-like code found.");
+            return String.join("\n", lines);
+        }
+
+        lines.add("| Location | Confidence | Rule | File:Line | First Seen | Last Seen | Redacted Excerpt |");
+        lines.add("|----------|------------|------|-----------|------------|-----------|------------------|");
+        for (GitSecretScanner.SecretFinding finding : shown) {
+            String firstSeen = finding.firstSeenCommit().isBlank() ? "-" : finding.firstSeenCommit();
+            String lastSeen = finding.lastSeenCommit().isBlank() ? "-" : finding.lastSeenCommit();
+            lines.add("| %s | %s | `%s` | `%s:%d` | `%s` | `%s` | `%s` |"
+                    .formatted(
+                            finding.location(),
+                            finding.confidence(),
+                            sanitizeTableCell(finding.rule()),
+                            sanitizeTableCell(finding.path()),
+                            finding.line(),
+                            firstSeen,
+                            lastSeen,
+                            sanitizeTableCell(finding.sample())));
+        }
         return String.join("\n", lines);
     }
 
@@ -862,7 +932,10 @@ public class CodeQualityToolsMcp {
     }
 
     private static String sanitizeTableCell(String value) {
-        return value.replace("|", "\\|");
+        // Backticks would let attacker-controlled text (e.g. committed file paths or scanned secret excerpts)
+        // escape from an inline code span and inject Markdown for downstream LLM consumers.
+        // Control characters (newlines, tabs, etc.) would break the single-line table-row format.
+        return value.replace("|", "\\|").replace("`", "'").replaceAll("\\p{Cntrl}", " ");
     }
 
     private static String formatSizeWeights(IAnalyzer.MaintainabilitySizeSmellWeights w) {

--- a/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
+++ b/brokk-core/src/test/java/ai/brokk/mcpserver/BrokkCoreMcpServerTest.java
@@ -108,7 +108,8 @@ class BrokkCoreMcpServerTest {
                 "reportExceptionHandlingSmells",
                 "reportStructuralCloneSmells",
                 "reportTestAssertionSmells",
-                "reportDeadCodeAndUnusedAbstractionSmells");
+                "reportDeadCodeAndUnusedAbstractionSmells",
+                "reportSecretLikeCode");
 
         for (var expected : expectedTools) {
             assertTrue(toolNames.contains(expected), "Missing tool: " + expected);
@@ -577,6 +578,49 @@ class BrokkCoreMcpServerTest {
         assertNotNull(result);
         assertFalse(result.isError() != null && result.isError());
         assertFalse(result.content().isEmpty());
+    }
+
+    @Test
+    void reportSecretLikeCodeRunsWithoutError() {
+        var result = callTool("reportSecretLikeCode", Map.of());
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        assertFalse(result.content().isEmpty());
+        String text = textOf(result);
+        assertTrue(text.contains("## brokk-secret-scan"), text);
+    }
+
+    @Test
+    void reportSecretLikeCodeFindsCommittedSecret() throws Exception {
+        commitTrackedFiles(
+                projectRoot,
+                Map.of(
+                        "config/app.properties",
+                        "aws_access_key_id=AKIAIOSFODNN7EXAMPLE\n"
+                                + "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"),
+                Instant.parse("2025-01-01T00:00:00Z"),
+                "Add fake credentials");
+
+        var result = callTool(
+                "reportSecretLikeCode",
+                Map.of(
+                        "maxFindings",
+                        50,
+                        "maxCommits",
+                        50,
+                        "includeHistoryOnly",
+                        false,
+                        "includeLowConfidence",
+                        false));
+        assertNotNull(result);
+        assertFalse(result.isError() != null && result.isError());
+        String text = textOf(result);
+        assertTrue(text.contains("## brokk-secret-scan"), text);
+        assertTrue(text.contains("config/app.properties"), text);
+        assertFalse(text.contains("AKIAIOSFODNN7EXAMPLE"), "literal AWS key id should be redacted: " + text);
+        assertFalse(
+                text.contains("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+                "literal AWS secret access key should be redacted: " + text);
     }
 
     @Test

--- a/brokk-core/src/test/java/ai/brokk/tools/CodeQualityToolsMcpTest.java
+++ b/brokk-core/src/test/java/ai/brokk/tools/CodeQualityToolsMcpTest.java
@@ -1,0 +1,39 @@
+package ai.brokk.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+class CodeQualityToolsMcpTest {
+
+    @Test
+    void sanitizeTableCellEscapesPipes() {
+        assertEquals("a\\|b", CodeQualityToolsMcp.sanitizeTableCell("a|b"));
+    }
+
+    @Test
+    void sanitizeTableCellReplacesBackticksWithApostrophes() {
+        // Backticks would let attacker-controlled values escape from a Markdown inline-code span.
+        String result = CodeQualityToolsMcp.sanitizeTableCell("bad`branch`");
+        assertFalse(result.contains("`"), result);
+        assertEquals("bad'branch'", result);
+    }
+
+    @Test
+    void sanitizeTableCellReplacesControlCharsWithSpaces() {
+        assertEquals("a b c", CodeQualityToolsMcp.sanitizeTableCell("a\nb\tc"));
+        assertEquals("x y", CodeQualityToolsMcp.sanitizeTableCell("x\ry"));
+    }
+
+    @Test
+    void sanitizeTableCellHandlesEmpty() {
+        assertEquals("", CodeQualityToolsMcp.sanitizeTableCell(""));
+    }
+
+    @Test
+    void sanitizeTableCellLeavesSafeAsciiUnchanged() {
+        String safe = "abc 123 / - _ . , : ; @ # $ % ^ & * ( ) [ ] { } < > ? ! = +";
+        assertEquals(safe, CodeQualityToolsMcp.sanitizeTableCell(safe));
+    }
+}

--- a/brokk-shared/src/main/java/ai/brokk/git/GitSecretScanner.java
+++ b/brokk-shared/src/main/java/ai/brokk/git/GitSecretScanner.java
@@ -136,10 +136,12 @@ public class GitSecretScanner {
                     0,
                     Set.of("sk_live_", "sk_test_", "rk_live_", "rk_test_")));
 
-    private final GitRepo repo;
+    private final IGitRepo repo;
+    private final Repository repository;
 
-    public GitSecretScanner(GitRepo repo) {
+    public GitSecretScanner(IGitRepo repo, Repository repository) {
         this.repo = repo;
+        this.repository = repository;
     }
 
     public SecretScanReport scan(int maxCommits, boolean includeHistoryOnly, boolean includeLowConfidence)
@@ -205,7 +207,6 @@ public class GitSecretScanner {
             String refName, boolean includeLowConfidence, Map<ObjectId, BlobContentScanResult> blobScanCache)
             throws GitAPIException, IOException {
         long startedNanos = System.nanoTime();
-        Repository repository = repo.getGit().getRepository();
         ObjectId ref = repository.resolve(refName + "^{commit}");
         if (ref == null) {
             ref = repository.resolve(refName);
@@ -279,7 +280,6 @@ public class GitSecretScanner {
             Map<ObjectId, BlobContentScanResult> blobScanCache,
             int maxInFlightBlobScans)
             throws GitAPIException, IOException {
-        Repository repository = repo.getGit().getRepository();
         ObjectId head = repository.resolve(Constants.HEAD);
         if (head == null) {
             return HistoryScanResult.EMPTY();

--- a/brokk-shared/src/main/java/ai/brokk/git/IGitRepo.java
+++ b/brokk-shared/src/main/java/ai/brokk/git/IGitRepo.java
@@ -74,6 +74,26 @@ public interface IGitRepo {
     }
 
     /**
+     * Returns the project root directory associated with this repository.
+     * Typically the same as the working tree root; may differ for nested project layouts.
+     *
+     * @return the project root path
+     */
+    default Path getProjectRoot() {
+        return getWorkTreeRoot();
+    }
+
+    /**
+     * Returns a short hash for the supplied revision (e.g. seven hex characters), when the implementation is
+     * JGit-backed.
+     *
+     * @throws UnsupportedOperationException if this repository is not JGit-backed
+     */
+    default String shortHash(String rev) {
+        throw new UnsupportedOperationException("shortHash not implemented");
+    }
+
+    /**
      * Returns the fixed gitignore files that apply to all paths in this repo.
      * These include: global gitignore, .git/info/exclude, and root .gitignore.
      * All fixed files apply at root scope; nested .gitignore files are collected separately


### PR DESCRIPTION
Fixes #3605

## Summary

Exposes `reportSecretLikeCode` through the brokk-core MCP server, mirroring the precedent set by PR #3616 (`reportDeadCodeAndUnusedAbstractionSmells`).

- Moves `GitSecretScanner` from `app/` to `brokk-shared/` so both `app` and `brokk-core` can consume it (neither module depends on the other; the only shared layer is `brokk-shared`).
- Adapts the scanner constructor from `(GitRepo)` to `(IGitRepo, Repository)` so `brokk-shared` does not need to know about either module's concrete `GitRepo` class. The JGit `Repository` is supplied by the caller after the existing `instanceof GitRepo` check.
- Adds `reportSecretLikeCode(maxFindings, maxCommits, includeHistoryOnly, includeLowConfidence)` to `CodeQualityToolsMcp` and registers it in `BrokkCoreMcpServer.toolSpecifications()` with `withReadLock`. All four parameters are optional; defaults (`100` findings, `2000` commits) match the app-layer wrapper.
- Adds `getProjectRoot()` and `shortHash(String)` defaults to `IGitRepo`. Promotes `getProjectRoot()` in both `GitRepo` classes (app + brokk-core) from package-private to public so it overrides the new interface method. `getGit()` is **not** added to the interface; callers narrow to `GitRepo` via `instanceof` and pass `getGit().getRepository()` to the scanner, keeping the JGit mutating API off the shared interface surface.

## Security: markdown injection

`sanitizeTableCell` is strengthened to escape backticks (`` ` `` → `'`) and replace control characters with spaces. Without this, attacker-controlled git tree paths or scanned file content could escape inline code spans in the MCP markdown output and inject prompt instructions into downstream LLM consumers. This bug was flagged HIGH by the security review.

## Tests

- New `reportSecretLikeCode` entry in `BrokkCoreMcpServerTest.expectedTools`.
- New smoke test `reportSecretLikeCodeRunsWithoutError` against the default JGit-backed fixture.
- New functional test `reportSecretLikeCodeFindsCommittedSecret` that commits AWS's published example credentials (`AKIAIOSFODNN7EXAMPLE`, `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` — these are AWS-allowlisted non-credential placeholders) and asserts the report header is emitted, the file path is referenced, and the literal values are redacted.
- The existing `app/src/test/java/ai/brokk/git/GitSecretScannerTest` continues to pass; its constructor call is updated to pass `repo.getGit().getRepository()` alongside the `GitRepo`.

## Test plan

- [x] `./gradlew :brokk-shared:check :brokk-core:check :app:check` passes (Spotless + ErrorProne + NullAway + tests).
- [x] New brokk-core tests pass.
- [x] Existing `GitSecretScannerTest` (app) passes.

## Follow-ups

- The MCP handler holds `withReadLock` for the full scan duration, and the scanner has known memory growth on very large repos. Both issues are inherent to the scanner and pre-existed in the app-layer wrapper; deferred to #3633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
