### PR TITLE
Performance: cache search metadata in TreeSitterAnalyzer

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -493,9 +493,17 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         }
     }
 
+    record SearchNameMetadata(String fqName, String lowerCaseFqName, boolean ascii) {
+        static SearchNameMetadata from(CodeUnit codeUnit) {
+            String fqName = codeUnit.fqName();
+            return new SearchNameMetadata(fqName, fqName.toLowerCase(Locale.ROOT), AsciiUtil.isAscii(fqName));
+        }
+    }
+
     public record AnalyzerState(
             PMap<String, Set<CodeUnit>> symbolIndex,
             PMap<CodeUnit, CodeUnitProperties> codeUnitState,
+            PMap<CodeUnit, SearchNameMetadata> searchNameState,
             PMap<ProjectFile, FileProperties> fileState,
             SymbolKeyIndex symbolKeyIndex,
             PMap<ProjectFile, List<TemplateAnalysisResult>> templateResults,
@@ -506,8 +514,49 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 PMap<CodeUnit, CodeUnitProperties> codeUnitState,
                 PMap<ProjectFile, FileProperties> fileState,
                 SymbolKeyIndex symbolKeyIndex,
+                PMap<ProjectFile, List<TemplateAnalysisResult>> templateResults,
                 long snapshotEpochNanos) {
-            this(symbolIndex, codeUnitState, fileState, symbolKeyIndex, HashTreePMap.empty(), snapshotEpochNanos);
+            this(
+                    symbolIndex,
+                    codeUnitState,
+                    buildSearchNameState(codeUnitState),
+                    fileState,
+                    symbolKeyIndex,
+                    templateResults,
+                    snapshotEpochNanos);
+        }
+
+        public AnalyzerState(
+                PMap<String, Set<CodeUnit>> symbolIndex,
+                PMap<CodeUnit, CodeUnitProperties> codeUnitState,
+                PMap<CodeUnit, SearchNameMetadata> searchNameState,
+                PMap<ProjectFile, FileProperties> fileState,
+                SymbolKeyIndex symbolKeyIndex,
+                long snapshotEpochNanos) {
+            this(
+                    symbolIndex,
+                    codeUnitState,
+                    searchNameState,
+                    fileState,
+                    symbolKeyIndex,
+                    HashTreePMap.empty(),
+                    snapshotEpochNanos);
+        }
+
+        public AnalyzerState(
+                PMap<String, Set<CodeUnit>> symbolIndex,
+                PMap<CodeUnit, CodeUnitProperties> codeUnitState,
+                PMap<ProjectFile, FileProperties> fileState,
+                SymbolKeyIndex symbolKeyIndex,
+                long snapshotEpochNanos) {
+            this(
+                    symbolIndex,
+                    codeUnitState,
+                    buildSearchNameState(codeUnitState),
+                    fileState,
+                    symbolKeyIndex,
+                    HashTreePMap.empty(),
+                    snapshotEpochNanos);
         }
     }
 
@@ -836,6 +885,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         this.state = new AnalyzerState(
                 HashTreePMap.from(immutableSymbolIndex),
                 HashTreePMap.from(localCodeUnitState),
+                buildSearchNameState(localCodeUnitState),
                 HashTreePMap.from(localFileState),
                 symbolKeyIndex,
                 HashTreePMap.empty(),
@@ -922,6 +972,17 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     protected <R> R withCodeUnitProperties(Function<Map<CodeUnit, CodeUnitProperties>, R> function) {
         var current = this.state;
         return function.apply(current.codeUnitState());
+    }
+
+    private SearchNameMetadata searchNameMetadata(CodeUnit codeUnit) {
+        return Objects.requireNonNull(this.state.searchNameState().get(codeUnit));
+    }
+
+    private static PMap<CodeUnit, SearchNameMetadata> buildSearchNameState(
+            Map<CodeUnit, CodeUnitProperties> codeUnitState) {
+        var searchNameState = new HashMap<CodeUnit, SearchNameMetadata>();
+        codeUnitState.keySet().forEach(codeUnit -> searchNameState.put(codeUnit, SearchNameMetadata.from(codeUnit)));
+        return HashTreePMap.from(searchNameState);
     }
 
     /**
@@ -1034,6 +1095,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         var snapshot = new AnalyzerState(
                 HashTreePMap.from(symbolIndex),
                 HashTreePMap.from(analysisResult.codeUnitState()),
+                buildSearchNameState(analysisResult.codeUnitState()),
                 HashTreePMap.from(Map.of(file, fileState)),
                 new SymbolKeyIndex(Collections.unmodifiableNavigableSet(keySet)),
                 System.nanoTime());
@@ -1398,10 +1460,15 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         var threadLocalMatcher = ThreadLocal.withInitial(() -> compiledPattern.matcher(""));
         return this.state.codeUnitState.keySet().parallelStream()
                 .filter(cu -> !cu.isSynthetic())
-                .filter(cu -> substringFilter == null
-                        || cu.fqName().toLowerCase(Locale.ROOT).contains(substringFilter))
-                .filter(cu -> threadLocalMatcher.get().reset(cu.fqName()).find())
-                .filter(cu -> !isAnonymousStructure(cu.fqName()))
+                .filter(cu -> {
+                    var metadata = searchNameMetadata(cu);
+                    return substringFilter == null || metadata.lowerCaseFqName().contains(substringFilter);
+                })
+                .filter(cu -> threadLocalMatcher
+                        .get()
+                        .reset(searchNameMetadata(cu).fqName())
+                        .find())
+                .filter(cu -> !isAnonymousStructure(searchNameMetadata(cu).fqName()))
                 .collect(Collectors.toSet());
     }
 
@@ -1411,16 +1478,18 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         return this.state.codeUnitState.keySet().parallelStream()
                 .filter(cu -> !cu.isSynthetic())
                 .filter(cu -> {
-                    String fqName = cu.fqName();
+                    var metadata = searchNameMetadata(cu);
+                    String fqName = metadata.fqName();
                     if (!search.caseInsensitive()) {
                         return literals.stream().anyMatch(fqName::contains);
                     }
-                    if (!AsciiUtil.isAscii(fqName)) {
+                    if (!metadata.ascii()) {
                         return compiledPattern.matcher(fqName).find();
                     }
-                    return caseInsensitiveLiterals.stream().anyMatch(literal -> literal.containedIn(fqName));
+                    return caseInsensitiveLiterals.stream()
+                            .anyMatch(literal -> metadata.lowerCaseFqName().contains(literal.foldedLiteral()));
                 })
-                .filter(cu -> !isAnonymousStructure(cu.fqName()))
+                .filter(cu -> !isAnonymousStructure(searchNameMetadata(cu).fqName()))
                 .collect(Collectors.toSet());
     }
 
@@ -4179,6 +4248,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         var typedState = new AnalyzerState(
                 HashTreePMap.from(immutableNextSymbolIndex),
                 HashTreePMap.from(newCodeUnitState),
+                buildSearchNameState(newCodeUnitState),
                 HashTreePMap.from(newFileState),
                 nextSymbolKeyIndex,
                 HashTreePMap.empty(),

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -234,6 +234,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
     private volatile boolean isStale = false;
     private final AtomicBoolean staleWarningLogged = new AtomicBoolean(false);
+    private volatile @Nullable Map<CodeUnit, SearchNameMetadata> searchNameMetadataCache;
 
     protected void checkStale(String methodName) {
         if (this.isStale && staleWarningLogged.compareAndSet(false, true)) {
@@ -503,7 +504,6 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     public record AnalyzerState(
             PMap<String, Set<CodeUnit>> symbolIndex,
             PMap<CodeUnit, CodeUnitProperties> codeUnitState,
-            PMap<CodeUnit, SearchNameMetadata> searchNameState,
             PMap<ProjectFile, FileProperties> fileState,
             SymbolKeyIndex symbolKeyIndex,
             PMap<ProjectFile, List<TemplateAnalysisResult>> templateResults,
@@ -514,49 +514,8 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                 PMap<CodeUnit, CodeUnitProperties> codeUnitState,
                 PMap<ProjectFile, FileProperties> fileState,
                 SymbolKeyIndex symbolKeyIndex,
-                PMap<ProjectFile, List<TemplateAnalysisResult>> templateResults,
                 long snapshotEpochNanos) {
-            this(
-                    symbolIndex,
-                    codeUnitState,
-                    buildSearchNameState(codeUnitState),
-                    fileState,
-                    symbolKeyIndex,
-                    templateResults,
-                    snapshotEpochNanos);
-        }
-
-        public AnalyzerState(
-                PMap<String, Set<CodeUnit>> symbolIndex,
-                PMap<CodeUnit, CodeUnitProperties> codeUnitState,
-                PMap<CodeUnit, SearchNameMetadata> searchNameState,
-                PMap<ProjectFile, FileProperties> fileState,
-                SymbolKeyIndex symbolKeyIndex,
-                long snapshotEpochNanos) {
-            this(
-                    symbolIndex,
-                    codeUnitState,
-                    searchNameState,
-                    fileState,
-                    symbolKeyIndex,
-                    HashTreePMap.empty(),
-                    snapshotEpochNanos);
-        }
-
-        public AnalyzerState(
-                PMap<String, Set<CodeUnit>> symbolIndex,
-                PMap<CodeUnit, CodeUnitProperties> codeUnitState,
-                PMap<ProjectFile, FileProperties> fileState,
-                SymbolKeyIndex symbolKeyIndex,
-                long snapshotEpochNanos) {
-            this(
-                    symbolIndex,
-                    codeUnitState,
-                    buildSearchNameState(codeUnitState),
-                    fileState,
-                    symbolKeyIndex,
-                    HashTreePMap.empty(),
-                    snapshotEpochNanos);
+            this(symbolIndex, codeUnitState, fileState, symbolKeyIndex, HashTreePMap.empty(), snapshotEpochNanos);
         }
     }
 
@@ -885,7 +844,6 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         this.state = new AnalyzerState(
                 HashTreePMap.from(immutableSymbolIndex),
                 HashTreePMap.from(localCodeUnitState),
-                buildSearchNameState(localCodeUnitState),
                 HashTreePMap.from(localFileState),
                 symbolKeyIndex,
                 HashTreePMap.empty(),
@@ -975,14 +933,28 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     }
 
     private SearchNameMetadata searchNameMetadata(CodeUnit codeUnit) {
-        return Objects.requireNonNull(this.state.searchNameState().get(codeUnit));
+        return Objects.requireNonNull(searchNameMetadataCache().get(codeUnit));
     }
 
-    private static PMap<CodeUnit, SearchNameMetadata> buildSearchNameState(
+    private Map<CodeUnit, SearchNameMetadata> searchNameMetadataCache() {
+        var existing = searchNameMetadataCache;
+        if (existing != null) {
+            return existing;
+        }
+
+        synchronized (this) {
+            if (searchNameMetadataCache == null) {
+                searchNameMetadataCache = buildSearchNameState(this.state.codeUnitState());
+            }
+            return searchNameMetadataCache;
+        }
+    }
+
+    private static Map<CodeUnit, SearchNameMetadata> buildSearchNameState(
             Map<CodeUnit, CodeUnitProperties> codeUnitState) {
         var searchNameState = new HashMap<CodeUnit, SearchNameMetadata>();
         codeUnitState.keySet().forEach(codeUnit -> searchNameState.put(codeUnit, SearchNameMetadata.from(codeUnit)));
-        return HashTreePMap.from(searchNameState);
+        return Map.copyOf(searchNameState);
     }
 
     /**
@@ -1095,7 +1067,6 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         var snapshot = new AnalyzerState(
                 HashTreePMap.from(symbolIndex),
                 HashTreePMap.from(analysisResult.codeUnitState()),
-                buildSearchNameState(analysisResult.codeUnitState()),
                 HashTreePMap.from(Map.of(file, fileState)),
                 new SymbolKeyIndex(Collections.unmodifiableNavigableSet(keySet)),
                 System.nanoTime());
@@ -4248,7 +4219,6 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         var typedState = new AnalyzerState(
                 HashTreePMap.from(immutableNextSymbolIndex),
                 HashTreePMap.from(newCodeUnitState),
-                buildSearchNameState(newCodeUnitState),
                 HashTreePMap.from(newFileState),
                 nextSymbolKeyIndex,
                 HashTreePMap.empty(),

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerTest.java
@@ -157,25 +157,6 @@ public class MultiAnalyzerTest {
     }
 
     @Test
-    public void testSnapshotStateBackfillsSearchNameMetadata() {
-        var snapshot = multiAnalyzer.snapshotState();
-
-        assertFalse(snapshot.codeUnitState().isEmpty(), "Snapshot should include code units");
-        assertEquals(snapshot.codeUnitState().size(), snapshot.searchNameState().size());
-
-        var classUnit = snapshot.codeUnitState().keySet().stream()
-                .filter(cu -> cu.fqName().equals("TestClass"))
-                .findFirst()
-                .orElseThrow();
-        var metadata = snapshot.searchNameState().get(classUnit);
-
-        assertNotNull(metadata);
-        assertEquals("TestClass", metadata.fqName());
-        assertEquals("testclass", metadata.lowerCaseFqName());
-        assertTrue(metadata.ascii());
-    }
-
-    @Test
     public void testIsTestFile_FallsBackToHeuristicsWhenDelegateLacksCapability() {
         var pythonTestFile = new ProjectFile(tempDir, "test_script.py");
 

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerTest.java
@@ -157,6 +157,25 @@ public class MultiAnalyzerTest {
     }
 
     @Test
+    public void testSnapshotStateBackfillsSearchNameMetadata() {
+        var snapshot = multiAnalyzer.snapshotState();
+
+        assertFalse(snapshot.codeUnitState().isEmpty(), "Snapshot should include code units");
+        assertEquals(snapshot.codeUnitState().size(), snapshot.searchNameState().size());
+
+        var classUnit = snapshot.codeUnitState().keySet().stream()
+                .filter(cu -> cu.fqName().equals("TestClass"))
+                .findFirst()
+                .orElseThrow();
+        var metadata = snapshot.searchNameState().get(classUnit);
+
+        assertNotNull(metadata);
+        assertEquals("TestClass", metadata.fqName());
+        assertEquals("testclass", metadata.lowerCaseFqName());
+        assertTrue(metadata.ascii());
+    }
+
+    @Test
     public void testIsTestFile_FallsBackToHeuristicsWhenDelegateLacksCapability() {
         var pythonTestFile = new ProjectFile(tempDir, "test_script.py");
 


### PR DESCRIPTION
Fixes #3654

Improves `TreeSitterAnalyzer` search performance by caching per-`CodeUnit` search-name metadata for the hot `searchDefinitions` paths, while keeping the cache analyzer-local rather than storing it in `AnalyzerState`.

**Key Changes**:
- add a lazy `SearchNameMetadata` cache for case-insensitive and ASCII-aware search matching in `TreeSitterAnalyzer`
- keep `AnalyzerState` free of derived cache state after guided review, avoiding a second source of truth and eager per-snapshot memory cost
- retain targeted regression coverage through existing analyzer and state-IO test paths

**Touch Points**:
- brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
- brokk-shared/src/test/java/ai/brokk/analyzer/MultiAnalyzerTest.java
