### PR TITLE
Prune structural clone comparisons and cache shingle counts

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -4874,8 +4874,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 .filter(cu -> isRelevantFile(cu.source()))
                 .map(cu -> buildCloneCandidateData(cu, resolved))
                 .flatMap(Optional::stream)
-                .map(candidate -> new CloneCandidateProfile(
-                        candidate, hashedShingleArray(candidate.normalizedTokens(), resolved.shingleSize())))
+                .map(candidate -> CloneCandidateProfile.create(candidate, resolved))
                 .toList();
         if (allCandidates.isEmpty()) {
             return List.of();
@@ -4896,6 +4895,9 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                     continue;
                 }
                 if (requestedFiles.contains(rightData.unit().source()) && compareCloneUnits(leftData, rightData) > 0) {
+                    continue;
+                }
+                if (!canReachCloneSimilarity(left, right, resolved)) {
                     continue;
                 }
                 int tokenSimilarity = computeCloneTokenSimilarity(left.shingles(), right.shingles(), resolved);
@@ -4978,13 +4980,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
     static int computeCloneTokenSimilarity(
             LongShingles leftShingles, LongShingles rightShingles, CloneSmellWeights weights) {
-        if (leftShingles.size() < weights.minSharedShingles() || rightShingles.size() < weights.minSharedShingles()) {
-            return 0;
-        }
-        int smallerSize = Math.min(leftShingles.size(), rightShingles.size());
-        int largerSize = Math.max(leftShingles.size(), rightShingles.size());
-        int maxPossibleSimilarity = (int) Math.round((smallerSize * 100.0) / largerSize);
-        if (maxPossibleSimilarity < weights.minSimilarityPercent()) {
+        if (!canReachCloneSimilarity(leftShingles.size(), rightShingles.size(), weights)) {
             return 0;
         }
         int intersectionSize = intersectionSize(leftShingles, rightShingles);
@@ -5005,6 +5001,29 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
             return fileComparison;
         }
         return left.unit().fqName().compareTo(right.unit().fqName());
+    }
+
+    private static boolean canReachCloneSimilarity(
+            CloneCandidateProfile left, CloneCandidateProfile right, CloneSmellWeights weights) {
+        if (!canReachCloneSimilarity(left.shingleCount(), right.shingleCount(), weights)) {
+            return false;
+        }
+        return canReachRoundedSimilarity(left.normalizedTokenCount(), right.normalizedTokenCount(), weights);
+    }
+
+    static boolean canReachCloneSimilarity(int leftShingleCount, int rightShingleCount, CloneSmellWeights weights) {
+        if (leftShingleCount < weights.minSharedShingles() || rightShingleCount < weights.minSharedShingles()) {
+            return false;
+        }
+        return canReachRoundedSimilarity(leftShingleCount, rightShingleCount, weights);
+    }
+
+    private static boolean canReachRoundedSimilarity(int leftCount, int rightCount, CloneSmellWeights weights) {
+        int smallerCount = Math.min(leftCount, rightCount);
+        int largerCount = Math.max(leftCount, rightCount);
+        assert largerCount > 0;
+        int maxPossibleSimilarity = (int) Math.round((smallerCount * 100.0) / largerCount);
+        return maxPossibleSimilarity >= weights.minSimilarityPercent();
     }
 
     private static int intersectionSize(LongShingles left, LongShingles right) {
@@ -5276,7 +5295,15 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         }
     }
 
-    private record CloneCandidateProfile(CloneCandidateData data, LongShingles shingles) {}
+    private record CloneCandidateProfile(
+            CloneCandidateData data, LongShingles shingles, int normalizedTokenCount, int shingleCount) {
+
+        private static CloneCandidateProfile create(CloneCandidateData data, CloneSmellWeights weights) {
+            LongShingles shingles = hashedShingleArray(data.normalizedTokens(), weights.shingleSize());
+            return new CloneCandidateProfile(
+                    data, shingles, data.normalizedTokens().size(), shingles.size());
+        }
+    }
 
     /**
      * Extracts potential type identifiers from source code.

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -5005,10 +5005,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
     private static boolean canReachCloneSimilarity(
             CloneCandidateProfile left, CloneCandidateProfile right, CloneSmellWeights weights) {
-        if (!canReachCloneSimilarity(left.shingleCount(), right.shingleCount(), weights)) {
-            return false;
-        }
-        return canReachRoundedSimilarity(left.normalizedTokenCount(), right.normalizedTokenCount(), weights);
+        return canReachCloneSimilarity(left.shingleCount(), right.shingleCount(), weights);
     }
 
     static boolean canReachCloneSimilarity(int leftShingleCount, int rightShingleCount, CloneSmellWeights weights) {
@@ -5295,13 +5292,11 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         }
     }
 
-    private record CloneCandidateProfile(
-            CloneCandidateData data, LongShingles shingles, int normalizedTokenCount, int shingleCount) {
+    private record CloneCandidateProfile(CloneCandidateData data, LongShingles shingles, int shingleCount) {
 
         private static CloneCandidateProfile create(CloneCandidateData data, CloneSmellWeights weights) {
             LongShingles shingles = hashedShingleArray(data.normalizedTokens(), weights.shingleSize());
-            return new CloneCandidateProfile(
-                    data, shingles, data.normalizedTokens().size(), shingles.size());
+            return new CloneCandidateProfile(data, shingles, shingles.size());
         }
     }
 

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java
@@ -94,6 +94,21 @@ class TreeSitterCloneSimilarityTest {
     }
 
     @Test
+    void candidatePrefilterStaysConservativeForRepetitiveTokenStreams() {
+        var left = repeatedTokens("A", "B", "C", 50);
+        var right = repeatedTokens("A", "B", "C", 100);
+        var weights = new IAnalyzer.CloneSmellWeights(1, 70, 2, 1, 70);
+        var leftShingles = TreeSitterAnalyzer.hashedShingles(left, weights.shingleSize());
+        var rightShingles = TreeSitterAnalyzer.hashedShingles(right, weights.shingleSize());
+
+        assertTrue(TreeSitterAnalyzer.canReachCloneSimilarity(
+                leftShingles.size(), rightShingles.size(), weights));
+        assertEquals(
+                100,
+                TreeSitterAnalyzer.computeCloneTokenSimilarity(leftShingles, rightShingles, weights));
+    }
+
+    @Test
     @Tag("benchmark")
     void computeCloneTokenSimilarity_RealisticPrimitiveShingleCardinalityBenchmark() {
         var left = TreeSitterAnalyzer.LongShingles.from(overlappingShingles(8_000, 0), 8_000);
@@ -162,5 +177,15 @@ class TreeSitterCloneSimilarityTest {
             shingles[i] = i + offset;
         }
         return shingles;
+    }
+
+    private static List<String> repeatedTokens(String first, String second, String third, int repetitions) {
+        var tokens = new java.util.ArrayList<String>(repetitions * 3);
+        for (int i = 0; i < repetitions; i++) {
+            tokens.add(first);
+            tokens.add(second);
+            tokens.add(third);
+        }
+        return List.copyOf(tokens);
     }
 }

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java
@@ -101,11 +101,8 @@ class TreeSitterCloneSimilarityTest {
         var leftShingles = TreeSitterAnalyzer.hashedShingles(left, weights.shingleSize());
         var rightShingles = TreeSitterAnalyzer.hashedShingles(right, weights.shingleSize());
 
-        assertTrue(TreeSitterAnalyzer.canReachCloneSimilarity(
-                leftShingles.size(), rightShingles.size(), weights));
-        assertEquals(
-                100,
-                TreeSitterAnalyzer.computeCloneTokenSimilarity(leftShingles, rightShingles, weights));
+        assertTrue(TreeSitterAnalyzer.canReachCloneSimilarity(leftShingles.size(), rightShingles.size(), weights));
+        assertEquals(100, TreeSitterAnalyzer.computeCloneTokenSimilarity(leftShingles, rightShingles, weights));
     }
 
     @Test

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java
@@ -1,6 +1,8 @@
 package ai.brokk.analyzer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -68,6 +70,27 @@ class TreeSitterCloneSimilarityTest {
         var weights = new IAnalyzer.CloneSmellWeights(1, 70, 1, 1, 70);
 
         assertEquals(70, TreeSitterAnalyzer.computeCloneTokenSimilarity(left, right, weights));
+    }
+
+    @Test
+    void candidatePrefilterRejectsPairsBelowMinSharedShingles() {
+        var weights = new IAnalyzer.CloneSmellWeights(1, 50, 1, 3, 70);
+
+        assertFalse(TreeSitterAnalyzer.canReachCloneSimilarity(2, 5, weights));
+    }
+
+    @Test
+    void candidatePrefilterRejectsPairsWhoseRoundedUpperBoundMissesThreshold() {
+        var weights = new IAnalyzer.CloneSmellWeights(1, 71, 1, 1, 70);
+
+        assertFalse(TreeSitterAnalyzer.canReachCloneSimilarity(699, 1000, weights));
+    }
+
+    @Test
+    void candidatePrefilterKeepsPairsAtRoundedUpperBoundThreshold() {
+        var weights = new IAnalyzer.CloneSmellWeights(1, 70, 1, 1, 70);
+
+        assertTrue(TreeSitterAnalyzer.canReachCloneSimilarity(699, 1000, weights));
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Prune structural clone candidate pairs earlier using cached shingle counts so `findStructuralCloneSmells` does less pairwise work.
- Keep similarity scoring exact while preserving conservative bounds, and add regression coverage for the pruning path and repetitive-token clone cases.

**Key Changes**:
- Added a `CloneCandidateProfile` factory that caches shingle metadata once per candidate.
- Introduced a conservative prefilter before exact intersection scoring in `TreeSitterAnalyzer`.
- Expanded clone-similarity tests to cover rounded upper bounds, shared-shingle thresholds, and repetitive token streams.

**Touch Points**:
- `brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java`
- `brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterCloneSimilarityTest.java`

### Testing
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.TreeSitterCloneSimilarityTest --tests ai.brokk.analyzer.code_quality.JavaCloneDetectionSmellTest`
- `./gradlew analyze` (started, but no final completion output was confirmed in this turn)