### PR TITLE
Reduce repeated sorting in analyzer and lead expansion

### DIFF
--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
@@ -250,8 +250,8 @@ public final class StaticAnalysisLeadExpansionService {
             return List.of();
         }
         record IndexedCodeUnit(int index, CodeUnit codeUnit) {}
-        var selected = new TreeSet<IndexedCodeUnit>(Comparator.comparing((IndexedCodeUnit indexed) ->
-                        indexed.codeUnit().fqName())
+        var selected = new TreeSet<IndexedCodeUnit>(Comparator.comparing(
+                        (IndexedCodeUnit indexed) -> indexed.codeUnit().fqName())
                 .thenComparingInt(IndexedCodeUnit::index));
         for (int index = 0; index < declarations.size(); index++) {
             var declaration = declarations.get(index);

--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
@@ -245,24 +245,25 @@ public final class StaticAnalysisLeadExpansionService {
         }
     }
 
-    private static List<CodeUnit> firstAlphabeticalSymbols(List<CodeUnit> declarations, int limit) {
+    static List<CodeUnit> firstAlphabeticalSymbols(List<CodeUnit> declarations, int limit) {
         if (limit <= 0) {
             return List.of();
         }
-        var selected = new TreeSet<CodeUnit>(Comparator.comparing(CodeUnit::fqName)
-                .thenComparing(cu -> cu.source().toString())
-                .thenComparing(cu -> cu.signature() == null ? "" : cu.signature())
-                .thenComparing(cu -> cu.kind().name()));
-        for (var declaration : declarations) {
+        record IndexedCodeUnit(int index, CodeUnit codeUnit) {}
+        var selected = new TreeSet<IndexedCodeUnit>(Comparator.comparing((IndexedCodeUnit indexed) ->
+                        indexed.codeUnit().fqName())
+                .thenComparingInt(IndexedCodeUnit::index));
+        for (int index = 0; index < declarations.size(); index++) {
+            var declaration = declarations.get(index);
             if (declaration.fqName().isBlank()) {
                 continue;
             }
-            selected.add(declaration);
+            selected.add(new IndexedCodeUnit(index, declaration));
             if (selected.size() > limit) {
                 selected.pollLast();
             }
         }
-        return List.copyOf(selected);
+        return selected.stream().map(IndexedCodeUnit::codeUnit).toList();
     }
 
     private static List<Candidate> topCandidates(Iterable<Candidate> candidates, int limit, PathCache pathCache) {

--- a/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
+++ b/app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 
@@ -87,11 +88,7 @@ public final class StaticAnalysisLeadExpansionService {
                 if (!sourceFile.exists()) {
                     continue;
                 }
-                var symbols = facts.declarations(sourceFile).stream()
-                        .filter(cu -> !cu.fqName().isBlank())
-                        .sorted(Comparator.comparing(CodeUnit::fqName))
-                        .limit(MAX_SYMBOLS_PER_FILE)
-                        .toList();
+                var symbols = firstAlphabeticalSymbols(facts.declarations(sourceFile), MAX_SYMBOLS_PER_FILE);
                 var symbolCount = 0;
                 for (var symbol : symbols) {
                     if (timedOut(deadline)) {
@@ -135,12 +132,7 @@ public final class StaticAnalysisLeadExpansionService {
 
             var ranked = new ArrayList<StaticAnalysisSeedDtos.SeedRecord>();
             var rank = 1;
-            for (var candidate : candidates.values().stream()
-                    .sorted(Comparator.comparingDouble(Candidate::score)
-                            .reversed()
-                            .thenComparing(candidate -> pathCache.externalPath(candidate.file)))
-                    .limit(request.maxResults())
-                    .toList()) {
+            for (var candidate : topCandidates(candidates.values(), request.maxResults(), pathCache)) {
                 ranked.add(candidate.toRecord(analyzer, rank++, pathCache.externalPath(candidate.file)));
             }
 
@@ -251,6 +243,52 @@ public final class StaticAnalysisLeadExpansionService {
             count++;
             fromIndex = index + needle.length();
         }
+    }
+
+    private static List<CodeUnit> firstAlphabeticalSymbols(List<CodeUnit> declarations, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        var selected = new TreeSet<CodeUnit>(Comparator.comparing(CodeUnit::fqName)
+                .thenComparing(cu -> cu.source().toString())
+                .thenComparing(cu -> cu.signature() == null ? "" : cu.signature())
+                .thenComparing(cu -> cu.kind().name()));
+        for (var declaration : declarations) {
+            if (declaration.fqName().isBlank()) {
+                continue;
+            }
+            selected.add(declaration);
+            if (selected.size() > limit) {
+                selected.pollLast();
+            }
+        }
+        return List.copyOf(selected);
+    }
+
+    private static List<Candidate> topCandidates(Iterable<Candidate> candidates, int limit, PathCache pathCache) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        record RankedCandidate(Candidate candidate, double score, String filePath) {}
+        var byRank = Comparator.comparingDouble(RankedCandidate::score)
+                .thenComparing(RankedCandidate::filePath, Comparator.reverseOrder());
+        var selected = new PriorityQueue<RankedCandidate>(byRank);
+        for (var candidate : candidates) {
+            var rankedCandidate =
+                    new RankedCandidate(candidate, candidate.score(), pathCache.externalPath(candidate.file));
+            if (selected.size() < limit) {
+                selected.add(rankedCandidate);
+            } else if (byRank.compare(rankedCandidate, selected.peek()) > 0) {
+                selected.poll();
+                selected.add(rankedCandidate);
+            }
+        }
+        return selected.stream()
+                .sorted(Comparator.comparingDouble(RankedCandidate::score)
+                        .reversed()
+                        .thenComparing(RankedCandidate::filePath))
+                .map(RankedCandidate::candidate)
+                .toList();
     }
 
     private List<ProjectFile> limitedSourceFiles(IAnalyzer analyzer, long limit, PathCache pathCache) {

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
@@ -339,6 +339,23 @@ class StaticAnalysisLeadExpansionServiceTest {
                         .toList());
     }
 
+    @Test
+    void expandLeads_preservesStableOrderWhenSameFqNameExceedsCap(@TempDir Path root) throws Exception {
+        var target = javaFile(root, "src/main/java/p/Target.java", "package p; class Target {}");
+        var declarations = new ArrayList<CodeUnit>();
+        for (int i = 0; i < 8; i++) {
+            declarations.add(new CodeUnit(target, CodeUnitType.FUNCTION, "p", "run", "(z%d)".formatted(i), false));
+        }
+        var lexicallyEarlierLateDeclaration = new CodeUnit(target, CodeUnitType.FUNCTION, "p", "run", "(a)", false);
+        declarations.add(lexicallyEarlierLateDeclaration);
+
+        var selected = StaticAnalysisLeadExpansionService.firstAlphabeticalSymbols(declarations, 8);
+
+        assertEquals(8, selected.size());
+        assertEquals(declarations.subList(0, 8), selected);
+        assertFalse(selected.contains(lexicallyEarlierLateDeclaration));
+    }
+
     private static StaticAnalysisLeadExpansionService service(Path root, TestAnalyzer analyzer) {
         return new StaticAnalysisLeadExpansionService(
                 new TestContextManager(new TestProject(root, Languages.JAVA), new TestConsoleIO(), Set.of(), analyzer));

--- a/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
+++ b/app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java
@@ -272,6 +272,73 @@ class StaticAnalysisLeadExpansionServiceTest {
         assertEquals(1, analyzer.directChildrenCalls(targetClass));
     }
 
+    @Test
+    void expandLeads_limitsSymbolsWithoutSortingEveryDeclaration(@TempDir Path root) throws Exception {
+        var target = javaFile(root, "src/main/java/p/Target.java", "package p; public class Target {}");
+        javaFile(root, "src/main/java/p/User.java", "package p; class User { A00 target; }");
+        var analyzer = new CountingAnalyzer();
+        analyzer.addDeclaration(new CodeUnit(target, CodeUnitType.CLASS, "p", "Target", null, false));
+        analyzer.addDeclaration(new CodeUnit(target, CodeUnitType.CLASS, "p", "A00", null, false));
+        for (int i = 0; i < 16; i++) {
+            analyzer.addDeclaration(new CodeUnit(target, CodeUnitType.CLASS, "p", "Z%02d".formatted(i), null, false));
+        }
+        var service = service(root, analyzer);
+
+        var response = service.expandLeads(new StaticAnalysisSeedDtos.NormalizedLeadExpansionRequest(
+                "scan-1",
+                List.of("src/main/java/p/Target.java"),
+                List.of("src/main/java/p/Target.java"),
+                5,
+                15_000,
+                false));
+
+        assertEquals(
+                "completed",
+                response.state(),
+                response.events().getLast().outcome().message());
+        assertEquals(
+                List.of("src/main/java/p/User.java"),
+                response.seeds().stream()
+                        .map(StaticAnalysisSeedDtos.SeedRecord::file)
+                        .toList());
+    }
+
+    @Test
+    void expandLeads_preservesDistinctDeclarationsWithSameFqName(@TempDir Path root) throws Exception {
+        var target = javaFile(root, "src/main/java/p/Target.java", "package p; public class Target {}");
+        javaFile(
+                root,
+                "src/main/java/p/User.java",
+                "package p; class User { int x = Target.run(1) + Target.run(2, 3); }");
+        var analyzer = new CountingAnalyzer();
+        var targetClass = new CodeUnit(target, CodeUnitType.CLASS, "p", "Target", null, false);
+        analyzer.addDeclaration(targetClass);
+        analyzer.setDirectChildren(
+                targetClass,
+                List.of(
+                        new CodeUnit(target, CodeUnitType.FUNCTION, "p.Target", "run", "(int)", false),
+                        new CodeUnit(target, CodeUnitType.FUNCTION, "p.Target", "run", "(int,int)", false)));
+        var service = service(root, analyzer);
+
+        var response = service.expandLeads(new StaticAnalysisSeedDtos.NormalizedLeadExpansionRequest(
+                "scan-1",
+                List.of("src/main/java/p/Target.java"),
+                List.of("src/main/java/p/Target.java"),
+                5,
+                15_000,
+                false));
+
+        assertEquals(
+                "completed",
+                response.state(),
+                response.events().getLast().outcome().message());
+        assertEquals(
+                List.of("src/main/java/p/User.java"),
+                response.seeds().stream()
+                        .map(StaticAnalysisSeedDtos.SeedRecord::file)
+                        .toList());
+    }
+
     private static StaticAnalysisLeadExpansionService service(Path root, TestAnalyzer analyzer) {
         return new StaticAnalysisLeadExpansionService(
                 new TestContextManager(new TestProject(root, Languages.JAVA), new TestConsoleIO(), Set.of(), analyzer));

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -4920,19 +4920,40 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                         rightData.excerpt()));
             }
         }
-        return findings.stream()
-                .sorted(Comparator.comparingInt(CloneSmell::score)
+        var sortedFindings = findings.stream()
+                .map(SortableCloneSmell::new)
+                .sorted(Comparator.comparingInt(SortableCloneSmell::score)
                         .reversed()
-                        .thenComparing(f -> f.file().toString())
-                        .thenComparing(CloneSmell::enclosingFqName)
-                        .thenComparing(f -> f.peerFile().toString())
-                        .thenComparing(CloneSmell::peerEnclosingFqName))
+                        .thenComparing(SortableCloneSmell::filePath)
+                        .thenComparing(SortableCloneSmell::enclosingFqName)
+                        .thenComparing(SortableCloneSmell::peerFilePath)
+                        .thenComparing(SortableCloneSmell::peerEnclosingFqName))
+                .map(SortableCloneSmell::finding)
                 .toList();
+        return List.copyOf(sortedFindings);
     }
 
     protected int refineCloneSimilarityPercent(
             CloneCandidateData left, CloneCandidateData right, int tokenSimilarity, CloneSmellWeights weights) {
         return tokenSimilarity;
+    }
+
+    private record SortableCloneSmell(
+            CloneSmell finding,
+            int score,
+            String filePath,
+            String enclosingFqName,
+            String peerFilePath,
+            String peerEnclosingFqName) {
+        private SortableCloneSmell(CloneSmell finding) {
+            this(
+                    finding,
+                    finding.score(),
+                    finding.file().toString(),
+                    finding.enclosingFqName(),
+                    finding.peerFile().toString(),
+                    finding.peerEnclosingFqName());
+        }
     }
 
     protected Optional<CloneCandidateData> buildCloneCandidateData(CodeUnit cu, CloneSmellWeights weights) {

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/AbstractCloneDetectionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/AbstractCloneDetectionSmellTest.java
@@ -31,4 +31,24 @@ abstract class AbstractCloneDetectionSmellTest {
             return analyzer.findStructuralCloneSmells(List.of(fileA, fileB), weights);
         }
     }
+
+    protected List<IAnalyzer.CloneSmell> analyzeThreeRequested(
+            String pathA,
+            String sourceA,
+            String pathB,
+            String sourceB,
+            String pathC,
+            String sourceC,
+            IAnalyzer.CloneSmellWeights weights) {
+        try (var built = InlineCoreProject.code(sourceA, pathA)
+                .addFile(sourceB, pathB)
+                .addFile(sourceC, pathC)
+                .build()) {
+            IAnalyzer analyzer = built.analyzer();
+            ProjectFile fileA = new ProjectFile(built.root(), pathA);
+            ProjectFile fileB = new ProjectFile(built.root(), pathB);
+            ProjectFile fileC = new ProjectFile(built.root(), pathC);
+            return analyzer.findStructuralCloneSmells(List.of(fileA, fileB, fileC), weights);
+        }
+    }
 }

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/JavaCloneDetectionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/JavaCloneDetectionSmellTest.java
@@ -308,6 +308,10 @@ public class JavaCloneDetectionSmellTest extends AbstractCloneDetectionSmellTest
                         "com/example/Alpha.java->com/example/Beta.java",
                         "com/example/Alpha.java->com/example/Gamma.java",
                         "com/example/Beta.java->com/example/Gamma.java"),
-                findings.stream().map(f -> f.file() + "->" + f.peerFile()).toList());
+                findings.stream()
+                        .map(f -> f.file().toString().replace('\\', '/')
+                                + "->"
+                                + f.peerFile().toString().replace('\\', '/'))
+                        .toList());
     }
 }

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/JavaCloneDetectionSmellTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/JavaCloneDetectionSmellTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.analyzer.IAnalyzer;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class JavaCloneDetectionSmellTest extends AbstractCloneDetectionSmellTest {
@@ -249,5 +250,64 @@ public class JavaCloneDetectionSmellTest extends AbstractCloneDetectionSmellTest
                 .count();
 
         assertEquals(1, forwardCount + reverseCount);
+    }
+
+    @Test
+    void ordersCloneFindingsDeterministicallyAcrossFilesAndPeers() {
+        String alpha =
+                """
+                package com.example;
+                class Alpha {
+                    int same(int input) {
+                        int total = input + 1;
+                        if (total > 10) {
+                            return total * 2;
+                        }
+                        return total - 3;
+                    }
+                }
+                """;
+        String beta =
+                """
+                package com.example;
+                class Beta {
+                    int same(int seed) {
+                        int amount = seed + 1;
+                        if (amount > 10) {
+                            return amount * 2;
+                        }
+                        return amount - 3;
+                    }
+                }
+                """;
+        String gamma =
+                """
+                package com.example;
+                class Gamma {
+                    int same(int seed) {
+                        int value = seed + 1;
+                        if (value > 10) {
+                            return value * 2;
+                        }
+                        return value - 3;
+                    }
+                }
+                """;
+
+        var findings = analyzeThreeRequested(
+                "com/example/Gamma.java",
+                gamma,
+                "com/example/Beta.java",
+                beta,
+                "com/example/Alpha.java",
+                alpha,
+                IAnalyzer.CloneSmellWeights.defaults());
+
+        assertEquals(
+                List.of(
+                        "com/example/Alpha.java->com/example/Beta.java",
+                        "com/example/Alpha.java->com/example/Gamma.java",
+                        "com/example/Beta.java->com/example/Gamma.java"),
+                findings.stream().map(f -> f.file() + "->" + f.peerFile()).toList());
     }
 }


### PR DESCRIPTION
### Summary
- Cache clone-smell sort keys before the final deterministic sort to reduce repeated string extraction in hot paths.
- Replace full-sort-plus-limit lead expansion with bounded deterministic selection to cut avoidable work while preserving ordering.
- Add regression coverage for stable ordering and capped symbol selection behavior.

**Key Changes**:
- `TreeSitterAnalyzer` now precomputes file and FQ name sort keys once per clone finding before ordering the results.
- `StaticAnalysisLeadExpansionService` uses bounded selection for symbols and ranked candidates, with tests covering deterministic output and same-`fqName` edge cases.

**Touch Points**:
- `app/src/main/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionService.java`
- `app/src/test/java/ai/brokk/executor/staticanalysis/StaticAnalysisLeadExpansionServiceTest.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java`
- `brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/AbstractCloneDetectionSmellTest.java`
- `brokk-shared/src/test/java/ai/brokk/analyzer/code_quality/JavaCloneDetectionSmellTest.java`

### Testing
- `./gradlew fix`
- `./gradlew tidy`
- `./gradlew :app:test --tests ai.brokk.executor.staticanalysis.StaticAnalysisLeadExpansionServiceTest`
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.code_quality.JavaCloneDetectionSmellTest`
- `./gradlew analyze`