### PR TITLE
Optimize static-analysis seed selection with bounded file sampling

### DIFF
--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
@@ -210,9 +211,8 @@ public final class StaticAnalysisLeadExpansionService {
     private Map<ProjectFile, Integer> textUsageCountByFile(
             IAnalyzer analyzer, CodeUnit symbol, long deadline, PathCache pathCache) throws InterruptedException {
         var counts = new LinkedHashMap<ProjectFile, Integer>();
-        var files = sourceFiles(analyzer).stream()
+        var files = limitedSourceFiles(analyzer, MAX_USAGE_CANDIDATE_FILES, pathCache).stream()
                 .sorted(Comparator.comparing(pathCache::externalPath))
-                .limit(MAX_USAGE_CANDIDATE_FILES)
                 .toList();
         for (var file : files) {
             if (timedOut(deadline) || Thread.currentThread().isInterrupted()) {
@@ -251,6 +251,28 @@ public final class StaticAnalysisLeadExpansionService {
             count++;
             fromIndex = index + needle.length();
         }
+    }
+
+    private List<ProjectFile> limitedSourceFiles(IAnalyzer analyzer, long limit, PathCache pathCache) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        record PathFile(String path, ProjectFile file) {}
+        var selected = new PriorityQueue<PathFile>(
+                Comparator.<PathFile, String>comparing(PathFile::path).reversed());
+        for (var file : sourceFiles(analyzer)) {
+            var pathFile = new PathFile(pathCache.externalPath(file), file);
+            if (selected.size() < limit) {
+                selected.add(pathFile);
+            } else if (pathFile.path().compareTo(selected.peek().path()) < 0) {
+                selected.poll();
+                selected.add(pathFile);
+            }
+        }
+        return selected.stream()
+                .sorted(Comparator.comparing(PathFile::path))
+                .map(PathFile::file)
+                .toList();
     }
 
     private Set<ProjectFile> sourceFiles(IAnalyzer analyzer) {

--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java
@@ -13,6 +13,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -203,10 +204,14 @@ public final class StaticAnalysisSeedService {
             IAnalyzer analyzer,
             StaticAnalysisRequestFacts facts) {
         if (timedOut(deadline)) return true;
-        var files = sourceFiles(analyzer).stream()
-                .sorted(Comparator.comparing(pathCache::externalPath))
-                .limit(Math.max(request.targetSeedCount() * 4L, request.targetSeedCount()))
-                .toList();
+        var files =
+                limitedSourceFiles(
+                                analyzer,
+                                Math.max(request.targetSeedCount() * 4L, request.targetSeedCount()),
+                                pathCache)
+                        .stream()
+                        .sorted(Comparator.comparing(pathCache::externalPath))
+                        .toList();
         for (var file : files) {
             if (timedOut(deadline)) return true;
             var maxComplexity = facts.maxCyclomaticComplexity(file);
@@ -317,9 +322,8 @@ public final class StaticAnalysisSeedService {
         var needed = request.targetSeedCount() - candidates.size();
         if (needed <= 0) return false;
         var capped = timedOut(deadline);
-        var files = sourceFiles(contextManager.getAnalyzer()).stream()
+        var files = limitedSourceFiles(contextManager.getAnalyzer(), needed, pathCache).stream()
                 .sorted(Comparator.comparing(pathCache::externalPath))
-                .limit(needed)
                 .toList();
         var rank = 1;
         for (var file : files) {
@@ -329,6 +333,28 @@ public final class StaticAnalysisSeedService {
             rank++;
         }
         return capped || timedOut(deadline);
+    }
+
+    private List<ProjectFile> limitedSourceFiles(IAnalyzer analyzer, long limit, PathCache pathCache) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        record PathFile(String path, ProjectFile file) {}
+        var selected = new PriorityQueue<PathFile>(
+                Comparator.<PathFile, String>comparing(PathFile::path).reversed());
+        for (var file : sourceFiles(analyzer)) {
+            var pathFile = new PathFile(pathCache.externalPath(file), file);
+            if (selected.size() < limit) {
+                selected.add(pathFile);
+            } else if (pathFile.path().compareTo(selected.peek().path()) < 0) {
+                selected.poll();
+                selected.add(pathFile);
+            }
+        }
+        return selected.stream()
+                .sorted(Comparator.comparing(PathFile::path))
+                .map(PathFile::file)
+                .toList();
     }
 
     private Set<ProjectFile> sourceFiles(IAnalyzer analyzer) {

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
@@ -4,19 +4,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.brokk.analyzer.CapabilityProvider;
 import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.CodeUnitType;
+import ai.brokk.analyzer.ImportAnalysisProvider;
 import ai.brokk.analyzer.Languages;
 import ai.brokk.analyzer.ProjectFile;
+import ai.brokk.analyzer.TypeHierarchyProvider;
 import ai.brokk.testutil.TestAnalyzer;
 import ai.brokk.testutil.TestConsoleIO;
 import ai.brokk.testutil.TestContextManager;
 import ai.brokk.testutil.TestProject;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -185,6 +191,44 @@ class StaticAnalysisLeadExpansionServiceTest {
     }
 
     @Test
+    void expandLeads_textFallbackCapsCandidateFilesWithDeterministicBoundedSelection(@TempDir Path root)
+            throws Exception {
+        var target = javaFile(root, "src/main/java/z/Target.java", "package z; public class Target {}");
+        var user = javaFile(root, "src/main/java/z/User.java", "package z; class User { Target target; }");
+        var files = new ArrayList<ProjectFile>();
+        files.add(target);
+        files.add(user);
+        for (int i = 0; i < 248; i++) {
+            files.add(javaFile(
+                    root, "src/main/java/z/Filler%03d.java".formatted(i), "package z; class Filler%d {}".formatted(i)));
+        }
+        var lexicallyEarlierOutsideCap =
+                javaFile(root, "src/main/java/a/Outside.java", "package a; class Outside { Target target; }");
+        files.add(lexicallyEarlierOutsideCap);
+        var analyzer = new FallbackOrderedFilesAnalyzer(files);
+        analyzer.addDeclaration(new CodeUnit(target, CodeUnitType.CLASS, "z", "Target", null, false));
+        var service = service(root, analyzer);
+
+        var response = service.expandLeads(new StaticAnalysisSeedDtos.NormalizedLeadExpansionRequest(
+                "scan-1",
+                List.of("src/main/java/z/Target.java"),
+                List.of("src/main/java/z/Target.java"),
+                5,
+                15_000,
+                false));
+
+        assertEquals(
+                "completed",
+                response.state(),
+                response.events().getLast().outcome().message());
+        assertEquals(
+                List.of("src/main/java/a/Outside.java"),
+                response.seeds().stream()
+                        .map(StaticAnalysisSeedDtos.SeedRecord::file)
+                        .toList());
+    }
+
+    @Test
     void literalOccurrenceCount_countsAdjacentRepeatedMatches() {
         assertEquals(2, StaticAnalysisLeadExpansionService.literalOccurrenceCount("TargetTarget", "Target"));
     }
@@ -267,6 +311,27 @@ class StaticAnalysisLeadExpansionServiceTest {
 
         private int directChildrenCalls(CodeUnit cu) {
             return directChildrenCalls.getOrDefault(cu, 0);
+        }
+    }
+
+    private static final class FallbackOrderedFilesAnalyzer extends TestAnalyzer {
+        private final List<ProjectFile> files;
+
+        private FallbackOrderedFilesAnalyzer(List<ProjectFile> files) {
+            this.files = List.copyOf(files);
+        }
+
+        @Override
+        public Set<ProjectFile> getAnalyzedFiles() {
+            return new LinkedHashSet<>(files);
+        }
+
+        @Override
+        public <T extends CapabilityProvider> Optional<T> as(Class<T> capability) {
+            if (capability == TypeHierarchyProvider.class || capability == ImportAnalysisProvider.class) {
+                throw new RuntimeException("force fallback");
+            }
+            return super.as(capability);
         }
     }
 }

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java
@@ -16,6 +16,7 @@ import ai.brokk.testutil.TestProject;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,6 +136,48 @@ class StaticAnalysisSeedServiceTest {
     }
 
     @Test
+    void fetchSeeds_capsWeightedSampleWithDeterministicBoundedSelection(@TempDir Path root) throws Exception {
+        var first = javaFile(root, "src/main/java/z/First.java", "class First {}");
+        var lexicallyEarlier = javaFile(root, "src/main/java/a/Later.java", "class Later {}");
+        var analyzer = new OrderedFilesAnalyzer(List.of(first, lexicallyEarlier));
+        analyzer.addDeclaration(new CodeUnit(first, CodeUnitType.CLASS, "z", "First", null, false));
+        analyzer.addDeclaration(new CodeUnit(lexicallyEarlier, CodeUnitType.CLASS, "a", "Later", null, false));
+        var service = service(root, analyzer);
+
+        var response = service.fetchSeeds(new StaticAnalysisSeedDtos.NormalizedRequest("scan-1", 1, 15_000, false));
+
+        assertEquals("completed", response.state());
+        assertEquals(1, response.seeds().size());
+        assertEquals("src/main/java/a/Later.java", response.seeds().getFirst().file());
+        assertEquals("weighted_sample", response.seeds().getFirst().selection().kind());
+    }
+
+    @Test
+    void fetchSeeds_capsSizeComplexityCandidatesWithDeterministicBoundedSelection(@TempDir Path root) throws Exception {
+        var first = javaFile(root, "src/main/java/z/First.java", "class First {}");
+        var second = javaFile(root, "src/main/java/z/Second.java", "class Second {}");
+        var third = javaFile(root, "src/main/java/z/Third.java", "class Third {}");
+        var fourth = javaFile(root, "src/main/java/z/Fourth.java", "class Fourth {}");
+        var lexicallyEarlier = javaFile(root, "src/main/java/a/Complex.java", "class Complex { void run() {} }");
+        var analyzer = new OrderedFilesAnalyzer(List.of(first, second, third, fourth, lexicallyEarlier));
+        analyzer.addDeclaration(new CodeUnit(first, CodeUnitType.CLASS, "z", "First", null, false));
+        analyzer.addDeclaration(new CodeUnit(second, CodeUnitType.CLASS, "z", "Second", null, false));
+        analyzer.addDeclaration(new CodeUnit(third, CodeUnitType.CLASS, "z", "Third", null, false));
+        analyzer.addDeclaration(new CodeUnit(fourth, CodeUnitType.CLASS, "z", "Fourth", null, false));
+        var complexMethod = new CodeUnit(lexicallyEarlier, CodeUnitType.FUNCTION, "a.Complex", "run", "()", false);
+        analyzer.addDeclaration(complexMethod);
+        analyzer.setComplexity(complexMethod, 50);
+        var service = service(root, analyzer);
+
+        var response = service.fetchSeeds(new StaticAnalysisSeedDtos.NormalizedRequest("scan-1", 1, 15_000, false));
+
+        assertEquals("completed", response.state());
+        assertEquals(1, response.seeds().size());
+        assertEquals("src/main/java/a/Complex.java", response.seeds().getFirst().file());
+        assertEquals("size_complexity", response.seeds().getFirst().selection().kind());
+    }
+
+    @Test
     void fetchSeeds_usesProjectSourceFilesWhenAnalyzerHasNoIndexedFiles(@TempDir Path root) throws Exception {
         javaFile(root, "src/main/java/Unindexed.java", "class Unindexed {}");
         var service = service(root, new TestAnalyzer());
@@ -200,6 +243,19 @@ class StaticAnalysisSeedServiceTest {
 
         private int directChildrenCalls(CodeUnit cu) {
             return directChildrenCalls.getOrDefault(cu, 0);
+        }
+    }
+
+    private static final class OrderedFilesAnalyzer extends TestAnalyzer {
+        private final List<ProjectFile> files;
+
+        private OrderedFilesAnalyzer(List<ProjectFile> files) {
+            this.files = List.copyOf(files);
+        }
+
+        @Override
+        public Set<ProjectFile> getAnalyzedFiles() {
+            return new LinkedHashSet<>(files);
         }
     }
 }


### PR DESCRIPTION
### Summary
- Avoid full source-file sorting in static-analysis seed selection and lead expansion.
- Use deterministic bounded top-k selection by path before sorting the smaller candidate set.
- Add regression coverage for capped selection in both seed generation and lead expansion fallback paths.

**Key Changes**:
- Replaced `Set.stream().limit(...)` sampling with a bounded heap so selection stays deterministic without sorting the entire project.
- Updated static-analysis tests to verify cap behavior and deterministic file choice under large input sets.

**Touch Points**:
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java`
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java`
- `app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java`
- `app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java`

### Testing
- Focused static-analysis unit tests passed.
- `fix tidy` passed.
- `analyze` passed.