### PR TITLE
Add report-only headless job policy

### DIFF
--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -655,16 +655,16 @@ public final class JobRunner {
                                                             "REPORT_ONLY",
                                                             "blocked",
                                                             "search, workspace_mutation, context_cleanup, subagents, shell, code_agent, auto_compress"));
-                                            var result = askUsingPlannerModel(
+                                            runDirectAnswer(
+                                                    jobId,
+                                                    "REPORT_ONLY",
+                                                    scope,
                                                     cm.liveContext(),
                                                     requireNonNull(
                                                             askPlannerModel,
                                                             "plannerModel required for REPORT_ONLY jobs"),
-                                                    spec.taskInput());
-                                            finalStopReason.set(result.stopDetails()
-                                                    .reason()
-                                                    .name());
-                                            scope.append(result);
+                                                    spec.taskInput(),
+                                                    finalStopReason);
                                         }
                                     }
                                     case ASK -> {
@@ -788,68 +788,14 @@ public final class JobRunner {
                                                 }
                                             }
 
-                                            try {
-                                                // Use helper that builds a workspace-only prompt and calls the
-                                                // planner model.
-                                                TaskResult askResult = askUsingPlannerModel(
-                                                        context, requireNonNull(askPlannerModel), spec.taskInput());
-                                                finalStopReason.set(askResult
-                                                        .stopDetails()
-                                                        .reason()
-                                                        .name());
-                                                scope.append(askResult);
-                                            } catch (Throwable t) {
-                                                // Do not allow a planner-model failure to abort the entire job.
-                                                logger.error(
-                                                        "ASK direct-answer failed for job {}: {}",
-                                                        jobId,
-                                                        t.getMessage(),
-                                                        t);
-                                                // Report to console (best-effort).
-                                                try {
-                                                    activeConsole.toolError(
-                                                            "ASK direct-answer failed: "
-                                                                    + (t.getMessage() == null
-                                                                            ? t.getClass()
-                                                                                    .getSimpleName()
-                                                                            : t.getMessage()),
-                                                            "ASK error");
-                                                } catch (Throwable ignore) {
-                                                    // best-effort only
-                                                }
-                                                // Append a non-fatal TaskResult indicating the failure so the task
-                                                // has a record,
-                                                // but do not rethrow (so job status handling can complete
-                                                // normally).
-                                                var stopDetails = new TaskResult.StopDetails(
-                                                        TaskResult.StopReason.LLM_ERROR,
-                                                        t.getMessage() == null
-                                                                ? t.getClass().getSimpleName()
-                                                                : t.getMessage());
-                                                List<ChatMessage> uiMessages = List.of(
-                                                        new UserMessage(spec.taskInput()),
-                                                        new SystemMessage("ASK direct-answer failed: "
-                                                                + stopDetails.explanation()));
-                                                context = context.addHistoryEntry(
-                                                        uiMessages,
-                                                        TaskResult.Type.ASK,
-                                                        requireNonNull(askPlannerModel),
-                                                        spec.taskInput());
-                                                var failureResult = new TaskResult(context, stopDetails);
-                                                try {
-                                                    scope.append(failureResult);
-                                                } catch (Throwable e2) {
-                                                    // If appending also fails, log it but keep proceeding so we can
-                                                    // update job status normally.
-                                                    logger.warn(
-                                                            "Failed to append ASK failure result for job {}: {}",
-                                                            jobId,
-                                                            e2.getMessage(),
-                                                            e2);
-                                                }
-                                                // Do not rethrow; allow outer flow to mark job completed
-                                                // (read-only) where appropriate.
-                                            }
+                                            runDirectAnswer(
+                                                    jobId,
+                                                    "ASK",
+                                                    scope,
+                                                    context,
+                                                    requireNonNull(askPlannerModel),
+                                                    spec.taskInput(),
+                                                    finalStopReason);
                                         }
                                     }
                                     case SEARCH -> {
@@ -1399,20 +1345,7 @@ public final class JobRunner {
                         current = current.completed(null);
                         logger.info("Job {} completed successfully", jobId);
                     }
-                    long lastSeq = store.getLastSeq(jobId);
-                    if (lastSeq >= 0) {
-                        current = current.withMetadata("lastSeq", Long.toString(lastSeq));
-                    }
-                    if (spec.executionPolicy() != null) {
-                        current = current.withMetadata(
-                                "executionPolicy",
-                                spec.executionPolicy().preset().name());
-                    }
-                    var stopReason = finalStopReason.get();
-                    if (stopReason != null) {
-                        current = current.withMetadata("stopReason", stopReason);
-                    }
-                    store.updateStatus(jobId, current);
+                    store.updateStatus(jobId, enrichStatusMetadata(jobId, current, spec, finalStopReason.get()));
                 }
             } catch (Throwable t) {
                 var failure = unwrapFailure(t);
@@ -1438,13 +1371,10 @@ public final class JobRunner {
                             s = s.cancelled();
                         }
 
-                        long lastSeq = store.getLastSeq(jobId);
-                        if (lastSeq >= 0) {
-                            s = s.withMetadata("lastSeq", Long.toString(lastSeq));
-                        }
+                        s = enrichStatusMetadata(jobId, s, spec, null);
 
                         // Update if state changed or if we enriched with missing metadata
-                        if (!alreadyCancelled || !hadLastSeq) {
+                        if (!alreadyCancelled || !hadLastSeq || spec.executionPolicy() != null) {
                             store.updateStatus(jobId, s);
                         } else {
                             logger.debug(
@@ -1472,11 +1402,7 @@ public final class JobRunner {
                             s = JobStatus.queued(jobId);
                         }
                         s = s.failed(errorMessage);
-                        long lastSeq = store.getLastSeq(jobId);
-                        if (lastSeq >= 0) {
-                            s = s.withMetadata("lastSeq", Long.toString(lastSeq));
-                        }
-                        store.updateStatus(jobId, s);
+                        store.updateStatus(jobId, enrichStatusMetadata(jobId, s, spec, null));
                     } catch (Exception e2) {
                         logger.warn("Failed to persist FAILED status for job {}", jobId, e2);
                     }
@@ -1739,6 +1665,63 @@ public final class JobRunner {
 
         ctx = ctx.addHistoryEntry(cm.getIo().getLlmRawMessages(), TaskResult.Type.ASK, model, question);
         return new TaskResult(ctx, stop);
+    }
+
+    private void runDirectAnswer(
+            String jobId,
+            String label,
+            ContextManager.TaskScope scope,
+            Context context,
+            StreamingChatModel model,
+            String question,
+            AtomicReference<String> finalStopReason) {
+        try {
+            var result = askUsingPlannerModel(context, model, question);
+            finalStopReason.set(result.stopDetails().reason().name());
+            scope.append(result);
+        } catch (Throwable t) {
+            logger.error("{} direct-answer failed for job {}: {}", label, jobId, t.getMessage(), t);
+            try {
+                cm.getIo()
+                        .toolError(
+                                label + " direct-answer failed: "
+                                        + (t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage()),
+                                label + " error");
+            } catch (Throwable ignore) {
+                // best-effort only
+            }
+
+            var stopDetails = new TaskResult.StopDetails(
+                    TaskResult.StopReason.LLM_ERROR,
+                    t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage());
+            finalStopReason.set(stopDetails.reason().name());
+            List<ChatMessage> uiMessages = List.of(
+                    new UserMessage(question),
+                    new SystemMessage(label + " direct-answer failed: " + stopDetails.explanation()));
+            var failureContext = context.addHistoryEntry(uiMessages, TaskResult.Type.ASK, model, question);
+            var failureResult = new TaskResult(failureContext, stopDetails);
+            try {
+                scope.append(failureResult);
+            } catch (Throwable e2) {
+                logger.warn("Failed to append {} failure result for job {}: {}", label, jobId, e2.getMessage(), e2);
+            }
+        }
+    }
+
+    private JobStatus enrichStatusMetadata(
+            String jobId, JobStatus status, JobSpec spec, @Nullable String finalStopReason) {
+        long lastSeq = store.getLastSeq(jobId);
+        if (lastSeq >= 0) {
+            status = status.withMetadata("lastSeq", Long.toString(lastSeq));
+        }
+        if (spec.executionPolicy() != null) {
+            status = status.withMetadata(
+                    "executionPolicy", spec.executionPolicy().preset().name());
+        }
+        if (finalStopReason != null) {
+            status = status.withMetadata("stopReason", finalStopReason);
+        }
+        return status;
     }
 
     private static List<Map<String, Object>> convertExcerpts(List<ReviewParser.CodeExcerpt> excerpts) {

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -48,6 +48,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -240,6 +241,7 @@ public final class JobRunner {
         ARCHITECT,
         CODE,
         ASK,
+        REPORT_ONLY,
         SEARCH,
         REVIEW,
         GUIDED_REVIEW,
@@ -254,7 +256,7 @@ public final class JobRunner {
 
     static SearchPrompts.Objective objectiveForMode(Mode mode) {
         return switch (mode) {
-            case ASK, SEARCH, REVIEW, GUIDED_REVIEW -> SearchPrompts.Objective.ANSWER_ONLY;
+            case ASK, REPORT_ONLY, SEARCH, REVIEW, GUIDED_REVIEW -> SearchPrompts.Objective.ANSWER_ONLY;
             case LUTZ -> SearchPrompts.Objective.LUTZ;
             case PLAN, ARCHITECT, CODE, ISSUE, ISSUE_DIAGNOSE, ISSUE_WRITER, LITE_AGENT, LITE_PLAN ->
                 SearchPrompts.Objective.TASKS_ONLY;
@@ -268,6 +270,7 @@ public final class JobRunner {
     public static Mode parseMode(JobSpec spec) {
         try {
             var tags = spec.tags();
+            if (spec.isReportOnly()) return Mode.REPORT_ONLY;
             var raw = tags.getOrDefault("mode", "").trim();
             if (raw.isEmpty()) return Mode.ARCHITECT;
             return Mode.valueOf(raw.toUpperCase(Locale.ROOT));
@@ -305,6 +308,14 @@ public final class JobRunner {
     /** Returns whether this JobRunner refuses write-capable agents. */
     public boolean isReadOnly() {
         return readOnly;
+    }
+
+    private void appendEventBestEffort(String jobId, String type, Object data) {
+        try {
+            store.appendEvent(jobId, JobEvent.of(type, data));
+        } catch (IOException e) {
+            logger.warn("Failed to append {} event for job {}: {}", type, jobId, e.getMessage());
+        }
     }
 
     /**
@@ -422,6 +433,7 @@ public final class JobRunner {
                 Mode mode = parseMode(spec);
 
                 var completed = new AtomicInteger(0);
+                var finalStopReason = new AtomicReference<String>();
 
                 var rawCodeModelName = spec.codeModel() != null
                         ? spec.codeModel()
@@ -460,9 +472,10 @@ public final class JobRunner {
                                         spec.scanModel().trim(), spec.reasoningLevel(), spec.temperature())
                                 : defaultScanModel(spec))
                         : null;
-                final StreamingChatModel askPlannerModel = mode == Mode.ASK || mode == Mode.ISSUE
-                        ? resolveModelOrThrow(spec.plannerModel(), spec.reasoningLevel(), spec.temperature())
-                        : null;
+                final StreamingChatModel askPlannerModel =
+                        mode == Mode.ASK || mode == Mode.REPORT_ONLY || mode == Mode.ISSUE
+                                ? resolveModelOrThrow(spec.plannerModel(), spec.reasoningLevel(), spec.temperature())
+                                : null;
                 final StreamingChatModel codeModeModel = mode == Mode.CODE
                         ? (hasCodeModelOverride
                                 ? resolveModelOrThrow(
@@ -487,7 +500,7 @@ public final class JobRunner {
                         switch (mode) {
                             case ARCHITECT, LUTZ, PLAN, ISSUE, LITE_AGENT, LITE_PLAN ->
                                 service.nameOf(requireNonNull(architectPlannerModel));
-                            case ASK -> service.nameOf(requireNonNull(askPlannerModel));
+                            case ASK, REPORT_ONLY -> service.nameOf(requireNonNull(askPlannerModel));
                             case SEARCH -> service.nameOf(requireNonNull(searchPlannerModel));
                             case CODE -> {
                                 var plannerName = spec.plannerModel();
@@ -502,6 +515,7 @@ public final class JobRunner {
                             case ARCHITECT, LUTZ, ISSUE, LITE_AGENT, LITE_PLAN ->
                                 service.nameOf(requireNonNull(architectCodeModel));
                             case ASK -> "(default, ignored for ASK)";
+                            case REPORT_ONLY -> "(default, ignored for REPORT_ONLY)";
                             case SEARCH -> "(default, ignored for SEARCH)";
                             case PLAN -> "(default, ignored for PLAN)";
                             case CODE -> service.nameOf(requireNonNull(codeModeModel));
@@ -512,7 +526,7 @@ public final class JobRunner {
                 boolean usesDefaultCodeModel =
                         switch (mode) {
                             case ARCHITECT, LUTZ, ISSUE, LITE_AGENT, LITE_PLAN -> !hasCodeModelOverride;
-                            case ASK, SEARCH, PLAN, REVIEW, GUIDED_REVIEW -> true;
+                            case ASK, REPORT_ONLY, SEARCH, PLAN, REVIEW, GUIDED_REVIEW -> true;
                             case CODE -> !hasCodeModelOverride;
                             case ISSUE_DIAGNOSE, ISSUE_WRITER -> true;
                         };
@@ -624,6 +638,32 @@ public final class JobRunner {
                                                 architectAgent.setReadOnly(true);
                                             }
                                             var result = architectAgent.executeWithScan();
+                                            scope.append(result);
+                                        }
+                                    }
+                                    case REPORT_ONLY -> {
+                                        try (var scope = cm.beginTaskUngrouped(spec.taskInput())) {
+                                            appendEventBestEffort(
+                                                    jobId,
+                                                    "POLICY_APPLIED",
+                                                    Map.of("preset", "REPORT_ONLY", "mode", "REPORT_ONLY"));
+                                            appendEventBestEffort(
+                                                    jobId,
+                                                    "POLICY_BLOCKED_TOOL",
+                                                    Map.of(
+                                                            "preset",
+                                                            "REPORT_ONLY",
+                                                            "blocked",
+                                                            "search, workspace_mutation, context_cleanup, subagents, shell, code_agent, auto_compress"));
+                                            var result = askUsingPlannerModel(
+                                                    cm.liveContext(),
+                                                    requireNonNull(
+                                                            askPlannerModel,
+                                                            "plannerModel required for REPORT_ONLY jobs"),
+                                                    spec.taskInput());
+                                            finalStopReason.set(result.stopDetails()
+                                                    .reason()
+                                                    .name());
                                             scope.append(result);
                                         }
                                     }
@@ -753,6 +793,10 @@ public final class JobRunner {
                                                 // planner model.
                                                 TaskResult askResult = askUsingPlannerModel(
                                                         context, requireNonNull(askPlannerModel), spec.taskInput());
+                                                finalStopReason.set(askResult
+                                                        .stopDetails()
+                                                        .reason()
+                                                        .name());
                                                 scope.append(askResult);
                                             } catch (Throwable t) {
                                                 // Do not allow a planner-model failure to abort the entire job.
@@ -1340,7 +1384,7 @@ public final class JobRunner {
 
                 // Optional compress after execution:
                 // - For ARCHITECT/LUTZ: per-task compression already honored via spec.autoCompress().
-                if (mode != Mode.ARCHITECT && mode != Mode.LUTZ && spec.autoCompress()) {
+                if (mode != Mode.ARCHITECT && mode != Mode.LUTZ && mode != Mode.REPORT_ONLY && spec.autoCompress()) {
                     logger.info("Job {} auto-compressing history", jobId);
                     cm.compressHistoryAsync().join();
                 }
@@ -1358,6 +1402,15 @@ public final class JobRunner {
                     long lastSeq = store.getLastSeq(jobId);
                     if (lastSeq >= 0) {
                         current = current.withMetadata("lastSeq", Long.toString(lastSeq));
+                    }
+                    if (spec.executionPolicy() != null) {
+                        current = current.withMetadata(
+                                "executionPolicy",
+                                spec.executionPolicy().preset().name());
+                    }
+                    var stopReason = finalStopReason.get();
+                    if (stopReason != null) {
+                        current = current.withMetadata("stopReason", stopReason);
                     }
                     store.updateStatus(jobId, current);
                 }

--- a/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
@@ -31,9 +31,16 @@ public record JobSpec(
         @JsonProperty("temperature") @Nullable Double temperature,
         @JsonProperty("temperatureCode") @Nullable Double temperatureCode,
         @JsonProperty("skipVerification") boolean skipVerification,
-        @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts) {
+        @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts,
+        @JsonProperty("executionPolicy") @Nullable ExecutionPolicy executionPolicy) {
 
     public static final int DEFAULT_MAX_ISSUE_FIX_ATTEMPTS = 20;
+
+    public enum ExecutionPolicyPreset {
+        REPORT_ONLY
+    }
+
+    public record ExecutionPolicy(@JsonProperty("preset") ExecutionPolicyPreset preset) {}
 
     public record ModelOverrides(
             @Nullable String reasoningLevel,
@@ -46,11 +53,7 @@ public record JobSpec(
      */
     private static final Set<String> SENSITIVE_TAG_KEYS = Set.of("github_token");
 
-    /**
-     * Returns a copy of tags with sensitive values redacted for safe persistence/logging.
-     * Sensitive keys are replaced with "[REDACTED]" rather than removed entirely,
-     * to preserve the structure for debugging while protecting the actual values.
-     */
+    /** Backward-compatible constructor for callers that do not specify an execution policy. */
     public JobSpec(
             @JsonProperty("taskInput") String taskInput,
             @JsonProperty("autoCommit") boolean autoCommit,
@@ -68,6 +71,45 @@ public record JobSpec(
             @JsonProperty("temperatureCode") @Nullable Double temperatureCode,
             @JsonProperty("skipVerification") boolean skipVerification,
             @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts) {
+        this(
+                taskInput,
+                autoCommit,
+                autoCompress,
+                plannerModel,
+                scanModel,
+                codeModel,
+                preScan,
+                tags,
+                sourceBranch,
+                targetBranch,
+                reasoningLevel,
+                reasoningLevelCode,
+                temperature,
+                temperatureCode,
+                skipVerification,
+                maxIssueFixAttempts,
+                null);
+    }
+
+    /** Normalizes nullable collection fields during deserialization and direct construction. */
+    public JobSpec(
+            @JsonProperty("taskInput") String taskInput,
+            @JsonProperty("autoCommit") boolean autoCommit,
+            @JsonProperty("autoCompress") boolean autoCompress,
+            @JsonProperty("plannerModel") String plannerModel,
+            @JsonProperty("scanModel") @Nullable String scanModel,
+            @JsonProperty("codeModel") @Nullable String codeModel,
+            @JsonProperty("preScan") boolean preScan,
+            @JsonProperty("tags") @Nullable Map<String, String> tags,
+            @JsonProperty("sourceBranch") @Nullable String sourceBranch,
+            @JsonProperty("targetBranch") @Nullable String targetBranch,
+            @JsonProperty("reasoningLevel") @Nullable String reasoningLevel,
+            @JsonProperty("reasoningLevelCode") @Nullable String reasoningLevelCode,
+            @JsonProperty("temperature") @Nullable Double temperature,
+            @JsonProperty("temperatureCode") @Nullable Double temperatureCode,
+            @JsonProperty("skipVerification") boolean skipVerification,
+            @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts,
+            @JsonProperty("executionPolicy") @Nullable ExecutionPolicy executionPolicy) {
         this.taskInput = taskInput;
         this.autoCommit = autoCommit;
         this.autoCompress = autoCompress;
@@ -84,6 +126,7 @@ public record JobSpec(
         this.temperatureCode = temperatureCode;
         this.skipVerification = skipVerification;
         this.maxIssueFixAttempts = maxIssueFixAttempts;
+        this.executionPolicy = executionPolicy;
     }
 
     public Map<String, String> redactedTags() {
@@ -94,6 +137,11 @@ public record JobSpec(
             }
         }
         return Map.copyOf(result);
+    }
+
+    @JsonIgnore
+    public boolean isReportOnly() {
+        return executionPolicy != null && executionPolicy.preset() == ExecutionPolicyPreset.REPORT_ONLY;
     }
 
     /**

--- a/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
@@ -40,7 +40,11 @@ public record JobSpec(
         REPORT_ONLY
     }
 
-    public record ExecutionPolicy(@JsonProperty("preset") ExecutionPolicyPreset preset) {}
+    public record ExecutionPolicy(@JsonProperty("preset") ExecutionPolicyPreset preset) {
+        public ExecutionPolicy(@JsonProperty("preset") @Nullable ExecutionPolicyPreset preset) {
+            this.preset = Objects.requireNonNull(preset, "preset");
+        }
+    }
 
     public record ModelOverrides(
             @Nullable String reasoningLevel,

--- a/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
@@ -107,7 +107,8 @@ public final class JobStore {
                 spec.temperature(),
                 spec.temperatureCode(),
                 spec.skipVerification(),
-                spec.maxIssueFixAttempts());
+                spec.maxIssueFixAttempts(),
+                spec.executionPolicy());
         objectMapper.writeValue(tempMetaFile.toFile(), specForPersistence);
         Files.move(tempMetaFile, metaFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
 
@@ -313,7 +314,8 @@ public final class JobStore {
                 spec.temperature(),
                 spec.temperatureCode(),
                 spec.skipVerification(),
-                spec.maxIssueFixAttempts());
+                spec.maxIssueFixAttempts(),
+                spec.executionPolicy());
 
         var tempMetaFile = metaFile.resolveSibling(".meta.json.tmp");
         objectMapper.writeValue(tempMetaFile.toFile(), updated);

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -174,6 +174,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         var overrides = validateModelOverrides(exchange, request);
         if (overrides == null) return;
 
+        var executionPolicy = Objects.requireNonNullElse(request.executionPolicy(), request.jobPolicy());
+
         var validJobContextTexts = validateContextTexts(exchange, request);
         if (validJobContextTexts == null && (request.contextText() != null || request.context() != null)) return;
 
@@ -197,7 +199,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
                 overrides.temperature(),
                 overrides.temperatureCode(),
                 skipVerificationFlag,
-                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS);
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                executionPolicy);
 
         if (awaitHeadlessInitOrRespond(exchange, null)) return;
 
@@ -742,6 +745,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             @Nullable Double temperature,
             @Nullable Double temperatureCode,
             @Nullable Boolean skipVerification,
+            JobSpec.@Nullable ExecutionPolicy executionPolicy,
+            JobSpec.@Nullable ExecutionPolicy jobPolicy,
             @Nullable String agent) {}
 
     private record ContextPayload(@Nullable List<String> text) {}

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -157,6 +157,15 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         if (sessionIdHeader != null) tags.put("session_id", sessionIdHeader.toString());
         if (githubToken != null && !githubToken.isBlank()) tags.put("github_token", githubToken);
 
+        var executionPolicy = request.executionPolicy() != null ? request.executionPolicy() : request.jobPolicy();
+        if (executionPolicy != null
+                && executionPolicy.preset() == JobSpec.ExecutionPolicyPreset.REPORT_ONLY
+                && request.agent() != null
+                && !request.agent().isBlank()) {
+            RouterUtil.sendValidationError(exchange, "agent is not allowed with REPORT_ONLY executionPolicy");
+            return;
+        }
+
         // If an agent is specified, validate it exists and route to SEARCH mode with an instruction
         String effectiveTaskInput = request.taskInput();
         if (request.agent() != null && !request.agent().isBlank()) {
@@ -173,8 +182,6 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
 
         var overrides = validateModelOverrides(exchange, request);
         if (overrides == null) return;
-
-        var executionPolicy = request.executionPolicy() != null ? request.executionPolicy() : request.jobPolicy();
 
         var validJobContextTexts = validateContextTexts(exchange, request);
         if (validJobContextTexts == null && (request.contextText() != null || request.context() != null)) return;

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -174,7 +174,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         var overrides = validateModelOverrides(exchange, request);
         if (overrides == null) return;
 
-        var executionPolicy = Objects.requireNonNullElse(request.executionPolicy(), request.jobPolicy());
+        var executionPolicy = request.executionPolicy() != null ? request.executionPolicy() : request.jobPolicy();
 
         var validJobContextTexts = validateContextTexts(exchange, request);
         if (validJobContextTexts == null && (request.contextText() != null || request.context() != null)) return;

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerIssueModeTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerIssueModeTest.java
@@ -94,6 +94,30 @@ class JobRunnerIssueModeTest {
     }
 
     @Test
+    void testReportOnlyPolicyOverridesSearchModeTag() {
+        var spec = new JobSpec(
+                "write final report",
+                false,
+                true,
+                "gpt-4",
+                null,
+                null,
+                false,
+                Map.of("mode", "SEARCH"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY));
+
+        assertEquals(JobRunner.Mode.REPORT_ONLY, JobRunner.parseMode(spec));
+    }
+
+    @Test
     void testParseMode_fallsBackToArchitect_onMissingBlankOrInvalidMode() {
         JobSpec missingMode =
                 JobSpec.of("task", false, false, "gpt-4", null, null, false, Map.of("x", "y"), (String) null);

--- a/app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
@@ -1,14 +1,17 @@
 package ai.brokk.executor.jobs;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class JobSpecTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Test
     void testOfPrReview_CreatesJobWithCorrectTags() {
@@ -67,6 +70,37 @@ class JobSpecTest {
         assertNull(spec.getRepoOwner());
         assertNull(spec.getRepoName());
         assertNull(spec.getPrNumber());
+    }
+
+    @Test
+    void executionPolicyPersistsThroughJson() throws Exception {
+        var spec = new JobSpec(
+                "write final report",
+                false,
+                true,
+                "planner",
+                null,
+                null,
+                false,
+                Map.of("mode", "SEARCH"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY));
+
+        var json = MAPPER.writeValueAsString(spec);
+        var roundTrip = MAPPER.readValue(json, JobSpec.class);
+
+        assertTrue(roundTrip.isReportOnly());
+        assertEquals(
+                JobSpec.ExecutionPolicyPreset.REPORT_ONLY,
+                requireNonNull(roundTrip.executionPolicy()).preset());
+        assertTrue(json.contains("\"executionPolicy\""));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -101,6 +102,16 @@ class JobSpecTest {
                 JobSpec.ExecutionPolicyPreset.REPORT_ONLY,
                 requireNonNull(roundTrip.executionPolicy()).preset());
         assertTrue(json.contains("\"executionPolicy\""));
+    }
+
+    @Test
+    void executionPolicyRejectsMissingPreset() {
+        assertThrows(Exception.class, () -> MAPPER.readValue("{\"executionPolicy\":{}}", JobSpec.class));
+    }
+
+    @Test
+    void executionPolicyRejectsNullPreset() {
+        assertThrows(Exception.class, () -> MAPPER.readValue("{\"executionPolicy\":{\"preset\":null}}", JobSpec.class));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -11,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -35,6 +37,68 @@ class JobStoreTest {
 
         var loadedSpec = store.loadSpec(result.jobId());
         assertEquals(spec.taskInput(), loadedSpec.taskInput());
+    }
+
+    @Test
+    void testCreateOrGetJob_PreservesExecutionPolicy(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var spec = new JobSpec(
+                "test task",
+                true,
+                true,
+                DEFAULT_PLANNER_MODEL,
+                null,
+                null,
+                false,
+                Map.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY));
+
+        var result = store.createOrGetJob("idem-key-policy", spec);
+        var loadedSpec = store.loadSpec(result.jobId());
+
+        assertNotNull(loadedSpec);
+        assertTrue(loadedSpec.isReportOnly());
+    }
+
+    @Test
+    void testPersistSessionId_PreservesExecutionPolicy(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var spec = new JobSpec(
+                "test task",
+                true,
+                true,
+                DEFAULT_PLANNER_MODEL,
+                null,
+                null,
+                false,
+                Map.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY));
+
+        var result = store.createOrGetJob("idem-key-policy-session", spec);
+        var sessionId = UUID.randomUUID();
+        store.persistSessionId(result.jobId(), sessionId);
+        var loadedSpec = store.loadSpec(result.jobId());
+
+        assertNotNull(loadedSpec);
+        assertTrue(loadedSpec.isReportOnly());
+        assertEquals(sessionId.toString(), loadedSpec.tags().get("session_id"));
+        assertNull(loadedSpec.tags().get("github_token"));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -124,6 +124,30 @@ class JobsRouterValidationTest {
         assertNotNull(response.get("jobId"));
     }
 
+    @Test
+    void postJobs_reportOnlyWithAgent_returnsValidationErrorAndDoesNotCreateJob() throws Exception {
+        Map<String, Object> body = Map.of(
+                "taskInput",
+                "test task",
+                "plannerModel",
+                "gpt-4",
+                "agent",
+                "architect-reviewer",
+                "executionPolicy",
+                Map.of("preset", "REPORT_ONLY"));
+
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
+        exchange.getRequestHeaders().set("Idempotency-Key", UUID.randomUUID().toString());
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(400, exchange.responseCode());
+        var payload = MAPPER.readValue(exchange.responseBodyBytes(), ErrorPayload.class);
+        assertEquals(ErrorPayload.Code.VALIDATION_ERROR, payload.code());
+        assertTrue(payload.message().contains("agent is not allowed"), payload.message());
+        assertEquals(fsSnapshotBefore, snapshotTree(jobStoreDir), "JobStore dir changed; job may have been created");
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"TUI Session", "New Session", "Session"})
     void postJobs_withDefaultSessionName_triggersAutoRename(String defaultName) throws Exception {

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -110,6 +110,20 @@ class JobsRouterValidationTest {
         assertEquals(fsSnapshotBefore, snapshotTree(jobStoreDir), "JobStore dir changed; job may have been created");
     }
 
+    @Test
+    void postJobs_withoutPolicyFields_acceptsLegacyRequest() throws Exception {
+        Map<String, Object> body = Map.of("taskInput", "test task", "plannerModel", "gpt-4");
+
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
+        exchange.getRequestHeaders().set("Idempotency-Key", UUID.randomUUID().toString());
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(201, exchange.responseCode());
+        var response = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+        assertNotNull(response.get("jobId"));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"TUI Session", "New Session", "Session"})
     void postJobs_withDefaultSessionName_triggersAutoRename(String defaultName) throws Exception {


### PR DESCRIPTION
### Description
Adds a generic report-only execution policy for Brokk headless jobs so final artifact generation can run through a direct planner path without search, workspace mutation, delegation, or automatic compression behavior.

**Key Changes**:
- Extends job specs and /v1/jobs request parsing with optional executionPolicy/jobPolicy support, including REPORT_ONLY policy validation and persistence.
- Routes report-only jobs through ASK-style direct answer execution, emits policy events, skips auto-compress, and preserves policy/status metadata for diagnostics.
- Adds regression coverage for policy parsing, legacy no-policy submissions, report-only mode selection, policy persistence, and invalid agent/policy combinations.

**Touch Points**:
- app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
- app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
- app/src/main/java/ai/brokk/executor/jobs/JobStore.java
- app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
- app/src/test/java/ai/brokk/executor/jobs/JobRunnerIssueModeTest.java
- app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
- app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
- app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java