### PR TITLE
Fix build-details inference state handling and add explicit settings endpoint

### DIFF
--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -170,6 +170,9 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
     private final AtomicReference<BuildDetailsInferenceState> buildDetailsInferenceState =
             new AtomicReference<>(BuildDetailsInferenceState.NOT_STARTED);
     private final AtomicReference<@Nullable String> buildDetailsInferenceDiagnostics = new AtomicReference<>();
+    private volatile @Nullable BuildDetailsInferenceResult lastBuildDetailsInferenceResult;
+    private volatile @Nullable Instant lastForcedBuildDetailsInferenceAt;
+    private static final Duration FORCE_BUILD_DETAILS_REINFERENCE_COOLDOWN = Duration.ofMinutes(1);
 
     // Style guide generation completion tracking
     private volatile CompletableFuture<String> styleGuideFuture = CompletableFuture.completedFuture("");
@@ -2063,6 +2066,13 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
                 return buildDetailsInferenceFuture;
             }
 
+            if (force) {
+                var throttled = throttledForcedInferenceResult();
+                if (throttled != null) {
+                    return CompletableFuture.completedFuture(throttled);
+                }
+            }
+
             if (!force) {
                 var completed = completedBuildDetailsResultIfAvailable();
                 if (completed != null) {
@@ -2072,6 +2082,9 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
 
             buildDetailsInferenceState.set(BuildDetailsInferenceState.RUNNING);
             buildDetailsInferenceDiagnostics.set(null);
+            if (force) {
+                lastForcedBuildDetailsInferenceAt = Instant.now();
+            }
             buildDetailsInferenceFuture =
                     submitBackgroundTask("Inferring build details", () -> runBuildDetailsInferenceTask(force));
             return buildDetailsInferenceFuture;
@@ -2080,9 +2093,16 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
 
     private @Nullable BuildDetailsInferenceResult completedBuildDetailsResultIfAvailable() {
         if (project.hasBuildDetails()) {
+            var details = project.awaitBuildDetails();
+            if (BuildDetails.EMPTY.equals(details)) {
+                buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_EMPTY);
+                var diagnostics = emptyBuildDetailsDiagnostics();
+                return new BuildDetailsInferenceResult("empty", details, diagnostics);
+            }
+
             buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_EXISTING);
             buildDetailsInferenceDiagnostics.set(null);
-            return new BuildDetailsInferenceResult("existing", project.awaitBuildDetails(), null);
+            return new BuildDetailsInferenceResult("existing", details, null);
         }
 
         var detailsFuture = project.getBuildDetailsFuture();
@@ -2094,8 +2114,7 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
             var details = detailsFuture.join();
             if (BuildDetails.EMPTY.equals(details)) {
                 buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_EMPTY);
-                var diagnostics = Objects.requireNonNullElse(
-                        buildDetailsInferenceDiagnostics.get(), "No build details have been inferred yet");
+                var diagnostics = emptyBuildDetailsDiagnostics();
                 return new BuildDetailsInferenceResult("empty", details, diagnostics);
             }
 
@@ -2103,10 +2122,8 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
             buildDetailsInferenceDiagnostics.set(null);
             return new BuildDetailsInferenceResult("inferred", details, null);
         } catch (CompletionException e) {
-            return failedBuildDetailsResult(
-                    Objects.requireNonNullElse(
-                            buildDetailsInferenceDiagnostics.get(), "Build details inference failed"),
-                    e.getCause());
+            logger.debug("Ignoring stale exceptional build-details future while checking completed result", e);
+            return null;
         }
     }
 
@@ -2124,11 +2141,6 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
                 throw new InterruptedException("Build details inference cancelled before execution");
             }
 
-            if (!project.getBuildDetailsFuture().isDone()) {
-                // Keep build-details-dependent file enumeration paths from blocking while inference runs.
-                project.setBuildDetails(BuildDetails.EMPTY);
-            }
-
             var inferredDetails = runBuildDetailsInference();
             if (Thread.currentThread().isInterrupted()) {
                 throw new InterruptedException("Build details inference cancelled after execution");
@@ -2142,24 +2154,28 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
                 io.showNotification(
                         IConsoleIO.NotificationRole.INFO,
                         "Could not determine build configuration - project structure may be unsupported or incomplete");
-                return new BuildDetailsInferenceResult("empty", inferredDetails, diagnostics);
+                var result = new BuildDetailsInferenceResult("empty", inferredDetails, diagnostics);
+                lastBuildDetailsInferenceResult = result;
+                return result;
             }
 
             buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_INFERRED);
             buildDetailsInferenceDiagnostics.set(null);
             io.showNotification(IConsoleIO.NotificationRole.INFO, "Build details inferred and saved");
-            return new BuildDetailsInferenceResult("inferred", inferredDetails, null);
+            var result = new BuildDetailsInferenceResult("inferred", inferredDetails, null);
+            lastBuildDetailsInferenceResult = result;
+            return result;
         } catch (InterruptedException e) {
             logger.debug("Build details inference interrupted");
             Thread.currentThread().interrupt();
-            return failedBuildDetailsResult("Build details inference interrupted", e);
+            return failedBuildDetailsResult("Build details inference interrupted");
         } catch (Exception e) {
             var msg =
                     "Build Information Agent did not complete successfully (aborted or errored). Build details not saved. Error: "
                             + e.getMessage();
             logger.error(msg, e);
             io.toolError(msg, "Build Information Agent failed");
-            return failedBuildDetailsResult(msg, e);
+            return failedBuildDetailsResult(msg);
         }
     }
 
@@ -2172,11 +2188,62 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
         return agent.execute();
     }
 
-    private BuildDetailsInferenceResult failedBuildDetailsResult(String diagnostics, @Nullable Throwable throwable) {
+    private BuildDetailsInferenceResult failedBuildDetailsResult(String diagnostics) {
         buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_FAILED);
         buildDetailsInferenceDiagnostics.set(diagnostics);
-        project.completeBuildDetailsExceptionally(throwable != null ? throwable : new RuntimeException(diagnostics));
-        return new BuildDetailsInferenceResult("failed", BuildDetails.EMPTY, diagnostics);
+        var result = new BuildDetailsInferenceResult("failed", BuildDetails.EMPTY, diagnostics);
+        lastBuildDetailsInferenceResult = result;
+        return result;
+    }
+
+    @Blocking
+    public BuildDetails awaitBuildDetailsForSettings() {
+        var inFlight = buildDetailsInferenceFuture;
+        if (inFlight != null && !inFlight.isDone()) {
+            try {
+                return inFlight.get().buildDetails();
+            } catch (ExecutionException e) {
+                logger.error("ExecutionException while awaiting build details inference for settings", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (!project.hasBuildDetails()) {
+            var result = inferBuildDetails(false).join();
+            return result.buildDetails();
+        }
+
+        return project.awaitBuildDetails();
+    }
+
+    private @Nullable BuildDetailsInferenceResult throttledForcedInferenceResult() {
+        if (!project.hasBuildDetails()) {
+            return null;
+        }
+        var lastForced = lastForcedBuildDetailsInferenceAt;
+        if (lastForced == null) {
+            return null;
+        }
+        if (lastForced.plus(FORCE_BUILD_DETAILS_REINFERENCE_COOLDOWN).isBefore(Instant.now())) {
+            return null;
+        }
+        var diagnostics = "Forced build-details reinference is temporarily throttled";
+        return new BuildDetailsInferenceResult("failed", project.awaitBuildDetails(), diagnostics);
+    }
+
+    private String emptyBuildDetailsDiagnostics() {
+        if (project.hasBuildDetails()) {
+            return Objects.requireNonNullElse(
+                    buildDetailsInferenceDiagnostics.get(), "Could not determine build configuration");
+        }
+        if (lastBuildDetailsInferenceResult != null && "empty".equals(lastBuildDetailsInferenceResult.status())) {
+            return Objects.requireNonNullElse(
+                    lastBuildDetailsInferenceResult.diagnostics(), "Could not determine build configuration");
+        }
+        return Objects.requireNonNullElse(
+                buildDetailsInferenceDiagnostics.get(), "No build details have been inferred yet");
     }
 
     public void reloadService() {

--- a/app/src/main/java/ai/brokk/ContextManager.java
+++ b/app/src/main/java/ai/brokk/ContextManager.java
@@ -165,8 +165,11 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
     private boolean lowBalanceNotified = false;
     private boolean freeTierNotified = false;
 
-    // BuildAgent task tracking for cancellation
-    private volatile @Nullable CompletableFuture<BuildDetails> buildAgentFuture;
+    // Build details inference tracking for cancellation and single-flight behavior
+    private volatile @Nullable CompletableFuture<BuildDetailsInferenceResult> buildDetailsInferenceFuture;
+    private final AtomicReference<BuildDetailsInferenceState> buildDetailsInferenceState =
+            new AtomicReference<>(BuildDetailsInferenceState.NOT_STARTED);
+    private final AtomicReference<@Nullable String> buildDetailsInferenceDiagnostics = new AtomicReference<>();
 
     // Style guide generation completion tracking
     private volatile CompletableFuture<String> styleGuideFuture = CompletableFuture.completedFuture("");
@@ -186,6 +189,17 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
 
     @SuppressWarnings("NullAway.Init")
     private AbstractWatchService watchService;
+
+    public enum BuildDetailsInferenceState {
+        NOT_STARTED,
+        RUNNING,
+        COMPLETED_EXISTING,
+        COMPLETED_INFERRED,
+        COMPLETED_EMPTY,
+        COMPLETED_FAILED
+    }
+
+    public record BuildDetailsInferenceResult(String status, BuildDetails buildDetails, @Nullable String diagnostics) {}
 
     @Override
     public ExecutorService getBackgroundTasks() {
@@ -1447,10 +1461,10 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
     }
 
     public CompletableFuture<Void> closeAsync(long awaitMillis) {
-        // Cancel BuildAgent task if still running
-        if (buildAgentFuture != null && !buildAgentFuture.isDone()) {
-            logger.debug("Cancelling BuildAgent task due to ContextManager shutdown");
-            buildAgentFuture.cancel(true);
+        // Cancel build details inference if still running
+        if (buildDetailsInferenceFuture != null && !buildDetailsInferenceFuture.isDone()) {
+            logger.debug("Cancelling build details inference due to ContextManager shutdown");
+            buildDetailsInferenceFuture.cancel(true);
         }
 
         // Close watchers before shutting down executors that may be used by them
@@ -2039,75 +2053,130 @@ public class ContextManager implements IAppContextManager, AutoCloseable {
      * background.
      */
     private synchronized void ensureBuildDetailsAsync() {
+        inferBuildDetails(false);
+    }
+
+    public CompletableFuture<BuildDetailsInferenceResult> inferBuildDetails(boolean force) {
+        synchronized (this) {
+            if (buildDetailsInferenceFuture != null && !buildDetailsInferenceFuture.isDone()) {
+                logger.debug("Build details inference already in progress, joining existing task");
+                return buildDetailsInferenceFuture;
+            }
+
+            if (!force) {
+                var completed = completedBuildDetailsResultIfAvailable();
+                if (completed != null) {
+                    return CompletableFuture.completedFuture(completed);
+                }
+            }
+
+            buildDetailsInferenceState.set(BuildDetailsInferenceState.RUNNING);
+            buildDetailsInferenceDiagnostics.set(null);
+            buildDetailsInferenceFuture =
+                    submitBackgroundTask("Inferring build details", () -> runBuildDetailsInferenceTask(force));
+            return buildDetailsInferenceFuture;
+        }
+    }
+
+    private @Nullable BuildDetailsInferenceResult completedBuildDetailsResultIfAvailable() {
         if (project.hasBuildDetails()) {
-            logger.debug("Using existing build details");
-            return;
+            buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_EXISTING);
+            buildDetailsInferenceDiagnostics.set(null);
+            return new BuildDetailsInferenceResult("existing", project.awaitBuildDetails(), null);
         }
 
-        if (project.isEmptyProject()) {
-            logger.debug("Project has no analyzable source files, skipping build details inference");
-            if (!project.hasBuildDetails()) {
-                project.saveBuildDetails(BuildDetails.EMPTY);
+        var detailsFuture = project.getBuildDetailsFuture();
+        if (!detailsFuture.isDone()) {
+            return null;
+        }
+
+        try {
+            var details = detailsFuture.join();
+            if (BuildDetails.EMPTY.equals(details)) {
+                buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_EMPTY);
+                var diagnostics = Objects.requireNonNullElse(
+                        buildDetailsInferenceDiagnostics.get(), "No build details have been inferred yet");
+                return new BuildDetailsInferenceResult("empty", details, diagnostics);
             }
-            return;
+
+            buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_INFERRED);
+            buildDetailsInferenceDiagnostics.set(null);
+            return new BuildDetailsInferenceResult("inferred", details, null);
+        } catch (CompletionException e) {
+            return failedBuildDetailsResult(
+                    Objects.requireNonNullElse(
+                            buildDetailsInferenceDiagnostics.get(), "Build details inference failed"),
+                    e.getCause());
+        }
+    }
+
+    private BuildDetailsInferenceResult runBuildDetailsInferenceTask(boolean force) {
+        if (!force) {
+            var completed = completedBuildDetailsResultIfAvailable();
+            if (completed != null) {
+                return completed;
+            }
         }
 
-        // Check if a BuildAgent task is already in progress
-        if (buildAgentFuture != null && !buildAgentFuture.isDone()) {
-            logger.debug("BuildAgent task already in progress, skipping");
-            return;
-        }
-
-        // No details found, run the BuildAgent asynchronously
-        buildAgentFuture = submitBackgroundTask("Inferring build details", () -> {
-            io.showNotification(IConsoleIO.NotificationRole.INFO, "Inferring project build details");
-
-            // Check if task was cancelled before starting
+        io.showNotification(IConsoleIO.NotificationRole.INFO, "Inferring project build details");
+        try {
             if (Thread.currentThread().isInterrupted()) {
-                logger.debug("BuildAgent task cancelled before execution");
-                return BuildDetails.EMPTY;
+                throw new InterruptedException("Build details inference cancelled before execution");
             }
 
-            BuildAgent agent = new BuildAgent(
-                    project,
-                    getLlm(serviceProvider.get().getScanModel(), "Infer build details", TaskResult.Type.NONE),
-                    toolRegistry.builder().register(new SearchTools(this)).build(),
-                    io);
-            BuildDetails inferredDetails;
-            try {
-                inferredDetails = agent.execute();
-            } catch (InterruptedException e) {
-                logger.debug("BuildAgent execution interrupted");
-                Thread.currentThread().interrupt();
-                return BuildDetails.EMPTY;
-            } catch (Exception e) {
-                var msg =
-                        "Build Information Agent did not complete successfully (aborted or errored). Build details not saved. Error: "
-                                + e.getMessage();
-                logger.error(msg, e);
-                io.toolError(msg, "Build Information Agent failed");
-                inferredDetails = BuildDetails.EMPTY;
+            if (!project.getBuildDetailsFuture().isDone()) {
+                // Keep build-details-dependent file enumeration paths from blocking while inference runs.
+                project.setBuildDetails(BuildDetails.EMPTY);
             }
 
-            // Check if task was cancelled after execution
+            var inferredDetails = runBuildDetailsInference();
             if (Thread.currentThread().isInterrupted()) {
-                logger.debug("BuildAgent task cancelled after execution, not saving results");
-                return BuildDetails.EMPTY;
+                throw new InterruptedException("Build details inference cancelled after execution");
             }
 
             project.saveBuildDetails(inferredDetails);
-
-            // Show appropriate notification based on whether build details were found
             if (BuildDetails.EMPTY.equals(inferredDetails)) {
+                var diagnostics = "Could not determine build configuration";
+                buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_EMPTY);
+                buildDetailsInferenceDiagnostics.set(diagnostics);
                 io.showNotification(
                         IConsoleIO.NotificationRole.INFO,
                         "Could not determine build configuration - project structure may be unsupported or incomplete");
-            } else {
-                io.showNotification(IConsoleIO.NotificationRole.INFO, "Build details inferred and saved");
+                return new BuildDetailsInferenceResult("empty", inferredDetails, diagnostics);
             }
 
-            return inferredDetails;
-        });
+            buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_INFERRED);
+            buildDetailsInferenceDiagnostics.set(null);
+            io.showNotification(IConsoleIO.NotificationRole.INFO, "Build details inferred and saved");
+            return new BuildDetailsInferenceResult("inferred", inferredDetails, null);
+        } catch (InterruptedException e) {
+            logger.debug("Build details inference interrupted");
+            Thread.currentThread().interrupt();
+            return failedBuildDetailsResult("Build details inference interrupted", e);
+        } catch (Exception e) {
+            var msg =
+                    "Build Information Agent did not complete successfully (aborted or errored). Build details not saved. Error: "
+                            + e.getMessage();
+            logger.error(msg, e);
+            io.toolError(msg, "Build Information Agent failed");
+            return failedBuildDetailsResult(msg, e);
+        }
+    }
+
+    protected BuildDetails runBuildDetailsInference() throws Exception {
+        var agent = new BuildAgent(
+                project,
+                getLlm(serviceProvider.get().getScanModel(), "Infer build details", TaskResult.Type.NONE),
+                toolRegistry.builder().register(new SearchTools(this)).build(),
+                io);
+        return agent.execute();
+    }
+
+    private BuildDetailsInferenceResult failedBuildDetailsResult(String diagnostics, @Nullable Throwable throwable) {
+        buildDetailsInferenceState.set(BuildDetailsInferenceState.COMPLETED_FAILED);
+        buildDetailsInferenceDiagnostics.set(diagnostics);
+        project.completeBuildDetailsExceptionally(throwable != null ? throwable : new RuntimeException(diagnostics));
+        return new BuildDetailsInferenceResult("failed", BuildDetails.EMPTY, diagnostics);
     }
 
     public void reloadService() {

--- a/app/src/main/java/ai/brokk/agents/BuildAgent.java
+++ b/app/src/main/java/ai/brokk/agents/BuildAgent.java
@@ -155,7 +155,7 @@ public class BuildAgent {
         logger.trace("Initial directory listing added to history: {}", initialResult.resultText());
 
         // Discover nested build files to hint at submodules/services
-        var allFiles = project.hasGit() ? project.getRepo().getTrackedFiles() : project.getAllFiles();
+        var allFiles = project.hasGit() ? project.getRepo().getTrackedFiles() : project.getAllFilesUnfiltered();
 
         var nestedBuildFiles = allFiles.stream()
                 .filter(pf -> {
@@ -198,11 +198,12 @@ public class BuildAgent {
 
         // Determine build system and set initial excluded directories
         // Use tracked files directly (not filtered) to ensure build files are visible
-        var files = project.getRepo().getTrackedFiles().stream()
-                .parallel()
-                .filter(f -> f.getParent().equals(Path.of("")))
-                .map(ProjectFile::toString)
-                .toList();
+        var files = (project.hasGit() ? project.getRepo().getTrackedFiles() : project.getAllFilesUnfiltered())
+                .stream()
+                        .parallel()
+                        .filter(f -> f.getParent().equals(Path.of("")))
+                        .map(ProjectFile::toString)
+                        .toList();
 
         // Early exit if project has no relevant files
         if (files.isEmpty()) {
@@ -623,7 +624,8 @@ public class BuildAgent {
 
         // Use tracked files (unfiltered) to ensure build files are visible during discovery
         // This is critical: getAllFiles() applies exclusion patterns which may hide build configs
-        return SearchTools.formatFilesInDirectory(project.getRepo().getTrackedFiles(), normalizedPath, directoryPath);
+        var files = project.hasGit() ? project.getRepo().getTrackedFiles() : project.getAllFilesUnfiltered();
+        return SearchTools.formatFilesInDirectory(files, normalizedPath, directoryPath);
     }
 
     @Tool("Report the gathered build details when ALL information is collected. DO NOT call this method before then.")
@@ -787,9 +789,10 @@ public class BuildAgent {
                 continue;
             }
 
-            var testFiles = project.getRepo().getTrackedFiles().stream()
-                    .filter(f -> f.toString().toLowerCase(Locale.ROOT).contains("test"))
-                    .toList();
+            var testFiles = (project.hasGit() ? project.getRepo().getTrackedFiles() : project.getAllFilesUnfiltered())
+                    .stream()
+                            .filter(f -> f.toString().toLowerCase(Locale.ROOT).contains("test"))
+                            .toList();
 
             if (testFiles.isEmpty()) {
                 continue;

--- a/app/src/main/java/ai/brokk/executor/routers/SettingsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/SettingsRouter.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -36,10 +38,17 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public final class SettingsRouter implements SimpleHttpServer.CheckedHttpHandler {
     private static final Logger logger = LogManager.getLogger(SettingsRouter.class);
+    private static final long INFER_BUILD_DETAILS_HTTP_TIMEOUT_SECONDS = 30;
     private final ContextManager contextManager;
+    private final long inferBuildDetailsHttpTimeoutSeconds;
 
     public SettingsRouter(ContextManager contextManager) {
+        this(contextManager, INFER_BUILD_DETAILS_HTTP_TIMEOUT_SECONDS);
+    }
+
+    SettingsRouter(ContextManager contextManager, long inferBuildDetailsHttpTimeoutSeconds) {
         this.contextManager = contextManager;
+        this.inferBuildDetailsHttpTimeoutSeconds = inferBuildDetailsHttpTimeoutSeconds;
     }
 
     @Override
@@ -77,7 +86,7 @@ public final class SettingsRouter implements SimpleHttpServer.CheckedHttpHandler
             var response = new HashMap<String, Object>();
 
             // Build details
-            var buildDetails = project.awaitBuildDetails();
+            var buildDetails = contextManager.awaitBuildDetailsForSettings();
             response.put("buildDetails", buildBuildDetailsMap(buildDetails));
 
             // Project settings
@@ -245,10 +254,12 @@ public final class SettingsRouter implements SimpleHttpServer.CheckedHttpHandler
         var request =
                 RouterUtil.parseJsonOr400(exchange, InferBuildDetailsRequest.class, "/v1/settings/infer-build-details");
         if (request == null) return;
+        var project = contextManager.getProject();
 
         try {
-            var result =
-                    contextManager.inferBuildDetails(request.forceEnabled()).get();
+            var result = contextManager
+                    .inferBuildDetails(request.forceEnabled())
+                    .get(inferBuildDetailsHttpTimeoutSeconds, TimeUnit.SECONDS);
             var diagnostics = result.diagnostics();
             SimpleHttpServer.sendJsonResponse(
                     exchange,
@@ -261,6 +272,15 @@ public final class SettingsRouter implements SimpleHttpServer.CheckedHttpHandler
             logger.error("Interrupted while handling POST /v1/settings/infer-build-details", e);
             SimpleHttpServer.sendJsonResponse(
                     exchange, 500, ErrorPayload.internalError("Interrupted while inferring build details", e));
+        } catch (TimeoutException e) {
+            logger.warn("Timed out handling POST /v1/settings/infer-build-details", e);
+            var currentDetails = project.hasBuildDetails() ? project.awaitBuildDetails() : BuildDetails.EMPTY;
+            SimpleHttpServer.sendJsonResponse(
+                    exchange,
+                    new InferBuildDetailsResponse(
+                            "failed",
+                            buildBuildDetailsMap(currentDetails),
+                            "Timed out waiting for build-details inference"));
         } catch (Exception e) {
             logger.error("Error handling POST /v1/settings/infer-build-details", e);
             SimpleHttpServer.sendJsonResponse(

--- a/app/src/main/java/ai/brokk/executor/routers/SettingsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/SettingsRouter.java
@@ -59,6 +59,15 @@ public final class SettingsRouter implements SimpleHttpServer.CheckedHttpHandler
             return;
         }
 
+        if (normalizedPath.equals("/v1/settings/infer-build-details")) {
+            if ("POST".equals(method)) {
+                handlePostInferBuildDetails(exchange);
+            } else {
+                RouterUtil.sendMethodNotAllowed(exchange);
+            }
+            return;
+        }
+
         SimpleHttpServer.sendJsonResponse(exchange, 404, ErrorPayload.of(ErrorPayload.Code.NOT_FOUND, "Not found"));
     }
 
@@ -229,6 +238,33 @@ public final class SettingsRouter implements SimpleHttpServer.CheckedHttpHandler
             logger.error("Error handling POST /v1/settings", e);
             SimpleHttpServer.sendJsonResponse(
                     exchange, 500, ErrorPayload.internalError("Failed to update settings", e));
+        }
+    }
+
+    private void handlePostInferBuildDetails(HttpExchange exchange) throws IOException {
+        var request =
+                RouterUtil.parseJsonOr400(exchange, InferBuildDetailsRequest.class, "/v1/settings/infer-build-details");
+        if (request == null) return;
+
+        try {
+            var result =
+                    contextManager.inferBuildDetails(request.forceEnabled()).get();
+            var diagnostics = result.diagnostics();
+            SimpleHttpServer.sendJsonResponse(
+                    exchange,
+                    new InferBuildDetailsResponse(
+                            result.status(),
+                            buildBuildDetailsMap(result.buildDetails()),
+                            diagnostics != null && !diagnostics.isBlank() ? diagnostics : null));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Interrupted while handling POST /v1/settings/infer-build-details", e);
+            SimpleHttpServer.sendJsonResponse(
+                    exchange, 500, ErrorPayload.internalError("Interrupted while inferring build details", e));
+        } catch (Exception e) {
+            logger.error("Error handling POST /v1/settings/infer-build-details", e);
+            SimpleHttpServer.sendJsonResponse(
+                    exchange, 500, ErrorPayload.internalError("Failed to infer build details", e));
         }
     }
 
@@ -418,6 +454,15 @@ public final class SettingsRouter implements SimpleHttpServer.CheckedHttpHandler
             @Nullable JsonNode issueProvider,
             @Nullable String dataRetentionPolicy,
             @Nullable UpdateLanguagesRequest analyzerLanguages) {}
+
+    private record InferBuildDetailsRequest(@Nullable Boolean force) {
+        boolean forceEnabled() {
+            return Boolean.TRUE.equals(force);
+        }
+    }
+
+    private record InferBuildDetailsResponse(
+            String status, Map<String, Object> buildDetails, @Nullable String diagnostics) {}
 
     private record UpdateBuildRequest(
             @Nullable String buildLintCommand,

--- a/app/src/main/java/ai/brokk/project/AbstractProject.java
+++ b/app/src/main/java/ai/brokk/project/AbstractProject.java
@@ -787,6 +787,12 @@ public abstract sealed class AbstractProject implements IProject permits MainPro
 
     @Override
     @Blocking
+    public final synchronized Set<ProjectFile> getAllFilesUnfiltered() {
+        return Set.copyOf(getAllFilesRaw());
+    }
+
+    @Override
+    @Blocking
     public final synchronized Optional<ProjectFile> getFileByRelPath(Path relPath) {
         if (filesByRelPathCache == null) {
             getAllFiles(); // Populate the cache (this uses a side effect, so linter won't see this)

--- a/app/src/main/java/ai/brokk/project/AbstractProject.java
+++ b/app/src/main/java/ai/brokk/project/AbstractProject.java
@@ -137,8 +137,6 @@ public abstract sealed class AbstractProject implements IProject permits MainPro
         var bdOpt = loadBuildDetails();
         if (bdOpt.isPresent()) {
             this.detailsFuture.complete(bdOpt.get());
-        } else {
-            this.detailsFuture.complete(BuildAgent.BuildDetails.EMPTY);
         }
     }
 
@@ -895,7 +893,7 @@ public abstract sealed class AbstractProject implements IProject permits MainPro
 
     @Override
     public boolean hasBuildDetails() {
-        return detailsFuture.isDone();
+        return projectProps.containsKey(BUILD_DETAILS_KEY);
     }
 
     @Override
@@ -1022,6 +1020,15 @@ public abstract sealed class AbstractProject implements IProject permits MainPro
             detailsFuture = CompletableFuture.completedFuture(details);
         } else {
             detailsFuture.complete(details);
+        }
+    }
+
+    @Override
+    public void completeBuildDetailsExceptionally(Throwable throwable) {
+        if (detailsFuture.isDone()) {
+            detailsFuture = CompletableFuture.failedFuture(throwable);
+        } else {
+            detailsFuture.completeExceptionally(throwable);
         }
     }
 

--- a/app/src/main/java/ai/brokk/project/AbstractProject.java
+++ b/app/src/main/java/ai/brokk/project/AbstractProject.java
@@ -1024,15 +1024,6 @@ public abstract sealed class AbstractProject implements IProject permits MainPro
     }
 
     @Override
-    public void completeBuildDetailsExceptionally(Throwable throwable) {
-        if (detailsFuture.isDone()) {
-            detailsFuture = CompletableFuture.failedFuture(throwable);
-        } else {
-            detailsFuture.completeExceptionally(throwable);
-        }
-    }
-
-    @Override
     public CompletableFuture<BuildAgent.BuildDetails> getBuildDetailsFuture() {
         return detailsFuture;
     }

--- a/app/src/main/java/ai/brokk/project/IProject.java
+++ b/app/src/main/java/ai/brokk/project/IProject.java
@@ -211,6 +211,10 @@ public interface IProject extends ICoreProject {
         throw new UnsupportedOperationException();
     }
 
+    default void completeBuildDetailsExceptionally(Throwable throwable) {
+        throw new UnsupportedOperationException();
+    }
+
     default void setRepo(IGitRepo repo) {
         throw new UnsupportedOperationException();
     }

--- a/app/src/main/java/ai/brokk/project/IProject.java
+++ b/app/src/main/java/ai/brokk/project/IProject.java
@@ -83,6 +83,17 @@ public interface IProject extends ICoreProject {
     }
 
     /**
+     * Returns the raw on-disk project files before build-details exclusions are applied.
+     *
+     * <p>This is for discovery flows like build-details inference that must not depend on already-resolved build
+     * details.
+     */
+    @Blocking
+    default Set<ProjectFile> getAllFilesUnfiltered() {
+        return getAllFiles();
+    }
+
+    /**
      * Finds a file in the project by its relative path.
      *
      * @param relPath the relative path to look up

--- a/app/src/main/java/ai/brokk/project/IProject.java
+++ b/app/src/main/java/ai/brokk/project/IProject.java
@@ -211,10 +211,6 @@ public interface IProject extends ICoreProject {
         throw new UnsupportedOperationException();
     }
 
-    default void completeBuildDetailsExceptionally(Throwable throwable) {
-        throw new UnsupportedOperationException();
-    }
-
     default void setRepo(IGitRepo repo) {
         throw new UnsupportedOperationException();
     }

--- a/app/src/test/java/ai/brokk/ContextManagerTest.java
+++ b/app/src/test/java/ai/brokk/ContextManagerTest.java
@@ -1,13 +1,17 @@
 package ai.brokk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.brokk.agents.BuildAgent;
 import ai.brokk.analyzer.ProjectFile;
 import ai.brokk.context.Context;
 import ai.brokk.context.ContextHistory;
 import ai.brokk.context.ContextOutputFragments;
 import ai.brokk.project.MainProject;
+import ai.brokk.testutil.NoOpConsoleIO;
 import ai.brokk.util.Messages;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
@@ -16,6 +20,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -294,6 +302,99 @@ class ContextManagerTest {
                     "History copy should preserve fragment-provided order");
         } finally {
             project.close();
+        }
+    }
+
+    @Test
+    void inferBuildDetails_returnsEmptyForEmptyInference() throws Exception {
+        var tempDir = Files.createTempDirectory("ctxmgr-infer-empty");
+        try (var project = new MainProject(tempDir);
+                var cm = new ContextManager(project) {
+                    @Override
+                    protected BuildAgent.BuildDetails runBuildDetailsInference() {
+                        return BuildAgent.BuildDetails.EMPTY;
+                    }
+                }) {
+            var result = cm.inferBuildDetails(false).get(5, TimeUnit.SECONDS);
+
+            assertEquals("empty", result.status());
+            assertEquals(BuildAgent.BuildDetails.EMPTY, result.buildDetails());
+            assertTrue(project.hasBuildDetails(), "Empty inference should still persist build details");
+        }
+    }
+
+    @Test
+    void inferBuildDetails_returnsFailedWithDiagnostics() throws Exception {
+        var tempDir = Files.createTempDirectory("ctxmgr-infer-failed");
+        try (var project = new MainProject(tempDir);
+                var cm = new ContextManager(project) {
+                    @Override
+                    protected BuildAgent.BuildDetails runBuildDetailsInference() {
+                        throw new RuntimeException("boom");
+                    }
+                }) {
+            var result = cm.inferBuildDetails(false).get(5, TimeUnit.SECONDS);
+
+            assertEquals("failed", result.status());
+            assertTrue(result.diagnostics().contains("boom"));
+            assertFalse(project.hasBuildDetails(), "Failed inference should not persist build details");
+            assertTrue(project.getBuildDetailsFuture().isCompletedExceptionally());
+        }
+    }
+
+    @Test
+    void inferBuildDetails_usesSingleFlightForConcurrentCallers() throws Exception {
+        var tempDir = Files.createTempDirectory("ctxmgr-infer-single-flight");
+        var started = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var calls = new AtomicInteger();
+
+        try (var project = new MainProject(tempDir);
+                var cm = new ContextManager(project) {
+                    @Override
+                    protected BuildAgent.BuildDetails runBuildDetailsInference() throws Exception {
+                        calls.incrementAndGet();
+                        started.countDown();
+                        assertTrue(release.await(5, TimeUnit.SECONDS));
+                        return BuildAgent.BuildDetails.EMPTY;
+                    }
+                }) {
+            CompletableFuture<ContextManager.BuildDetailsInferenceResult> first = cm.inferBuildDetails(false);
+            assertTrue(started.await(5, TimeUnit.SECONDS));
+            CompletableFuture<ContextManager.BuildDetailsInferenceResult> second = cm.inferBuildDetails(false);
+
+            assertSame(first, second);
+            release.countDown();
+            assertEquals("empty", first.get(5, TimeUnit.SECONDS).status());
+            assertEquals(1, calls.get());
+        }
+    }
+
+    @Test
+    void createHeadlessAndEndpointShareSameInFlightInference() throws Exception {
+        var tempDir = Files.createTempDirectory("ctxmgr-headless-share-inflight");
+        var started = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var calls = new AtomicInteger();
+
+        try (var project = new MainProject(tempDir);
+                var cm = new ContextManager(project) {
+                    @Override
+                    protected BuildAgent.BuildDetails runBuildDetailsInference() throws Exception {
+                        calls.incrementAndGet();
+                        started.countDown();
+                        assertTrue(release.await(5, TimeUnit.SECONDS));
+                        return BuildAgent.BuildDetails.EMPTY;
+                    }
+                }) {
+            cm.createHeadless(true, new NoOpConsoleIO());
+            assertTrue(started.await(5, TimeUnit.SECONDS));
+
+            var explicit = cm.inferBuildDetails(false);
+            release.countDown();
+
+            assertEquals("empty", explicit.get(5, TimeUnit.SECONDS).status());
+            assertEquals(1, calls.get());
         }
     }
 }

--- a/app/src/test/java/ai/brokk/ContextManagerTest.java
+++ b/app/src/test/java/ai/brokk/ContextManagerTest.java
@@ -338,7 +338,7 @@ class ContextManagerTest {
             assertEquals("failed", result.status());
             assertTrue(result.diagnostics().contains("boom"));
             assertFalse(project.hasBuildDetails(), "Failed inference should not persist build details");
-            assertTrue(project.getBuildDetailsFuture().isCompletedExceptionally());
+            assertFalse(project.getBuildDetailsFuture().isCompletedExceptionally());
         }
     }
 

--- a/app/src/test/java/ai/brokk/agents/BuildAgentTest.java
+++ b/app/src/test/java/ai/brokk/agents/BuildAgentTest.java
@@ -1357,7 +1357,8 @@ class BuildAgentTest {
 
         var cm = new TestContextManager(project);
         var llm = cm.getLlm(new TestScriptedLanguageModel("No tool call"), "test", ai.brokk.TaskResult.Type.NONE);
-        var registry = new ToolRegistry().builder().register(new SearchTools(cm)).build();
+        var registry =
+                new ToolRegistry().builder().register(new SearchTools(cm)).build();
         var agent = new BuildAgent(project, llm, registry, new TestConsoleIO());
 
         assertEquals(BuildAgent.BuildDetails.EMPTY, agent.execute());

--- a/app/src/test/java/ai/brokk/agents/BuildAgentTest.java
+++ b/app/src/test/java/ai/brokk/agents/BuildAgentTest.java
@@ -16,6 +16,7 @@ import ai.brokk.testutil.TestAnalyzer;
 import ai.brokk.testutil.TestConsoleIO;
 import ai.brokk.testutil.TestContextManager;
 import ai.brokk.testutil.TestProject;
+import ai.brokk.tools.SearchTools;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.BuildTools;
@@ -1341,5 +1342,24 @@ class BuildAgentTest {
         } finally {
             Environment.shellCommandRunnerFactory = originalFactory;
         }
+    }
+
+    @Test
+    void execute_nonGitProjectUsesUnfilteredFilesForDiscovery(@TempDir Path tempDir) throws Exception {
+        Files.writeString(tempDir.resolve("README.md"), "x");
+
+        var project = new TestProject(tempDir) {
+            @Override
+            public Set<ProjectFile> getAllFiles() {
+                throw new AssertionError("Build details inference should not use filtered getAllFiles()");
+            }
+        }.withoutRepo();
+
+        var cm = new TestContextManager(project);
+        var llm = cm.getLlm(new TestScriptedLanguageModel("No tool call"), "test", ai.brokk.TaskResult.Type.NONE);
+        var registry = new ToolRegistry().builder().register(new SearchTools(cm)).build();
+        var agent = new BuildAgent(project, llm, registry, new TestConsoleIO());
+
+        assertEquals(BuildAgent.BuildDetails.EMPTY, agent.execute());
     }
 }

--- a/app/src/test/java/ai/brokk/executor/routers/SettingsRouterTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/SettingsRouterTest.java
@@ -1,6 +1,7 @@
 package ai.brokk.executor.routers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,6 +14,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -339,6 +342,159 @@ class SettingsRouterTest {
                 var buildDetails = (Map<String, Object>) response.get("buildDetails");
                 assertEquals("gradlew build", buildDetails.get("buildLintCommand"));
             }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handlePostInferBuildDetails_returnsEmptyOnRepeatedNonForcedCallsAfterEmptyInference() throws Exception {
+        try (var emptyProject = new MainProject(project.getRoot());
+                var emptyContextManager = new ContextManager(emptyProject) {
+                    @Override
+                    protected BuildDetails runBuildDetailsInference() {
+                        return BuildDetails.EMPTY;
+                    }
+                }) {
+            var emptyRouter = new SettingsRouter(emptyContextManager);
+
+            var firstExchange = TestHttpExchange.jsonRequest("POST", "/v1/settings/infer-build-details", Map.of());
+            emptyRouter.handle(firstExchange);
+            Map<String, Object> first = MAPPER.readValue(firstExchange.responseBodyBytes(), new TypeReference<>() {});
+            assertEquals("empty", first.get("status"));
+
+            var secondExchange = TestHttpExchange.jsonRequest("POST", "/v1/settings/infer-build-details", Map.of());
+            emptyRouter.handle(secondExchange);
+            Map<String, Object> second = MAPPER.readValue(secondExchange.responseBodyBytes(), new TypeReference<>() {});
+            assertEquals("empty", second.get("status"));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handleGetSettings_waitsForInFlightInference() throws Exception {
+        var waitingRoot = java.nio.file.Files.createTempDirectory("settings-router-waits-for-inference");
+        try (var waitingProject = new MainProject(waitingRoot)) {
+            var started = new CountDownLatch(1);
+            var release = new CountDownLatch(1);
+            try (var waitingContextManager = new ContextManager(waitingProject) {
+                @Override
+                protected BuildDetails runBuildDetailsInference() throws Exception {
+                    started.countDown();
+                    assertTrue(release.await(5, TimeUnit.SECONDS));
+                    return INFERRED_DETAILS;
+                }
+            }) {
+                var waitingRouter = new SettingsRouter(waitingContextManager);
+                waitingContextManager.createHeadless(true, new ai.brokk.testutil.NoOpConsoleIO());
+                assertTrue(started.await(5, TimeUnit.SECONDS));
+
+                var getFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+                    try {
+                        var exchange = TestHttpExchange.request("GET", "/v1/settings");
+                        waitingRouter.handle(exchange);
+                        return exchange;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+                Thread.sleep(200);
+                assertFalse(getFuture.isDone(), "GET /v1/settings should wait for in-flight inference");
+
+                release.countDown();
+                var exchange = getFuture.get(5, TimeUnit.SECONDS);
+                Map<String, Object> response = MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+                var buildDetails = (Map<String, Object>) response.get("buildDetails");
+                assertEquals("gradlew build", buildDetails.get("buildLintCommand"));
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handleGetSettings_afterFailedInferenceRetriesAndReturnsEmpty() throws Exception {
+        var failedRoot = java.nio.file.Files.createTempDirectory("settings-router-retries-after-failure");
+        try (var failedProject = new MainProject(failedRoot)) {
+            var calls = new AtomicInteger();
+            try (var failedContextManager = new ContextManager(failedProject) {
+                @Override
+                protected BuildDetails runBuildDetailsInference() {
+                    if (calls.getAndIncrement() == 0) {
+                        throw new RuntimeException("boom");
+                    }
+                    return BuildDetails.EMPTY;
+                }
+            }) {
+                var failedRouter = new SettingsRouter(failedContextManager);
+
+                var postExchange = TestHttpExchange.jsonRequest("POST", "/v1/settings/infer-build-details", Map.of());
+                failedRouter.handle(postExchange);
+                Map<String, Object> post = MAPPER.readValue(postExchange.responseBodyBytes(), new TypeReference<>() {});
+                assertEquals("failed", post.get("status"));
+
+                var getExchange = TestHttpExchange.request("GET", "/v1/settings");
+                failedRouter.handle(getExchange);
+                Map<String, Object> get = MAPPER.readValue(getExchange.responseBodyBytes(), new TypeReference<>() {});
+                var buildDetails = (Map<String, Object>) get.get("buildDetails");
+                assertEquals(List.of(), buildDetails.get("exclusionPatterns"));
+                assertEquals(2, calls.get(), "GET /v1/settings should retry inference after failure");
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handlePostInferBuildDetails_forceIsThrottledWhenRepeated() throws Exception {
+        try (var throttledProject = new MainProject(project.getRoot())) {
+            throttledProject.saveBuildDetails(INFERRED_DETAILS);
+            var calls = new AtomicInteger();
+            try (var throttledContextManager = new ContextManager(throttledProject) {
+                @Override
+                protected BuildDetails runBuildDetailsInference() {
+                    calls.incrementAndGet();
+                    return INFERRED_DETAILS;
+                }
+            }) {
+                var throttledRouter = new SettingsRouter(throttledContextManager);
+
+                var firstExchange =
+                        TestHttpExchange.jsonRequest("POST", "/v1/settings/infer-build-details", Map.of("force", true));
+                throttledRouter.handle(firstExchange);
+                Map<String, Object> first =
+                        MAPPER.readValue(firstExchange.responseBodyBytes(), new TypeReference<>() {});
+                assertEquals("inferred", first.get("status"));
+
+                var secondExchange =
+                        TestHttpExchange.jsonRequest("POST", "/v1/settings/infer-build-details", Map.of("force", true));
+                throttledRouter.handle(secondExchange);
+                Map<String, Object> second =
+                        MAPPER.readValue(secondExchange.responseBodyBytes(), new TypeReference<>() {});
+                assertEquals("failed", second.get("status"));
+                assertEquals(1, calls.get());
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handlePostInferBuildDetails_timesOutBoundedly() throws Exception {
+        try (var timeoutProject = new MainProject(project.getRoot());
+                var timeoutContextManager = new ContextManager(timeoutProject) {
+                    @Override
+                    public java.util.concurrent.CompletableFuture<ContextManager.BuildDetailsInferenceResult>
+                            inferBuildDetails(boolean force) {
+                        return new java.util.concurrent.CompletableFuture<>();
+                    }
+                }) {
+            var timeoutRouter = new SettingsRouter(timeoutContextManager, 1);
+
+            var exchange = TestHttpExchange.jsonRequest("POST", "/v1/settings/infer-build-details", Map.of());
+            timeoutRouter.handle(exchange);
+
+            assertEquals(200, exchange.responseCode());
+            Map<String, Object> response = MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+            assertEquals("failed", response.get("status"));
+            assertEquals("Timed out waiting for build-details inference", response.get("diagnostics"));
         }
     }
 

--- a/app/src/test/java/ai/brokk/executor/routers/SettingsRouterTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/SettingsRouterTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,19 @@ class SettingsRouterTest {
     private SettingsRouter settingsRouter;
     private ContextManager contextManager;
     private MainProject project;
+
+    private static final BuildDetails INFERRED_DETAILS = new BuildDetails(
+            "gradlew build",
+            true,
+            "gradlew test",
+            true,
+            "gradlew test --tests {{items}}",
+            true,
+            Set.of("build"),
+            Map.of(),
+            null,
+            "",
+            List.of());
 
     @BeforeEach
     void setUp(@TempDir Path tempDir) throws Exception {
@@ -256,6 +270,76 @@ class SettingsRouterTest {
         assertEquals("/bin/zsh", shellConfig.get("executable"));
 
         assertEquals("MINIMAL", response.get("dataRetentionPolicy"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handlePostInferBuildDetails_returnsExistingWhenSavedDetailsExist() throws Exception {
+        var existing = new BuildDetails(
+                "saved-build",
+                true,
+                "saved-test",
+                true,
+                "saved-test-some",
+                true,
+                Set.of("node_modules"),
+                Map.of(),
+                null,
+                "",
+                List.of());
+        project.saveBuildDetails(existing);
+
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/settings/infer-build-details", Map.of());
+        settingsRouter.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        Map<String, Object> response = MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+        assertEquals("existing", response.get("status"));
+
+        var buildDetails = (Map<String, Object>) response.get("buildDetails");
+        assertEquals("saved-build", buildDetails.get("buildLintCommand"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handlePostInferBuildDetails_forceBypassesExistingReuse() throws Exception {
+        try (var forceProject = new MainProject(project.getRoot())) {
+            forceProject.saveBuildDetails(new BuildDetails(
+                    "saved-build",
+                    true,
+                    "saved-test",
+                    true,
+                    "saved-test-some",
+                    true,
+                    Set.of("node_modules"),
+                    Map.of(),
+                    null,
+                    "",
+                    List.of()));
+
+            var calls = new AtomicInteger();
+            try (var forceContextManager = new ContextManager(forceProject) {
+                @Override
+                protected BuildDetails runBuildDetailsInference() {
+                    calls.incrementAndGet();
+                    return INFERRED_DETAILS;
+                }
+            }) {
+                var forceRouter = new SettingsRouter(forceContextManager);
+
+                var exchange =
+                        TestHttpExchange.jsonRequest("POST", "/v1/settings/infer-build-details", Map.of("force", true));
+                forceRouter.handle(exchange);
+
+                assertEquals(200, exchange.responseCode());
+                Map<String, Object> response = MAPPER.readValue(exchange.responseBodyBytes(), new TypeReference<>() {});
+                assertEquals("inferred", response.get("status"));
+                assertEquals(1, calls.get());
+
+                var buildDetails = (Map<String, Object>) response.get("buildDetails");
+                assertEquals("gradlew build", buildDetails.get("buildLintCommand"));
+            }
+        }
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/testutil/TestProject.java
+++ b/app/src/test/java/ai/brokk/testutil/TestProject.java
@@ -88,6 +88,16 @@ public class TestProject implements IProject {
     }
 
     @Override
+    public void completeBuildDetailsExceptionally(Throwable throwable) {
+        this.buildDetailsExplicitlySet = false;
+        if (!detailsFuture.isDone()) {
+            detailsFuture.completeExceptionally(throwable);
+            return;
+        }
+        detailsFuture = CompletableFuture.failedFuture(throwable);
+    }
+
+    @Override
     public boolean hasBuildDetails() {
         return buildDetailsExplicitlySet;
     }

--- a/app/src/test/java/ai/brokk/testutil/TestProject.java
+++ b/app/src/test/java/ai/brokk/testutil/TestProject.java
@@ -88,16 +88,6 @@ public class TestProject implements IProject {
     }
 
     @Override
-    public void completeBuildDetailsExceptionally(Throwable throwable) {
-        this.buildDetailsExplicitlySet = false;
-        if (!detailsFuture.isDone()) {
-            detailsFuture.completeExceptionally(throwable);
-            return;
-        }
-        detailsFuture = CompletableFuture.failedFuture(throwable);
-    }
-
-    @Override
     public boolean hasBuildDetails() {
         return buildDetailsExplicitlySet;
     }

--- a/app/src/test/java/ai/brokk/testutil/TestProject.java
+++ b/app/src/test/java/ai/brokk/testutil/TestProject.java
@@ -305,6 +305,11 @@ public class TestProject implements IProject {
 
     @Override
     public Set<ProjectFile> getAllFiles() {
+        return filterExcludedFiles(getAllFilesUnfiltered());
+    }
+
+    @Override
+    public Set<ProjectFile> getAllFilesUnfiltered() {
         if (allFilesSupplier != null) {
             return allFilesSupplier.get();
         }


### PR DESCRIPTION
### Summary
- Reworked build-details inference so `ContextManager` owns in-flight state, diagnostics, and result classification instead of using the project future as transient orchestration state.
- Added `POST /v1/settings/infer-build-details` with bounded handling, kept `GET /v1/settings` coherent with the same coordinator, and preserved compatibility for existing build-details consumers.
- Fixed the state-model issues called out in review: `EMPTY` is now classified as `empty`, failed inference is no longer leaked through the project future, and repeated forced reinference is throttled.

**Key Changes**:
- Introduced explicit build-details inference state/result tracking in `ContextManager`, including single-flight coordination, last-result storage, and diagnostics.
- Removed exceptional completion and placeholder `EMPTY` writes from project initialization, so persisted build-details remain value-based and stable.
- Added the new settings endpoint and updated legacy settings reads to await the same inference path with a bounded timeout and consistent failure handling.
- Expanded regression coverage for empty vs existing classification, shared in-flight inference, failed inference compatibility, timeout handling, and force-throttle behavior.

**Touch Points**:
- `app/src/main/java/ai/brokk/ContextManager.java`
- `app/src/main/java/ai/brokk/executor/routers/SettingsRouter.java`
- `app/src/main/java/ai/brokk/project/AbstractProject.java`
- `app/src/main/java/ai/brokk/project/IProject.java`
- `app/src/test/java/ai/brokk/ContextManagerTest.java`
- `app/src/test/java/ai/brokk/executor/routers/SettingsRouterTest.java`
- `app/src/test/java/ai/brokk/testutil/TestProject.java`

### Testing
- `./gradlew :app:test --tests ai.brokk.ContextManagerTest --tests ai.brokk.executor.routers.SettingsRouterTest`
- `./gradlew fix tidy`
- `./gradlew analyze`