### PR TITLE
Cache CodeUnit hash codes to remove allocation from analyzer hot paths

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/CodeUnit.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/CodeUnit.java
@@ -29,6 +29,8 @@ public class CodeUnit implements Comparable<CodeUnit> {
 
     private final transient String fqName;
 
+    private final transient int hashCode;
+
     @JsonCreator
     public CodeUnit(
             @JsonProperty("source") ProjectFile source,
@@ -47,6 +49,7 @@ public class CodeUnit implements Comparable<CodeUnit> {
         this.signature = signature;
         this.synthetic = synthetic;
         this.fqName = packageName.isEmpty() ? shortName : packageName + "." + shortName;
+        this.hashCode = computeHashCode();
     }
 
     public CodeUnit(
@@ -246,8 +249,17 @@ public class CodeUnit implements Comparable<CodeUnit> {
 
     @Override
     public int hashCode() {
-        // Hash code based on the derived fully qualified name, kind, source file, signature AND synthetic flag
-        return Objects.hash(kind, fqName(), source, signature, synthetic);
+        return hashCode;
+    }
+
+    private int computeHashCode() {
+        // CodeUnit is a hot map/set key in analyzer paths; keep hashCode() cached and allocation-free.
+        int result = kind.hashCode();
+        result = 31 * result + fqName.hashCode();
+        result = 31 * result + Objects.hashCode(source);
+        result = 31 * result + Objects.hashCode(signature);
+        result = 31 * result + Boolean.hashCode(synthetic);
+        return result;
     }
 
     @Override

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/CodeUnitTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/CodeUnitTest.java
@@ -1,0 +1,68 @@
+package ai.brokk.analyzer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CodeUnitTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void equalCodeUnitsHaveEqualHashCodes() {
+        var source = new ProjectFile(tempDir, "src/Foo.java");
+        var first = new CodeUnit(source, CodeUnitType.FUNCTION, "com.example", "Foo.bar", "(int)", false);
+        var second = new CodeUnit(source, CodeUnitType.FUNCTION, "com.example", "Foo.bar", "(int)", false);
+
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+
+    @Test
+    void signatureIsPartOfIdentity() {
+        var source = new ProjectFile(tempDir, "src/Foo.java");
+        var first = new CodeUnit(source, CodeUnitType.FUNCTION, "com.example", "Foo.bar", "(int)", false);
+        var second = new CodeUnit(source, CodeUnitType.FUNCTION, "com.example", "Foo.bar", "(String)", false);
+
+        assertNotEquals(first, second);
+    }
+
+    @Test
+    void nullSignatureIsDistinctFromPresentSignature() {
+        var source = new ProjectFile(tempDir, "src/Foo.java");
+        var withoutSignature = new CodeUnit(source, CodeUnitType.FUNCTION, "com.example", "Foo.bar", null, false);
+        var withSignature = new CodeUnit(source, CodeUnitType.FUNCTION, "com.example", "Foo.bar", "(int)", false);
+
+        assertNotEquals(withoutSignature, withSignature);
+    }
+
+    @Test
+    void syntheticFlagIsPartOfIdentity() {
+        var source = new ProjectFile(tempDir, "src/Foo.java");
+        var real = new CodeUnit(source, CodeUnitType.FUNCTION, "com.example", "Foo.bar", "(int)", false);
+        var synthetic = new CodeUnit(source, CodeUnitType.FUNCTION, "com.example", "Foo.bar", "(int)", true);
+
+        assertNotEquals(real, synthetic);
+    }
+
+    @Test
+    void sourceIsPartOfIdentity() {
+        var firstSource = new ProjectFile(tempDir, "src/Foo.java");
+        var secondSource = new ProjectFile(tempDir, "src/OtherFoo.java");
+        var first = new CodeUnit(firstSource, CodeUnitType.CLASS, "com.example", "Foo", null, false);
+        var second = new CodeUnit(secondSource, CodeUnitType.CLASS, "com.example", "Foo", null, false);
+
+        assertNotEquals(first, second);
+    }
+
+    @Test
+    void hashCodeAllowsNullSource() {
+        var codeUnit = new CodeUnit(null, CodeUnitType.CLASS, "java.util", "List", null, false);
+
+        assertDoesNotThrow(codeUnit::hashCode);
+    }
+}


### PR DESCRIPTION
### Summary
- Cache `CodeUnit.hashCode()` in a transient field so repeated map/set lookups avoid `Objects.hash(...)` varargs allocation.
- Keep identity semantics unchanged across `kind`, `fqName`, `source`, `signature`, and `synthetic`.
- Add focused tests covering equality, overload/signature identity, synthetic identity, and null-source safety.

### Testing
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.CodeUnitTest`
- `./gradlew :brokk-shared:test`
- `./gradlew fix tidy`
- `./gradlew analyze`