### PR TITLE
Reduce Go import memory pressure and fix reverse import resolution

### DIFF
--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.treesitter.TSLanguage;
@@ -40,6 +41,7 @@ import org.treesitter.TreeSitterGo;
 
 public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalysisProvider {
     static final Logger log = LoggerFactory.getLogger(GoAnalyzer.class); // Changed to package-private
+    private volatile @Nullable Map<String, Set<CodeUnit>> codeUnitsByPackage;
 
     @Override
     public boolean isFileLevelModule(CodeUnit cu, boolean topLevel) {
@@ -1054,12 +1056,21 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
 
     @Override
     public Set<CodeUnit> importedCodeUnitsOf(ProjectFile file) {
-        return performImportedCodeUnitsOf(file);
+        return resolveImports(file, importStatementsOf(file));
     }
 
     @Override
     public Set<ProjectFile> referencingFilesOf(ProjectFile file) {
-        return performReferencingFilesOf(file);
+        Set<ProjectFile> referencers = new LinkedHashSet<>();
+        withFileProperties(fileProperties -> {
+            fileProperties.forEach((sourceFile, properties) -> {
+                if (couldImportFile(sourceFile, properties.importStatements(), file)) {
+                    referencers.add(sourceFile);
+                }
+            });
+            return null;
+        });
+        return Collections.unmodifiableSet(referencers);
     }
 
     @Override
@@ -1314,14 +1325,40 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
         // Instead, find all CodeUnits whose packageName matches the imported package.
         Set<CodeUnit> resolved = new LinkedHashSet<>();
         if (!importedPackageNames.isEmpty()) {
-            for (CodeUnit cu : snapshotState().codeUnitState().keySet()) {
-                if (!cu.isModule() && importedPackageNames.contains(cu.packageName())) {
-                    resolved.add(cu);
-                }
+            Map<String, Set<CodeUnit>> packageIndex = codeUnitsByPackage();
+            for (String packageName : importedPackageNames) {
+                resolved.addAll(packageIndex.getOrDefault(packageName, Set.of()));
             }
         }
 
         return Collections.unmodifiableSet(resolved);
+    }
+
+    private Map<String, Set<CodeUnit>> codeUnitsByPackage() {
+        var cached = codeUnitsByPackage;
+        if (cached != null) {
+            return cached;
+        }
+
+        synchronized (this) {
+            if (codeUnitsByPackage == null) {
+                var mutable = new HashMap<String, Set<CodeUnit>>();
+                snapshotState().codeUnitState().keySet().stream()
+                        .filter(cu -> !cu.isModule())
+                        .forEach(cu -> mutable.computeIfAbsent(cu.packageName(), ignored -> new LinkedHashSet<>())
+                                .add(cu));
+
+                var immutable = new HashMap<String, Set<CodeUnit>>();
+                mutable.forEach((packageName, codeUnits) -> immutable.put(packageName, Set.copyOf(codeUnits)));
+                codeUnitsByPackage = Map.copyOf(immutable);
+            }
+            return Objects.requireNonNull(codeUnitsByPackage);
+        }
+    }
+
+    @VisibleForTesting
+    boolean genericImportCacheIsEmptyForTesting() {
+        return getCache().imports().isEmpty();
     }
 
     private String resolveImportPathToPackageName(String importPath) {
@@ -1337,19 +1374,23 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
                 // We check if the file is inside a directory matching the import path.
                 // e.g., import "mymodule/pkg" matches "vendor/mymodule/pkg/file.go"
                 if (relPath.contains("/" + path + "/") || relPath.startsWith(path + "/")) {
+                    String cachedPackageName = cachedPackageNameOf(pf);
+                    if (!cachedPackageName.isEmpty()) {
+                        return cachedPackageName;
+                    }
 
                     // Read the file and determine its package name
-                    Optional<SourceContent> content = SourceContent.read(pf);
-                    if (content.isPresent()) {
-                        String pkgName = withTreeOf(
-                                pf,
-                                tree -> Optional.ofNullable(tree.getRootNode())
-                                        .map(rootNode -> determinePackageName(pf, rootNode, rootNode, content.get()))
-                                        .orElse(""),
-                                "");
-                        if (!pkgName.isEmpty()) {
-                            return pkgName;
-                        }
+                    String pkgName = withSource(
+                            pf,
+                            content -> withTreeOf(
+                                    pf,
+                                    tree -> Optional.ofNullable(tree.getRootNode())
+                                            .map(rootNode -> determinePackageName(pf, rootNode, rootNode, content))
+                                            .orElse(""),
+                                    ""),
+                            "");
+                    if (!pkgName.isEmpty()) {
+                        return pkgName;
                     }
                 }
             }

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java
@@ -1062,14 +1062,14 @@ public final class GoAnalyzer extends TreeSitterAnalyzer implements ImportAnalys
     @Override
     public Set<ProjectFile> referencingFilesOf(ProjectFile file) {
         Set<ProjectFile> referencers = new LinkedHashSet<>();
-        withFileProperties(fileProperties -> {
-            fileProperties.forEach((sourceFile, properties) -> {
-                if (couldImportFile(sourceFile, properties.importStatements(), file)) {
-                    referencers.add(sourceFile);
-                }
-            });
-            return null;
-        });
+        for (ProjectFile sourceFile : candidateFilesThatCouldImport(file)) {
+            boolean importsTarget = resolveImports(sourceFile, importStatementsOf(sourceFile)).stream()
+                    .map(CodeUnit::source)
+                    .anyMatch(file::equals);
+            if (importsTarget) {
+                referencers.add(sourceFile);
+            }
+        }
         return Collections.unmodifiableSet(referencers);
     }
 

--- a/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
+++ b/brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java
@@ -1314,19 +1314,7 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
         }
 
         // 2. Phase 1: Filter candidates using cheap text-based matching
-        List<ProjectFile> allFiles = List.copyOf(this.state.fileState().keySet());
-        int totalFiles = allFiles.size();
-        notifyProgressListener(0, totalFiles, "Filtering import candidates");
-
-        var filterReporter = new DebouncedProgressReporter(totalFiles, "Filtering import candidates", 100);
-        List<ProjectFile> candidates = allFiles.stream()
-                .filter(f -> {
-                    boolean matches = couldImportFile(f, fileProperties(f).importStatements(), file);
-                    filterReporter.increment();
-                    return matches;
-                })
-                .toList();
-        filterReporter.reportFinal();
+        List<ProjectFile> candidates = candidateFilesThatCouldImport(file);
 
         // 4. Phase 2: Resolve imports for candidates to populate reverse cache
         int totalCandidates = candidates.size();
@@ -1345,6 +1333,23 @@ public abstract class TreeSitterAnalyzer implements IAnalyzer, TypeAliasProvider
             return Set.of();
         }
         return Collections.unmodifiableSet(new HashSet<>(resolved));
+    }
+
+    protected List<ProjectFile> candidateFilesThatCouldImport(ProjectFile file) {
+        List<ProjectFile> allFiles = List.copyOf(this.state.fileState().keySet());
+        int totalFiles = allFiles.size();
+        notifyProgressListener(0, totalFiles, "Filtering import candidates");
+
+        var filterReporter = new DebouncedProgressReporter(totalFiles, "Filtering import candidates", 100);
+        List<ProjectFile> candidates = allFiles.stream()
+                .filter(f -> {
+                    boolean matches = couldImportFile(f, fileProperties(f).importStatements(), file);
+                    filterReporter.increment();
+                    return matches;
+                })
+                .toList();
+        filterReporter.reportFinal();
+        return candidates;
     }
 
     protected Set<String> typeIdentifiersOf(ProjectFile file) {

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/GoAnalyzerTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/GoAnalyzerTest.java
@@ -1575,4 +1575,68 @@ public class GoAnalyzerTest {
                 inlineAnalyzer.genericImportCacheIsEmptyForTesting(),
                 "Go referencing-file lookup should not force generic import cache population");
     }
+
+    @Test
+    void referencingFilesOfExcludesBlankImports() throws IOException {
+        var project = InlineCoreProject.code(
+                        """
+                        package png
+                        func Decode() {}
+                        """,
+                        "image/png/png.go")
+                .addFileContents(
+                        """
+                        package main
+                        import _ "image/png"
+                        func main() {}
+                        """,
+                        "main.go")
+                .build();
+        var inlineAnalyzer = new GoAnalyzer(project);
+        var targetFile = new ProjectFile(project.getRoot(), Path.of("image", "png", "png.go"));
+        var importer = new ProjectFile(project.getRoot(), "main.go");
+
+        var referencers = inlineAnalyzer.referencingFilesOf(targetFile);
+
+        assertFalse(referencers.contains(importer), "Blank imports should not be reverse import referencers");
+        assertTrue(
+                inlineAnalyzer.genericImportCacheIsEmptyForTesting(),
+                "Go referencing-file lookup should not force generic import cache population");
+    }
+
+    @Test
+    void referencingFilesOfExcludesUnresolvedRootPackageCandidates() throws IOException {
+        var project = InlineCoreProject.code(
+                        """
+                        package main
+                        func Root() {}
+                        """,
+                        "main.go")
+                .addFileContents(
+                        """
+                        package foo
+                        func F() {}
+                        """,
+                        "pkg/foo/foo.go")
+                .addFileContents(
+                        """
+                        package worker
+                        import "myproject/pkg/foo"
+                        func work() { foo.F() }
+                        """,
+                        "worker/worker.go")
+                .build();
+        var inlineAnalyzer = new GoAnalyzer(project);
+        var rootFile = new ProjectFile(project.getRoot(), "main.go");
+        var unrelatedImporter = new ProjectFile(project.getRoot(), Path.of("worker", "worker.go"));
+
+        var referencers = inlineAnalyzer.referencingFilesOf(rootFile);
+
+        assertFalse(
+                referencers.contains(unrelatedImporter),
+                "Slash-containing imports should not be final root-package referencers unless resolved imports target the root file");
+        assertTrue(
+                inlineAnalyzer.genericImportCacheIsEmptyForTesting(),
+                "Go referencing-file lookup should not force generic import cache population");
+    }
 }

--- a/brokk-shared/src/test/java/ai/brokk/analyzer/GoAnalyzerTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/analyzer/GoAnalyzerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import ai.brokk.AnalyzerUtil;
 import ai.brokk.testutil.AnalyzerCreator;
 import ai.brokk.testutil.CoreTestProject;
+import ai.brokk.testutil.InlineCoreProject;
 import ai.brokk.testutil.InlineTestProjectCreator;
 import ai.brokk.testutil.TestCodeProject;
 import java.io.IOException;
@@ -1491,5 +1492,87 @@ public class GoAnalyzerTest {
         assertTrue(
                 aliases.contains(IAnalyzer.SourceLookupAlias.anySource("server.Server.Evaluate")),
                 "Expected type arguments to be stripped through tree-sitter. Found: " + aliases);
+    }
+
+    @Test
+    void importedCodeUnitsOfDoesNotPopulateGenericImportCache() throws IOException {
+        var project = InlineCoreProject.code(
+                        """
+                        package big
+                        func A() {}
+                        func B() {}
+                        func C() {}
+                        """,
+                        "big/a.go")
+                .addFileContents(
+                        """
+                        package main
+                        import "big"
+                        func main() { big.A() }
+                        """,
+                        "cmd/one.go")
+                .addFileContents(
+                        """
+                        package main
+                        import "big"
+                        func other() { big.B() }
+                        """,
+                        "cmd/two.go")
+                .build();
+        var inlineAnalyzer = new GoAnalyzer(project);
+        var firstImporter = new ProjectFile(project.getRoot(), Path.of("cmd", "one.go"));
+        var secondImporter = new ProjectFile(project.getRoot(), Path.of("cmd", "two.go"));
+
+        var firstImports = inlineAnalyzer.importedCodeUnitsOf(firstImporter);
+        var secondImports = inlineAnalyzer.importedCodeUnitsOf(secondImporter);
+
+        assertTrue(firstImports.stream().anyMatch(cu -> cu.fqName().equals("big.A")), "Expected big.A import");
+        assertTrue(secondImports.stream().anyMatch(cu -> cu.fqName().equals("big.B")), "Expected big.B import");
+        assertTrue(
+                inlineAnalyzer.genericImportCacheIsEmptyForTesting(),
+                "Go import resolution should not retain per-file CodeUnit sets in the generic import cache");
+    }
+
+    @Test
+    void referencingFilesOfUsesDirectImportMetadataWithoutGenericImportCache() throws IOException {
+        var project = InlineCoreProject.code(
+                        """
+                        package utils
+                        func A() {}
+                        """,
+                        "pkg/utils/a.go")
+                .addFileContents(
+                        """
+                        package utils
+                        func B() {}
+                        """,
+                        "pkg/utils/b.go")
+                .addFileContents(
+                        """
+                        package main
+                        import "myproject/pkg/utils"
+                        func main() { utils.A() }
+                        """,
+                        "cmd/main.go")
+                .addFileContents(
+                        """
+                        package worker
+                        import u "myproject/pkg/utils"
+                        func work() { u.B() }
+                        """,
+                        "internal/worker/worker.go")
+                .build();
+        var inlineAnalyzer = new GoAnalyzer(project);
+        var targetInSamePackage = new ProjectFile(project.getRoot(), Path.of("pkg", "utils", "b.go"));
+        var mainFile = new ProjectFile(project.getRoot(), Path.of("cmd", "main.go"));
+        var workerFile = new ProjectFile(project.getRoot(), Path.of("internal", "worker", "worker.go"));
+
+        var referencers = inlineAnalyzer.referencingFilesOf(targetInSamePackage);
+
+        assertTrue(referencers.contains(mainFile), "Expected direct importer of utils package");
+        assertTrue(referencers.contains(workerFile), "Expected aliased direct importer of utils package");
+        assertTrue(
+                inlineAnalyzer.genericImportCacheIsEmptyForTesting(),
+                "Go referencing-file lookup should not force generic import cache population");
     }
 }


### PR DESCRIPTION
### Summary
- Reduce heap retention in Go import/reference analysis by avoiding the generic bidirectional import cache for Go and using a snapshot-level package index for import resolution.
- Keep `referencingFilesOf` correct by resolving candidate imports transiently before returning referencers, while extracting the shared candidate filter into `TreeSitterAnalyzer` to avoid duplicated logic.
- Add regression coverage for blank imports and unresolved root-package candidates, plus cache-retention checks.

**Key Changes**:
- `GoAnalyzer.importedCodeUnitsOf(...)` now resolves imports directly against a cached `packageName -> CodeUnit` index, instead of populating the shared imports cache.
- `GoAnalyzer.referencingFilesOf(...)` now uses the shared candidate filter, then verifies each candidate through `resolveImports(...)` so reverse lookup stays consistent with forward resolution.
- `TreeSitterAnalyzer` now exposes a shared `candidateFilesThatCouldImport(...)` helper to keep the import-candidate scan single-sourced.
- Added Go tests covering cache non-persistence, blank-import exclusion, and avoiding false-positive reverse references.

**Touch Points**:
- `brokk-shared/src/main/java/ai/brokk/analyzer/GoAnalyzer.java`
- `brokk-shared/src/main/java/ai/brokk/analyzer/TreeSitterAnalyzer.java`
- `brokk-shared/src/test/java/ai/brokk/analyzer/GoAnalyzerTest.java`

### Testing
- `./gradlew :brokk-shared:test --tests ai.brokk.analyzer.imports.GoImportTest --tests ai.brokk.analyzer.GoAnalyzerTest`
- `./gradlew fix tidy`
- `./gradlew analyze`
- `git diff --check`