### PR TITLE
Reduce TreeSitter analyzer warm-up cost

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JavascriptAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JavascriptAnalyzer.java
@@ -4,7 +4,10 @@ import static ai.brokk.analyzer.javascript.Constants.*;
 
 import ai.brokk.analyzer.cache.AnalyzerCache;
 import ai.brokk.project.ICoreProject;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.jetbrains.annotations.Nullable;
 import org.treesitter.TSLanguage;
 import org.treesitter.TSNode;
@@ -12,13 +15,29 @@ import org.treesitter.TSParser;
 import org.treesitter.TSQuery;
 import org.treesitter.TSQueryCapture;
 import org.treesitter.TSQueryCursor;
-import org.treesitter.TSQueryException;
 import org.treesitter.TSQueryMatch;
 import org.treesitter.TSTree;
 import org.treesitter.TreeSitterJavascript;
 import org.treesitter.TsxNodeType;
 
 public class JavascriptAnalyzer extends JsTsAnalyzer {
+    private static final String JSX_RETURN_QUERY_CACHE_KEY = "javascript.jsxReturn";
+    private static final String JSX_RETURN_QUERY =
+            """
+    (return_statement (jsx_element) @jsx_return)
+    (return_statement (jsx_self_closing_element) @jsx_return)
+    (return_statement (parenthesized_expression (jsx_element)) @jsx_return)
+    (return_statement (parenthesized_expression (jsx_self_closing_element)) @jsx_return)
+    """;
+    private static final String MUTATION_QUERY_CACHE_KEY = "javascript.mutations";
+    private static final String MUTATION_QUERY =
+            """
+    (assignment_expression left: (identifier) @mutated.id)
+    (assignment_expression left: (member_expression property: (property_identifier) @mutated.id))
+    (assignment_expression left: (subscript_expression index: _ @mutated.id))
+    (update_expression argument: (identifier) @mutated.id)
+    (update_expression argument: (member_expression property: (property_identifier) @mutated.id))
+    """;
     private static final LanguageSyntaxProfile JS_SYNTAX_PROFILE = new LanguageSyntaxProfile(
             Set.of(nodeType(TsxNodeType.CLASS_DECLARATION), CLASS_EXPRESSION, nodeType(TsxNodeType.CLASS_)),
             Set.of(
@@ -44,6 +63,9 @@ public class JavascriptAnalyzer extends JsTsAnalyzer {
             ASYNC, // asyncKeywordNodeType
             Set.of() // modifierNodeTypes
             );
+    private final Cache<ProjectFile, Map<CodeUnit, List<String>>> enrichedFunctionSignaturesByFile =
+            Caffeine.newBuilder().maximumSize(1000).build();
+    private final AtomicInteger skeletonEnrichmentParseCount = new AtomicInteger(0);
 
     public JavascriptAnalyzer(ICoreProject project) {
         this(project, ProgressListener.NOOP);
@@ -147,39 +169,7 @@ public class JavascriptAnalyzer extends JsTsAnalyzer {
     @Override
     protected ResolvedNodes resolveSignatureNodes(
             TSNode definitionNode, String simpleName, SkeletonType refined, SourceContent sourceContent) {
-        TSNode nodeForSignature = definitionNode;
-        TSNode nodeForContent = definitionNode;
-
-        // 1. Unwrap export statement
-        if (nodeType(TsxNodeType.EXPORT_STATEMENT).equals(definitionNode.getType())) {
-            TSNode declarationInExport = definitionNode.getChildByFieldName(FIELD_DECLARATION);
-            if (declarationInExport != null) {
-                nodeForSignature = declarationInExport;
-                nodeForContent = declarationInExport;
-            }
-        }
-
-        // 2. Unwrap variable declaration to specific declarator for content/body extraction
-        if (refined == SkeletonType.FIELD_LIKE || refined == SkeletonType.FUNCTION_LIKE) {
-            String nodeType = nodeForContent.getType();
-            if (nodeType(TsxNodeType.LEXICAL_DECLARATION).equals(nodeType)
-                    || nodeType(TsxNodeType.VARIABLE_DECLARATION).equals(nodeType)) {
-                // Find the variable_declarator child that matches the simpleName
-                for (TSNode child : nodeForContent.getChildren()) {
-                    if (nodeType(TsxNodeType.VARIABLE_DECLARATOR).equals(child.getType())) {
-                        TSNode nameNode = child.getChildByFieldName(
-                                getLanguageSyntaxProfile().identifierFieldName());
-                        if (nameNode != null
-                                && sourceContent.substringFrom(nameNode).equals(simpleName)) {
-                            nodeForContent = child;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        return new ResolvedNodes(nodeForSignature, nodeForContent);
+        return resolveJsTsSignatureNodes(definitionNode, simpleName, refined, sourceContent);
     }
 
     @Override
@@ -198,24 +188,7 @@ public class JavascriptAnalyzer extends JsTsAnalyzer {
             String paramsText,
             String returnTypeText,
             String indent) {
-        // The 'indent' parameter is now "" when called from buildSignatureString.
-        String inferredReturnType = returnTypeText;
-
-        // Infer JSX.Element return type if no explicit return type is present AND:
-        // 1. It's an exported function/component starting with an uppercase letter (common React convention).
-        // OR
-        // 2. It's a method named "render" (classic React class component method).
-        boolean isExported = exportPrefix.trim().startsWith("export");
-        boolean isComponentName = !functionName.isEmpty() && Character.isUpperCase(functionName.charAt(0));
-        boolean isRenderMethod = "render".equals(functionName);
-
-        if ((isRenderMethod || (isExported && isComponentName)) && returnTypeText.isEmpty()) {
-            if (returnsJsxElement(funcNode, sourceContent)) {
-                inferredReturnType = "JSX.Element";
-            }
-        }
-
-        String tsReturnTypeSuffix = !inferredReturnType.isEmpty() ? ": " + inferredReturnType : "";
+        String tsReturnTypeSuffix = !returnTypeText.isEmpty() ? ": " + returnTypeText : "";
         String signature;
         String bodySuffix = " " + bodyPlaceholder();
 
@@ -244,6 +217,65 @@ public class JavascriptAnalyzer extends JsTsAnalyzer {
         return signature + bodySuffix; // Do not prepend indent here
     }
 
+    @Override
+    protected void buildFunctionSkeleton(
+            TSNode funcNode,
+            Optional<String> providedNameOpt,
+            SourceContent sourceContent,
+            String indent,
+            List<String> lines,
+            String exportPrefix,
+            boolean includePresentationDetails) {
+        TSNode valueNode = unwrapJsTsFunctionValueNode(funcNode);
+        if (nodeType(TsxNodeType.ARROW_FUNCTION).equals(valueNode.getType())) {
+            String functionName = providedNameOpt.orElseGet(
+                    () -> extractSimpleName(funcNode, sourceContent).orElse(""));
+            TSNode paramsNode = valueNode.getChildByFieldName(FIELD_PARAMETERS);
+            String paramsText = formatParameterList(paramsNode, sourceContent);
+            String asyncPrefix = hasAsyncModifier(valueNode, sourceContent) ? "async " : "";
+            String returnTypeText = includePresentationDetails
+                    ? enhanceFunctionReturnTypeForPresentation(valueNode, sourceContent, exportPrefix, functionName, "")
+                    : "";
+            String signature = renderFunctionDeclaration(
+                    valueNode,
+                    sourceContent,
+                    exportPrefix,
+                    asyncPrefix,
+                    functionName,
+                    "",
+                    paramsText,
+                    returnTypeText,
+                    indent);
+            if (!signature.isBlank()) {
+                lines.add(signature);
+            }
+            return;
+        }
+
+        super.buildFunctionSkeleton(
+                funcNode, providedNameOpt, sourceContent, indent, lines, exportPrefix, includePresentationDetails);
+    }
+
+    @Override
+    protected String enhanceFunctionReturnTypeForPresentation(
+            TSNode funcNode,
+            SourceContent sourceContent,
+            String exportPrefix,
+            String functionName,
+            String returnTypeText) {
+        if (!returnTypeText.isEmpty()) {
+            return returnTypeText;
+        }
+
+        boolean isExported = exportPrefix.trim().startsWith("export");
+        boolean isComponentName = !functionName.isEmpty() && Character.isUpperCase(functionName.charAt(0));
+        boolean isRenderMethod = "render".equals(functionName);
+        if ((isRenderMethod || (isExported && isComponentName)) && returnsJsxElement(funcNode, sourceContent)) {
+            return "JSX.Element";
+        }
+        return returnTypeText;
+    }
+
     private boolean isJsxNode(@Nullable TSNode node) {
         if (node == null) return false;
         String type = node.getType();
@@ -266,40 +298,17 @@ public class JavascriptAnalyzer extends JsTsAnalyzer {
             }
         }
 
-        // Case 2: Explicit return statement: return <div />; or return (<div />);
-        // We need a small query to run over the bodyNode.
-        // Create a specific, local query for this check.
-        // TSLanguage and TSQuery are not AutoCloseable.
-        TSLanguage jsLanguage = getTSLanguage(); // Use thread-local language instance
-        try {
-            // Query for return statements that directly return a JSX element, or one wrapped in parentheses.
-            // Each line is a separate pattern; the query matches if any of them are found.
-            // The @jsx_return capture is on the JSX node itself.
-            // Queries for return statements that directly return a JSX element or one wrapped in parentheses.
-            // Note: Removed jsx_fragment queries as they were causing TSQueryErrorField,
-            // potentially due to grammar version or query engine specifics.
-            // Standard jsx_element (e.g. <></> becoming <JsxElement name={null}>) might cover fragments.
-            String jsxReturnQueryStr =
-                    """
-    (return_statement (jsx_element) @jsx_return)
-    (return_statement (jsx_self_closing_element) @jsx_return)
-    (return_statement (parenthesized_expression (jsx_element)) @jsx_return)
-    (return_statement (parenthesized_expression (jsx_self_closing_element)) @jsx_return)
-    """;
-
-            try (TSQuery returnJsxQuery = new TSQuery(jsLanguage, jsxReturnQueryStr);
-                    TSQueryCursor cursor = new TSQueryCursor()) {
-                cursor.exec(returnJsxQuery, bodyNode, sourceContent.text());
-                TSQueryMatch match = new TSQueryMatch();
-                if (cursor.nextMatch(match)) {
-                    return true; // Found a JSX return
-                }
-            }
-        } catch (TSQueryException e) {
-            // Log specific query exceptions, which usually indicate a problem with the query string itself.
-            log.error("Invalid TSQuery for JSX return type inference: {}", e.getMessage(), e);
-        }
-        return false;
+        return withCachedInlineQuery(
+                JSX_RETURN_QUERY_CACHE_KEY,
+                JSX_RETURN_QUERY,
+                returnJsxQuery -> {
+                    try (TSQueryCursor cursor = new TSQueryCursor()) {
+                        cursor.exec(returnJsxQuery, bodyNode, sourceContent.text());
+                        TSQueryMatch match = new TSQueryMatch();
+                        return cursor.nextMatch(match);
+                    }
+                },
+                false);
     }
 
     @Override
@@ -310,30 +319,27 @@ public class JavascriptAnalyzer extends JsTsAnalyzer {
         }
 
         Set<String> mutatedIdentifiers = new HashSet<>();
-        String mutationQueryStr =
-                """
-    (assignment_expression left: (identifier) @mutated.id)
-    (assignment_expression left: (member_expression property: (property_identifier) @mutated.id))
-    (assignment_expression left: (subscript_expression index: _ @mutated.id))
-    (update_expression argument: (identifier) @mutated.id)
-    (update_expression argument: (member_expression property: (property_identifier) @mutated.id))
-    """;
-
-        TSLanguage jsLanguage = getTSLanguage();
-        try (TSQuery mutationQuery = new TSQuery(jsLanguage, mutationQueryStr);
-                TSQueryCursor cursor = new TSQueryCursor()) {
-            cursor.exec(mutationQuery, bodyNode, sourceContent.text());
-            TSQueryMatch match = new TSQueryMatch();
-            while (cursor.nextMatch(match)) {
-                for (TSQueryCapture capture : match.getCaptures()) {
-                    String captureName = mutationQuery.getCaptureNameForId(capture.getIndex());
-                    if ("mutated.id".equals(captureName)) {
-                        TSNode node = capture.getNode();
-                        mutatedIdentifiers.add(sourceContent.substringFrom(node));
+        withCachedInlineQuery(
+                MUTATION_QUERY_CACHE_KEY,
+                MUTATION_QUERY,
+                mutationQuery -> {
+                    try (TSQueryCursor cursor = new TSQueryCursor()) {
+                        cursor.exec(mutationQuery, bodyNode, sourceContent.text());
+                        TSQueryMatch match = new TSQueryMatch();
+                        while (cursor.nextMatch(match)) {
+                            for (TSQueryCapture capture : match.getCaptures()) {
+                                String captureName = mutationQuery.getCaptureNameForId(capture.getIndex());
+                                if ("mutated.id".equals(captureName)) {
+                                    TSNode node = capture.getNode();
+                                    mutatedIdentifiers.add(sourceContent.substringFrom(node));
+                                }
+                            }
+                            match = new TSQueryMatch();
+                        }
                     }
-                }
-            }
-        }
+                    return true;
+                },
+                false);
 
         if (!mutatedIdentifiers.isEmpty()) {
             List<String> sortedMutations = new ArrayList<>(mutatedIdentifiers);
@@ -342,6 +348,107 @@ public class JavascriptAnalyzer extends JsTsAnalyzer {
         }
 
         return List.of();
+    }
+
+    @Override
+    protected List<String> signaturesForSkeleton(CodeUnit codeUnit) {
+        List<String> stored = super.signaturesForSkeleton(codeUnit);
+        if (!codeUnit.isFunction()) {
+            return stored;
+        }
+        return enrichedFunctionSignaturesOf(codeUnit.source()).getOrDefault(codeUnit, stored);
+    }
+
+    @Override
+    protected List<String> signaturesForDisplay(CodeUnit codeUnit) {
+        return codeUnit.isFunction() ? signaturesForSkeleton(codeUnit) : super.signaturesForDisplay(codeUnit);
+    }
+
+    protected int getSkeletonEnrichmentParseCount() {
+        return skeletonEnrichmentParseCount.get();
+    }
+
+    private Map<CodeUnit, List<String>> enrichedFunctionSignaturesOf(ProjectFile file) {
+        Map<CodeUnit, List<String>> cached = enrichedFunctionSignaturesByFile.getIfPresent(file);
+        if (cached != null) {
+            return cached;
+        }
+
+        SourceContent sourceContent = cache().sources().get(file);
+        if (sourceContent == null) {
+            return Map.of();
+        }
+
+        Map<CodeUnit, List<String>> computed = buildEnrichedFunctionSignatures(file, sourceContent);
+        enrichedFunctionSignaturesByFile.put(file, computed);
+        return computed;
+    }
+
+    private Map<CodeUnit, List<String>> buildEnrichedFunctionSignatures(ProjectFile file, SourceContent sourceContent) {
+        skeletonEnrichmentParseCount.incrementAndGet();
+        try (TSTree tree = getTSParser().parseString(null, sourceContent.text())) {
+            if (tree == null) {
+                return Map.of();
+            }
+
+            Map<CodeUnit, List<String>> enriched = new HashMap<>();
+            for (CodeUnit codeUnit : getDeclarations(file)) {
+                if (!codeUnit.isFunction()) {
+                    continue;
+                }
+                TSNode functionNode = findJsTsFunctionDefinitionNode(
+                        primaryNodeForCodeUnit(tree, codeUnit), sourceContent, codeUnit.identifier());
+                if (functionNode == null) {
+                    continue;
+                }
+
+                ResolvedNodes resolved = resolveSignatureNodes(
+                        functionNode, codeUnit.identifier(), SkeletonType.FUNCTION_LIKE, sourceContent);
+                String exportPrefix = getVisibilityPrefix(resolved.signatureNode(), sourceContent)
+                        .strip();
+                if (!exportPrefix.isEmpty()) {
+                    exportPrefix += " ";
+                }
+
+                List<String> signatureLines = new ArrayList<>();
+                TSNode bodyNode = unwrapJsTsFunctionValueNode(resolved.contentNode())
+                        .getChildByFieldName(getLanguageSyntaxProfile().bodyFieldName());
+                if (bodyNode != null) {
+                    signatureLines.addAll(getExtraFunctionComments(bodyNode, sourceContent, codeUnit));
+                }
+                buildFunctionSkeleton(
+                        resolved.contentNode(),
+                        Optional.of(codeUnit.identifier()),
+                        sourceContent,
+                        "",
+                        signatureLines,
+                        exportPrefix,
+                        true);
+                if (!signatureLines.isEmpty()) {
+                    enriched.put(
+                            codeUnit, List.of(String.join("\n", signatureLines).stripTrailing()));
+                }
+            }
+            return Map.copyOf(enriched);
+        } catch (Exception e) {
+            log.debug("Failed to enrich JS function signatures for {}: {}", file, e.getMessage());
+            return Map.of();
+        }
+    }
+
+    private boolean hasAsyncModifier(TSNode functionNode, SourceContent sourceContent) {
+        String raw = sourceContent.substringFrom(functionNode).stripLeading();
+        if (raw.startsWith("async ")) {
+            return true;
+        }
+        String asyncNodeType = getLanguageSyntaxProfile().asyncKeywordNodeType();
+        for (TSNode child : functionNode.getChildren()) {
+            if ((!asyncNodeType.isEmpty() && asyncNodeType.equals(child.getType()))
+                    || ASYNC.equals(sourceContent.substringFrom(child).strip())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
@@ -260,6 +260,98 @@ public abstract class JsTsAnalyzer extends TreeSitterAnalyzer implements ImportA
         return computed;
     }
 
+    protected final ResolvedNodes resolveJsTsSignatureNodes(
+            TSNode definitionNode, String simpleName, SkeletonType refined, SourceContent sourceContent) {
+        TSNode nodeForSignature = definitionNode;
+        TSNode nodeForContent = definitionNode;
+
+        if (nodeType(TsxNodeType.EXPORT_STATEMENT).equals(definitionNode.getType())) {
+            TSNode declarationInExport = definitionNode.getChildByFieldName(FIELD_DECLARATION);
+            if (declarationInExport != null) {
+                nodeForSignature = declarationInExport;
+                nodeForContent = declarationInExport;
+            }
+        }
+
+        if (refined == SkeletonType.FIELD_LIKE || refined == SkeletonType.FUNCTION_LIKE) {
+            String nodeType = nodeForContent.getType();
+            if (nodeType(TsxNodeType.LEXICAL_DECLARATION).equals(nodeType)
+                    || nodeType(TsxNodeType.VARIABLE_DECLARATION).equals(nodeType)) {
+                for (TSNode child : nodeForContent.getChildren()) {
+                    if (nodeType(TsxNodeType.VARIABLE_DECLARATOR).equals(child.getType())) {
+                        TSNode nameNode = child.getChildByFieldName(
+                                getLanguageSyntaxProfile().identifierFieldName());
+                        if (nameNode != null
+                                && sourceContent.substringFrom(nameNode).equals(simpleName)) {
+                            nodeForContent = child;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return new ResolvedNodes(nodeForSignature, nodeForContent);
+    }
+
+    protected final TSNode unwrapJsTsFunctionValueNode(TSNode node) {
+        if (!nodeType(TsxNodeType.VARIABLE_DECLARATOR).equals(node.getType())) {
+            return node;
+        }
+        TSNode valueNode = node.getChildByFieldName(FIELD_VALUE);
+        if (valueNode != null) {
+            return valueNode;
+        }
+        return node.getChildren().stream()
+                .filter(child ->
+                        getLanguageSyntaxProfile().functionLikeNodeTypes().contains(child.getType()))
+                .findFirst()
+                .orElse(node);
+    }
+
+    protected final @Nullable TSNode findJsTsFunctionDefinitionNode(
+            @Nullable TSNode startNode, SourceContent sourceContent, String identifier) {
+        for (TSNode current = startNode; current != null; current = current.getParent()) {
+            TSNode functionNode = resolveJsTsFunctionDefinitionNode(current, sourceContent, identifier);
+            if (functionNode != null) {
+                return functionNode;
+            }
+        }
+        return null;
+    }
+
+    private @Nullable TSNode resolveJsTsFunctionDefinitionNode(
+            TSNode node, SourceContent sourceContent, String identifier) {
+        Optional<String> extractedName = extractSimpleName(node, sourceContent);
+        if (extractedName.isPresent() && extractedName.get().equals(identifier)) {
+            return node;
+        }
+
+        String nodeType = node.getType();
+        if (nodeType(TsxNodeType.EXPORT_STATEMENT).equals(nodeType)) {
+            TSNode declaration = node.getChildByFieldName(FIELD_DECLARATION);
+            return declaration == null
+                    ? null
+                    : resolveJsTsFunctionDefinitionNode(declaration, sourceContent, identifier);
+        }
+        if (nodeType(TsxNodeType.LEXICAL_DECLARATION).equals(nodeType)
+                || nodeType(TsxNodeType.VARIABLE_DECLARATION).equals(nodeType)) {
+            return node.getChildren().stream()
+                    .filter(child -> nodeType(TsxNodeType.VARIABLE_DECLARATOR).equals(child.getType()))
+                    .map(child -> resolveJsTsFunctionDefinitionNode(child, sourceContent, identifier))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (nodeType(TsxNodeType.VARIABLE_DECLARATOR).equals(nodeType)) {
+            TSNode nameNode = node.getChildByFieldName(FIELD_NAME);
+            if (nameNode != null && identifier.equals(sourceContent.substringFrom(nameNode))) {
+                return unwrapJsTsFunctionValueNode(node);
+            }
+        }
+        return null;
+    }
+
     public Map<String, Set<String>> heritageIndex() {
         Map<String, Set<String>> cached = cache().heritageIndex();
         if (cached != null) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -66,6 +66,8 @@ import org.treesitter.*;
 public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider, TestDetectionProvider {
 
     protected static final Logger log = LoggerFactory.getLogger(TreeSitterAnalyzer.class);
+    static final String ANALYZER_MAX_PARALLELISM_PROPERTY = "brokk.analyzer.maxParallelism";
+    static final int DEFAULT_ANALYZER_MAX_PARALLELISM = 4;
     private static final Set<String> COMMENT_NODE_TYPES =
             Set.of("comment", "line_comment", "block_comment", "doc_comment", "documentation_comment");
     private static final Set<String> WHITESPACE_NODE_TYPES = Set.of("whitespace", "newline");
@@ -296,6 +298,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
      */
     private final ThreadLocal<Map<QueryType, TSQuery>> threadLocalQueries =
             ThreadLocal.withInitial(() -> new EnumMap<>(QueryType.class));
+    private final ThreadLocal<Map<String, TSQuery>> threadLocalInlineQueries = ThreadLocal.withInitial(HashMap::new);
 
     /* Test-only hook to count query compilations. */
     private final AtomicInteger queryCompilationCount = new AtomicInteger(0);
@@ -366,6 +369,36 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     }
 
     /**
+     * Provides borrowed access to a cached compiled inline query for the duration of the provided function.
+     *
+     * <p>This is intended for analyzer-local helper queries that are hot enough to justify reuse but do not fit the
+     * fixed {@link QueryType} enum.
+     *
+     * @param cacheKey unique key for this helper query within the analyzer
+     * @param querySource Tree-sitter query source
+     * @param fn function to execute with the cached query
+     * @param defaultValue fallback value if compilation fails
+     * @param <T> return type
+     * @return function result or {@code defaultValue} if the query could not be compiled
+     */
+    protected final <T> T withCachedInlineQuery(
+            String cacheKey, String querySource, Function<TSQuery, T> fn, T defaultValue) {
+        Map<String, TSQuery> cache = threadLocalInlineQueries.get();
+        TSQuery query = cache.get(cacheKey);
+        if (query == null) {
+            try {
+                query = new TSQuery(getTSLanguage(), querySource);
+                queryCompilationCount.incrementAndGet();
+                cache.put(cacheKey, query);
+            } catch (TSQueryException e) {
+                log.error("Failed to compile cached inline query {}: {}", cacheKey, e.getMessage(), e);
+                return defaultValue;
+            }
+        }
+        return fn.apply(query);
+    }
+
+    /**
      * Creates a new query instance for the specified type.
      * The caller is responsible for closing the returned query.
      *
@@ -378,6 +411,28 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
             return null;
         }
         return new TSQuery(getTSLanguage(), source);
+    }
+
+    static int configuredAnalyzerMaxParallelism() {
+        String configured = System.getProperty(ANALYZER_MAX_PARALLELISM_PROPERTY);
+        if (configured == null || configured.isBlank()) {
+            return DEFAULT_ANALYZER_MAX_PARALLELISM;
+        }
+        try {
+            return Math.max(1, Integer.parseInt(configured));
+        } catch (NumberFormatException e) {
+            log.warn(
+                    "Invalid {} value '{}'; using default {}",
+                    ANALYZER_MAX_PARALLELISM_PROPERTY,
+                    configured,
+                    DEFAULT_ANALYZER_MAX_PARALLELISM);
+            return DEFAULT_ANALYZER_MAX_PARALLELISM;
+        }
+    }
+
+    static int computeAnalyzerParallelism(int availableProcessors, int configuredCap, int totalWork) {
+        int boundedWork = Math.max(1, totalWork);
+        return Math.max(1, Math.min(Math.min(availableProcessors, configuredCap), boundedWork));
     }
 
     /**
@@ -738,13 +793,26 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         List<CompletableFuture<?>> futures = new ArrayList<>();
         int totalFiles = filesToProcess.size();
         var progressReporter = new DebouncedProgressReporter(totalFiles, "Parsing " + language.name() + " files", 100);
+        int configuredParallelismCap = configuredAnalyzerMaxParallelism();
+        String configuredParallelismValue = System.getProperty(ANALYZER_MAX_PARALLELISM_PROPERTY);
+        int parseParallelism = computeAnalyzerParallelism(
+                Runtime.getRuntime().availableProcessors(), configuredParallelismCap, totalFiles);
+        int ingestParallelism = computeAnalyzerParallelism(
+                Runtime.getRuntime().availableProcessors(), configuredParallelismCap, totalFiles);
+        log.debug(
+                "[{}] Analyzer parallelism: availableProcessors={}, configuredCap={}, propertyValue={}, parse={}, ingest={}, files={}",
+                language.name(),
+                Runtime.getRuntime().availableProcessors(),
+                configuredParallelismCap,
+                configuredParallelismValue == null ? "<default>" : configuredParallelismValue,
+                parseParallelism,
+                ingestParallelism,
+                totalFiles);
 
         // Executors: virtual threads for I/O/parsing, single-thread for ingestion
         try (var ioExecutor = ExecutorsUtil.newVirtualThreadExecutor("ts-io-", IO_VT_CAP);
-                var parseExecutor = ExecutorsUtil.newFixedThreadExecutor(
-                        "ts-parse-", Runtime.getRuntime().availableProcessors());
-                var ingestExecutor = ExecutorsUtil.newFixedThreadExecutor(
-                        "ts-ingest-", Runtime.getRuntime().availableProcessors())) {
+                var parseExecutor = ExecutorsUtil.newFixedThreadExecutor("ts-parse-", parseParallelism);
+                var ingestExecutor = ExecutorsUtil.newFixedThreadExecutor("ts-ingest-", ingestParallelism)) {
             for (var pf : filesToProcess) {
                 // we do our own exception handling so LoggingFuture is not appropriate here
                 CompletableFuture<Void> future = CompletableFuture.supplyAsync(
@@ -1017,9 +1085,17 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         return codeUnitProperties(codeUnit).signaturesList();
     }
 
+    protected List<String> signaturesForSkeleton(CodeUnit codeUnit) {
+        return signaturesOf(codeUnit);
+    }
+
+    protected List<String> signaturesForDisplay(CodeUnit codeUnit) {
+        return signaturesOf(codeUnit);
+    }
+
     @Override
     public List<String> getDisplaySignatures(CodeUnit codeUnit) {
-        var displaySignatures = signaturesOf(codeUnit).stream()
+        var displaySignatures = signaturesForDisplay(codeUnit).stream()
                 .map(TreeSitterAnalyzer::normalizeDisplaySignature)
                 .filter(signature -> !signature.isBlank())
                 .distinct()
@@ -1683,7 +1759,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
     }
 
     private void reconstructSkeletonRecursive(CodeUnit cu, String indent, boolean headerOnly, StringBuilder sb) {
-        final List<String> sigList = signaturesOf(cu);
+        final List<String> sigList = signaturesForSkeleton(cu);
 
         if (sigList.isEmpty()) {
             // It's possible for some CUs (e.g., a namespace CU acting only as a parent) to not have direct textual
@@ -2754,7 +2830,8 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
                                     sourceContent,
                                     primaryCaptureName,
                                     defInfo.modifierKeywords(),
-                                    file);
+                                    file,
+                                    false);
                             acc.setHasBody(
                                     cu, computeHasBody(resolved.contentNode(), primaryCaptureName, sourceContent));
                             if (CaptureNames.TYPEALIAS_DEFINITION.equals(primaryCaptureName)) {
@@ -3317,7 +3394,8 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
             SourceContent sourceContent,
             String primaryCaptureName,
             List<String> capturedModifierKeywords,
-            ProjectFile file) {
+            ProjectFile file,
+            boolean includePresentationDetails) {
 
         var signatureLines = new ArrayList<String>();
         var profile = getLanguageSyntaxProfile();
@@ -3419,13 +3497,19 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
             case FUNCTION_LIKE: {
                 // Extra comments derived from the function body if any.
                 TSNode bodyNode = nodeForContent.getChildByFieldName(profile.bodyFieldName());
-                if (bodyNode != null) {
+                if (includePresentationDetails && bodyNode != null) {
                     for (String c : getExtraFunctionComments(bodyNode, sourceContent, null)) {
                         if (!c.isBlank()) signatureLines.add(c);
                     }
                 }
                 buildFunctionSkeleton(
-                        nodeForContent, Optional.of(simpleName), sourceContent, "", signatureLines, exportPrefix);
+                        nodeForContent,
+                        Optional.of(simpleName),
+                        sourceContent,
+                        "",
+                        signatureLines,
+                        exportPrefix,
+                        includePresentationDetails);
                 break;
             }
 
@@ -3516,7 +3600,8 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
             SourceContent sourceContent,
             String indent,
             List<String> lines,
-            String exportPrefix) {
+            String exportPrefix,
+            boolean includePresentationDetails) {
         var profile = getLanguageSyntaxProfile();
         String functionName;
         TSNode nameNode = funcNode.getChildByFieldName(profile.identifierFieldName());
@@ -3573,6 +3658,10 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
 
         String paramsText = formatParameterList(paramsNode, sourceContent);
         String returnTypeText = formatReturnType(returnTypeNode, sourceContent);
+        if (includePresentationDetails) {
+            returnTypeText = enhanceFunctionReturnTypeForPresentation(
+                    funcNode, sourceContent, exportPrefix, functionName, returnTypeText);
+        }
 
         // Extract type parameters if available
         String typeParamsText = "";
@@ -3624,6 +3713,15 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         if (!functionLine.isBlank()) {
             lines.add(functionLine);
         }
+    }
+
+    protected String enhanceFunctionReturnTypeForPresentation(
+            TSNode funcNode,
+            SourceContent sourceContent,
+            String exportPrefix,
+            String functionName,
+            String returnTypeText) {
+        return returnTypeText;
     }
 
     /**
@@ -4206,7 +4304,18 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         var deletedCount = new AtomicInteger(0);
         var reanalyzeNanos = new AtomicLong(0L);
 
-        int parallelism = Math.max(1, Math.min(Runtime.getRuntime().availableProcessors(), total));
+        int configuredParallelismCap = configuredAnalyzerMaxParallelism();
+        String configuredParallelismValue = System.getProperty(ANALYZER_MAX_PARALLELISM_PROPERTY);
+        int parallelism =
+                computeAnalyzerParallelism(Runtime.getRuntime().availableProcessors(), configuredParallelismCap, total);
+        log.debug(
+                "[{}] Update parallelism: availableProcessors={}, configuredCap={}, propertyValue={}, update={}, files={}",
+                language.name(),
+                Runtime.getRuntime().availableProcessors(),
+                configuredParallelismCap,
+                configuredParallelismValue == null ? "<default>" : configuredParallelismValue,
+                parallelism,
+                total);
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         var progressReporter = new DebouncedProgressReporter(total, "Updating " + language.name() + " files", 100);
 
@@ -4318,7 +4427,18 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         }
 
         // new or modified files (parallelized)
-        int parallelism = Math.max(1, Runtime.getRuntime().availableProcessors());
+        int configuredParallelismCap = configuredAnalyzerMaxParallelism();
+        String configuredParallelismValue = System.getProperty(ANALYZER_MAX_PARALLELISM_PROPERTY);
+        int parallelism = computeAnalyzerParallelism(
+                Runtime.getRuntime().availableProcessors(), configuredParallelismCap, currentFiles.size());
+        log.debug(
+                "[{}] Detect parallelism: availableProcessors={}, configuredCap={}, propertyValue={}, detect={}, files={}",
+                language.name(),
+                Runtime.getRuntime().availableProcessors(),
+                configuredParallelismCap,
+                configuredParallelismValue == null ? "<default>" : configuredParallelismValue,
+                parallelism,
+                currentFiles.size());
         var concurrentChanged = ConcurrentHashMap.<ProjectFile>newKeySet();
 
         try (var detectExecutor = ExecutorsUtil.newFixedThreadExecutor("ts-detect-", parallelism)) {

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TypescriptAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TypescriptAnalyzer.java
@@ -528,39 +528,7 @@ public final class TypescriptAnalyzer extends JsTsAnalyzer {
     @Override
     protected ResolvedNodes resolveSignatureNodes(
             TSNode definitionNode, String simpleName, SkeletonType refined, SourceContent sourceContent) {
-        TSNode nodeForSignature = definitionNode;
-        TSNode nodeForContent = definitionNode;
-
-        // 1. Unwrap export statement
-        if (nodeType(TsxNodeType.EXPORT_STATEMENT).equals(definitionNode.getType())) {
-            TSNode declarationInExport = definitionNode.getChildByFieldName(FIELD_DECLARATION);
-            if (declarationInExport != null) {
-                nodeForSignature = declarationInExport;
-                nodeForContent = declarationInExport;
-            }
-        }
-
-        // 2. Unwrap variable declaration to specific declarator for content/body extraction
-        if (refined == SkeletonType.FIELD_LIKE || refined == SkeletonType.FUNCTION_LIKE) {
-            String nodeType = nodeForContent.getType();
-            if (nodeType(TsxNodeType.LEXICAL_DECLARATION).equals(nodeType)
-                    || nodeType(TsxNodeType.VARIABLE_DECLARATION).equals(nodeType)) {
-                // Find the variable_declarator child that matches the simpleName
-                for (TSNode child : nodeForContent.getChildren()) {
-                    if (nodeType(TsxNodeType.VARIABLE_DECLARATOR).equals(child.getType())) {
-                        TSNode nameNode = child.getChildByFieldName(
-                                getLanguageSyntaxProfile().identifierFieldName());
-                        if (nameNode != null
-                                && sourceContent.substringFrom(nameNode).equals(simpleName)) {
-                            nodeForContent = child;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        return new ResolvedNodes(nodeForSignature, nodeForContent);
+        return resolveJsTsSignatureNodes(definitionNode, simpleName, refined, sourceContent);
     }
 
     @Override
@@ -918,10 +886,11 @@ public final class TypescriptAnalyzer extends JsTsAnalyzer {
             SourceContent sourceContent,
             String indent,
             List<String> lines,
-            String exportPrefix) {
+            String exportPrefix,
+            boolean includePresentationDetails) {
         // Handle variable_declarator containing arrow function
         if (nodeType(TsxNodeType.VARIABLE_DECLARATOR).equals(funcNode.getType())) {
-            TSNode valueNode = funcNode.getChildByFieldName(FIELD_VALUE);
+            TSNode valueNode = unwrapJsTsFunctionValueNode(funcNode);
             if (valueNode != null && nodeType(TsxNodeType.ARROW_FUNCTION).equals(valueNode.getType())) {
                 // Build the const/let declaration with arrow function
                 String fullDeclaration = sourceContent.substringFrom(funcNode).strip();
@@ -979,7 +948,8 @@ public final class TypescriptAnalyzer extends JsTsAnalyzer {
         }
 
         // For all other cases, use the parent implementation
-        super.buildFunctionSkeleton(funcNode, providedNameOpt, sourceContent, indent, lines, exportPrefix);
+        super.buildFunctionSkeleton(
+                funcNode, providedNameOpt, sourceContent, indent, lines, exportPrefix, includePresentationDetails);
     }
 
     @Override

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/JavascriptAnalyzerTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/JavascriptAnalyzerTest.java
@@ -7,6 +7,8 @@ import ai.brokk.AnalyzerUtil;
 import ai.brokk.testutil.CoreTestProject;
 import ai.brokk.testutil.InlineTestProjectCreator;
 import ai.brokk.testutil.TestCodeProject;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -281,6 +283,145 @@ public final class JavascriptAnalyzerTest {
         assertTrue(mecSkeletonOpt.isPresent(), "getSkeleton should find MyExportedComponent by FQ name.");
         assertCodeEquals(
                 expectedMecSkeleton, mecSkeletonOpt.get(), "getSkeleton for MyExportedComponent FQ name mismatch.");
+    }
+
+    @Test
+    void testStoredFunctionSignaturesStayCheapWhileSkeletonsStayRich() {
+        ProjectFile featuresFile = new ProjectFile(jsTestProject.getRoot(), "FeaturesTest.jsx");
+        CodeUnit componentCu = CodeUnit.fn(featuresFile, "", "MyExportedComponent");
+
+        List<String> storedSignatures = jsAnalyzer.signaturesOf(componentCu);
+        assertEquals(1, storedSignatures.size(), "Expected a single stored signature for MyExportedComponent.");
+        assertFalse(
+                storedSignatures.getFirst().contains("// mutates:"), "Stored signature should skip mutation comments.");
+        assertFalse(storedSignatures.getFirst().contains("JSX.Element"), "Stored signature should skip JSX inference.");
+
+        String skeleton = jsAnalyzer.getSkeleton(componentCu).orElseThrow();
+        assertTrue(skeleton.contains("// mutates: counter, wasUpdated"));
+        assertTrue(skeleton.contains("export function MyExportedComponent(props): JSX.Element ..."));
+    }
+
+    @Test
+    void testDisplaySignaturesStayRichForJsFunctions() {
+        ProjectFile featuresFile = new ProjectFile(jsTestProject.getRoot(), "FeaturesTest.jsx");
+        CodeUnit componentCu = CodeUnit.fn(featuresFile, "", "MyExportedComponent");
+
+        List<String> displaySignatures = jsAnalyzer.getDisplaySignatures(componentCu);
+        assertEquals(1, displaySignatures.size());
+        assertEquals(
+                "// mutates: counter, wasUpdated export function MyExportedComponent(props): JSX.Element ...",
+                displaySignatures.getFirst());
+    }
+
+    @Test
+    void testFileScopedJsSkeletonEnrichmentParsesOncePerFile() {
+        try (var project = TestCodeProject.fromResourceDir("testcode-js", Languages.JAVASCRIPT)) {
+            var analyzer = new JavascriptAnalyzer(project);
+            ProjectFile featuresFile = new ProjectFile(project.getRoot(), "FeaturesTest.jsx");
+            CodeUnit componentCu = CodeUnit.fn(featuresFile, "", "MyExportedComponent");
+
+            int before = analyzer.getSkeletonEnrichmentParseCount();
+            var skeletons = analyzer.getSkeletons(featuresFile);
+            int afterSkeletons = analyzer.getSkeletonEnrichmentParseCount();
+            analyzer.getSkeleton(componentCu).orElseThrow();
+            analyzer.getDisplaySignatures(componentCu);
+            int afterReuse = analyzer.getSkeletonEnrichmentParseCount();
+
+            assertFalse(skeletons.isEmpty());
+            assertEquals(before + 1, afterSkeletons, "Expected a single parse to enrich the whole file.");
+            assertEquals(
+                    afterSkeletons,
+                    afterReuse,
+                    "Subsequent skeleton/display reads should reuse the file-scoped cache.");
+        }
+    }
+
+    @Test
+    void testRepeatedJsSkeletonRenderingReusesHelperQueries() {
+        String code =
+                """
+                export function Widget(props) {
+                    props.count += 1;
+                    return <div>{props.count}</div>;
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.code(code, "Widget.jsx").build()) {
+            var analyzer = new JavascriptAnalyzer(project);
+            var widgetCu = CodeUnit.fn(new ProjectFile(project.getRoot(), "Widget.jsx"), "", "Widget");
+
+            int before = analyzer.getQueryCompilationCount();
+            String firstSkeleton = analyzer.getSkeleton(widgetCu).orElseThrow();
+            int afterFirst = analyzer.getQueryCompilationCount();
+            String secondSkeleton = analyzer.getSkeleton(widgetCu).orElseThrow();
+            int afterSecond = analyzer.getQueryCompilationCount();
+            assertEquals(1, analyzer.getSkeletonEnrichmentParseCount());
+
+            assertTrue(afterFirst >= before + 2, "First rich skeleton render should compile the helper queries once.");
+            assertEquals(
+                    afterFirst, afterSecond, "Repeated rich skeleton rendering should reuse cached helper queries.");
+            assertCodeEquals(firstSkeleton, secondSkeleton);
+        }
+    }
+
+    @Test
+    void testAsyncArrowFunctionsRetainAsyncInRichSkeletons() {
+        String code =
+                """
+                export const AsyncWidget = async ({ id }) => {
+                    return <div>{id}</div>;
+                };
+                """;
+
+        try (var project =
+                InlineTestProjectCreator.code(code, "AsyncWidget.jsx").build()) {
+            var analyzer = new JavascriptAnalyzer(project);
+            var widgetCu = CodeUnit.fn(new ProjectFile(project.getRoot(), "AsyncWidget.jsx"), "", "AsyncWidget");
+
+            assertCodeEquals(
+                    "export async AsyncWidget({ id }): JSX.Element => ...",
+                    analyzer.getSkeleton(widgetCu).orElseThrow());
+            assertEquals(
+                    "export async AsyncWidget({ id }): JSX.Element => ...",
+                    analyzer.getDisplaySignatures(widgetCu).getFirst());
+        }
+    }
+
+    @Test
+    void testLoadedJsAnalyzerFallsBackToStoredSignaturesWithoutReadingLiveDisk() throws Exception {
+        String original =
+                """
+                export function Widget(props) {
+                    props.count += 1;
+                    return <div>{props.count}</div>;
+                }
+                """;
+
+        try (var project = InlineTestProjectCreator.code(original, "Widget.jsx").build()) {
+            var analyzer = new JavascriptAnalyzer(project);
+            Path stateFile = Languages.JAVASCRIPT.getStoragePath(project);
+            TreeSitterStateIO.save(analyzer.snapshotState(), stateFile, Languages.JAVASCRIPT);
+            var loadedState = TreeSitterStateIO.load(stateFile);
+
+            Files.writeString(
+                    project.getRoot().resolve("Widget.jsx"),
+                    """
+                    export function Widget() {
+                        return null;
+                    }
+                    """);
+            project.invalidateAllFiles();
+
+            var loaded = JavascriptAnalyzer.fromState(project, loadedState, IAnalyzer.ProgressListener.NOOP);
+            var widgetCu = CodeUnit.fn(new ProjectFile(project.getRoot(), "Widget.jsx"), "", "Widget");
+
+            assertCodeEquals(
+                    "export function Widget(props) ...",
+                    loaded.getSkeleton(widgetCu).orElseThrow());
+            assertEquals(
+                    "export function Widget(props) ...",
+                    loaded.getDisplaySignatures(widgetCu).getFirst());
+        }
     }
 
     @Test

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterAnalyzerTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterAnalyzerTest.java
@@ -1,0 +1,49 @@
+package ai.brokk.analyzer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@ResourceLock(value = TreeSitterAnalyzer.ANALYZER_MAX_PARALLELISM_PROPERTY, mode = ResourceAccessMode.READ_WRITE)
+final class TreeSitterAnalyzerTest {
+
+    @Test
+    void testConfiguredAnalyzerMaxParallelismDefaultsToConservativeCap() {
+        String original = System.getProperty(TreeSitterAnalyzer.ANALYZER_MAX_PARALLELISM_PROPERTY);
+        try {
+            System.clearProperty(TreeSitterAnalyzer.ANALYZER_MAX_PARALLELISM_PROPERTY);
+            assertEquals(4, TreeSitterAnalyzer.configuredAnalyzerMaxParallelism());
+            assertEquals(4, TreeSitterAnalyzer.computeAnalyzerParallelism(16, 4, Integer.MAX_VALUE));
+        } finally {
+            restoreProperty(original);
+        }
+    }
+
+    @Test
+    void testConfiguredAnalyzerMaxParallelismHonorsOverride() {
+        String original = System.getProperty(TreeSitterAnalyzer.ANALYZER_MAX_PARALLELISM_PROPERTY);
+        try {
+            System.setProperty(TreeSitterAnalyzer.ANALYZER_MAX_PARALLELISM_PROPERTY, "7");
+            assertEquals(7, TreeSitterAnalyzer.configuredAnalyzerMaxParallelism());
+            assertEquals(7, TreeSitterAnalyzer.computeAnalyzerParallelism(16, 7, Integer.MAX_VALUE));
+        } finally {
+            restoreProperty(original);
+        }
+    }
+
+    @Test
+    void testComputeAnalyzerParallelismClampsToWorkSize() {
+        assertEquals(3, TreeSitterAnalyzer.computeAnalyzerParallelism(16, 8, 3));
+        assertEquals(1, TreeSitterAnalyzer.computeAnalyzerParallelism(16, 8, 0));
+    }
+
+    private static void restoreProperty(String original) {
+        if (original == null) {
+            System.clearProperty(TreeSitterAnalyzer.ANALYZER_MAX_PARALLELISM_PROPERTY);
+        } else {
+            System.setProperty(TreeSitterAnalyzer.ANALYZER_MAX_PARALLELISM_PROPERTY, original);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Reduce headless analyzer warm-up cost by capping analyzer parallelism, reusing hot JS query objects, and moving richer JS presentation work onto a file-scoped lazy path that stays snapshot-safe.

**Key Changes**:
- cap analyzer-owned parse, ingest, update, and detect parallelism with the `brokk.analyzer.maxParallelism` override and add debug logging for the effective settings
- reuse cached JS helper queries, unify JS/TS wrapper resolution, and make JS skeleton/display enrichment file-scoped rather than per-function
- keep stored signatures cheap while restoring rich JS skeleton and display output, including JSX inference, mutation comments, and async exported arrow rendering
- add regression coverage for parallelism sizing, JS enrichment reuse, async arrows, rich display signatures, and restored-analyzer fallback behavior

**Touch Points**:
- brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/JsTsAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/JavascriptAnalyzer.java
- brokk-shared/src/main/java/ai/brokk/analyzer/TypescriptAnalyzer.java
- brokk-shared/src/test/java/ai/brokk/analyzer/JavascriptAnalyzerTest.java
- brokk-shared/src/test/java/ai/brokk/analyzer/TreeSitterAnalyzerTest.java

Verification:
- `./gradlew :brokk-core:shadowJar --rerun-tasks`
- `./gradlew :brokk-shared:test --rerun-tasks --tests ai.brokk.analyzer.TreeSitterAnalyzerTest --tests ai.brokk.analyzer.JavascriptAnalyzerTest`
- `./gradlew fix tidy`
- `./gradlew analyze`
