### PR TITLE
Optimize ASCII case-insensitive matching in analyzer search paths

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1407,6 +1407,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
     private Set<CodeUnit> searchDefinitionsByLiterals(RegexLiteralSet search, Pattern compiledPattern) {
         var literals = search.literals();
+        var caseInsensitiveLiterals = search.caseInsensitiveLiterals();
         return this.state.codeUnitState.keySet().parallelStream()
                 .filter(cu -> !cu.isSynthetic())
                 .filter(cu -> {
@@ -1417,7 +1418,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                     if (!AsciiUtil.isAscii(fqName)) {
                         return compiledPattern.matcher(fqName).find();
                     }
-                    return literals.stream().anyMatch(literal -> AsciiUtil.containsIgnoreCase(fqName, literal));
+                    return caseInsensitiveLiterals.stream().anyMatch(literal -> literal.containedIn(fqName));
                 })
                 .filter(cu -> !isAnonymousStructure(cu.fqName()))
                 .collect(Collectors.toSet());

--- a/brokk-shared/src/main/java/ai/brokk/util/AsciiUtil.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/AsciiUtil.java
@@ -3,6 +3,16 @@ package ai.brokk.util;
 public final class AsciiUtil {
     private AsciiUtil() {}
 
+    public record CaseInsensitiveLiteral(String literal, String foldedLiteral) {
+        public CaseInsensitiveLiteral(String literal) {
+            this(literal, foldAscii(literal));
+        }
+
+        public boolean containedIn(String haystack) {
+            return containsFoldedIgnoreCase(haystack, foldedLiteral);
+        }
+    }
+
     public static boolean isAscii(CharSequence text) {
         for (int i = 0; i < text.length(); i++) {
             if (!isAscii(text.charAt(i))) {
@@ -13,9 +23,22 @@ public final class AsciiUtil {
     }
 
     public static boolean containsIgnoreCase(String haystack, String needle) {
-        int maxStart = haystack.length() - needle.length();
+        return containsFoldedIgnoreCase(haystack, foldAscii(needle));
+    }
+
+    private static boolean containsFoldedIgnoreCase(String haystack, String foldedNeedle) {
+        if (foldedNeedle.isEmpty()) {
+            return true;
+        }
+
+        int maxStart = haystack.length() - foldedNeedle.length();
+        if (maxStart < 0) {
+            return false;
+        }
+
+        char first = foldedNeedle.charAt(0);
         for (int start = 0; start <= maxStart; start++) {
-            if (regionMatchesIgnoreCase(haystack, start, needle)) {
+            if (toLower(haystack.charAt(start)) == first && regionMatchesFolded(haystack, start, foldedNeedle)) {
                 return true;
             }
         }
@@ -26,13 +49,21 @@ public final class AsciiUtil {
         return ch < 128;
     }
 
-    private static boolean regionMatchesIgnoreCase(String haystack, int start, String needle) {
-        for (int i = 0; i < needle.length(); i++) {
-            if (toLower(haystack.charAt(start + i)) != toLower(needle.charAt(i))) {
+    private static boolean regionMatchesFolded(String haystack, int start, String foldedNeedle) {
+        for (int i = 1; i < foldedNeedle.length(); i++) {
+            if (toLower(haystack.charAt(start + i)) != foldedNeedle.charAt(i)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private static String foldAscii(String text) {
+        char[] chars = text.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            chars[i] = toLower(chars[i]);
+        }
+        return new String(chars);
     }
 
     private static char toLower(char ch) {

--- a/brokk-shared/src/main/java/ai/brokk/util/RegexLiteralSet.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/RegexLiteralSet.java
@@ -14,7 +14,16 @@ import org.jetbrains.annotations.Nullable;
  * {@code (?i).*?(?:\QFoo\E|\QBar\E).*?}. Any pattern outside that small grammar must return {@link Optional#empty()}
  * so the caller keeps using normal regex matching.
  */
-public record RegexLiteralSet(List<String> literals, boolean caseInsensitive) {
+public record RegexLiteralSet(
+        List<String> literals,
+        boolean caseInsensitive,
+        List<AsciiUtil.CaseInsensitiveLiteral> caseInsensitiveLiterals) {
+    public RegexLiteralSet {
+        literals = List.copyOf(literals);
+        caseInsensitiveLiterals = List.copyOf(caseInsensitiveLiterals);
+        assert caseInsensitive || caseInsensitiveLiterals.isEmpty();
+    }
+
     public static Optional<RegexLiteralSet> fromContainsPattern(Pattern pattern, @Nullable String substringFilter) {
         String regex = pattern.pattern();
         if (regex.startsWith("(?i)")) {
@@ -28,7 +37,7 @@ public record RegexLiteralSet(List<String> literals, boolean caseInsensitive) {
             if (!AsciiUtil.isAscii(substringFilter)) {
                 return Optional.empty();
             }
-            return Optional.of(new RegexLiteralSet(List.of(substringFilter), true));
+            return Optional.of(create(List.of(substringFilter), true));
         }
         return fromLiteralPattern(regex, false);
     }
@@ -54,7 +63,17 @@ public record RegexLiteralSet(List<String> literals, boolean caseInsensitive) {
             }
             literals.add(literal.get());
         }
-        return Optional.of(new RegexLiteralSet(List.copyOf(literals), caseInsensitive));
+        return Optional.of(create(literals, caseInsensitive));
+    }
+
+    private static RegexLiteralSet create(List<String> literals, boolean caseInsensitive) {
+        var copiedLiterals = List.copyOf(literals);
+        var caseInsensitiveLiterals = caseInsensitive
+                ? copiedLiterals.stream()
+                        .map(AsciiUtil.CaseInsensitiveLiteral::new)
+                        .toList()
+                : List.<AsciiUtil.CaseInsensitiveLiteral>of();
+        return new RegexLiteralSet(copiedLiterals, caseInsensitive, caseInsensitiveLiterals);
     }
 
     private static String stripContainsWrapper(String regex) {

--- a/brokk-shared/src/test/java/ai/brokk/util/AsciiUtilTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/util/AsciiUtilTest.java
@@ -1,0 +1,44 @@
+package ai.brokk.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class AsciiUtilTest {
+    @Test
+    void containsIgnoreCaseMatchesEmptyNeedle() {
+        assertTrue(AsciiUtil.containsIgnoreCase("Haystack", ""));
+        assertTrue(new AsciiUtil.CaseInsensitiveLiteral("").containedIn("Haystack"));
+    }
+
+    @Test
+    void containsIgnoreCaseRejectsNeedleLongerThanHaystack() {
+        assertFalse(AsciiUtil.containsIgnoreCase("short", "longer needle"));
+        assertFalse(new AsciiUtil.CaseInsensitiveLiteral("longer needle").containedIn("short"));
+    }
+
+    @Test
+    void containsIgnoreCaseMatchesOneCharacterNeedle() {
+        assertTrue(AsciiUtil.containsIgnoreCase("abc", "B"));
+        assertTrue(new AsciiUtil.CaseInsensitiveLiteral("B").containedIn("abc"));
+        assertFalse(AsciiUtil.containsIgnoreCase("abc", "D"));
+    }
+
+    @Test
+    void containsIgnoreCaseMatchesMixedCaseAscii() {
+        assertTrue(AsciiUtil.containsIgnoreCase("com.Example.Service", "example.service"));
+        assertTrue(new AsciiUtil.CaseInsensitiveLiteral("EXAMPLE.SERVICE").containedIn("com.Example.Service"));
+    }
+
+    @Test
+    void containsIgnoreCaseSkipsStartsWithMissingFirstCharacter() {
+        assertFalse(AsciiUtil.containsIgnoreCase("bbbbbbbb", "Ab"));
+        assertFalse(new AsciiUtil.CaseInsensitiveLiteral("Ab").containedIn("bbbbbbbb"));
+    }
+
+    @Test
+    void containsIgnoreCaseContinuesAfterPartialCandidateMatch() {
+        assertTrue(AsciiUtil.containsIgnoreCase("abxAbC", "abc"));
+        assertTrue(new AsciiUtil.CaseInsensitiveLiteral("abc").containedIn("abxAbC"));
+    }
+}

--- a/brokk-shared/src/test/java/ai/brokk/util/RegexLiteralSetTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/util/RegexLiteralSetTest.java
@@ -1,0 +1,52 @@
+package ai.brokk.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class RegexLiteralSetTest {
+    @Test
+    void caseInsensitiveLiteralPatternBuildsPrecomputedAsciiMatchers() {
+        var search = RegexLiteralSet.fromContainsPattern(
+                        Pattern.compile("(?i).*?(?:\\Qmethod1\\E|\\QField2\\E).*?"), null)
+                .orElseThrow();
+
+        assertTrue(search.caseInsensitive());
+        assertEquals(List.of("method1", "Field2"), search.literals());
+        assertEquals(2, search.caseInsensitiveLiterals().size());
+        assertTrue(search.caseInsensitiveLiterals().stream().anyMatch(literal -> literal.containedIn("A.METHOD1")));
+        assertTrue(search.caseInsensitiveLiterals().stream().anyMatch(literal -> literal.containedIn("D.field2")));
+    }
+
+    @Test
+    void caseSensitiveLiteralPatternDoesNotBuildCaseInsensitiveMatchers() {
+        var search = RegexLiteralSet.fromContainsPattern(Pattern.compile(".*?\\Qmethod1\\E.*?"), null)
+                .orElseThrow();
+
+        assertFalse(search.caseInsensitive());
+        assertEquals(List.of("method1"), search.literals());
+        assertTrue(search.caseInsensitiveLiterals().isEmpty());
+    }
+
+    @Test
+    void nonAsciiCaseInsensitiveLiteralFallsBackToRegex() {
+        var dottedCapitalI = Character.toString(0x0130);
+
+        assertTrue(
+                RegexLiteralSet.fromContainsPattern(Pattern.compile("(?i).*?\\Q" + dottedCapitalI + "ndex\\E.*?"), null)
+                        .isEmpty());
+    }
+
+    @Test
+    void substringFilterBuildsPrecomputedAsciiMatcher() {
+        var search = RegexLiteralSet.fromContainsPattern(Pattern.compile("(?i).*?\\Qmethod1\\E.*?"), "method1")
+                .orElseThrow();
+
+        assertTrue(search.caseInsensitive());
+        assertEquals(List.of("method1"), search.literals());
+        assertEquals(1, search.caseInsensitiveLiterals().size());
+        assertTrue(search.caseInsensitiveLiterals().getFirst().containedIn("A.METHOD1"));
+    }
+}


### PR DESCRIPTION
### Summary
- Precompute folded ASCII literals for analyzer definition searches so case-insensitive literal matching avoids repeated lowercase work per candidate.
- Keep the existing regex fallback for non-ASCII names and unsupported patterns.
- Add focused tests for `AsciiUtil` fast paths and `RegexLiteralSet` literal recognition.

**Key Changes**
- `AsciiUtil` now uses a folded-literal helper with early exits for empty and overlong needles, plus a first-character precheck before full region comparison.
- `RegexLiteralSet` now stores precomputed case-insensitive literal matchers and only builds them for ASCII-safe literal patterns.
- `TreeSitterAnalyzer` uses the precomputed matchers on the hot literal-search path.

**Touch Points**
- `brokk-shared/src/main/java/ai/brokk/util/AsciiUtil.java`
- `brokk-shared/src/main/java/ai/brokk/util/RegexLiteralSet.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java`
- `brokk-shared/src/test/java/ai/brokk/util/AsciiUtilTest.java`
- `brokk-shared/src/test/java/ai/brokk/util/RegexLiteralSetTest.java`

### Testing
- Added unit coverage for ASCII contains behavior, precomputed literal matching, and Unicode fallback handling.
- Local validation passed with targeted analyzer/util tests, `./gradlew fix tidy`, and `./gradlew analyze`.