### PR TITLE
Fix headless job lifecycle readiness and cancellation

### DIFF
--- a/app/src/main/java/ai/brokk/executor/jobs/ErrorPayload.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/ErrorPayload.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
  * @param message A human-readable error message.
  * @param details Additional details; null if no extra information is available.
  */
-public record ErrorPayload(String code, String message, @Nullable String details) {
+public record ErrorPayload(String code, String message, @Nullable Object details) {
 
     /**
      * Validate that code and message are non-blank.
@@ -50,6 +50,10 @@ public record ErrorPayload(String code, String message, @Nullable String details
      */
     public static ErrorPayload of(String code, String message) {
         return new ErrorPayload(code, message, null);
+    }
+
+    public static ErrorPayload of(String code, String message, Object details) {
+        return new ErrorPayload(code, message, details);
     }
 
     /**

--- a/app/src/main/java/ai/brokk/executor/jobs/ErrorPayload.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/ErrorPayload.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
  * @param message A human-readable error message.
  * @param details Additional details; null if no extra information is available.
  */
-public record ErrorPayload(String code, String message, @Nullable Object details) {
+public record ErrorPayload(String code, String message, @Nullable String details) {
 
     /**
      * Validate that code and message are non-blank.
@@ -52,7 +52,7 @@ public record ErrorPayload(String code, String message, @Nullable Object details
         return new ErrorPayload(code, message, null);
     }
 
-    public static ErrorPayload of(String code, String message, Object details) {
+    public static ErrorPayload of(String code, String message, String details) {
         return new ErrorPayload(code, message, details);
     }
 

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -1447,10 +1447,10 @@ public final class JobRunner {
      *
      * @param jobId The job ID to cancel
      */
-    public void cancel(String jobId) {
+    public boolean cancel(String jobId) {
         if (activeJobId == null || !Objects.equals(activeJobId, jobId)) {
             logger.info("Cancel requested for job {}, but no active job or different jobId", jobId);
-            return;
+            return false;
         }
 
         logger.info("Cancelling job {}", jobId);
@@ -1463,27 +1463,26 @@ public final class JobRunner {
             logger.debug("Failed to interrupt LLM action", ignore);
         }
 
-        // Update status to CANCELLED if not already terminal
+        // Update status to CANCELLING if not already terminal; the runner marks CANCELLED after it drains.
         try {
             JobStatus s = store.loadStatus(jobId);
             if (s != null) {
                 String state = s.state();
                 // Only transition if not already in a terminal state
-                if (!JobStatus.State.COMPLETED.name().equals(state)
-                        && !JobStatus.State.FAILED.name().equals(state)
-                        && !JobStatus.State.CANCELLED.name().equals(state)) {
-                    s = s.cancelled();
+                if (!JobStatus.isTerminalState(state)) {
+                    s = s.cancelling();
                     long lastSeq = store.getLastSeq(jobId);
                     if (lastSeq >= 0) {
                         s = s.withMetadata("lastSeq", Long.toString(lastSeq));
                     }
                     store.updateStatus(jobId, s);
-                    logger.info("Job {} status updated to CANCELLED", jobId);
+                    logger.info("Job {} status updated to CANCELLING", jobId);
                 }
             }
         } catch (Exception e) {
-            logger.warn("Failed to mark job {} as CANCELLED", jobId, e);
+            logger.warn("Failed to mark job {} as CANCELLING", jobId, e);
         }
+        return true;
     }
 
     private record AppliedOverrides(

--- a/app/src/main/java/ai/brokk/executor/jobs/JobStatus.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobStatus.java
@@ -22,6 +22,7 @@ public record JobStatus(
     public enum State {
         QUEUED,
         RUNNING,
+        CANCELLING,
         COMPLETED,
         FAILED,
         CANCELLED
@@ -84,6 +85,20 @@ public record JobStatus(
                 null,
                 null,
                 metadata);
+    }
+
+    public JobStatus cancelling() {
+        return new JobStatus(jobId, State.CANCELLING.name(), startTime, endTime, progressPercent, null, null, metadata);
+    }
+
+    public boolean terminal() {
+        return isTerminalState(state);
+    }
+
+    public static boolean isTerminalState(String state) {
+        return State.COMPLETED.name().equals(state)
+                || State.FAILED.name().equals(state)
+                || State.CANCELLED.name().equals(state);
     }
 
     /**

--- a/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
@@ -273,6 +273,23 @@ public final class JobStore {
         return objectMapper.readValue(metaFile.toFile(), JobSpec.class);
     }
 
+    public @Nullable UUID loadPersistedSessionId(String jobId) throws IOException {
+        var spec = loadSpec(jobId);
+        if (spec == null) {
+            return null;
+        }
+        var raw = spec.tags().get("session_id");
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(raw);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Job {} has invalid persisted session_id '{}'", jobId, raw);
+            return null;
+        }
+    }
+
     /**
      * Persist the effective session id for a job in meta.json.
      *

--- a/app/src/main/java/ai/brokk/executor/routers/JobLifecycleResponses.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobLifecycleResponses.java
@@ -1,0 +1,83 @@
+package ai.brokk.executor.routers;
+
+import ai.brokk.executor.JobReservation;
+import ai.brokk.executor.jobs.ErrorPayload;
+import ai.brokk.executor.jobs.JobStatus;
+import ai.brokk.executor.jobs.JobStore;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+final class JobLifecycleResponses {
+    static final int RETRY_AFTER_MS = 1000;
+
+    private JobLifecycleResponses() {}
+
+    static Map<String, Object> readiness(JobStore jobStore, JobReservation reservation) throws IOException {
+        var activeJobId = reservation.current();
+        var response = new LinkedHashMap<String, Object>();
+        response.put("readyForJobSubmission", activeJobId == null);
+        response.put("activeJobId", activeJobId);
+        response.put("activeJobState", activeJobState(jobStore, activeJobId));
+        response.put("retryAfterMs", activeJobId == null ? 0 : RETRY_AFTER_MS);
+        response.put("terminal", activeJobId == null);
+        return response;
+    }
+
+    static Map<String, Object> status(JobStatus status, JobReservation reservation) {
+        var response = new LinkedHashMap<String, Object>();
+        response.put("jobId", status.jobId());
+        response.put("state", status.state());
+        response.put("startTime", status.startTime());
+        response.put("endTime", status.endTime());
+        response.put("progressPercent", status.progressPercent());
+        response.put("result", status.result());
+        response.put("error", status.error());
+        response.put("metadata", status.metadata());
+        response.put("terminal", status.terminal());
+        response.put("executorReady", executorReady(reservation));
+        return response;
+    }
+
+    static Map<String, Object> cancelResponse(
+            String jobId, @Nullable JobStatus status, boolean cancelRequested, JobReservation reservation) {
+        var state = status != null ? status.state() : "UNKNOWN";
+        var response = new LinkedHashMap<String, Object>();
+        response.put("jobId", jobId);
+        response.put("cancelRequested", cancelRequested);
+        response.put("state", state);
+        response.put("terminal", status == null || JobStatus.isTerminalState(state));
+        response.put("executorReady", executorReady(reservation));
+        response.put("activeJobId", reservation.current());
+        return response;
+    }
+
+    static ErrorPayload jobInProgress(JobStore jobStore, JobReservation reservation) throws IOException {
+        return ErrorPayload.of("JOB_IN_PROGRESS", "A job is currently executing", busyDetails(jobStore, reservation));
+    }
+
+    private static Map<String, Object> busyDetails(JobStore jobStore, JobReservation reservation) throws IOException {
+        var activeJobId = reservation.current();
+        var details = new LinkedHashMap<String, Object>();
+        details.put("activeJobId", activeJobId);
+        details.put("activeJobState", activeJobState(jobStore, activeJobId));
+        details.put("readyForJobSubmission", false);
+        details.put("retryAfterMs", RETRY_AFTER_MS);
+        return details;
+    }
+
+    private static @Nullable String activeJobState(JobStore jobStore, @Nullable String activeJobId) throws IOException {
+        if (activeJobId == null) {
+            return null;
+        }
+        var status = jobStore.loadStatus(activeJobId);
+        return status != null ? status.state() : "UNKNOWN";
+    }
+
+    private static boolean executorReady(JobReservation reservation) {
+        return reservation.current() == null;
+    }
+}

--- a/app/src/main/java/ai/brokk/executor/routers/JobLifecycleResponses.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobLifecycleResponses.java
@@ -4,23 +4,29 @@ import ai.brokk.executor.JobReservation;
 import ai.brokk.executor.jobs.ErrorPayload;
 import ai.brokk.executor.jobs.JobStatus;
 import ai.brokk.executor.jobs.JobStore;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
 final class JobLifecycleResponses {
     static final int RETRY_AFTER_MS = 1000;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<LinkedHashMap<String, Object>> STATUS_MAP_TYPE = new TypeReference<>() {};
 
     private JobLifecycleResponses() {}
 
-    static Map<String, Object> readiness(JobStore jobStore, JobReservation reservation) throws IOException {
+    static Map<String, Object> readiness(
+            JobStore jobStore, JobReservation reservation, @Nullable UUID requesterSessionId) throws IOException {
         var activeJobId = reservation.current();
         var response = new LinkedHashMap<String, Object>();
         response.put("readyForJobSubmission", activeJobId == null);
-        response.put("activeJobId", activeJobId);
+        response.put("activeJobId", visibleActiveJobId(jobStore, reservation, requesterSessionId));
         response.put("activeJobState", activeJobState(jobStore, activeJobId));
         response.put("retryAfterMs", activeJobId == null ? 0 : RETRY_AFTER_MS);
         response.put("terminal", activeJobId == null);
@@ -28,22 +34,20 @@ final class JobLifecycleResponses {
     }
 
     static Map<String, Object> status(JobStatus status, JobReservation reservation) {
-        var response = new LinkedHashMap<String, Object>();
-        response.put("jobId", status.jobId());
-        response.put("state", status.state());
-        response.put("startTime", status.startTime());
-        response.put("endTime", status.endTime());
-        response.put("progressPercent", status.progressPercent());
-        response.put("result", status.result());
-        response.put("error", status.error());
-        response.put("metadata", status.metadata());
+        var response = OBJECT_MAPPER.convertValue(status, STATUS_MAP_TYPE);
         response.put("terminal", status.terminal());
         response.put("executorReady", executorReady(reservation));
         return response;
     }
 
     static Map<String, Object> cancelResponse(
-            String jobId, @Nullable JobStatus status, boolean cancelRequested, JobReservation reservation) {
+            JobStore jobStore,
+            String jobId,
+            @Nullable JobStatus status,
+            boolean cancelRequested,
+            JobReservation reservation,
+            @Nullable UUID requesterSessionId)
+            throws IOException {
         var state = status != null ? status.state() : "UNKNOWN";
         var response = new LinkedHashMap<String, Object>();
         response.put("jobId", jobId);
@@ -51,18 +55,24 @@ final class JobLifecycleResponses {
         response.put("state", state);
         response.put("terminal", status == null || JobStatus.isTerminalState(state));
         response.put("executorReady", executorReady(reservation));
-        response.put("activeJobId", reservation.current());
+        response.put(
+                "activeJobId", cancelRequested ? jobId : visibleActiveJobId(jobStore, reservation, requesterSessionId));
         return response;
     }
 
-    static ErrorPayload jobInProgress(JobStore jobStore, JobReservation reservation) throws IOException {
-        return ErrorPayload.of("JOB_IN_PROGRESS", "A job is currently executing", busyDetails(jobStore, reservation));
+    static ErrorPayload jobInProgress(JobStore jobStore, JobReservation reservation, @Nullable UUID requesterSessionId)
+            throws IOException {
+        return ErrorPayload.of(
+                "JOB_IN_PROGRESS",
+                "A job is currently executing",
+                busyDetails(jobStore, reservation, requesterSessionId));
     }
 
-    private static Map<String, Object> busyDetails(JobStore jobStore, JobReservation reservation) throws IOException {
+    private static Map<String, Object> busyDetails(
+            JobStore jobStore, JobReservation reservation, @Nullable UUID requesterSessionId) throws IOException {
         var activeJobId = reservation.current();
         var details = new LinkedHashMap<String, Object>();
-        details.put("activeJobId", activeJobId);
+        details.put("activeJobId", visibleActiveJobId(jobStore, reservation, requesterSessionId));
         details.put("activeJobState", activeJobState(jobStore, activeJobId));
         details.put("readyForJobSubmission", false);
         details.put("retryAfterMs", RETRY_AFTER_MS);
@@ -75,6 +85,19 @@ final class JobLifecycleResponses {
         }
         var status = jobStore.loadStatus(activeJobId);
         return status != null ? status.state() : "UNKNOWN";
+    }
+
+    private static @Nullable String visibleActiveJobId(
+            JobStore jobStore, JobReservation reservation, @Nullable UUID requesterSessionId) throws IOException {
+        var activeJobId = reservation.current();
+        if (activeJobId == null || requesterSessionId == null) {
+            return null;
+        }
+        var spec = jobStore.loadSpec(activeJobId);
+        if (spec == null) {
+            return null;
+        }
+        return requesterSessionId.toString().equals(spec.tags().get("session_id")) ? activeJobId : null;
     }
 
     private static boolean executorReady(JobReservation reservation) {

--- a/app/src/main/java/ai/brokk/executor/routers/JobLifecycleResponses.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobLifecycleResponses.java
@@ -1,7 +1,6 @@
 package ai.brokk.executor.routers;
 
 import ai.brokk.executor.JobReservation;
-import ai.brokk.executor.jobs.ErrorPayload;
 import ai.brokk.executor.jobs.JobStatus;
 import ai.brokk.executor.jobs.JobStore;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -9,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.UUID;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -21,12 +19,11 @@ final class JobLifecycleResponses {
 
     private JobLifecycleResponses() {}
 
-    static Map<String, Object> readiness(
-            JobStore jobStore, JobReservation reservation, @Nullable UUID requesterSessionId) throws IOException {
+    static Map<String, Object> readiness(JobStore jobStore, JobReservation reservation) throws IOException {
         var activeJobId = reservation.current();
         var response = new LinkedHashMap<String, Object>();
         response.put("readyForJobSubmission", activeJobId == null);
-        response.put("activeJobId", visibleActiveJobId(jobStore, reservation, requesterSessionId));
+        response.put("activeJobId", null);
         response.put("activeJobState", activeJobState(jobStore, activeJobId));
         response.put("retryAfterMs", activeJobId == null ? 0 : RETRY_AFTER_MS);
         response.put("terminal", activeJobId == null);
@@ -41,13 +38,7 @@ final class JobLifecycleResponses {
     }
 
     static Map<String, Object> cancelResponse(
-            JobStore jobStore,
-            String jobId,
-            @Nullable JobStatus status,
-            boolean cancelRequested,
-            JobReservation reservation,
-            @Nullable UUID requesterSessionId)
-            throws IOException {
+            String jobId, @Nullable JobStatus status, boolean cancelRequested, JobReservation reservation) {
         var state = status != null ? status.state() : "UNKNOWN";
         var response = new LinkedHashMap<String, Object>();
         response.put("jobId", jobId);
@@ -55,28 +46,18 @@ final class JobLifecycleResponses {
         response.put("state", state);
         response.put("terminal", status == null || JobStatus.isTerminalState(state));
         response.put("executorReady", executorReady(reservation));
-        response.put(
-                "activeJobId", cancelRequested ? jobId : visibleActiveJobId(jobStore, reservation, requesterSessionId));
+        response.put("activeJobId", cancelRequested ? jobId : null);
         return response;
     }
 
-    static ErrorPayload jobInProgress(JobStore jobStore, JobReservation reservation, @Nullable UUID requesterSessionId)
-            throws IOException {
-        return ErrorPayload.of(
-                "JOB_IN_PROGRESS",
-                "A job is currently executing",
-                busyDetails(jobStore, reservation, requesterSessionId));
+    static JobInProgressError jobInProgress(JobStore jobStore, JobReservation reservation) throws IOException {
+        return new JobInProgressError(
+                "JOB_IN_PROGRESS", "A job is currently executing", busyDetails(jobStore, reservation));
     }
 
-    private static Map<String, Object> busyDetails(
-            JobStore jobStore, JobReservation reservation, @Nullable UUID requesterSessionId) throws IOException {
+    private static JobInProgressDetails busyDetails(JobStore jobStore, JobReservation reservation) throws IOException {
         var activeJobId = reservation.current();
-        var details = new LinkedHashMap<String, Object>();
-        details.put("activeJobId", visibleActiveJobId(jobStore, reservation, requesterSessionId));
-        details.put("activeJobState", activeJobState(jobStore, activeJobId));
-        details.put("readyForJobSubmission", false);
-        details.put("retryAfterMs", RETRY_AFTER_MS);
-        return details;
+        return new JobInProgressDetails(null, activeJobState(jobStore, activeJobId), false, RETRY_AFTER_MS);
     }
 
     private static @Nullable String activeJobState(JobStore jobStore, @Nullable String activeJobId) throws IOException {
@@ -87,20 +68,15 @@ final class JobLifecycleResponses {
         return status != null ? status.state() : "UNKNOWN";
     }
 
-    private static @Nullable String visibleActiveJobId(
-            JobStore jobStore, JobReservation reservation, @Nullable UUID requesterSessionId) throws IOException {
-        var activeJobId = reservation.current();
-        if (activeJobId == null || requesterSessionId == null) {
-            return null;
-        }
-        var spec = jobStore.loadSpec(activeJobId);
-        if (spec == null) {
-            return null;
-        }
-        return requesterSessionId.toString().equals(spec.tags().get("session_id")) ? activeJobId : null;
-    }
-
     private static boolean executorReady(JobReservation reservation) {
         return reservation.current() == null;
     }
+
+    record JobInProgressError(String code, String message, JobInProgressDetails details) {}
+
+    record JobInProgressDetails(
+            @Nullable String activeJobId,
+            @Nullable String activeJobState,
+            boolean readyForJobSubmission,
+            int retryAfterMs) {}
 }

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -90,6 +90,11 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             return;
         }
 
+        if (path.equals("/v1/jobs/status") && method.equals("GET")) {
+            handleGetJobsStatus(exchange);
+            return;
+        }
+
         if (path.equals("/v1/jobs/pr-review") && method.equals("POST")) {
             handlePostPrReviewJob(exchange);
             return;
@@ -238,7 +243,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
 
         if (!jobReservation.tryReserve(jobId)) {
             SimpleHttpServer.sendJsonResponse(
-                    exchange, 409, ErrorPayload.of("JOB_IN_PROGRESS", "A job is currently executing"));
+                    exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
             return;
         }
         try {
@@ -350,7 +355,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         if (createResult.isNewJob()) {
             if (!jobReservation.tryReserve(jobId)) {
                 SimpleHttpServer.sendJsonResponse(
-                        exchange, 409, ErrorPayload.of("JOB_IN_PROGRESS", "A job is currently executing"));
+                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
                 return;
             }
             try {
@@ -424,7 +429,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         if (createResult.isNewJob()) {
             if (!jobReservation.tryReserve(jobId)) {
                 SimpleHttpServer.sendJsonResponse(
-                        exchange, 409, ErrorPayload.of("JOB_IN_PROGRESS", "A job is currently executing"));
+                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
                 return;
             }
             try {
@@ -462,7 +467,11 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             SimpleHttpServer.sendJsonResponse(exchange, 404, ErrorPayload.jobNotFound(jobId));
             return;
         }
-        SimpleHttpServer.sendJsonResponse(exchange, status);
+        SimpleHttpServer.sendJsonResponse(exchange, JobLifecycleResponses.status(status, jobReservation));
+    }
+
+    private void handleGetJobsStatus(HttpExchange exchange) throws IOException {
+        SimpleHttpServer.sendJsonResponse(exchange, JobLifecycleResponses.readiness(jobStore, jobReservation));
     }
 
     private void handleGetJobEvents(HttpExchange exchange, String jobId) throws IOException {
@@ -494,9 +503,12 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
 
     private void handleCancelJob(HttpExchange exchange, String jobId) throws IOException {
         try {
-            jobRunner.cancel(jobId);
-            exchange.sendResponseHeaders(202, 0);
-            exchange.close();
+            boolean cancelRequested = jobRunner.cancel(jobId);
+            var status = jobStore.loadStatus(jobId);
+            SimpleHttpServer.sendJsonResponse(
+                    exchange,
+                    202,
+                    JobLifecycleResponses.cancelResponse(jobId, status, cancelRequested, jobReservation));
         } catch (Exception e) {
             logger.error("Error handling POST /v1/jobs/{}/cancel", jobId, e);
             var error = ErrorPayload.internalError("Failed to cancel job", e);

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -243,7 +243,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
 
         if (!jobReservation.tryReserve(jobId)) {
             SimpleHttpServer.sendJsonResponse(
-                    exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation, sessionIdHeader));
+                    exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
             return;
         }
         try {
@@ -355,7 +355,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         if (createResult.isNewJob()) {
             if (!jobReservation.tryReserve(jobId)) {
                 SimpleHttpServer.sendJsonResponse(
-                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation, null));
+                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
                 return;
             }
             try {
@@ -429,7 +429,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         if (createResult.isNewJob()) {
             if (!jobReservation.tryReserve(jobId)) {
                 SimpleHttpServer.sendJsonResponse(
-                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation, null));
+                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
                 return;
             }
             try {
@@ -471,9 +471,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
     }
 
     private void handleGetJobsStatus(HttpExchange exchange) throws IOException {
-        SimpleHttpServer.sendJsonResponse(
-                exchange,
-                JobLifecycleResponses.readiness(jobStore, jobReservation, parseOptionalSessionHeader(exchange)));
+        SimpleHttpServer.sendJsonResponse(exchange, JobLifecycleResponses.readiness(jobStore, jobReservation));
     }
 
     private void handleGetJobEvents(HttpExchange exchange, String jobId) throws IOException {
@@ -510,13 +508,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             SimpleHttpServer.sendJsonResponse(
                     exchange,
                     202,
-                    JobLifecycleResponses.cancelResponse(
-                            jobStore,
-                            jobId,
-                            status,
-                            cancelRequested,
-                            jobReservation,
-                            parseOptionalSessionHeader(exchange)));
+                    JobLifecycleResponses.cancelResponse(jobId, status, cancelRequested, jobReservation));
         } catch (Exception e) {
             logger.error("Error handling POST /v1/jobs/{}/cancel", jobId, e);
             var error = ErrorPayload.internalError("Failed to cancel job", e);
@@ -573,19 +565,6 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
                 .anyMatch(session -> session.id().equals(sessionId));
     }
 
-    private @Nullable UUID parseOptionalSessionHeader(HttpExchange exchange) {
-        var sessionIdStr = exchange.getRequestHeaders().getFirst("X-Session-Id");
-        if (sessionIdStr == null || sessionIdStr.isBlank()) {
-            return null;
-        }
-        try {
-            return UUID.fromString(sessionIdStr);
-        } catch (IllegalArgumentException e) {
-            logger.debug("Ignoring invalid X-Session-Id header for lifecycle response: {}", sessionIdStr);
-            return null;
-        }
-    }
-
     private UUID ensureActiveSessionForSubmission(@Nullable UUID requestedSessionId) throws Exception {
         if (requestedSessionId != null) {
             if (!hasKnownSession(requestedSessionId)) {
@@ -633,25 +612,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         return contextManager.getCurrentSessionId();
     }
 
-    private @Nullable UUID loadPersistedJobSessionId(String jobId) throws IOException {
-        var spec = jobStore.loadSpec(jobId);
-        if (spec == null) {
-            return null;
-        }
-        var raw = spec.tags().get("session_id");
-        if (raw == null || raw.isBlank()) {
-            return null;
-        }
-        try {
-            return UUID.fromString(raw);
-        } catch (IllegalArgumentException e) {
-            logger.warn("Job {} has invalid persisted session_id '{}'", jobId, raw);
-            return null;
-        }
-    }
-
     private UUID resolveReplaySessionId(String jobId, @Nullable UUID requestedSessionId) throws Exception {
-        var persisted = loadPersistedJobSessionId(jobId);
+        var persisted = jobStore.loadPersistedSessionId(jobId);
         if (persisted != null) {
             return persisted;
         }

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -243,7 +243,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
 
         if (!jobReservation.tryReserve(jobId)) {
             SimpleHttpServer.sendJsonResponse(
-                    exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
+                    exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation, sessionIdHeader));
             return;
         }
         try {
@@ -355,7 +355,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         if (createResult.isNewJob()) {
             if (!jobReservation.tryReserve(jobId)) {
                 SimpleHttpServer.sendJsonResponse(
-                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
+                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation, null));
                 return;
             }
             try {
@@ -429,7 +429,7 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         if (createResult.isNewJob()) {
             if (!jobReservation.tryReserve(jobId)) {
                 SimpleHttpServer.sendJsonResponse(
-                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
+                        exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation, null));
                 return;
             }
             try {
@@ -471,7 +471,9 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
     }
 
     private void handleGetJobsStatus(HttpExchange exchange) throws IOException {
-        SimpleHttpServer.sendJsonResponse(exchange, JobLifecycleResponses.readiness(jobStore, jobReservation));
+        SimpleHttpServer.sendJsonResponse(
+                exchange,
+                JobLifecycleResponses.readiness(jobStore, jobReservation, parseOptionalSessionHeader(exchange)));
     }
 
     private void handleGetJobEvents(HttpExchange exchange, String jobId) throws IOException {
@@ -508,7 +510,13 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             SimpleHttpServer.sendJsonResponse(
                     exchange,
                     202,
-                    JobLifecycleResponses.cancelResponse(jobId, status, cancelRequested, jobReservation));
+                    JobLifecycleResponses.cancelResponse(
+                            jobStore,
+                            jobId,
+                            status,
+                            cancelRequested,
+                            jobReservation,
+                            parseOptionalSessionHeader(exchange)));
         } catch (Exception e) {
             logger.error("Error handling POST /v1/jobs/{}/cancel", jobId, e);
             var error = ErrorPayload.internalError("Failed to cancel job", e);
@@ -563,6 +571,19 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
     private boolean hasKnownSession(UUID sessionId) {
         return contextManager.getProject().getSessionManager().listSessions().stream()
                 .anyMatch(session -> session.id().equals(sessionId));
+    }
+
+    private @Nullable UUID parseOptionalSessionHeader(HttpExchange exchange) {
+        var sessionIdStr = exchange.getRequestHeaders().getFirst("X-Session-Id");
+        if (sessionIdStr == null || sessionIdStr.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(sessionIdStr);
+        } catch (IllegalArgumentException e) {
+            logger.debug("Ignoring invalid X-Session-Id header for lifecycle response: {}", sessionIdStr);
+            return null;
+        }
     }
 
     private UUID ensureActiveSessionForSubmission(@Nullable UUID requestedSessionId) throws Exception {

--- a/app/src/main/java/ai/brokk/executor/routers/ReviewRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/ReviewRouter.java
@@ -98,7 +98,7 @@ public final class ReviewRouter implements SimpleHttpServer.CheckedHttpHandler {
             if (isNewJob) {
                 if (!jobReservation.tryReserve(jobId)) {
                     SimpleHttpServer.sendJsonResponse(
-                            exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
+                            exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation, null));
                     return;
                 }
                 try {

--- a/app/src/main/java/ai/brokk/executor/routers/ReviewRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/ReviewRouter.java
@@ -98,7 +98,7 @@ public final class ReviewRouter implements SimpleHttpServer.CheckedHttpHandler {
             if (isNewJob) {
                 if (!jobReservation.tryReserve(jobId)) {
                     SimpleHttpServer.sendJsonResponse(
-                            exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation, null));
+                            exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
                     return;
                 }
                 try {

--- a/app/src/main/java/ai/brokk/executor/routers/ReviewRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/ReviewRouter.java
@@ -98,7 +98,7 @@ public final class ReviewRouter implements SimpleHttpServer.CheckedHttpHandler {
             if (isNewJob) {
                 if (!jobReservation.tryReserve(jobId)) {
                     SimpleHttpServer.sendJsonResponse(
-                            exchange, 409, ErrorPayload.of("JOB_IN_PROGRESS", "A job is currently executing"));
+                            exchange, 409, JobLifecycleResponses.jobInProgress(jobStore, jobReservation));
                     return;
                 }
                 try {

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerTest.java
@@ -101,6 +101,18 @@ class JobRunnerTest {
     }
 
     @Test
+    void jobStatusTerminalTreatsCancellingAsNonTerminal() {
+        var queued = JobStatus.queued("job-1");
+
+        assertFalse(queued.terminal());
+        assertFalse(queued.withState(JobStatus.State.RUNNING.name()).terminal());
+        assertFalse(queued.cancelling().terminal());
+        assertTrue(queued.completed(null).terminal());
+        assertTrue(queued.failed("boom").terminal());
+        assertTrue(queued.cancelled().terminal());
+    }
+
+    @Test
     void maybeAnnotateDiffBlocks_rewritesDiffFence_whenClosingFenceOnOwnLine() {
         String body = "Before\n```diff\n@@ -1,0 +1,1 @@\n+foo\n```\nAfter\n";
         String result = IssueRewriterAgent.maybeAnnotateDiffBlocks(body);

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerTest.java
@@ -13,13 +13,18 @@ import ai.brokk.TaskResult;
 import ai.brokk.agents.IssueRewriterAgent;
 import ai.brokk.agents.TestScriptedLanguageModel;
 import ai.brokk.cli.MemoryConsole;
+import ai.brokk.project.MainProject;
 import ai.brokk.prompts.SearchPrompts;
 import ai.brokk.tasks.TaskList;
+import ai.brokk.testutil.NoOpConsoleIO;
 import ai.brokk.testutil.TestProject;
 import ai.brokk.testutil.TestService;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiChatResponseMetadata;
 import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.output.FinishReason;
@@ -28,8 +33,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.Blocking;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -110,6 +118,87 @@ class JobRunnerTest {
         assertTrue(queued.completed(null).terminal());
         assertTrue(queued.failed("boom").terminal());
         assertTrue(queued.cancelled().terminal());
+    }
+
+    @Test
+    void cancelActiveJobTransitionsThroughCancellingThenCancelled() throws Exception {
+        var project = MainProject.forTests(tempDir);
+        var modelEntered = new CountDownLatch(1);
+        var releaseModel = new CountDownLatch(1);
+        StreamingChatModel blockingModel = new StreamingChatModel() {
+            @Override
+            public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                modelEntered.countDown();
+                try {
+                    releaseModel.await(5, TimeUnit.SECONDS);
+                    handler.onCompleteResponse(ChatResponse.builder()
+                            .aiMessage(new AiMessage("done"))
+                            .build());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        Service.Provider provider = new Service.Provider() {
+            private TestService svc = serviceFor(project);
+
+            @Override
+            public ai.brokk.AbstractService get() {
+                return svc;
+            }
+
+            @Override
+            public void reinit(ai.brokk.project.IProject p) {
+                svc = serviceFor(p);
+            }
+
+            private TestService serviceFor(ai.brokk.project.IProject p) {
+                return new TestService(p) {
+                    @Override
+                    public @Nullable StreamingChatModel getModel(
+                            Service.ModelConfig config,
+                            @Nullable OpenAiChatRequestParameters.Builder parametersOverride) {
+                        return blockingModel;
+                    }
+                };
+            }
+        };
+
+        try (var cm = new ContextManager(project, provider)) {
+            cm.createHeadless(true, new NoOpConsoleIO());
+            var store = new JobStore(tempDir.resolve("job-store-active-cancel"));
+            var runner = new JobRunner(cm, store);
+            var spec = JobSpec.of(
+                    "hold until cancelled",
+                    false,
+                    false,
+                    "test-model",
+                    null,
+                    null,
+                    false,
+                    Map.of("mode", "ASK"),
+                    null,
+                    null,
+                    null);
+            var jobId = store.createOrGetJob("active-cancel", spec).jobId();
+            var future = runner.runAsync(jobId, spec, new NoOpConsoleIO());
+
+            assertTrue(modelEntered.await(5, TimeUnit.SECONDS), "ASK model should start before cancellation");
+            assertTrue(runner.cancel(jobId));
+            var cancelling = store.loadStatus(jobId);
+            assertNotNull(cancelling);
+            assertEquals(JobStatus.State.CANCELLING.name(), cancelling.state());
+            assertFalse(cancelling.terminal());
+
+            releaseModel.countDown();
+            future.get(5, TimeUnit.SECONDS);
+            var cancelled = store.loadStatus(jobId);
+            assertNotNull(cancelled);
+            assertEquals(JobStatus.State.CANCELLED.name(), cancelled.state());
+            assertTrue(cancelled.terminal());
+            runner.shutdown();
+        }
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
@@ -102,6 +102,43 @@ class JobStoreTest {
     }
 
     @Test
+    void loadPersistedSessionId_returnsNullWhenMissing(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var result = store.createOrGetJob("idem-key-session-missing", JobSpec.of("test task", DEFAULT_PLANNER_MODEL));
+
+        assertNull(store.loadPersistedSessionId(result.jobId()));
+    }
+
+    @Test
+    void loadPersistedSessionId_returnsPersistedSession(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var result = store.createOrGetJob("idem-key-session-valid", JobSpec.of("test task", DEFAULT_PLANNER_MODEL));
+        var sessionId = UUID.randomUUID();
+
+        store.persistSessionId(result.jobId(), sessionId);
+
+        assertEquals(sessionId, store.loadPersistedSessionId(result.jobId()));
+    }
+
+    @Test
+    void loadPersistedSessionId_returnsNullForInvalidPersistedSession(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var spec = JobSpec.of(
+                "test task",
+                false,
+                false,
+                DEFAULT_PLANNER_MODEL,
+                null,
+                null,
+                false,
+                Map.of("session_id", "not-a-uuid"),
+                (String) null);
+        var result = store.createOrGetJob("idem-key-session-invalid", spec);
+
+        assertNull(store.loadPersistedSessionId(result.jobId()));
+    }
+
+    @Test
     void testCreateOrGetJob_Idempotency(@TempDir Path tempDir) throws Exception {
         var store = new JobStore(tempDir);
         var spec = JobSpec.of("test task", DEFAULT_PLANNER_MODEL);

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -240,6 +240,110 @@ class JobsRouterValidationTest {
     }
 
     @Test
+    void getJobsStatus_whenIdle_reportsReady() throws Exception {
+        var exchange = TestHttpExchange.jsonRequest("GET", "/v1/jobs/status", Map.of());
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+        assertEquals(true, payload.get("readyForJobSubmission"));
+        assertEquals(null, payload.get("activeJobId"));
+        assertEquals(null, payload.get("activeJobState"));
+        assertEquals(0, payload.get("retryAfterMs"));
+        assertEquals(true, payload.get("terminal"));
+    }
+
+    @Test
+    void getJobsStatus_whenReserved_reportsActiveJobState() throws Exception {
+        String jobId = createQueuedJob("reserved status");
+        assertTrue(jobReservation.tryReserve(jobId));
+        try {
+            var exchange = TestHttpExchange.jsonRequest("GET", "/v1/jobs/status", Map.of());
+
+            jobsRouter.handle(exchange);
+
+            assertEquals(200, exchange.responseCode());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+            assertEquals(false, payload.get("readyForJobSubmission"));
+            assertEquals(jobId, payload.get("activeJobId"));
+            assertEquals("QUEUED", payload.get("activeJobState"));
+            assertEquals(1000, payload.get("retryAfterMs"));
+            assertEquals(false, payload.get("terminal"));
+        } finally {
+            jobReservation.releaseIfOwner(jobId);
+        }
+    }
+
+    @Test
+    void postJobs_whenReserved_returnsStructuredJobInProgressDetails() throws Exception {
+        String activeJobId = createQueuedJob("active job");
+        assertTrue(jobReservation.tryReserve(activeJobId));
+        try {
+            Map<String, Object> body = Map.of("taskInput", "blocked job", "plannerModel", "gpt-4");
+            var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
+            exchange.getRequestHeaders()
+                    .set("Idempotency-Key", UUID.randomUUID().toString());
+
+            jobsRouter.handle(exchange);
+
+            assertEquals(409, exchange.responseCode());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+            assertEquals("JOB_IN_PROGRESS", payload.get("code"));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> details = (Map<String, Object>) payload.get("details");
+            assertEquals(activeJobId, details.get("activeJobId"));
+            assertEquals("QUEUED", details.get("activeJobState"));
+            assertEquals(false, details.get("readyForJobSubmission"));
+            assertEquals(1000, details.get("retryAfterMs"));
+        } finally {
+            jobReservation.releaseIfOwner(activeJobId);
+        }
+    }
+
+    @Test
+    void cancelInactivePersistedJob_returnsStructuredLifecycleResponse() throws Exception {
+        String jobId = createQueuedJob("inactive cancel");
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs/" + jobId + "/cancel", Map.of());
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(202, exchange.responseCode());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+        assertEquals(jobId, payload.get("jobId"));
+        assertEquals(false, payload.get("cancelRequested"));
+        assertEquals("QUEUED", payload.get("state"));
+        assertEquals(false, payload.get("terminal"));
+        assertEquals(true, payload.get("executorReady"));
+        assertEquals(null, payload.get("activeJobId"));
+    }
+
+    @Test
+    void getJobStatus_includesTerminalAndExecutorReady() throws Exception {
+        String jobId = createQueuedJob("status metadata");
+        assertTrue(jobReservation.tryReserve(jobId));
+        try {
+            var exchange = TestHttpExchange.jsonRequest("GET", "/v1/jobs/" + jobId, Map.of());
+
+            jobsRouter.handle(exchange);
+
+            assertEquals(200, exchange.responseCode());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+            assertEquals(jobId, payload.get("jobId"));
+            assertEquals("QUEUED", payload.get("state"));
+            assertEquals(false, payload.get("terminal"));
+            assertEquals(false, payload.get("executorReady"));
+        } finally {
+            jobReservation.releaseIfOwner(jobId);
+        }
+    }
+
+    @Test
     void postJobs_withSessionHeader_waitsForHeadlessInit_beforeUnknownSessionValidation() throws Exception {
         var failingInit = new CompletableFuture<Void>();
         failingInit.completeExceptionally(new IllegalStateException("init failed"));
@@ -516,6 +620,11 @@ class JobsRouterValidationTest {
         assertTrue(payload.message().contains("temperatureCode must be between 0.0 and 2.0"), payload.message());
 
         assertEquals(fsSnapshotBefore, snapshotTree(jobStoreDir), "JobStore dir changed; job may have been created");
+    }
+
+    private String createQueuedJob(String taskInput) throws IOException {
+        var spec = JobSpec.of(taskInput, "gpt-4");
+        return jobStore.createOrGetJob(UUID.randomUUID().toString(), spec).jobId();
     }
 
     private static List<String> snapshotTree(Path root) throws IOException {

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -1,22 +1,33 @@
 package ai.brokk.executor.routers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.ContextManager;
+import ai.brokk.Service;
 import ai.brokk.executor.JobReservation;
 import ai.brokk.executor.jobs.ErrorPayload;
 import ai.brokk.executor.jobs.JobRunner;
 import ai.brokk.executor.jobs.JobSpec;
+import ai.brokk.executor.jobs.JobStatus;
 import ai.brokk.executor.jobs.JobStore;
 import ai.brokk.project.MainProject;
+import ai.brokk.testutil.NoOpConsoleIO;
+import ai.brokk.testutil.TestService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpPrincipal;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -32,7 +43,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -278,7 +292,7 @@ class JobsRouterValidationTest {
     }
 
     @Test
-    void getJobsStatus_withOwningSession_reportsActiveJobId() throws Exception {
+    void getJobsStatus_withOwningSession_doesNotRevealActiveJobId() throws Exception {
         var sessionId = UUID.randomUUID();
         String jobId = createQueuedJob("reserved owner status");
         jobStore.persistSessionId(jobId, sessionId);
@@ -293,7 +307,7 @@ class JobsRouterValidationTest {
             @SuppressWarnings("unchecked")
             Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
             assertEquals(false, payload.get("readyForJobSubmission"));
-            assertEquals(jobId, payload.get("activeJobId"));
+            assertEquals(null, payload.get("activeJobId"));
             assertEquals("QUEUED", payload.get("activeJobState"));
         } finally {
             jobReservation.releaseIfOwner(jobId);
@@ -328,7 +342,7 @@ class JobsRouterValidationTest {
     }
 
     @Test
-    void postJobs_whenReservedBySameSession_returnsStructuredJobInProgressDetailsWithActiveJobId() throws Exception {
+    void postJobs_whenReservedBySameSession_doesNotRevealActiveJobId() throws Exception {
         var sessionId = jobsRouter
                 .contextManager
                 .getProject()
@@ -352,7 +366,7 @@ class JobsRouterValidationTest {
             Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
             @SuppressWarnings("unchecked")
             Map<String, Object> details = (Map<String, Object>) payload.get("details");
-            assertEquals(activeJobId, details.get("activeJobId"));
+            assertEquals(null, details.get("activeJobId"));
             assertEquals("QUEUED", details.get("activeJobState"));
         } finally {
             jobReservation.releaseIfOwner(activeJobId);
@@ -375,6 +389,110 @@ class JobsRouterValidationTest {
         assertEquals(false, payload.get("terminal"));
         assertEquals(true, payload.get("executorReady"));
         assertEquals(null, payload.get("activeJobId"));
+    }
+
+    @Test
+    void cancelActiveJob_returnsStructuredDrainingResponse(@TempDir Path tempDir) throws Exception {
+        var projectRoot = tempDir.resolve("project");
+        Files.createDirectories(projectRoot);
+        var project = MainProject.forTests(projectRoot);
+        var modelEntered = new CountDownLatch(1);
+        var releaseModel = new CountDownLatch(1);
+        StreamingChatModel blockingModel = new StreamingChatModel() {
+            @Override
+            public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                modelEntered.countDown();
+                try {
+                    releaseModel.await(5, TimeUnit.SECONDS);
+                    handler.onCompleteResponse(ChatResponse.builder()
+                            .aiMessage(new AiMessage("done"))
+                            .build());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        Service.Provider provider = new Service.Provider() {
+            private TestService svc = serviceFor(project);
+
+            @Override
+            public ai.brokk.AbstractService get() {
+                return svc;
+            }
+
+            @Override
+            public void reinit(ai.brokk.project.IProject p) {
+                svc = serviceFor(p);
+            }
+
+            private TestService serviceFor(ai.brokk.project.IProject p) {
+                return new TestService(p) {
+                    @Override
+                    public @Nullable StreamingChatModel getModel(
+                            Service.ModelConfig config,
+                            @Nullable OpenAiChatRequestParameters.Builder parametersOverride) {
+                        return blockingModel;
+                    }
+                };
+            }
+        };
+
+        try (var cm = new ContextManager(project, provider)) {
+            cm.createHeadless(true, new NoOpConsoleIO());
+            var activeStore = new JobStore(tempDir.resolve("job-store-active-cancel"));
+            var activeRunner = new JobRunner(cm, activeStore);
+            var activeReservation = new JobReservation();
+            var router = new JobsRouter(
+                    cm,
+                    activeStore,
+                    activeRunner,
+                    activeReservation,
+                    CompletableFuture.completedFuture(null),
+                    cm.getAgentStore());
+            var spec = JobSpec.of(
+                    "hold until router cancel",
+                    false,
+                    false,
+                    "test-model",
+                    null,
+                    null,
+                    false,
+                    Map.of("mode", "ASK"),
+                    null,
+                    null,
+                    null);
+            var jobId = activeStore.createOrGetJob("router-active-cancel", spec).jobId();
+            assertTrue(activeReservation.tryReserve(jobId));
+            var future = activeRunner.runAsync(jobId, spec, new NoOpConsoleIO());
+
+            try {
+                assertTrue(modelEntered.await(5, TimeUnit.SECONDS), "ASK model should start before cancellation");
+                var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs/" + jobId + "/cancel", Map.of());
+
+                router.handle(exchange);
+
+                assertEquals(202, exchange.responseCode());
+                @SuppressWarnings("unchecked")
+                Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+                assertEquals(jobId, payload.get("jobId"));
+                assertEquals(true, payload.get("cancelRequested"));
+                assertEquals(JobStatus.State.CANCELLING.name(), payload.get("state"));
+                assertEquals(false, payload.get("terminal"));
+                assertEquals(false, payload.get("executorReady"));
+                assertEquals(jobId, payload.get("activeJobId"));
+
+                var cancelling = activeStore.loadStatus(jobId);
+                assertNotNull(cancelling);
+                assertEquals(JobStatus.State.CANCELLING.name(), cancelling.state());
+                assertFalse(cancelling.terminal());
+            } finally {
+                releaseModel.countDown();
+                future.get(5, TimeUnit.SECONDS);
+                activeRunner.shutdown();
+                activeReservation.releaseIfOwner(jobId);
+            }
+        }
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -268,10 +268,33 @@ class JobsRouterValidationTest {
             @SuppressWarnings("unchecked")
             Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
             assertEquals(false, payload.get("readyForJobSubmission"));
-            assertEquals(jobId, payload.get("activeJobId"));
+            assertEquals(null, payload.get("activeJobId"));
             assertEquals("QUEUED", payload.get("activeJobState"));
             assertEquals(1000, payload.get("retryAfterMs"));
             assertEquals(false, payload.get("terminal"));
+        } finally {
+            jobReservation.releaseIfOwner(jobId);
+        }
+    }
+
+    @Test
+    void getJobsStatus_withOwningSession_reportsActiveJobId() throws Exception {
+        var sessionId = UUID.randomUUID();
+        String jobId = createQueuedJob("reserved owner status");
+        jobStore.persistSessionId(jobId, sessionId);
+        assertTrue(jobReservation.tryReserve(jobId));
+        try {
+            var exchange = TestHttpExchange.jsonRequest("GET", "/v1/jobs/status", Map.of());
+            exchange.getRequestHeaders().set("X-Session-Id", sessionId.toString());
+
+            jobsRouter.handle(exchange);
+
+            assertEquals(200, exchange.responseCode());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+            assertEquals(false, payload.get("readyForJobSubmission"));
+            assertEquals(jobId, payload.get("activeJobId"));
+            assertEquals("QUEUED", payload.get("activeJobState"));
         } finally {
             jobReservation.releaseIfOwner(jobId);
         }
@@ -295,10 +318,42 @@ class JobsRouterValidationTest {
             assertEquals("JOB_IN_PROGRESS", payload.get("code"));
             @SuppressWarnings("unchecked")
             Map<String, Object> details = (Map<String, Object>) payload.get("details");
-            assertEquals(activeJobId, details.get("activeJobId"));
+            assertEquals(null, details.get("activeJobId"));
             assertEquals("QUEUED", details.get("activeJobState"));
             assertEquals(false, details.get("readyForJobSubmission"));
             assertEquals(1000, details.get("retryAfterMs"));
+        } finally {
+            jobReservation.releaseIfOwner(activeJobId);
+        }
+    }
+
+    @Test
+    void postJobs_whenReservedBySameSession_returnsStructuredJobInProgressDetailsWithActiveJobId() throws Exception {
+        var sessionId = jobsRouter
+                .contextManager
+                .getProject()
+                .getSessionManager()
+                .newSession("Owner")
+                .id();
+        String activeJobId = createQueuedJob("owned active job");
+        jobStore.persistSessionId(activeJobId, sessionId);
+        assertTrue(jobReservation.tryReserve(activeJobId));
+        try {
+            Map<String, Object> body = Map.of("taskInput", "blocked owned job", "plannerModel", "gpt-4");
+            var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
+            exchange.getRequestHeaders()
+                    .set("Idempotency-Key", UUID.randomUUID().toString());
+            exchange.getRequestHeaders().set("X-Session-Id", sessionId.toString());
+
+            jobsRouter.handle(exchange);
+
+            assertEquals(409, exchange.responseCode());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> payload = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> details = (Map<String, Object>) payload.get("details");
+            assertEquals(activeJobId, details.get("activeJobId"));
+            assertEquals("QUEUED", details.get("activeJobState"));
         } finally {
             jobReservation.releaseIfOwner(activeJobId);
         }

--- a/app/src/test/java/ai/brokk/testutil/ExecutorTestUtil.java
+++ b/app/src/test/java/ai/brokk/testutil/ExecutorTestUtil.java
@@ -15,6 +15,7 @@ public final class ExecutorTestUtil {
 
     /**
      * Polls the job status endpoint until the job reaches a terminal state (COMPLETED, FAILED, or CANCELLED).
+     * CANCELLING is intentionally non-terminal because the executor may still be draining the active reservation.
      *
      * @param baseUrl   the base URL of the executor (e.g., "http://127.0.0.1:8080")
      * @param jobId     the job ID to poll


### PR DESCRIPTION
### Description
Implements lifecycle-only fixes for headless job submission readiness and cancellation semantics for #3635, including the follow-up guided-review fixes.

**Key Changes**:
- Adds structured job lifecycle readiness, cancellation, and busy responses while keeping active job IDs hidden from public readiness/busy endpoints.
- Adds `CANCELLING` lifecycle semantics, terminal/executor readiness metadata, and structured cancellation responses.
- Centralizes persisted session lookup in `JobStore` and keeps `ErrorPayload.details` narrow while using a typed `JOB_IN_PROGRESS` response.
- Adds focused router and job-store tests for readiness, busy responses, active cancellation, and persisted session lookup.

**Touch Points**:
- `ErrorPayload.java`
- `JobStatus.java`
- `JobRunner.java`
- `JobStore.java`
- `JobLifecycleResponses.java`
- `JobsRouter.java`
- `ReviewRouter.java`
- `JobsRouterValidationTest.java`
- `JobRunnerTest.java`
- `JobStoreTest.java`
- `ExecutorTestUtil.java`

Verification:
- `./gradlew :app:test --tests ai.brokk.executor.routers.JobsRouterValidationTest --tests ai.brokk.executor.jobs.JobRunnerTest --tests ai.brokk.executor.jobs.JobStoreTest`
- `./gradlew fix tidy`
- `./gradlew analyze`
