### PR TITLE
Replace regex split fallback usage counting with literal scanning

### DIFF
--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
@@ -19,7 +19,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 
@@ -236,7 +235,7 @@ public final class StaticAnalysisLeadExpansionService {
             }
             try {
                 var text = Files.readString(file.absPath());
-                var count = text.split(Pattern.quote(symbol.identifier()), -1).length - 1;
+                var count = literalOccurrenceCount(text, symbol.identifier());
                 if (count > 0) {
                     counts.put(file, count);
                 }
@@ -245,6 +244,22 @@ public final class StaticAnalysisLeadExpansionService {
             }
         }
         return counts;
+    }
+
+    static int literalOccurrenceCount(String text, String needle) {
+        if (needle.isEmpty()) {
+            return 0;
+        }
+        var count = 0;
+        var fromIndex = 0;
+        while (true) {
+            var index = text.indexOf(needle, fromIndex);
+            if (index < 0) {
+                return count;
+            }
+            count++;
+            fromIndex = index + needle.length();
+        }
     }
 
     private Set<ProjectFile> sourceFiles(IAnalyzer analyzer) {

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
@@ -129,6 +129,45 @@ class StaticAnalysisLeadExpansionServiceTest {
         assertTrue(response.seeds().isEmpty());
     }
 
+    @Test
+    void expandLeads_skipsFilesWithoutLiteralFallbackMatches(@TempDir Path root) throws Exception {
+        var target = javaFile(root, "src/main/java/p/Target.java", "package p; public class Target {}");
+        javaFile(root, "src/main/java/p/User.java", "package p; class User { String value = \"missing\"; }");
+        var analyzer = new TestAnalyzer();
+        analyzer.addDeclaration(new CodeUnit(target, CodeUnitType.CLASS, "p", "Target", null, false));
+        var service = service(root, analyzer);
+
+        var response = service.expandLeads(new StaticAnalysisSeedDtos.NormalizedLeadExpansionRequest(
+                "scan-1",
+                List.of("src/main/java/p/Target.java"),
+                List.of("src/main/java/p/Target.java"),
+                5,
+                15_000,
+                false));
+
+        assertEquals(
+                "skipped",
+                response.state(),
+                response.events().getLast().outcome().message());
+        assertTrue(response.seeds().isEmpty());
+    }
+
+    @Test
+    void literalOccurrenceCount_countsAdjacentRepeatedMatches() {
+        assertEquals(2, StaticAnalysisLeadExpansionService.literalOccurrenceCount("TargetTarget", "Target"));
+    }
+
+    @Test
+    void literalOccurrenceCount_countsRegexShapedNeedleLiterally() {
+        assertEquals(1, StaticAnalysisLeadExpansionService.literalOccurrenceCount("A.B AxB", "A.B"));
+    }
+
+    @Test
+    void literalOccurrenceCount_returnsZeroForMissingAndEmptyNeedle() {
+        assertEquals(0, StaticAnalysisLeadExpansionService.literalOccurrenceCount("Target", "Missing"));
+        assertEquals(0, StaticAnalysisLeadExpansionService.literalOccurrenceCount("Target", ""));
+    }
+
     private static StaticAnalysisLeadExpansionService service(Path root, TestAnalyzer analyzer) {
         return new StaticAnalysisLeadExpansionService(
                 new TestContextManager(new TestProject(root, Languages.JAVA), new TestConsoleIO(), Set.of(), analyzer));


### PR DESCRIPTION
### Summary
- Replaced the fallback usage-counting path in `StaticAnalysisLeadExpansionService` with a literal `indexOf`-based counter to avoid regex matcher and split allocations.
- Added focused regression coverage for adjacent matches, regex-shaped literals, and empty or missing needles.

### Key Changes
- `text.split(Pattern.quote(...), -1).length - 1` now uses `literalOccurrenceCount(...)` for the fallback file scan.
- The new helper keeps the match semantics literal and returns `0` for an empty needle.
- Added a service-level no-match regression plus direct helper tests to lock the edge cases down.

### Touch Points
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java`
- `app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java`

### Testing
- `./gradlew :app:test --tests ai.brokk.executor.staticanalysis.StaticAnalysisLeadExpansionServiceTest`
- `./gradlew fix tidy`
- `./gradlew analyze`