### PR TITLE
Bound static-analysis request facts with Caffeine caches

### DIFF
--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
@@ -11,7 +11,6 @@ import ai.brokk.analyzer.usages.UsageFinder;
 import ai.brokk.util.PathNormalizer;
 import java.nio.file.Files;
 import java.time.Duration;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -68,6 +67,7 @@ public final class StaticAnalysisLeadExpansionService {
         var capped = false;
         try {
             var analyzer = contextManager.getAnalyzer();
+            var facts = new StaticAnalysisRequestFacts(analyzer);
             var finder = new UsageFinder(
                     contextManager.getProject(),
                     analyzer,
@@ -86,7 +86,7 @@ public final class StaticAnalysisLeadExpansionService {
                 if (!sourceFile.exists()) {
                     continue;
                 }
-                var symbols = declarations(analyzer, sourceFile).stream()
+                var symbols = facts.declarations(sourceFile).stream()
                         .filter(cu -> !cu.fqName().isBlank())
                         .sorted(Comparator.comparing(CodeUnit::fqName))
                         .limit(MAX_SYMBOLS_PER_FILE)
@@ -193,17 +193,6 @@ public final class StaticAnalysisLeadExpansionService {
             return new StaticAnalysisSeedDtos.Response(
                     request.scanId(), StaticAnalysisSeedDtos.PHASE_STATIC_SEED, "failed", List.of(), List.of(), events);
         }
-    }
-
-    private static List<CodeUnit> declarations(IAnalyzer analyzer, ProjectFile file) {
-        var result = new ArrayList<CodeUnit>();
-        var work = new ArrayDeque<>(analyzer.getTopLevelDeclarations(file));
-        while (!work.isEmpty()) {
-            var next = work.removeFirst();
-            result.add(next);
-            work.addAll(analyzer.getDirectChildren(next));
-        }
-        return result;
     }
 
     private static Map<ProjectFile, Integer> usageCountByFile(FuzzyResult result) {

--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisRequestFacts.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisRequestFacts.java
@@ -1,0 +1,61 @@
+package ai.brokk.executor.staticanalysis;
+
+import ai.brokk.analyzer.CodeUnit;
+import ai.brokk.analyzer.IAnalyzer;
+import ai.brokk.analyzer.ProjectFile;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+final class StaticAnalysisRequestFacts {
+    private static final Logger logger = LogManager.getLogger(StaticAnalysisRequestFacts.class);
+    private static final long MAX_FILES = 10_000;
+
+    private final IAnalyzer analyzer;
+    private final Cache<ProjectFile, List<CodeUnit>> declarationsByFile =
+            Caffeine.newBuilder().maximumSize(MAX_FILES).build();
+    private final Cache<ProjectFile, Integer> maxCyclomaticComplexityByFile =
+            Caffeine.newBuilder().maximumSize(MAX_FILES).build();
+
+    StaticAnalysisRequestFacts(IAnalyzer analyzer) {
+        this.analyzer = analyzer;
+    }
+
+    List<CodeUnit> declarations(ProjectFile file) {
+        return declarationsByFile.get(file, this::computeDeclarations);
+    }
+
+    int maxCyclomaticComplexity(ProjectFile file) {
+        return maxCyclomaticComplexityByFile.get(file, this::computeMaxCyclomaticComplexity);
+    }
+
+    private List<CodeUnit> computeDeclarations(ProjectFile file) {
+        var result = new ArrayList<CodeUnit>();
+        var work = new ArrayDeque<>(analyzer.getTopLevelDeclarations(file));
+        while (!work.isEmpty()) {
+            var next = work.removeFirst();
+            result.add(next);
+            work.addAll(analyzer.getDirectChildren(next));
+        }
+        return List.copyOf(result);
+    }
+
+    private int computeMaxCyclomaticComplexity(ProjectFile file) {
+        try {
+            return declarations(file).stream()
+                    .filter(CodeUnit::isFunction)
+                    .mapToInt(analyzer::computeCyclomaticComplexity)
+                    .max()
+                    .orElse(0);
+        } catch (Exception e) {
+            logger.debug("Unable to compute max cyclomatic complexity for {}", file, e);
+            return 0;
+        }
+    }
+}

--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java
@@ -1,7 +1,6 @@
 package ai.brokk.executor.staticanalysis;
 
 import ai.brokk.IAppContextManager;
-import ai.brokk.analyzer.CodeUnit;
 import ai.brokk.analyzer.IAnalyzer;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.git.GitHotspotAnalyzer;
@@ -61,9 +60,11 @@ public final class StaticAnalysisSeedService {
         var capped = false;
 
         try {
+            var analyzer = contextManager.getAnalyzer();
+            var facts = new StaticAnalysisRequestFacts(analyzer);
             capped |= addWeightedSampleSeeds(request, candidates, deadline, pathCache);
             capped |= addGitHotspots(request, candidates, deadline, pathCache);
-            capped |= addSizeComplexitySeeds(request, candidates, deadline, pathCache);
+            capped |= addSizeComplexitySeeds(request, candidates, deadline, pathCache, analyzer, facts);
             capped |= addUsageExpansionSeeds(request, candidates, deadline, pathCache);
 
             var seeds = candidates.values().stream()
@@ -198,16 +199,17 @@ public final class StaticAnalysisSeedService {
             StaticAnalysisSeedDtos.NormalizedRequest request,
             Map<String, Candidate> candidates,
             long deadline,
-            PathCache pathCache) {
+            PathCache pathCache,
+            IAnalyzer analyzer,
+            StaticAnalysisRequestFacts facts) {
         if (timedOut(deadline)) return true;
-        IAnalyzer analyzer = contextManager.getAnalyzer();
         var files = sourceFiles(analyzer).stream()
                 .sorted(Comparator.comparing(pathCache::externalPath))
                 .limit(Math.max(request.targetSeedCount() * 4L, request.targetSeedCount()))
                 .toList();
         for (var file : files) {
             if (timedOut(deadline)) return true;
-            var maxComplexity = maxCyclomaticComplexity(analyzer, file);
+            var maxComplexity = facts.maxCyclomaticComplexity(file);
             var sizeBytes = file.size().orElse(0L);
             if (maxComplexity < COMPLEXITY_SIGNAL_THRESHOLD && sizeBytes < LARGE_FILE_BYTES_THRESHOLD) continue;
 
@@ -338,28 +340,6 @@ public final class StaticAnalysisSeedService {
         return project.getAnalyzerLanguages().stream()
                 .flatMap(language -> project.getAnalyzableFiles(language).stream())
                 .collect(Collectors.toSet());
-    }
-
-    private static int maxCyclomaticComplexity(IAnalyzer analyzer, ProjectFile file) {
-        try {
-            return analyzer.getTopLevelDeclarations(file).stream()
-                    .flatMap(cu -> flatten(analyzer, cu).stream())
-                    .filter(CodeUnit::isFunction)
-                    .mapToInt(analyzer::computeCyclomaticComplexity)
-                    .max()
-                    .orElse(0);
-        } catch (Exception e) {
-            return 0;
-        }
-    }
-
-    private static List<CodeUnit> flatten(IAnalyzer analyzer, CodeUnit root) {
-        var result = new ArrayList<CodeUnit>();
-        result.add(root);
-        for (var child : analyzer.getDirectChildren(root)) {
-            result.addAll(flatten(analyzer, child));
-        }
-        return result;
     }
 
     private Candidate candidate(

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
@@ -14,7 +14,9 @@ import ai.brokk.testutil.TestContextManager;
 import ai.brokk.testutil.TestProject;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -198,6 +200,34 @@ class StaticAnalysisLeadExpansionServiceTest {
         assertEquals(0, StaticAnalysisLeadExpansionService.literalOccurrenceCount("Target", ""));
     }
 
+    @Test
+    void expandLeads_reusesCachedDeclarationTraversalForDuplicateFrontierFile(@TempDir Path root) throws Exception {
+        var target = javaFile(root, "src/main/java/p/Target.java", "package p; public class Target {}");
+        javaFile(root, "src/main/java/p/User.java", "package p; class User { Target target; }");
+        var targetClass = new CodeUnit(target, CodeUnitType.CLASS, "p", "Target", null, false);
+        var targetMethod = new CodeUnit(target, CodeUnitType.FUNCTION, "p.Target", "run", "()", false);
+        var analyzer = new CountingAnalyzer();
+        analyzer.addDeclaration(targetClass);
+        analyzer.setDirectChildren(targetClass, List.of(targetMethod));
+        var service = service(root, analyzer);
+
+        var response = service.expandLeads(new StaticAnalysisSeedDtos.NormalizedLeadExpansionRequest(
+                "scan-1",
+                List.of("src/main/java/p/Target.java"),
+                List.of("src/main/java/p/Target.java", "src/main/java/p/Target.java"),
+                5,
+                15_000,
+                false));
+
+        assertEquals(
+                "completed",
+                response.state(),
+                response.events().getLast().outcome().message());
+        assertFalse(response.seeds().isEmpty());
+        assertEquals(1, analyzer.topLevelDeclarationCalls(target));
+        assertEquals(1, analyzer.directChildrenCalls(targetClass));
+    }
+
     private static StaticAnalysisLeadExpansionService service(Path root, TestAnalyzer analyzer) {
         return new StaticAnalysisLeadExpansionService(
                 new TestContextManager(new TestProject(root, Languages.JAVA), new TestConsoleIO(), Set.of(), analyzer));
@@ -208,5 +238,35 @@ class StaticAnalysisLeadExpansionServiceTest {
         Files.createDirectories(file.absPath().getParent());
         Files.writeString(file.absPath(), source);
         return file;
+    }
+
+    private static final class CountingAnalyzer extends TestAnalyzer {
+        private final Map<ProjectFile, Integer> topLevelDeclarationCalls = new HashMap<>();
+        private final Map<CodeUnit, Integer> directChildrenCalls = new HashMap<>();
+        private final Map<CodeUnit, List<CodeUnit>> directChildren = new HashMap<>();
+
+        @Override
+        public List<CodeUnit> getTopLevelDeclarations(ProjectFile file) {
+            topLevelDeclarationCalls.merge(file, 1, Integer::sum);
+            return super.getTopLevelDeclarations(file);
+        }
+
+        @Override
+        public List<CodeUnit> getDirectChildren(CodeUnit cu) {
+            directChildrenCalls.merge(cu, 1, Integer::sum);
+            return directChildren.getOrDefault(cu, List.of());
+        }
+
+        private void setDirectChildren(CodeUnit cu, List<CodeUnit> children) {
+            directChildren.put(cu, List.copyOf(children));
+        }
+
+        private int topLevelDeclarationCalls(ProjectFile file) {
+            return topLevelDeclarationCalls.getOrDefault(file, 0);
+        }
+
+        private int directChildrenCalls(CodeUnit cu) {
+            return directChildrenCalls.getOrDefault(cu, 0);
+        }
     }
 }

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java
@@ -15,7 +15,9 @@ import ai.brokk.testutil.TestContextManager;
 import ai.brokk.testutil.TestProject;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -114,6 +116,25 @@ class StaticAnalysisSeedServiceTest {
     }
 
     @Test
+    void fetchSeeds_reusesCachedDeclarationTraversalForComplexity(@TempDir Path root) throws Exception {
+        var file = javaFile(root, "src/main/java/Complex.java", "class Complex { void run() {} }");
+        var clazz = new CodeUnit(file, CodeUnitType.CLASS, "", "Complex", null, false);
+        var method = new CodeUnit(file, CodeUnitType.FUNCTION, "Complex", "run", "()", false);
+        var analyzer = new CountingAnalyzer();
+        analyzer.addDeclaration(clazz);
+        analyzer.setDirectChildren(clazz, List.of(method));
+        analyzer.setComplexity(method, 22);
+        var service = service(root, analyzer);
+
+        var response = service.fetchSeeds(new StaticAnalysisSeedDtos.NormalizedRequest("scan-1", 5, 15_000, false));
+
+        assertEquals("completed", response.state());
+        assertEquals("size_complexity", response.seeds().getFirst().selection().kind());
+        assertEquals(1, analyzer.topLevelDeclarationCalls(file));
+        assertEquals(1, analyzer.directChildrenCalls(clazz));
+    }
+
+    @Test
     void fetchSeeds_usesProjectSourceFilesWhenAnalyzerHasNoIndexedFiles(@TempDir Path root) throws Exception {
         javaFile(root, "src/main/java/Unindexed.java", "class Unindexed {}");
         var service = service(root, new TestAnalyzer());
@@ -150,5 +171,35 @@ class StaticAnalysisSeedServiceTest {
         Files.createDirectories(file.absPath().getParent());
         Files.writeString(file.absPath(), source);
         return file;
+    }
+
+    private static final class CountingAnalyzer extends TestAnalyzer {
+        private final Map<ProjectFile, Integer> topLevelDeclarationCalls = new HashMap<>();
+        private final Map<CodeUnit, Integer> directChildrenCalls = new HashMap<>();
+        private final Map<CodeUnit, List<CodeUnit>> directChildren = new HashMap<>();
+
+        @Override
+        public List<CodeUnit> getTopLevelDeclarations(ProjectFile file) {
+            topLevelDeclarationCalls.merge(file, 1, Integer::sum);
+            return super.getTopLevelDeclarations(file);
+        }
+
+        @Override
+        public List<CodeUnit> getDirectChildren(CodeUnit cu) {
+            directChildrenCalls.merge(cu, 1, Integer::sum);
+            return directChildren.getOrDefault(cu, List.of());
+        }
+
+        private void setDirectChildren(CodeUnit cu, List<CodeUnit> children) {
+            directChildren.put(cu, List.copyOf(children));
+        }
+
+        private int topLevelDeclarationCalls(ProjectFile file) {
+            return topLevelDeclarationCalls.getOrDefault(file, 0);
+        }
+
+        private int directChildrenCalls(CodeUnit cu) {
+            return directChildrenCalls.getOrDefault(cu, 0);
+        }
     }
 }


### PR DESCRIPTION
### Summary
- Add a request-scoped helper for static-analysis facts so declaration traversal and max cyclomatic complexity are reused within a single request.
- Bound the memoization with Caffeine to avoid unbounded caching while preserving existing seed and lead-expansion behavior.
- Add regression tests that verify repeated same-file traversal is reused during seed selection and lead expansion.

### Key Changes
- Introduced `StaticAnalysisRequestFacts` with bounded per-request caches for declarations and max complexity.
- Rewired static-analysis seed generation and lead expansion to use the shared helper instead of re-traversing the same file trees.
- Added focused counting-analyzer tests for request-local reuse and kept the existing response behavior unchanged.

### Touch Points
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisRequestFacts.java`
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedService.java`
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java`
- `app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisSeedServiceTest.java`
- `app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java`

### Testing
- `./gradlew :app:test --tests ai.brokk.executor.staticanalysis.StaticAnalysisSeedServiceTest --tests ai.brokk.executor.staticanalysis.StaticAnalysisLeadExpansionServiceTest`
- `./gradlew fix tidy`
- `./gradlew analyze`