### PR TITLE
Cache normalized ProjectFile paths in static analysis seed and lead expansion

### DIFF
--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
@@ -41,11 +41,12 @@ public final class StaticAnalysisLeadExpansionService {
     }
 
     public StaticAnalysisSeedDtos.Response expandLeads(StaticAnalysisSeedDtos.NormalizedLeadExpansionRequest request) {
+        var pathCache = new PathCache();
         var knownFiles = request.knownFiles().stream()
-                .map(this::normalizePath)
+                .map(pathCache::normalize)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         var frontierFiles = request.frontierFiles().stream()
-                .map(this::normalizePath)
+                .map(pathCache::normalize)
                 .collect(Collectors.toCollection(ArrayList::new));
         if (frontierFiles.isEmpty()) {
             frontierFiles.addAll(knownFiles);
@@ -106,14 +107,15 @@ public final class StaticAnalysisLeadExpansionService {
                         }
                         usageCountByFile = usageCountByFile(query.result());
                     } catch (RuntimeException e) {
-                        usageCountByFile = textUsageCountByFile(analyzer, symbol, deadline);
+                        usageCountByFile = textUsageCountByFile(analyzer, symbol, deadline, pathCache);
                     }
                     for (var entry : usageCountByFile.entrySet()) {
                         var file = entry.getKey();
-                        if (file.equals(sourceFile) || knownFiles.contains(externalPath(file))) {
+                        var filePath = pathCache.externalPath(file);
+                        if (file.equals(sourceFile) || knownFiles.contains(filePath)) {
                             continue;
                         }
-                        var candidate = candidates.computeIfAbsent(externalPath(file), ignored -> new Candidate(file));
+                        var candidate = candidates.computeIfAbsent(filePath, ignored -> new Candidate(file));
                         candidate.merge(
                                 sourcePath,
                                 sourceRank,
@@ -136,10 +138,10 @@ public final class StaticAnalysisLeadExpansionService {
             for (var candidate : candidates.values().stream()
                     .sorted(Comparator.comparingDouble(Candidate::score)
                             .reversed()
-                            .thenComparing(candidate -> externalPath(candidate.file)))
+                            .thenComparing(candidate -> pathCache.externalPath(candidate.file)))
                     .limit(request.maxResults())
                     .toList()) {
-                ranked.add(candidate.toRecord(analyzer, rank++, externalPath(candidate.file)));
+                ranked.add(candidate.toRecord(analyzer, rank++, pathCache.externalPath(candidate.file)));
             }
 
             var state = capped || timedOut(deadline) ? "capped" : ranked.isEmpty() ? "skipped" : "completed";
@@ -217,11 +219,11 @@ public final class StaticAnalysisLeadExpansionService {
         return counts;
     }
 
-    private Map<ProjectFile, Integer> textUsageCountByFile(IAnalyzer analyzer, CodeUnit symbol, long deadline)
-            throws InterruptedException {
+    private Map<ProjectFile, Integer> textUsageCountByFile(
+            IAnalyzer analyzer, CodeUnit symbol, long deadline, PathCache pathCache) throws InterruptedException {
         var counts = new LinkedHashMap<ProjectFile, Integer>();
         var files = sourceFiles(analyzer).stream()
-                .sorted(Comparator.comparing(this::externalPath))
+                .sorted(Comparator.comparing(pathCache::externalPath))
                 .limit(MAX_USAGE_CANDIDATE_FILES)
                 .toList();
         for (var file : files) {
@@ -260,16 +262,6 @@ public final class StaticAnalysisLeadExpansionService {
         return System.nanoTime() >= deadlineNanos;
     }
 
-    private String normalizePath(String path) {
-        return PathNormalizer.canonicalizeForProject(
-                path, contextManager.getProject().getRoot());
-    }
-
-    private String externalPath(ProjectFile file) {
-        return PathNormalizer.canonicalizeForProject(
-                file.toString(), contextManager.getProject().getRoot());
-    }
-
     private static StaticAnalysisSeedDtos.Event event(
             String scanId,
             String state,
@@ -281,6 +273,19 @@ public final class StaticAnalysisLeadExpansionService {
             List<String> findingTypes) {
         return StaticAnalysisSeedDtos.event(
                 scanId, state, tools, files, null, null, code, message, findingCount, findingTypes, List.of());
+    }
+
+    private final class PathCache {
+        private final Map<ProjectFile, String> externalPaths = new LinkedHashMap<>();
+
+        private String normalize(String path) {
+            return PathNormalizer.canonicalizeForProject(
+                    path, contextManager.getProject().getRoot());
+        }
+
+        private String externalPath(ProjectFile file) {
+            return externalPaths.computeIfAbsent(file, key -> normalize(key.toString()));
+        }
     }
 
     private static final class Candidate {

--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java
@@ -42,6 +42,7 @@ public final class StaticAnalysisSeedService {
     }
 
     public StaticAnalysisSeedDtos.Response fetchSeeds(StaticAnalysisSeedDtos.NormalizedRequest request) {
+        var pathCache = new PathCache();
         var events = new ArrayList<StaticAnalysisSeedDtos.Event>();
         events.add(event(
                 request.scanId(),
@@ -60,25 +61,25 @@ public final class StaticAnalysisSeedService {
         var capped = false;
 
         try {
-            capped |= addWeightedSampleSeeds(request, candidates, deadline);
-            capped |= addGitHotspots(request, candidates, deadline);
-            capped |= addSizeComplexitySeeds(request, candidates, deadline);
-            capped |= addUsageExpansionSeeds(request, candidates, deadline);
+            capped |= addWeightedSampleSeeds(request, candidates, deadline, pathCache);
+            capped |= addGitHotspots(request, candidates, deadline, pathCache);
+            capped |= addSizeComplexitySeeds(request, candidates, deadline, pathCache);
+            capped |= addUsageExpansionSeeds(request, candidates, deadline, pathCache);
 
             var seeds = candidates.values().stream()
                     .sorted(Comparator.comparingDouble(Candidate::score)
                             .reversed()
-                            .thenComparing(candidate -> externalPath(candidate.file)))
+                            .thenComparing(candidate -> pathCache.externalPath(candidate.file)))
                     .limit(request.targetSeedCount())
                     .toList();
 
             var records = new ArrayList<StaticAnalysisSeedDtos.SeedRecord>();
             var rank = 1;
             for (var seed : seeds) {
-                records.add(seed.toRecord(rank++, externalPath(seed.file)));
+                records.add(seed.toRecord(rank++, pathCache.externalPath(seed.file)));
             }
             var previews = request.includePreview()
-                    ? addPreviewFindings(records, deadline)
+                    ? addPreviewFindings(records, deadline, pathCache)
                     : List.<StaticAnalysisSeedDtos.Preview>of();
 
             if (records.isEmpty()) {
@@ -149,7 +150,10 @@ public final class StaticAnalysisSeedService {
     }
 
     private boolean addGitHotspots(
-            StaticAnalysisSeedDtos.NormalizedRequest request, Map<String, Candidate> candidates, long deadline) {
+            StaticAnalysisSeedDtos.NormalizedRequest request,
+            Map<String, Candidate> candidates,
+            long deadline,
+            PathCache pathCache) {
         if (timedOut(deadline)) return true;
         if (!(contextManager.getRepo() instanceof GitRepo gitRepo)) return false;
 
@@ -167,7 +171,7 @@ public final class StaticAnalysisSeedService {
             for (var file : report.files()) {
                 if (timedOut(deadline)) return true;
                 var score = 0.35 + (0.45 * file.churn() / Math.max(1.0, maxChurn));
-                var candidate = candidate(candidates, file.path(), score, "git_hotspot");
+                var candidate = candidate(candidates, pathCache.normalize(file.path()), score, "git_hotspot");
                 candidate.addSignal(
                         "git_churn",
                         Map.of(
@@ -191,11 +195,14 @@ public final class StaticAnalysisSeedService {
     }
 
     private boolean addSizeComplexitySeeds(
-            StaticAnalysisSeedDtos.NormalizedRequest request, Map<String, Candidate> candidates, long deadline) {
+            StaticAnalysisSeedDtos.NormalizedRequest request,
+            Map<String, Candidate> candidates,
+            long deadline,
+            PathCache pathCache) {
         if (timedOut(deadline)) return true;
         IAnalyzer analyzer = contextManager.getAnalyzer();
         var files = sourceFiles(analyzer).stream()
-                .sorted(Comparator.comparing(this::externalPath))
+                .sorted(Comparator.comparing(pathCache::externalPath))
                 .limit(Math.max(request.targetSeedCount() * 4L, request.targetSeedCount()))
                 .toList();
         for (var file : files) {
@@ -205,7 +212,7 @@ public final class StaticAnalysisSeedService {
             if (maxComplexity < COMPLEXITY_SIGNAL_THRESHOLD && sizeBytes < LARGE_FILE_BYTES_THRESHOLD) continue;
 
             var score = Math.min(0.95, 0.45 + (maxComplexity / 50.0) + (sizeBytes / 200_000.0));
-            var candidate = candidate(candidates, externalPath(file), score, "size_complexity");
+            var candidate = candidate(candidates, pathCache.externalPath(file), score, "size_complexity");
             if (maxComplexity > 0) {
                 candidate.addSignal("complexity", Map.of("maxCyclomaticComplexity", maxComplexity));
             }
@@ -219,7 +226,7 @@ public final class StaticAnalysisSeedService {
     }
 
     private List<StaticAnalysisSeedDtos.Preview> addPreviewFindings(
-            List<StaticAnalysisSeedDtos.SeedRecord> records, long deadline) {
+            List<StaticAnalysisSeedDtos.SeedRecord> records, long deadline, PathCache pathCache) {
         if (timedOut(deadline)) return List.of();
         IAnalyzer analyzer = contextManager.getAnalyzer();
         var weights = IAnalyzer.MaintainabilitySizeSmellWeights.defaults();
@@ -242,14 +249,14 @@ public final class StaticAnalysisSeedService {
                 if (timedOut(deadline) || previews.size() >= PREVIEW_FINDING_CAP) {
                     break;
                 }
-                previews.add(toPreview(seed, finding));
+                previews.add(toPreview(seed, finding, pathCache));
             }
         }
         return previews;
     }
 
     private StaticAnalysisSeedDtos.Preview toPreview(
-            StaticAnalysisSeedDtos.SeedRecord seed, IAnalyzer.MaintainabilitySizeSmell finding) {
+            StaticAnalysisSeedDtos.SeedRecord seed, IAnalyzer.MaintainabilitySizeSmell finding, PathCache pathCache) {
         var cu = finding.codeUnit();
         var range = finding.range();
         var lineStart = range.isEmpty() ? null : range.startLine() + 1;
@@ -267,7 +274,7 @@ public final class StaticAnalysisSeedService {
         var message = "%s scored %d in %s".formatted(cu.fqName(), finding.score(), cu.source());
         return new StaticAnalysisSeedDtos.Preview(
                 UUID.randomUUID().toString(),
-                externalPath(cu.source()),
+                pathCache.externalPath(cu.source()),
                 LONG_METHOD_TOOL,
                 finding.score(),
                 title,
@@ -281,7 +288,10 @@ public final class StaticAnalysisSeedService {
     }
 
     private boolean addUsageExpansionSeeds(
-            StaticAnalysisSeedDtos.NormalizedRequest request, Map<String, Candidate> candidates, long deadline)
+            StaticAnalysisSeedDtos.NormalizedRequest request,
+            Map<String, Candidate> candidates,
+            long deadline,
+            PathCache pathCache)
             throws InterruptedException {
         if (timedOut(deadline)) return true;
         if (contextManager.liveContext().allFragments().findAny().isEmpty()) return false;
@@ -289,7 +299,8 @@ public final class StaticAnalysisSeedService {
         var rank = 1;
         for (var file : related) {
             if (timedOut(deadline)) return true;
-            var candidate = candidate(candidates, externalPath(file), 0.55 - (rank * 0.01), "usage_expansion");
+            var candidate =
+                    candidate(candidates, pathCache.externalPath(file), 0.55 - (rank * 0.01), "usage_expansion");
             candidate.addSignal("usage_connectivity", Map.of("relatedRank", rank));
             rank++;
         }
@@ -297,17 +308,21 @@ public final class StaticAnalysisSeedService {
     }
 
     private boolean addWeightedSampleSeeds(
-            StaticAnalysisSeedDtos.NormalizedRequest request, Map<String, Candidate> candidates, long deadline) {
+            StaticAnalysisSeedDtos.NormalizedRequest request,
+            Map<String, Candidate> candidates,
+            long deadline,
+            PathCache pathCache) {
         var needed = request.targetSeedCount() - candidates.size();
         if (needed <= 0) return false;
         var capped = timedOut(deadline);
         var files = sourceFiles(contextManager.getAnalyzer()).stream()
-                .sorted(Comparator.comparing(this::externalPath))
+                .sorted(Comparator.comparing(pathCache::externalPath))
                 .limit(needed)
                 .toList();
         var rank = 1;
         for (var file : files) {
-            var candidate = candidate(candidates, externalPath(file), 0.2 - (rank * 0.001), "weighted_sample");
+            var candidate =
+                    candidate(candidates, pathCache.externalPath(file), 0.2 - (rank * 0.001), "weighted_sample");
             candidate.addSignal("size", Map.of("bytes", file.size().orElse(0L)));
             rank++;
         }
@@ -347,8 +362,8 @@ public final class StaticAnalysisSeedService {
         return result;
     }
 
-    private Candidate candidate(Map<String, Candidate> candidates, String path, double score, String selectionKind) {
-        var normalizedPath = normalizePath(path);
+    private Candidate candidate(
+            Map<String, Candidate> candidates, String normalizedPath, double score, String selectionKind) {
         return candidates
                 .computeIfAbsent(
                         normalizedPath,
@@ -359,16 +374,6 @@ public final class StaticAnalysisSeedService {
 
     private static boolean timedOut(long deadlineNanos) {
         return System.nanoTime() >= deadlineNanos;
-    }
-
-    private String normalizePath(String path) {
-        return PathNormalizer.canonicalizeForProject(
-                path, contextManager.getProject().getRoot());
-    }
-
-    private String externalPath(ProjectFile file) {
-        return PathNormalizer.canonicalizeForProject(
-                file.toString(), contextManager.getProject().getRoot());
     }
 
     private static StaticAnalysisSeedDtos.Event event(
@@ -383,6 +388,19 @@ public final class StaticAnalysisSeedService {
             List<String> findingTypes) {
         return StaticAnalysisSeedDtos.event(
                 scanId, state, tools, files, selection, null, code, message, findingCount, findingTypes, List.of());
+    }
+
+    private final class PathCache {
+        private final Map<ProjectFile, String> externalPaths = new LinkedHashMap<>();
+
+        private String normalize(String path) {
+            return PathNormalizer.canonicalizeForProject(
+                    path, contextManager.getProject().getRoot());
+        }
+
+        private String externalPath(ProjectFile file) {
+            return externalPaths.computeIfAbsent(file, key -> normalize(key.toString()));
+        }
     }
 
     private static final class Candidate {

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
@@ -51,6 +51,36 @@ class StaticAnalysisLeadExpansionServiceTest {
     }
 
     @Test
+    void expandLeads_ordersEqualScoreCandidatesByNormalizedPath(@TempDir Path root) throws Exception {
+        var target = javaFile(root, "src/main/java/p/Target.java", "package p; public class Target {}");
+        javaFile(root, "src/main/java/p/ZUser.java", "package p; class ZUser { Target target; }");
+        javaFile(root, "src/main/java/p/AUser.java", "package p; class AUser { Target target; }");
+        var analyzer = new TestAnalyzer();
+        analyzer.addDeclaration(new CodeUnit(target, CodeUnitType.CLASS, "p", "Target", null, false));
+        var service = service(root, analyzer);
+
+        var response = service.expandLeads(new StaticAnalysisSeedDtos.NormalizedLeadExpansionRequest(
+                "scan-1",
+                List.of("src/main/java/p/Target.java"),
+                List.of("src/main/java/p/Target.java"),
+                5,
+                15_000,
+                false));
+
+        assertEquals(
+                "completed",
+                response.state(),
+                response.events().getLast().outcome().message());
+        assertEquals(
+                List.of("src/main/java/p/AUser.java", "src/main/java/p/ZUser.java"),
+                response.seeds().stream()
+                        .map(StaticAnalysisSeedDtos.SeedRecord::file)
+                        .toList());
+        assertEquals(1, response.seeds().getFirst().rank());
+        assertEquals("usage_expansion", response.seeds().getFirst().selection().kind());
+    }
+
+    @Test
     void expandLeads_suggestsTestAssertionToolForTestFiles(@TempDir Path root) throws Exception {
         var target = javaFile(root, "src/main/java/p/Target.java", "package p; public class Target {}");
         var testFile =

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java
@@ -93,6 +93,27 @@ class StaticAnalysisSeedServiceTest {
     }
 
     @Test
+    void fetchSeeds_ordersWeightedSamplesByNormalizedPath(@TempDir Path root) throws Exception {
+        var zFile = javaFile(root, "src/main/java/Zed.java", "class Zed {}");
+        var aFile = javaFile(root, "src/main/java/Alpha.java", "class Alpha {}");
+        var analyzer = new TestAnalyzer();
+        analyzer.addDeclaration(new CodeUnit(zFile, CodeUnitType.CLASS, "", "Zed", null, false));
+        analyzer.addDeclaration(new CodeUnit(aFile, CodeUnitType.CLASS, "", "Alpha", null, false));
+        var service = service(root, analyzer);
+
+        var response = service.fetchSeeds(new StaticAnalysisSeedDtos.NormalizedRequest("scan-1", 5, 15_000, false));
+
+        assertEquals("completed", response.state());
+        assertEquals(
+                List.of("src/main/java/Alpha.java", "src/main/java/Zed.java"),
+                response.seeds().stream()
+                        .map(StaticAnalysisSeedDtos.SeedRecord::file)
+                        .toList());
+        assertEquals(1, response.seeds().getFirst().rank());
+        assertEquals("weighted_sample", response.seeds().getFirst().selection().kind());
+    }
+
+    @Test
     void fetchSeeds_usesProjectSourceFilesWhenAnalyzerHasNoIndexedFiles(@TempDir Path root) throws Exception {
         javaFile(root, "src/main/java/Unindexed.java", "class Unindexed {}");
         var service = service(root, new TestAnalyzer());


### PR DESCRIPTION
### Summary
- Add invocation-scoped caching for normalized `ProjectFile` paths in static-analysis seed selection and lead expansion.
- Reduce repeated `PathNormalizer.canonicalizeForProject(...)` work in sorting, candidate lookup, known-file checks, previews, and record creation.
- Keep normalization behavior and response output unchanged while lowering allocation pressure in hot scan paths.

**Key Changes**:
- Introduced a small per-request path cache in both static-analysis services and threaded it through the existing seed/lead flows.
- Added regression tests to preserve deterministic ordering, known-file deduping, and usage-expansion output behavior.

**Touch Points**:
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java`
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java`
- `app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java`
- `app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java`

### Testing
- `./gradlew :app:test --tests ai.brokk.executor.staticanalysis.StaticAnalysisSeedServiceTest --tests ai.brokk.executor.staticanalysis.StaticAnalysisLeadExpansionServiceTest`
- `./gradlew fix tidy`
- `./gradlew analyze`