### PR TITLE
brokk-acp-rust: switch Ollama discovery to /v1/models

### DIFF
--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "brokk-acp-rust"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/brokk-acp-rust/Cargo.lock
+++ b/brokk-acp-rust/Cargo.lock
@@ -184,6 +184,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +306,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "webbrowser",
+ "wiremock",
  "zip",
 ]
 
@@ -849,6 +860,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1481,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2000,6 +2036,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4404,6 +4450,29 @@ checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/brokk-acp-rust/Cargo.toml
+++ b/brokk-acp-rust/Cargo.toml
@@ -80,3 +80,8 @@ sha2 = "0.10"
 # marker + AGENTS.md/CLAUDE.md fixtures) without polluting the working
 # directory.
 tempfile = "3"
+# Used by `discovery::tests` to mock the Ollama `/v1/models` HTTP
+# response shape and validate that `discover_ollama` parses it
+# correctly. Without a mock, the existing tests only exercise the
+# connection-refused error path.
+wiremock = "0.6"

--- a/brokk-acp-rust/README.md
+++ b/brokk-acp-rust/README.md
@@ -24,7 +24,7 @@ The server is composed of several specialized modules:
 
 ## Configuration / CLI Options
 
-The server binary is named `brokk-acp`. It is **zero-config by design**: at startup it reads `~/.codex/auth.json` for Codex credentials and probes `http://localhost:11434/api/tags` for Ollama, presenting whatever responds as a single combined picker. Models are tagged on the wire as `codex::<id>` and `ollama::<id>` so identical names from different sources stay distinct.
+The server binary is named `brokk-acp`. It is **zero-config by design**: at startup it reads `~/.codex/auth.json` for Codex credentials and probes `http://localhost:11434/v1/models` for Ollama, presenting whatever responds as a single combined picker. Models are tagged on the wire as `codex::<id>` and `ollama::<id>` so identical names from different sources stay distinct.
 
 There are no flags to point at a different Ollama URL or restrict the picker. If your daemon listens elsewhere, run `ollama serve` on the default port.
 

--- a/brokk-acp-rust/src/agent.rs
+++ b/brokk-acp-rust/src/agent.rs
@@ -654,7 +654,7 @@ pub async fn run_agent(
     let sessions_new = sessions.clone();
     // Throttle background discovery refreshes so a burst of session/new
     // calls (e.g. an editor reconnecting and re-creating sessions) doesn't
-    // pile up redundant probes against /api/tags and /codex/models. We
+    // pile up redundant probes against /v1/models and /codex/models. We
     // hold this owned Mutex via try_lock_owned: when a refresh is already
     // in flight, the next try_lock returns None and we skip the spawn.
     //

--- a/brokk-acp-rust/src/discovery.rs
+++ b/brokk-acp-rust/src/discovery.rs
@@ -1,5 +1,5 @@
 //! Auto-discover available LLM models from Codex (`~/.codex/auth.json`),
-//! a local Ollama daemon (`http://localhost:11434/api/tags`), and
+//! a local Ollama daemon (`http://localhost:11434/v1/models`), and
 //! OpenRouter (`https://openrouter.ai/api/v1/models`, gated on the
 //! `OPENROUTER_API_KEY` env var).
 //!
@@ -97,18 +97,18 @@ pub const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 pub const OPENROUTER_API_KEY_ENV: &str = "OPENROUTER_API_KEY";
 
 // ---------------------------------------------------------------------------
-// Ollama discovery (native /api/tags)
+// Ollama discovery (OpenAI-compatible /v1/models)
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
-struct OllamaTagsResponse {
+struct OpenAiModelsResponse {
     #[serde(default)]
-    models: Vec<OllamaTagEntry>,
+    data: Vec<OpenAiModelEntry>,
 }
 
 #[derive(Debug, Deserialize)]
-struct OllamaTagEntry {
-    name: String,
+struct OpenAiModelEntry {
+    id: String,
 }
 
 /// Build a short-timeout HTTP client tuned for discovery. Ollama is local;
@@ -121,16 +121,17 @@ pub fn discovery_http_client() -> reqwest::Client {
         .expect("failed to build discovery HTTP client")
 }
 
-/// Query Ollama's native `/api/tags` endpoint. Native API, not the
-/// OpenAI-compatible `/v1/models` -- `/api/tags` is the canonical list of
-/// downloaded models and includes tag suffixes (`llama3:latest`) that
-/// `/v1/models` strips.
+/// Query Ollama's OpenAI-compatible `/v1/models` endpoint. Recent Ollama
+/// versions preserve tag suffixes (`llama3:latest`) in the OpenAI shim,
+/// so we use it directly instead of the native `/api/tags`. This also
+/// keeps the parsing identical to any other OpenAI-compatible local
+/// server a user might run on the same port.
 pub async fn discover_ollama(
     http: &reqwest::Client,
     base_url: &str,
 ) -> Result<Vec<DiscoveredModel>> {
     let base = base_url.trim_end_matches('/');
-    let url = format!("{base}/api/tags");
+    let url = format!("{base}/v1/models");
     let resp = http
         .get(&url)
         .send()
@@ -138,14 +139,14 @@ pub async fn discover_ollama(
         .with_context(|| format!("GET {url}"))?;
     let status = resp.status();
     if !status.is_success() {
-        anyhow::bail!("ollama /api/tags returned HTTP {status}");
+        anyhow::bail!("ollama /v1/models returned HTTP {status}");
     }
-    let parsed: OllamaTagsResponse = resp.json().await.context("parsing /api/tags JSON")?;
+    let parsed: OpenAiModelsResponse = resp.json().await.context("parsing /v1/models JSON")?;
     Ok(parsed
-        .models
+        .data
         .into_iter()
         .map(|m| DiscoveredModel {
-            id: m.name,
+            id: m.id,
             source: ModelSource::Ollama,
         })
         .collect())

--- a/brokk-acp-rust/src/discovery.rs
+++ b/brokk-acp-rust/src/discovery.rs
@@ -27,7 +27,6 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
 
 /// Where a discovered model came from. The variant is encoded into the
 /// wire id so the routing backend doesn't need a per-request map lookup.
@@ -100,17 +99,6 @@ pub const OPENROUTER_API_KEY_ENV: &str = "OPENROUTER_API_KEY";
 // Ollama discovery (OpenAI-compatible /v1/models)
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Deserialize)]
-struct OpenAiModelsResponse {
-    #[serde(default)]
-    data: Vec<OpenAiModelEntry>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OpenAiModelEntry {
-    id: String,
-}
-
 /// Build a short-timeout HTTP client tuned for discovery. Ollama is local;
 /// if it's not running we want to fail fast, not block startup for 30s.
 pub fn discovery_http_client() -> reqwest::Client {
@@ -141,7 +129,8 @@ pub async fn discover_ollama(
     if !status.is_success() {
         anyhow::bail!("ollama /v1/models returned HTTP {status}");
     }
-    let parsed: OpenAiModelsResponse = resp.json().await.context("parsing /v1/models JSON")?;
+    let parsed: crate::llm_client::ModelsResponse =
+        resp.json().await.context("parsing /v1/models JSON")?;
     Ok(parsed
         .data
         .into_iter()
@@ -243,6 +232,37 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// `discover_ollama` parses the OpenAI-shape `/v1/models` body and
+    /// preserves tag suffixes (`llama3:latest`) verbatim through to
+    /// `DiscoveredModel.id`. Without this test, the existing
+    /// `discover_all_*` cases only hit the connect-refused error path
+    /// via `TEST_DEAD_OLLAMA_URL`, so the JSON parsing path was never
+    /// exercised.
+    #[tokio::test]
+    async fn discover_ollama_parses_v1_models_shape() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list",
+                "data": [
+                    {"id": "llama3:latest", "object": "model"},
+                    {"id": "qwen3.6:35b-a3b-coding-mxfp8", "object": "model"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let http = discovery_http_client();
+        let models = discover_ollama(&http, &server.uri()).await.expect("ok");
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "llama3:latest");
+        assert_eq!(models[0].source, ModelSource::Ollama);
+        assert_eq!(models[1].id, "qwen3.6:35b-a3b-coding-mxfp8");
+    }
 
     /// `wire_id` round-trips through `split_wire_id` for every source,
     /// preserves Ollama tag suffixes (the inner colon in `llama3:latest`),

--- a/brokk-acp-rust/src/llm_client.rs
+++ b/brokk-acp-rust/src/llm_client.rs
@@ -247,13 +247,14 @@ struct ChatCompletionRequest {
 }
 
 #[derive(Debug, Deserialize)]
-struct ModelEntry {
-    id: String,
+pub(crate) struct ModelEntry {
+    pub(crate) id: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct ModelsResponse {
-    data: Vec<ModelEntry>,
+pub(crate) struct ModelsResponse {
+    #[serde(default)]
+    pub(crate) data: Vec<ModelEntry>,
 }
 
 // SSE chunk types for streaming (extended for tool calls)

--- a/brokk-acp-rust/src/main.rs
+++ b/brokk-acp-rust/src/main.rs
@@ -25,7 +25,7 @@ use crate::multi_backend::MultiBackend;
 
 /// Brokk ACP Server -- Rust-based Agent Client Protocol server with
 /// zero-config auto-discovery: at startup we read `~/.codex/auth.json`
-/// for Codex credentials and probe `http://localhost:11434/api/tags`
+/// for Codex credentials and probe `http://localhost:11434/v1/models`
 /// for Ollama, and the model picker shows whatever is reachable. No
 /// flags are required (or even available) to point at a different
 /// Ollama URL or restrict the picker -- if Ollama isn't on the default
@@ -202,12 +202,12 @@ async fn build_codex_backend() -> Option<Arc<dyn LlmBackend>> {
 /// Build the Ollama chat backend. Always pointed at the default
 /// `http://localhost:11434`; chat requests go through Ollama's
 /// OpenAI-compatible `/v1/chat/completions` shim, while discovery
-/// (handled by `discovery.rs`) hits the native `/api/tags`. Ollama
-/// doesn't require an API key for local use.
+/// (handled by `discovery.rs`) hits the OpenAI-compatible `/v1/models`.
+/// Ollama doesn't require an API key for local use.
 fn build_ollama_backend() -> Arc<dyn LlmBackend> {
     let chat_url = format!("{}/v1", discovery::OLLAMA_DEFAULT_URL);
     tracing::info!(
-        "Ollama backend wired at {chat_url} (chat) and {}/api/tags (discovery); \
+        "Ollama backend wired at {chat_url} (chat) and {}/v1/models (discovery); \
          models become available if/when the daemon responds",
         discovery::OLLAMA_DEFAULT_URL
     );


### PR DESCRIPTION
## Summary
- Switch the Ollama discovery probe from the native `/api/tags` endpoint to the OpenAI-compatible `/v1/models` shim.
- Recent Ollama versions preserve tag suffixes (e.g. `llama3:latest`, `qwen3.6:35b-a3b-coding-mxfp8`) on `/v1/models`, so the original rationale for using `/api/tags` no longer applies.
- Discovery parser now matches the standard OpenAI shape (`{data: [{id}]}`), which also makes the same code path work for any OpenAI-compatible local server a user happens to be running on port 11434.

## Test plan
- [x] `cargo check -p brokk-acp-rust` clean
- [x] `cargo test -p brokk-acp-rust discovery::` -- 5/5 pass
- [ ] Manual smoke: start Ollama with a tagged model, run `brokk-acp` and verify the wire id in the model picker carries the tag suffix