### PR TITLE
Add strict JSON response schemas for headless jobs

### DIFF
--- a/app/src/main/java/ai/brokk/AbstractService.java
+++ b/app/src/main/java/ai/brokk/AbstractService.java
@@ -714,14 +714,6 @@ public abstract class AbstractService implements ExceptionReporter.ReportingServ
         var name = nameOf(model);
         var info = getModelInfo(name);
 
-        if (name.contains("gemini")) {
-            return false;
-        }
-
-        if (name.contains("gpt-5")) {
-            return false;
-        }
-
         if (info.isEmpty()) {
             logger.warn("Model info not found for name {}, assuming no JSON schema support.", name);
             return false;

--- a/app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
@@ -1,0 +1,199 @@
+package ai.brokk.executor.jobs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.jetbrains.annotations.Nullable;
+
+public final class JobResponseSchemaSupport {
+    private JobResponseSchemaSupport() {}
+
+    public static Optional<String> validate(@Nullable JobSpec.ResponseSchema responseSchema) {
+        if (responseSchema == null) {
+            return Optional.empty();
+        }
+        if (responseSchema.name().isBlank()) {
+            return Optional.of("responseSchema.name is required");
+        }
+        try {
+            var root = responseSchema.schema();
+            if (!root.isObject()) {
+                return Optional.of("responseSchema.schema must be a JSON object");
+            }
+            if (!"object".equals(typeOf(root))) {
+                return Optional.of("responseSchema.schema root type must be object");
+            }
+            toElement(root, "responseSchema.schema");
+            return Optional.empty();
+        } catch (IllegalArgumentException e) {
+            return Optional.of(
+                    Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName()));
+        }
+    }
+
+    public static ResponseFormat toResponseFormat(JobSpec.ResponseSchema responseSchema) {
+        var schema = JsonSchema.builder()
+                .name(responseSchema.name().strip())
+                .rootElement(toElement(responseSchema.schema(), "responseSchema.schema"))
+                .build();
+        return ResponseFormat.builder()
+                .type(ResponseFormatType.JSON)
+                .jsonSchema(schema)
+                .build();
+    }
+
+    private static JsonSchemaElement toElement(JsonNode node, String path) {
+        if (!node.isObject()) {
+            throw new IllegalArgumentException(path + " must be an object");
+        }
+        var type = typeOf(node);
+        return switch (type) {
+            case "object" -> objectSchema(node, path);
+            case "array" -> arraySchema(node, path);
+            case "string" -> stringSchema(node, path);
+            case "integer" ->
+                JsonIntegerSchema.builder().description(description(node, path)).build();
+            case "number" ->
+                JsonNumberSchema.builder().description(description(node, path)).build();
+            case "boolean" ->
+                JsonBooleanSchema.builder().description(description(node, path)).build();
+            default -> throw new IllegalArgumentException(path + ".type is unsupported: " + type);
+        };
+    }
+
+    private static JsonObjectSchema objectSchema(JsonNode node, String path) {
+        var builder = JsonObjectSchema.builder().description(description(node, path));
+
+        var propertiesNode = node.get("properties");
+        if (propertiesNode != null) {
+            if (!propertiesNode.isObject()) {
+                throw new IllegalArgumentException(path + ".properties must be an object");
+            }
+            propertiesNode
+                    .properties()
+                    .forEach(entry -> builder.addProperty(
+                            entry.getKey(), toElement(entry.getValue(), path + ".properties." + entry.getKey())));
+        }
+
+        var required = required(node, path);
+        builder.required(required);
+
+        if (propertiesNode != null) {
+            var propertyNames = new HashSet<String>();
+            propertiesNode.propertyStream().map(Map.Entry::getKey).forEach(propertyNames::add);
+            var unknownRequired = required.stream()
+                    .filter(name -> !propertyNames.contains(name))
+                    .toList();
+            if (!unknownRequired.isEmpty()) {
+                throw new IllegalArgumentException(path + ".required contains unknown properties: " + unknownRequired);
+            }
+        }
+
+        var additionalProperties = node.get("additionalProperties");
+        if (additionalProperties != null) {
+            if (!additionalProperties.isBoolean()) {
+                throw new IllegalArgumentException(path + ".additionalProperties must be a boolean");
+            }
+            if (additionalProperties.booleanValue()) {
+                throw new IllegalArgumentException(
+                        path + ".additionalProperties=true is not supported for strict schemas");
+            }
+            builder.additionalProperties(false);
+        } else {
+            builder.additionalProperties(false);
+        }
+
+        return builder.build();
+    }
+
+    private static JsonArraySchema arraySchema(JsonNode node, String path) {
+        var items = node.get("items");
+        if (items == null) {
+            throw new IllegalArgumentException(path + ".items is required for array schemas");
+        }
+        return JsonArraySchema.builder()
+                .description(description(node, path))
+                .items(toElement(items, path + ".items"))
+                .build();
+    }
+
+    private static JsonSchemaElement stringSchema(JsonNode node, String path) {
+        var enumNode = node.get("enum");
+        if (enumNode == null) {
+            return JsonStringSchema.builder()
+                    .description(description(node, path))
+                    .build();
+        }
+        if (!enumNode.isArray() || enumNode.isEmpty()) {
+            throw new IllegalArgumentException(path + ".enum must be a non-empty array");
+        }
+        var values = new ArrayList<String>();
+        for (var value : enumNode) {
+            if (!value.isTextual()) {
+                throw new IllegalArgumentException(path + ".enum must contain only strings");
+            }
+            values.add(value.textValue());
+        }
+        return JsonEnumSchema.builder()
+                .description(description(node, path))
+                .enumValues(values)
+                .build();
+    }
+
+    private static List<String> required(JsonNode node, String path) {
+        var requiredNode = node.get("required");
+        if (requiredNode == null) {
+            return List.of();
+        }
+        if (!requiredNode.isArray()) {
+            throw new IllegalArgumentException(path + ".required must be an array");
+        }
+        var result = new ArrayList<String>();
+        var seen = new HashSet<String>();
+        for (var value : requiredNode) {
+            if (!value.isTextual() || value.textValue().isBlank()) {
+                throw new IllegalArgumentException(path + ".required must contain nonblank strings");
+            }
+            if (!seen.add(value.textValue())) {
+                throw new IllegalArgumentException(
+                        path + ".required contains duplicate property: " + value.textValue());
+            }
+            result.add(value.textValue());
+        }
+        return List.copyOf(result);
+    }
+
+    private static String typeOf(JsonNode node) {
+        var typeNode = node.get("type");
+        if (typeNode == null || !typeNode.isTextual() || typeNode.textValue().isBlank()) {
+            throw new IllegalArgumentException("schema type is required");
+        }
+        return typeNode.textValue();
+    }
+
+    private static @Nullable String description(JsonNode node, String path) {
+        var description = node.get("description");
+        if (description == null) {
+            return null;
+        }
+        if (!description.isTextual()) {
+            throw new IllegalArgumentException(path + ".description must be a string");
+        }
+        return description.textValue();
+    }
+}

--- a/app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
@@ -15,12 +15,24 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import org.jetbrains.annotations.Nullable;
 
 public final class JobResponseSchemaSupport {
+    static final int MAX_NAME_LENGTH = 128;
+    static final int MAX_STRING_LENGTH = 2048;
+    static final int MAX_DEPTH = 12;
+    static final int MAX_NODES = 256;
+    static final int MAX_PROPERTIES = 128;
+    static final int MAX_ENUM_VALUES = 128;
+    private static final Set<String> OBJECT_KEYS =
+            Set.of("type", "description", "properties", "required", "additionalProperties");
+    private static final Set<String> ARRAY_KEYS = Set.of("type", "description", "items");
+    private static final Set<String> STRING_KEYS = Set.of("type", "description", "enum");
+    private static final Set<String> SCALAR_KEYS = Set.of("type", "description");
+
     private JobResponseSchemaSupport() {}
 
     public static Optional<String> validate(@Nullable JobSpec.ResponseSchema responseSchema) {
@@ -30,6 +42,9 @@ public final class JobResponseSchemaSupport {
         if (responseSchema.name().isBlank()) {
             return Optional.of("responseSchema.name is required");
         }
+        if (responseSchema.name().strip().length() > MAX_NAME_LENGTH) {
+            return Optional.of("responseSchema.name is too long");
+        }
         try {
             var root = responseSchema.schema();
             if (!root.isObject()) {
@@ -38,7 +53,7 @@ public final class JobResponseSchemaSupport {
             if (!"object".equals(typeOf(root))) {
                 return Optional.of("responseSchema.schema root type must be object");
             }
-            toElement(root, "responseSchema.schema");
+            toElement(root, "responseSchema.schema", new Limits());
             return Optional.empty();
         } catch (IllegalArgumentException e) {
             return Optional.of(
@@ -49,7 +64,7 @@ public final class JobResponseSchemaSupport {
     public static ResponseFormat toResponseFormat(JobSpec.ResponseSchema responseSchema) {
         var schema = JsonSchema.builder()
                 .name(responseSchema.name().strip())
-                .rootElement(toElement(responseSchema.schema(), "responseSchema.schema"))
+                .rootElement(toElement(responseSchema.schema(), "responseSchema.schema", new Limits()))
                 .build();
         return ResponseFormat.builder()
                 .type(ResponseFormatType.JSON)
@@ -57,51 +72,90 @@ public final class JobResponseSchemaSupport {
                 .build();
     }
 
-    private static JsonSchemaElement toElement(JsonNode node, String path) {
+    private static JsonSchemaElement toElement(JsonNode node, String path, Limits limits) {
         if (!node.isObject()) {
             throw new IllegalArgumentException(path + " must be an object");
         }
+        limits.enterNode(path);
         var type = typeOf(node);
         return switch (type) {
-            case "object" -> objectSchema(node, path);
-            case "array" -> arraySchema(node, path);
+            case "object" -> objectSchema(node, path, limits);
+            case "array" -> arraySchema(node, path, limits);
             case "string" -> stringSchema(node, path);
             case "integer" ->
-                JsonIntegerSchema.builder().description(description(node, path)).build();
+                scalarSchema(
+                        node,
+                        path,
+                        JsonIntegerSchema.builder()
+                                .description(description(node, path))
+                                .build());
             case "number" ->
-                JsonNumberSchema.builder().description(description(node, path)).build();
+                scalarSchema(
+                        node,
+                        path,
+                        JsonNumberSchema.builder()
+                                .description(description(node, path))
+                                .build());
             case "boolean" ->
-                JsonBooleanSchema.builder().description(description(node, path)).build();
+                scalarSchema(
+                        node,
+                        path,
+                        JsonBooleanSchema.builder()
+                                .description(description(node, path))
+                                .build());
             default -> throw new IllegalArgumentException(path + ".type is unsupported: " + type);
         };
     }
 
-    private static JsonObjectSchema objectSchema(JsonNode node, String path) {
+    private static JsonSchemaElement scalarSchema(JsonNode node, String path, JsonSchemaElement schema) {
+        ensureSupportedKeys(node, path, SCALAR_KEYS);
+        return schema;
+    }
+
+    private static JsonObjectSchema objectSchema(JsonNode node, String path, Limits limits) {
+        ensureSupportedKeys(node, path, OBJECT_KEYS);
         var builder = JsonObjectSchema.builder().description(description(node, path));
 
         var propertiesNode = node.get("properties");
+        var propertyNames = new HashSet<String>();
         if (propertiesNode != null) {
             if (!propertiesNode.isObject()) {
                 throw new IllegalArgumentException(path + ".properties must be an object");
             }
-            propertiesNode
-                    .properties()
-                    .forEach(entry -> builder.addProperty(
-                            entry.getKey(), toElement(entry.getValue(), path + ".properties." + entry.getKey())));
+            if (propertiesNode.size() > MAX_PROPERTIES) {
+                throw new IllegalArgumentException(path + ".properties has too many properties");
+            }
+            propertiesNode.properties().forEach(entry -> {
+                validateString(entry.getKey(), path + ".properties property name", MAX_NAME_LENGTH);
+                if (!propertyNames.add(entry.getKey())) {
+                    throw new IllegalArgumentException(
+                            path + ".properties contains duplicate property: " + entry.getKey());
+                }
+                builder.addProperty(
+                        entry.getKey(),
+                        toElement(entry.getValue(), path + ".properties." + entry.getKey(), limits.child()));
+            });
         }
 
         var required = required(node, path);
         builder.required(required);
 
         if (propertiesNode != null) {
-            var propertyNames = new HashSet<String>();
-            propertiesNode.propertyStream().map(Map.Entry::getKey).forEach(propertyNames::add);
             var unknownRequired = required.stream()
                     .filter(name -> !propertyNames.contains(name))
                     .toList();
             if (!unknownRequired.isEmpty()) {
                 throw new IllegalArgumentException(path + ".required contains unknown properties: " + unknownRequired);
             }
+            var missingRequired = propertyNames.stream()
+                    .filter(name -> !required.contains(name))
+                    .toList();
+            if (!missingRequired.isEmpty()) {
+                throw new IllegalArgumentException(
+                        path + ".required must include every property for strict schemas: " + missingRequired);
+            }
+        } else if (!required.isEmpty()) {
+            throw new IllegalArgumentException(path + ".required cannot be used without properties");
         }
 
         var additionalProperties = node.get("additionalProperties");
@@ -121,18 +175,20 @@ public final class JobResponseSchemaSupport {
         return builder.build();
     }
 
-    private static JsonArraySchema arraySchema(JsonNode node, String path) {
+    private static JsonArraySchema arraySchema(JsonNode node, String path, Limits limits) {
+        ensureSupportedKeys(node, path, ARRAY_KEYS);
         var items = node.get("items");
         if (items == null) {
             throw new IllegalArgumentException(path + ".items is required for array schemas");
         }
         return JsonArraySchema.builder()
                 .description(description(node, path))
-                .items(toElement(items, path + ".items"))
+                .items(toElement(items, path + ".items", limits.child()))
                 .build();
     }
 
     private static JsonSchemaElement stringSchema(JsonNode node, String path) {
+        ensureSupportedKeys(node, path, STRING_KEYS);
         var enumNode = node.get("enum");
         if (enumNode == null) {
             return JsonStringSchema.builder()
@@ -142,11 +198,15 @@ public final class JobResponseSchemaSupport {
         if (!enumNode.isArray() || enumNode.isEmpty()) {
             throw new IllegalArgumentException(path + ".enum must be a non-empty array");
         }
+        if (enumNode.size() > MAX_ENUM_VALUES) {
+            throw new IllegalArgumentException(path + ".enum has too many values");
+        }
         var values = new ArrayList<String>();
         for (var value : enumNode) {
             if (!value.isTextual()) {
                 throw new IllegalArgumentException(path + ".enum must contain only strings");
             }
+            validateString(value.textValue(), path + ".enum value", MAX_STRING_LENGTH);
             values.add(value.textValue());
         }
         return JsonEnumSchema.builder()
@@ -163,12 +223,16 @@ public final class JobResponseSchemaSupport {
         if (!requiredNode.isArray()) {
             throw new IllegalArgumentException(path + ".required must be an array");
         }
+        if (requiredNode.size() > MAX_PROPERTIES) {
+            throw new IllegalArgumentException(path + ".required has too many entries");
+        }
         var result = new ArrayList<String>();
         var seen = new HashSet<String>();
         for (var value : requiredNode) {
             if (!value.isTextual() || value.textValue().isBlank()) {
                 throw new IllegalArgumentException(path + ".required must contain nonblank strings");
             }
+            validateString(value.textValue(), path + ".required value", MAX_NAME_LENGTH);
             if (!seen.add(value.textValue())) {
                 throw new IllegalArgumentException(
                         path + ".required contains duplicate property: " + value.textValue());
@@ -183,6 +247,7 @@ public final class JobResponseSchemaSupport {
         if (typeNode == null || !typeNode.isTextual() || typeNode.textValue().isBlank()) {
             throw new IllegalArgumentException("schema type is required");
         }
+        validateString(typeNode.textValue(), "schema type", MAX_NAME_LENGTH);
         return typeNode.textValue();
     }
 
@@ -194,6 +259,49 @@ public final class JobResponseSchemaSupport {
         if (!description.isTextual()) {
             throw new IllegalArgumentException(path + ".description must be a string");
         }
+        validateString(description.textValue(), path + ".description", MAX_STRING_LENGTH);
         return description.textValue();
+    }
+
+    private static void ensureSupportedKeys(JsonNode node, String path, Set<String> supported) {
+        node.properties().forEach(entry -> {
+            if (!supported.contains(entry.getKey())) {
+                throw new IllegalArgumentException(path + "." + entry.getKey() + " is not supported");
+            }
+        });
+    }
+
+    private static void validateString(String value, String path, int maxLength) {
+        if (value.length() > maxLength) {
+            throw new IllegalArgumentException(path + " is too long");
+        }
+    }
+
+    private static final class Limits {
+        private final int depth;
+        private final int[] nodes;
+
+        Limits() {
+            this(0, new int[1]);
+        }
+
+        private Limits(int depth, int[] nodes) {
+            this.depth = depth;
+            this.nodes = nodes;
+        }
+
+        void enterNode(String path) {
+            if (depth > MAX_DEPTH) {
+                throw new IllegalArgumentException(path + " exceeds maximum schema depth");
+            }
+            nodes[0]++;
+            if (nodes[0] > MAX_NODES) {
+                throw new IllegalArgumentException("responseSchema.schema has too many schema nodes");
+            }
+        }
+
+        Limits child() {
+            return new Limits(depth + 1, nodes);
+        }
     }
 }

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -817,8 +817,20 @@ public final class JobRunner {
                                                             trimmedScanModel, spec.reasoningLevel(), spec.temperature())
                                                     : defaultScanModel(spec);
 
-                                            // SearchAgent now handles scanning internally via execute()
-                                            var scanConfig = LutzAgent.ScanConfig.withModel(scanModelToUse);
+                                            var responseFormat = responseFormatOrNull(spec);
+                                            var finalAnswerModel = responseFormat == null
+                                                    ? null
+                                                    : resolveModelOrThrow(
+                                                            spec.plannerModel(),
+                                                            spec.reasoningLevel(),
+                                                            spec.temperature());
+                                            if (responseFormat != null) {
+                                                ensureResponseSchemaSupported(requireNonNull(finalAnswerModel));
+                                            }
+
+                                            var scanConfig = responseFormat == null
+                                                    ? LutzAgent.ScanConfig.withModel(scanModelToUse)
+                                                    : new LutzAgent.ScanConfig(true, scanModelToUse, false, true);
                                             var searchAgent = new LutzAgent(
                                                     context,
                                                     spec.taskInput(),
@@ -831,25 +843,23 @@ public final class JobRunner {
                                             if (readOnly) {
                                                 searchAgent.setReadOnly(true);
                                             }
-                                            var result = searchAgent.execute();
-                                            scope.append(result);
-                                            if (spec.responseSchema() != null
-                                                    && result.stopDetails().reason() == TaskResult.StopReason.SUCCESS) {
+                                            if (responseFormat == null) {
+                                                var result = searchAgent.execute();
+                                                scope.append(result);
+                                                finalStopReason.set(result.stopDetails()
+                                                        .reason()
+                                                        .name());
+                                            } else {
+                                                context = searchAgent.scanContext();
                                                 runDirectAnswer(
                                                         jobId,
                                                         "SEARCH",
                                                         scope,
-                                                        result.context(),
-                                                        requireNonNull(
-                                                                scanModelToUse,
-                                                                "scan model unavailable for SEARCH jobs"),
+                                                        context,
+                                                        requireNonNull(finalAnswerModel),
                                                         spec.taskInput(),
-                                                        responseFormatOrNull(spec),
+                                                        responseFormat,
                                                         finalStopReason);
-                                            } else {
-                                                finalStopReason.set(result.stopDetails()
-                                                        .reason()
-                                                        .name());
                                             }
                                         }
                                     }
@@ -1659,9 +1669,8 @@ public final class JobRunner {
      */
     private TaskResult askUsingPlannerModel(
             Context ctx, StreamingChatModel model, String question, @Nullable ResponseFormat responseFormat) {
-        if (responseFormat != null && !cm.getService().supportsJsonSchema(model)) {
-            throw new IllegalArgumentException(
-                    "MODEL_UNSUPPORTED_RESPONSE_SCHEMA: " + cm.getService().nameOf(model));
+        if (responseFormat != null) {
+            ensureResponseSchemaSupported(model);
         }
 
         var svc = cm.getService();
@@ -1678,7 +1687,11 @@ public final class JobRunner {
         try {
             response = responseFormat == null
                     ? llm.sendRequest(messages)
-                    : llm.sendRequest(messages, llm.requestOptions().withResponseFormat(responseFormat));
+                    : llm.sendRequest(
+                            messages,
+                            llm.requestOptions()
+                                    .withResponseFormat(responseFormat)
+                                    .withMaxAttempts(1));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             stop = new TaskResult.StopDetails(TaskResult.StopReason.INTERRUPTED);
@@ -1686,12 +1699,15 @@ public final class JobRunner {
 
         // Determine stop details based on the response
         if (response != null) {
+            if (responseFormat != null && response.error() != null) {
+                throw new RuntimeException(response.error());
+            }
             stop = TaskResult.StopDetails.fromResponse(response);
         }
 
         requireNonNull(stop);
 
-        ctx = ctx.addHistoryEntry(cm.getIo().getLlmRawMessages(), TaskResult.Type.ASK, model, question);
+        ctx = ctx.addHistoryEntry(llmRawMessagesOrEmpty(), TaskResult.Type.ASK, model, question);
         return new TaskResult(ctx, stop);
     }
 
@@ -1704,10 +1720,6 @@ public final class JobRunner {
             String question,
             @Nullable ResponseFormat responseFormat,
             AtomicReference<String> finalStopReason) {
-        if (responseFormat != null && !cm.getService().supportsJsonSchema(model)) {
-            throw new IllegalArgumentException(
-                    "MODEL_UNSUPPORTED_RESPONSE_SCHEMA: " + cm.getService().nameOf(model));
-        }
         try {
             var result = askUsingPlannerModel(context, model, question, responseFormat);
             finalStopReason.set(result.stopDetails().reason().name());
@@ -1722,6 +1734,15 @@ public final class JobRunner {
                                 label + " error");
             } catch (Throwable ignore) {
                 // best-effort only
+            }
+            if (responseFormat != null) {
+                if (t instanceof RuntimeException re) {
+                    throw re;
+                }
+                if (t instanceof Error error) {
+                    throw error;
+                }
+                throw new RuntimeException(t);
             }
 
             var stopDetails = new TaskResult.StopDetails(
@@ -1743,6 +1764,21 @@ public final class JobRunner {
 
     private static @Nullable ResponseFormat responseFormatOrNull(JobSpec spec) {
         return spec.responseSchema() == null ? null : JobResponseSchemaSupport.toResponseFormat(spec.responseSchema());
+    }
+
+    private void ensureResponseSchemaSupported(StreamingChatModel model) {
+        if (!cm.getService().supportsJsonSchema(model)) {
+            throw new IllegalArgumentException(
+                    "MODEL_UNSUPPORTED_RESPONSE_SCHEMA: " + cm.getService().nameOf(model));
+        }
+    }
+
+    private List<ChatMessage> llmRawMessagesOrEmpty() {
+        try {
+            return cm.getIo().getLlmRawMessages();
+        } catch (UnsupportedOperationException e) {
+            return List.of();
+        }
     }
 
     private JobStatus enrichStatusMetadata(

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -31,6 +31,7 @@ import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -664,6 +665,7 @@ public final class JobRunner {
                                                             askPlannerModel,
                                                             "plannerModel required for REPORT_ONLY jobs"),
                                                     spec.taskInput(),
+                                                    responseFormatOrNull(spec),
                                                     finalStopReason);
                                         }
                                     }
@@ -795,6 +797,7 @@ public final class JobRunner {
                                                     context,
                                                     requireNonNull(askPlannerModel),
                                                     spec.taskInput(),
+                                                    responseFormatOrNull(spec),
                                                     finalStopReason);
                                         }
                                     }
@@ -830,6 +833,24 @@ public final class JobRunner {
                                             }
                                             var result = searchAgent.execute();
                                             scope.append(result);
+                                            if (spec.responseSchema() != null
+                                                    && result.stopDetails().reason() == TaskResult.StopReason.SUCCESS) {
+                                                runDirectAnswer(
+                                                        jobId,
+                                                        "SEARCH",
+                                                        scope,
+                                                        result.context(),
+                                                        requireNonNull(
+                                                                scanModelToUse,
+                                                                "scan model unavailable for SEARCH jobs"),
+                                                        spec.taskInput(),
+                                                        responseFormatOrNull(spec),
+                                                        finalStopReason);
+                                            } else {
+                                                finalStopReason.set(result.stopDetails()
+                                                        .reason()
+                                                        .name());
+                                            }
                                         }
                                     }
                                     case REVIEW -> {
@@ -1636,7 +1657,13 @@ public final class JobRunner {
      * @param question the user's question / task text
      * @return a TaskResult suitable for appending to a TaskScope
      */
-    private TaskResult askUsingPlannerModel(Context ctx, StreamingChatModel model, String question) {
+    private TaskResult askUsingPlannerModel(
+            Context ctx, StreamingChatModel model, String question, @Nullable ResponseFormat responseFormat) {
+        if (responseFormat != null && !cm.getService().supportsJsonSchema(model)) {
+            throw new IllegalArgumentException(
+                    "MODEL_UNSUPPORTED_RESPONSE_SCHEMA: " + cm.getService().nameOf(model));
+        }
+
         var svc = cm.getService();
         var meta = new TaskResult.TaskMeta(TaskResult.Type.ASK, Service.ModelConfig.from(model, svc));
 
@@ -1649,7 +1676,9 @@ public final class JobRunner {
         TaskResult.StopDetails stop = null;
         Llm.StreamingResult response = null;
         try {
-            response = llm.sendRequest(messages);
+            response = responseFormat == null
+                    ? llm.sendRequest(messages)
+                    : llm.sendRequest(messages, llm.requestOptions().withResponseFormat(responseFormat));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             stop = new TaskResult.StopDetails(TaskResult.StopReason.INTERRUPTED);
@@ -1673,9 +1702,14 @@ public final class JobRunner {
             Context context,
             StreamingChatModel model,
             String question,
+            @Nullable ResponseFormat responseFormat,
             AtomicReference<String> finalStopReason) {
+        if (responseFormat != null && !cm.getService().supportsJsonSchema(model)) {
+            throw new IllegalArgumentException(
+                    "MODEL_UNSUPPORTED_RESPONSE_SCHEMA: " + cm.getService().nameOf(model));
+        }
         try {
-            var result = askUsingPlannerModel(context, model, question);
+            var result = askUsingPlannerModel(context, model, question, responseFormat);
             finalStopReason.set(result.stopDetails().reason().name());
             scope.append(result);
         } catch (Throwable t) {
@@ -1705,6 +1739,10 @@ public final class JobRunner {
                 logger.warn("Failed to append {} failure result for job {}: {}", label, jobId, e2.getMessage(), e2);
             }
         }
+    }
+
+    private static @Nullable ResponseFormat responseFormatOrNull(JobSpec spec) {
+        return spec.responseSchema() == null ? null : JobResponseSchemaSupport.toResponseFormat(spec.responseSchema());
     }
 
     private JobStatus enrichStatusMetadata(

--- a/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
@@ -196,6 +196,32 @@ public record JobSpec(
         return Map.copyOf(result);
     }
 
+    public JobSpec withTags(Map<String, String> tags) {
+        return new JobSpec(
+                taskInput,
+                autoCommit,
+                autoCompress,
+                plannerModel,
+                scanModel,
+                codeModel,
+                preScan,
+                tags,
+                sourceBranch,
+                targetBranch,
+                reasoningLevel,
+                reasoningLevelCode,
+                temperature,
+                temperatureCode,
+                skipVerification,
+                maxIssueFixAttempts,
+                executionPolicy,
+                responseSchema);
+    }
+
+    public JobSpec withRedactedTags() {
+        return withTags(redactedTags());
+    }
+
     @JsonIgnore
     public boolean isReportOnly() {
         return executionPolicy != null && executionPolicy.preset() == ExecutionPolicyPreset.REPORT_ONLY;

--- a/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
@@ -2,6 +2,7 @@ package ai.brokk.executor.jobs;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -32,7 +33,8 @@ public record JobSpec(
         @JsonProperty("temperatureCode") @Nullable Double temperatureCode,
         @JsonProperty("skipVerification") boolean skipVerification,
         @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts,
-        @JsonProperty("executionPolicy") @Nullable ExecutionPolicy executionPolicy) {
+        @JsonProperty("executionPolicy") @Nullable ExecutionPolicy executionPolicy,
+        @JsonProperty("responseSchema") @Nullable ResponseSchema responseSchema) {
 
     public static final int DEFAULT_MAX_ISSUE_FIX_ATTEMPTS = 20;
 
@@ -43,6 +45,14 @@ public record JobSpec(
     public record ExecutionPolicy(@JsonProperty("preset") ExecutionPolicyPreset preset) {
         public ExecutionPolicy(@JsonProperty("preset") @Nullable ExecutionPolicyPreset preset) {
             this.preset = Objects.requireNonNull(preset, "preset");
+        }
+    }
+
+    public record ResponseSchema(@JsonProperty("name") String name, @JsonProperty("schema") JsonNode schema) {
+        public ResponseSchema(
+                @JsonProperty("name") @Nullable String name, @JsonProperty("schema") @Nullable JsonNode schema) {
+            this.name = Objects.requireNonNull(name, "name");
+            this.schema = Objects.requireNonNull(schema, "schema");
         }
     }
 
@@ -92,6 +102,7 @@ public record JobSpec(
                 temperatureCode,
                 skipVerification,
                 maxIssueFixAttempts,
+                null,
                 null);
     }
 
@@ -114,6 +125,47 @@ public record JobSpec(
             @JsonProperty("skipVerification") boolean skipVerification,
             @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts,
             @JsonProperty("executionPolicy") @Nullable ExecutionPolicy executionPolicy) {
+        this(
+                taskInput,
+                autoCommit,
+                autoCompress,
+                plannerModel,
+                scanModel,
+                codeModel,
+                preScan,
+                tags,
+                sourceBranch,
+                targetBranch,
+                reasoningLevel,
+                reasoningLevelCode,
+                temperature,
+                temperatureCode,
+                skipVerification,
+                maxIssueFixAttempts,
+                executionPolicy,
+                null);
+    }
+
+    /** Normalizes nullable collection fields during deserialization and direct construction. */
+    public JobSpec(
+            @JsonProperty("taskInput") String taskInput,
+            @JsonProperty("autoCommit") boolean autoCommit,
+            @JsonProperty("autoCompress") boolean autoCompress,
+            @JsonProperty("plannerModel") String plannerModel,
+            @JsonProperty("scanModel") @Nullable String scanModel,
+            @JsonProperty("codeModel") @Nullable String codeModel,
+            @JsonProperty("preScan") boolean preScan,
+            @JsonProperty("tags") @Nullable Map<String, String> tags,
+            @JsonProperty("sourceBranch") @Nullable String sourceBranch,
+            @JsonProperty("targetBranch") @Nullable String targetBranch,
+            @JsonProperty("reasoningLevel") @Nullable String reasoningLevel,
+            @JsonProperty("reasoningLevelCode") @Nullable String reasoningLevelCode,
+            @JsonProperty("temperature") @Nullable Double temperature,
+            @JsonProperty("temperatureCode") @Nullable Double temperatureCode,
+            @JsonProperty("skipVerification") boolean skipVerification,
+            @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts,
+            @JsonProperty("executionPolicy") @Nullable ExecutionPolicy executionPolicy,
+            @JsonProperty("responseSchema") @Nullable ResponseSchema responseSchema) {
         this.taskInput = taskInput;
         this.autoCommit = autoCommit;
         this.autoCompress = autoCompress;
@@ -131,6 +183,7 @@ public record JobSpec(
         this.skipVerification = skipVerification;
         this.maxIssueFixAttempts = maxIssueFixAttempts;
         this.executionPolicy = executionPolicy;
+        this.responseSchema = responseSchema;
     }
 
     public Map<String, String> redactedTags() {

--- a/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
@@ -165,7 +165,7 @@ public final class JobStore {
      * @param status The new status
      * @throws IOException If I/O fails
      */
-    public void updateStatus(String jobId, JobStatus status) throws IOException {
+    public synchronized void updateStatus(String jobId, JobStatus status) throws IOException {
         var jobDir = jobsDir.resolve(jobId);
         var statusFile = jobDir.resolve("status.json");
         var tempStatusFile = jobDir.resolve(".status.json.tmp");
@@ -184,7 +184,7 @@ public final class JobStore {
      * @return The job status, or null if the job does not exist
      * @throws IOException If I/O fails
      */
-    public @Nullable JobStatus loadStatus(String jobId) throws IOException {
+    public synchronized @Nullable JobStatus loadStatus(String jobId) throws IOException {
         var statusFile = jobsDir.resolve(jobId).resolve("status.json");
         if (!Files.exists(statusFile)) {
             return null;

--- a/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
@@ -108,7 +108,8 @@ public final class JobStore {
                 spec.temperatureCode(),
                 spec.skipVerification(),
                 spec.maxIssueFixAttempts(),
-                spec.executionPolicy());
+                spec.executionPolicy(),
+                spec.responseSchema());
         objectMapper.writeValue(tempMetaFile.toFile(), specForPersistence);
         Files.move(tempMetaFile, metaFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
 
@@ -332,7 +333,8 @@ public final class JobStore {
                 spec.temperatureCode(),
                 spec.skipVerification(),
                 spec.maxIssueFixAttempts(),
-                spec.executionPolicy());
+                spec.executionPolicy(),
+                spec.responseSchema());
 
         var tempMetaFile = metaFile.resolveSibling(".meta.json.tmp");
         objectMapper.writeValue(tempMetaFile.toFile(), updated);

--- a/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
@@ -91,25 +91,7 @@ public final class JobStore {
         // Write meta.json (immutable) - use redacted tags to avoid persisting secrets
         var metaFile = jobDir.resolve("meta.json");
         var tempMetaFile = jobDir.resolve(".meta.json.tmp");
-        var specForPersistence = new JobSpec(
-                spec.taskInput(),
-                spec.autoCommit(),
-                spec.autoCompress(),
-                spec.plannerModel(),
-                spec.scanModel(),
-                spec.codeModel(),
-                spec.preScan(),
-                spec.redactedTags(),
-                spec.sourceBranch(),
-                spec.targetBranch(),
-                spec.reasoningLevel(),
-                spec.reasoningLevelCode(),
-                spec.temperature(),
-                spec.temperatureCode(),
-                spec.skipVerification(),
-                spec.maxIssueFixAttempts(),
-                spec.executionPolicy(),
-                spec.responseSchema());
+        var specForPersistence = spec.withRedactedTags();
         objectMapper.writeValue(tempMetaFile.toFile(), specForPersistence);
         Files.move(tempMetaFile, metaFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
 
@@ -316,25 +298,7 @@ public final class JobStore {
 
         var tags = new HashMap<>(spec.tags());
         tags.put("session_id", desired);
-        var updated = new JobSpec(
-                spec.taskInput(),
-                spec.autoCommit(),
-                spec.autoCompress(),
-                spec.plannerModel(),
-                spec.scanModel(),
-                spec.codeModel(),
-                spec.preScan(),
-                tags,
-                spec.sourceBranch(),
-                spec.targetBranch(),
-                spec.reasoningLevel(),
-                spec.reasoningLevelCode(),
-                spec.temperature(),
-                spec.temperatureCode(),
-                spec.skipVerification(),
-                spec.maxIssueFixAttempts(),
-                spec.executionPolicy(),
-                spec.responseSchema());
+        var updated = spec.withTags(tags);
 
         var tempMetaFile = metaFile.resolveSibling(".meta.json.tmp");
         objectMapper.writeValue(tempMetaFile.toFile(), updated);

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -179,14 +179,6 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         if (parsedResponseSchema.invalid()) return;
         var responseSchema = parsedResponseSchema.responseSchema();
 
-        if (responseSchema != null) {
-            var responseSchemaError = JobResponseSchemaSupport.validate(responseSchema);
-            if (responseSchemaError.isPresent()) {
-                RouterUtil.sendValidationError(exchange, responseSchemaError.get());
-                return;
-            }
-        }
-
         // If an agent is specified, validate it exists and route to SEARCH mode with an instruction
         String effectiveTaskInput = request.taskInput();
         if (request.agent() != null && !request.agent().isBlank()) {
@@ -205,6 +197,13 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             RouterUtil.sendValidationError(
                     exchange, "responseSchema is only supported for REPORT_ONLY, ASK, and SEARCH jobs");
             return;
+        }
+        if (responseSchema != null) {
+            var responseSchemaError = JobResponseSchemaSupport.validate(responseSchema);
+            if (responseSchemaError.isPresent()) {
+                RouterUtil.sendValidationError(exchange, responseSchemaError.get());
+                return;
+            }
         }
 
         var overrides = validateModelOverrides(exchange, request);

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -10,10 +10,14 @@ import ai.brokk.executor.agents.AgentDefinition;
 import ai.brokk.executor.agents.AgentStore;
 import ai.brokk.executor.http.SimpleHttpServer;
 import ai.brokk.executor.jobs.ErrorPayload;
+import ai.brokk.executor.jobs.JobResponseSchemaSupport;
 import ai.brokk.executor.jobs.JobRunner;
 import ai.brokk.executor.jobs.JobSpec;
 import ai.brokk.executor.jobs.JobStore;
 import ai.brokk.executor.jobs.PrReviewService;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
@@ -171,6 +175,18 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             return;
         }
 
+        var parsedResponseSchema = parseResponseSchema(exchange, request.responseSchema());
+        if (parsedResponseSchema.invalid()) return;
+        var responseSchema = parsedResponseSchema.responseSchema();
+
+        if (responseSchema != null) {
+            var responseSchemaError = JobResponseSchemaSupport.validate(responseSchema);
+            if (responseSchemaError.isPresent()) {
+                RouterUtil.sendValidationError(exchange, responseSchemaError.get());
+                return;
+            }
+        }
+
         // If an agent is specified, validate it exists and route to SEARCH mode with an instruction
         String effectiveTaskInput = request.taskInput();
         if (request.agent() != null && !request.agent().isBlank()) {
@@ -183,6 +199,12 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             tags.putIfAbsent("mode", "SEARCH");
             effectiveTaskInput = "Use the callCustomAgent tool to invoke the '%s' agent for the following task:\n\n%s"
                     .formatted(agentName, request.taskInput());
+        }
+
+        if (responseSchema != null && !allowsResponseSchema(executionPolicy, tags)) {
+            RouterUtil.sendValidationError(
+                    exchange, "responseSchema is only supported for REPORT_ONLY, ASK, and SEARCH jobs");
+            return;
         }
 
         var overrides = validateModelOverrides(exchange, request);
@@ -212,7 +234,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
                 overrides.temperatureCode(),
                 skipVerificationFlag,
                 JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
-                executionPolicy);
+                executionPolicy,
+                responseSchema);
 
         if (awaitHeadlessInitOrRespond(exchange, null)) return;
 
@@ -659,6 +682,31 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
                 .findFirst();
     }
 
+    private record ParsedResponseSchema(JobSpec.@Nullable ResponseSchema responseSchema, boolean invalid) {}
+
+    private static ParsedResponseSchema parseResponseSchema(HttpExchange exchange, @Nullable JsonNode rawResponseSchema)
+            throws IOException {
+        if (rawResponseSchema == null || rawResponseSchema.isNull()) {
+            return new ParsedResponseSchema(null, false);
+        }
+        try {
+            return new ParsedResponseSchema(
+                    OBJECT_MAPPER.treeToValue(rawResponseSchema, JobSpec.ResponseSchema.class), false);
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            RouterUtil.sendValidationError(exchange, "Invalid responseSchema");
+            return new ParsedResponseSchema(null, true);
+        }
+    }
+
+    private static boolean allowsResponseSchema(
+            JobSpec.@Nullable ExecutionPolicy executionPolicy, Map<String, String> tags) {
+        if (executionPolicy != null && executionPolicy.preset() == JobSpec.ExecutionPolicyPreset.REPORT_ONLY) {
+            return true;
+        }
+        var mode = tags.getOrDefault("mode", "").strip().toUpperCase(Locale.ROOT);
+        return mode.equals("ASK") || mode.equals("SEARCH");
+    }
+
     private JobSpec.@Nullable ModelOverrides validateModelOverrides(HttpExchange exchange, JobSpecRequest request)
             throws IOException {
         String rl = null;
@@ -749,7 +797,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             @Nullable Boolean skipVerification,
             JobSpec.@Nullable ExecutionPolicy executionPolicy,
             JobSpec.@Nullable ExecutionPolicy jobPolicy,
-            @Nullable String agent) {}
+            @Nullable String agent,
+            @JsonProperty("responseSchema") @Nullable JsonNode responseSchema) {}
 
     private record ContextPayload(@Nullable List<String> text) {}
 

--- a/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
+++ b/app/src/test/java/ai/brokk/ServiceCodexGatingTest.java
@@ -7,6 +7,7 @@ import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
 import ai.brokk.project.TestConfigHelper;
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -109,6 +110,27 @@ class ServiceCodexGatingTest {
         assertFalse(available.containsKey("gpt-5.2-codex"));
     }
 
+    @Test
+    void supportsJsonSchemaUsesModelMetadataWithoutNameVeto(@TempDir Path tempDir) {
+        var projectRoot = tempDir.resolve("dummy-project");
+        projectRoot.toFile().mkdirs();
+        var service = new GatingTestService(new MainProject(projectRoot));
+        service.addSchemaModel("gpt-5.4", true);
+        service.addSchemaModel("gemini-3-pro", true);
+        service.addSchemaModel("legacy-model", false);
+
+        assertTrue(service.supportsJsonSchema(model("gpt-5.4")));
+        assertTrue(service.supportsJsonSchema(model("gemini-3-pro")));
+        assertFalse(service.supportsJsonSchema(model("legacy-model")));
+    }
+
+    private static OpenAiStreamingChatModel model(String name) {
+        return OpenAiStreamingChatModel.builder()
+                .apiKey("test-key")
+                .modelName(name)
+                .build();
+    }
+
     /**
      * Subclass of AbstractService to allow populating protected model maps.
      */
@@ -127,6 +149,11 @@ class ServiceCodexGatingTest {
                 info.put("is_codex", true);
             }
             modelInfoMap.put(name, info);
+        }
+
+        void addSchemaModel(String name, boolean supportsResponseSchema) {
+            modelLocations.put(name, name);
+            modelInfoMap.put(name, Map.of("supports_response_schema", supportsResponseSchema));
         }
 
         @Override

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
@@ -1,0 +1,216 @@
+package ai.brokk.executor.jobs;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.brokk.AbstractService;
+import ai.brokk.ContextManager;
+import ai.brokk.Service;
+import ai.brokk.project.IProject;
+import ai.brokk.project.MainProject;
+import ai.brokk.testutil.NoOpConsoleIO;
+import ai.brokk.testutil.TestService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JobRunnerResponseSchemaTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    private ContextManager cm;
+    private JobRunner runner;
+    private CapturingModel model;
+    private CapturingService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var workspaceDir = tempDir.resolve("workspace");
+        Files.createDirectories(workspaceDir.resolve(".brokk/llm-history"));
+        Files.writeString(workspaceDir.resolve(".brokk/project.properties"), "# test", StandardCharsets.UTF_8);
+
+        var project = new MainProject(workspaceDir);
+        model = new CapturingModel();
+        service = new CapturingService(project, model);
+        Service.Provider provider = new Service.Provider() {
+            @Override
+            public AbstractService get() {
+                return service;
+            }
+
+            @Override
+            public void reinit(IProject project) {
+                // Keep the capturing service stable for assertions.
+            }
+        };
+        cm = new ContextManager(project, provider);
+        cm.createHeadless(true, new NoOpConsoleIO());
+        runner = new JobRunner(cm, new JobStore(tempDir.resolve("jobstore")));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (runner != null) {
+            runner.shutdown();
+        }
+        if (cm != null) {
+            cm.close();
+        }
+    }
+
+    @Test
+    void askWithResponseSchemaAppliesResponseFormatToFinalRequest() throws Exception {
+        var spec = spec(Map.of("mode", "ASK"), null, responseSchema());
+
+        runner.runAsync("ask-schema", spec, new NoOpConsoleIO()).get(5, TimeUnit.SECONDS);
+
+        var responseFormat = requireNonNull(responseFormatRequest().parameters().responseFormat());
+        assertEquals("StrictReport", responseFormat.jsonSchema().name());
+    }
+
+    @Test
+    void reportOnlyWithResponseSchemaAppliesResponseFormatToFinalRequest() throws Exception {
+        var spec = spec(
+                Map.of(), new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY), responseSchema());
+
+        runner.runAsync("report-schema", spec, new NoOpConsoleIO()).get(5, TimeUnit.SECONDS);
+
+        var responseFormat = requireNonNull(responseFormatRequest().parameters().responseFormat());
+        assertEquals("StrictReport", responseFormat.jsonSchema().name());
+    }
+
+    @Test
+    void askWithoutResponseSchemaLeavesResponseFormatUnset() throws Exception {
+        var spec = spec(Map.of("mode", "ASK"), null, null);
+
+        runner.runAsync("ask-no-schema", spec, new NoOpConsoleIO()).get(5, TimeUnit.SECONDS);
+
+        assertNotNull(model.requests);
+        assertEquals(
+                0,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+    }
+
+    @Test
+    void responseSchemaFailsWhenModelDoesNotSupportJsonSchema() {
+        service.supportsJsonSchema = false;
+        var spec = spec(Map.of("mode", "ASK"), null, responseSchema());
+
+        var thrown = assertThrows(
+                ExecutionException.class, () -> runner.runAsync("ask-schema-unsupported", spec, new NoOpConsoleIO())
+                        .get(5, TimeUnit.SECONDS));
+
+        var cause = requireNonNull(thrown.getCause());
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        assertEquals("MODEL_UNSUPPORTED_RESPONSE_SCHEMA: stub-model", cause.getMessage());
+    }
+
+    private static JobSpec spec(
+            Map<String, String> tags,
+            @Nullable JobSpec.ExecutionPolicy executionPolicy,
+            @Nullable JobSpec.ResponseSchema responseSchema) {
+        return new JobSpec(
+                "write a strict response",
+                false,
+                false,
+                "planner",
+                null,
+                null,
+                false,
+                tags,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                executionPolicy,
+                responseSchema);
+    }
+
+    private static JobSpec.ResponseSchema responseSchema() {
+        try {
+            return new JobSpec.ResponseSchema(
+                    "StrictReport",
+                    MAPPER.readTree(
+                            """
+                            {
+                              "type": "object",
+                              "properties": {
+                                "summary": { "type": "string" }
+                              },
+                              "required": ["summary"],
+                              "additionalProperties": false
+                            }
+                            """));
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private ChatRequest responseFormatRequest() {
+        return model.requests.stream()
+                .filter(request -> request.parameters().responseFormat() != null)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static final class CapturingService extends TestService {
+        private final StreamingChatModel model;
+        private boolean supportsJsonSchema = true;
+
+        CapturingService(IProject project, StreamingChatModel model) {
+            super(project);
+            this.model = model;
+        }
+
+        @Override
+        public boolean supportsJsonSchema(StreamingChatModel model) {
+            return supportsJsonSchema;
+        }
+
+        @Override
+        public @Nullable StreamingChatModel getModel(
+                ModelConfig config, @Nullable OpenAiChatRequestParameters.Builder parametersOverride) {
+            return model;
+        }
+    }
+
+    private static final class CapturingModel implements StreamingChatModel {
+        private final CopyOnWriteArrayList<ChatRequest> requests = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            requests.add(chatRequest);
+            handler.onCompleteResponse(ChatResponse.builder()
+                    .aiMessage(new AiMessage("{\"summary\":\"ok\"}"))
+                    .build());
+        }
+    }
+}

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
@@ -12,8 +12,8 @@ import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
 import ai.brokk.testutil.NoOpConsoleIO;
 import ai.brokk.testutil.TestService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -22,6 +22,7 @@ import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
@@ -33,13 +34,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class JobRunnerResponseSchemaTest {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
     @TempDir
     Path tempDir;
 
     private ContextManager cm;
     private JobRunner runner;
+    private JobStore store;
     private CapturingModel model;
     private CapturingService service;
 
@@ -64,8 +64,9 @@ class JobRunnerResponseSchemaTest {
             }
         };
         cm = new ContextManager(project, provider);
-        cm.createHeadless(true, new NoOpConsoleIO());
-        runner = new JobRunner(cm, new JobStore(tempDir.resolve("jobstore")));
+        cm.createHeadless(true, new RawMessagesConsole());
+        store = new JobStore(tempDir.resolve("jobstore"));
+        runner = new JobRunner(cm, store);
     }
 
     @AfterEach
@@ -80,9 +81,9 @@ class JobRunnerResponseSchemaTest {
 
     @Test
     void askWithResponseSchemaAppliesResponseFormatToFinalRequest() throws Exception {
-        var spec = spec(Map.of("mode", "ASK"), null, responseSchema());
+        var spec = spec(Map.of("mode", "ASK"), null, ResponseSchemaFixtures.validResponseSchema());
 
-        runner.runAsync("ask-schema", spec, new NoOpConsoleIO()).get(5, TimeUnit.SECONDS);
+        runner.runAsync("ask-schema", spec, new RawMessagesConsole()).get(5, TimeUnit.SECONDS);
 
         var responseFormat = requireNonNull(responseFormatRequest().parameters().responseFormat());
         assertEquals("StrictReport", responseFormat.jsonSchema().name());
@@ -91,9 +92,11 @@ class JobRunnerResponseSchemaTest {
     @Test
     void reportOnlyWithResponseSchemaAppliesResponseFormatToFinalRequest() throws Exception {
         var spec = spec(
-                Map.of(), new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY), responseSchema());
+                Map.of(),
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY),
+                ResponseSchemaFixtures.validResponseSchema());
 
-        runner.runAsync("report-schema", spec, new NoOpConsoleIO()).get(5, TimeUnit.SECONDS);
+        runner.runAsync("report-schema", spec, new RawMessagesConsole()).get(5, TimeUnit.SECONDS);
 
         var responseFormat = requireNonNull(responseFormatRequest().parameters().responseFormat());
         assertEquals("StrictReport", responseFormat.jsonSchema().name());
@@ -103,7 +106,7 @@ class JobRunnerResponseSchemaTest {
     void askWithoutResponseSchemaLeavesResponseFormatUnset() throws Exception {
         var spec = spec(Map.of("mode", "ASK"), null, null);
 
-        runner.runAsync("ask-no-schema", spec, new NoOpConsoleIO()).get(5, TimeUnit.SECONDS);
+        runner.runAsync("ask-no-schema", spec, new RawMessagesConsole()).get(5, TimeUnit.SECONDS);
 
         assertNotNull(model.requests);
         assertEquals(
@@ -116,17 +119,70 @@ class JobRunnerResponseSchemaTest {
     @Test
     void responseSchemaFailsWhenModelDoesNotSupportJsonSchema() {
         service.supportsJsonSchema = false;
-        var spec = spec(Map.of("mode", "ASK"), null, responseSchema());
+        var spec = spec(Map.of("mode", "ASK"), null, ResponseSchemaFixtures.validResponseSchema());
 
-        var thrown = assertThrows(
-                ExecutionException.class, () -> runner.runAsync("ask-schema-unsupported", spec, new NoOpConsoleIO())
-                        .get(5, TimeUnit.SECONDS));
+        var thrown = assertThrows(ExecutionException.class, () -> runner.runAsync(
+                        "ask-schema-unsupported", spec, new RawMessagesConsole())
+                .get(5, TimeUnit.SECONDS));
 
         var cause = requireNonNull(thrown.getCause());
         while (cause.getCause() != null) {
             cause = cause.getCause();
         }
         assertEquals("MODEL_UNSUPPORTED_RESPONSE_SCHEMA: stub-model", cause.getMessage());
+    }
+
+    @Test
+    void searchWithResponseSchemaPreflightsFinalModelBeforeScan() {
+        service.supportsJsonSchema = false;
+        var spec = spec(Map.of("mode", "SEARCH"), null, ResponseSchemaFixtures.validResponseSchema());
+
+        var thrown = assertThrows(ExecutionException.class, () -> runner.runAsync(
+                        "search-schema-unsupported", spec, new RawMessagesConsole())
+                .get(5, TimeUnit.SECONDS));
+
+        var cause = requireNonNull(thrown.getCause());
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        assertEquals("MODEL_UNSUPPORTED_RESPONSE_SCHEMA: stub-model", cause.getMessage());
+        assertEquals(
+                0,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+    }
+
+    @Test
+    void searchWithResponseSchemaUsesOneStructuredFinalCall() throws Exception {
+        var spec = spec(Map.of("mode", "SEARCH"), null, ResponseSchemaFixtures.validResponseSchema());
+
+        runner.runAsync("search-schema", spec, new RawMessagesConsole()).get(5, TimeUnit.SECONDS);
+
+        assertEquals(
+                1,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+        assertEquals(
+                "StrictReport",
+                requireNonNull(responseFormatRequest().parameters().responseFormat())
+                        .jsonSchema()
+                        .name());
+    }
+
+    @Test
+    void schemaBackedDirectAnswerFailureFailsJob() throws Exception {
+        model.throwOnResponseFormat = true;
+        var spec = spec(Map.of("mode", "ASK"), null, ResponseSchemaFixtures.validResponseSchema());
+
+        assertThrows(
+                ExecutionException.class, () -> runner.runAsync("ask-schema-rejected", spec, new RawMessagesConsole())
+                        .get(5, TimeUnit.SECONDS));
+
+        assertEquals(
+                JobStatus.State.FAILED.name(),
+                requireNonNull(store.loadStatus("ask-schema-rejected")).state());
     }
 
     private static JobSpec spec(
@@ -152,26 +208,6 @@ class JobRunnerResponseSchemaTest {
                 JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
                 executionPolicy,
                 responseSchema);
-    }
-
-    private static JobSpec.ResponseSchema responseSchema() {
-        try {
-            return new JobSpec.ResponseSchema(
-                    "StrictReport",
-                    MAPPER.readTree(
-                            """
-                            {
-                              "type": "object",
-                              "properties": {
-                                "summary": { "type": "string" }
-                              },
-                              "required": ["summary"],
-                              "additionalProperties": false
-                            }
-                            """));
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
     }
 
     private ChatRequest responseFormatRequest() {
@@ -204,13 +240,24 @@ class JobRunnerResponseSchemaTest {
 
     private static final class CapturingModel implements StreamingChatModel {
         private final CopyOnWriteArrayList<ChatRequest> requests = new CopyOnWriteArrayList<>();
+        private boolean throwOnResponseFormat;
 
         @Override
         public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
             requests.add(chatRequest);
+            if (throwOnResponseFormat && chatRequest.parameters().responseFormat() != null) {
+                throw new IllegalArgumentException("provider rejected response schema");
+            }
             handler.onCompleteResponse(ChatResponse.builder()
                     .aiMessage(new AiMessage("{\"summary\":\"ok\"}"))
                     .build());
+        }
+    }
+
+    private static final class RawMessagesConsole extends NoOpConsoleIO {
+        @Override
+        public List<ChatMessage> getLlmRawMessages() {
+            return List.of();
         }
     }
 }

--- a/app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
@@ -106,17 +106,6 @@ class JobSpecTest {
 
     @Test
     void responseSchemaPersistsThroughJson() throws Exception {
-        var schema = MAPPER.readTree(
-                """
-                {
-                  "type": "object",
-                  "properties": {
-                    "summary": { "type": "string" }
-                  },
-                  "required": ["summary"],
-                  "additionalProperties": false
-                }
-                """);
         var spec = new JobSpec(
                 "write final report",
                 false,
@@ -135,15 +124,45 @@ class JobSpecTest {
                 false,
                 JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
                 new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY),
-                new JobSpec.ResponseSchema("SlopCopSniffTest", schema));
+                ResponseSchemaFixtures.validResponseSchema());
 
         var json = MAPPER.writeValueAsString(spec);
         var roundTrip = MAPPER.readValue(json, JobSpec.class);
 
-        assertEquals(
-                "SlopCopSniffTest", requireNonNull(roundTrip.responseSchema()).name());
+        assertEquals("StrictReport", requireNonNull(roundTrip.responseSchema()).name());
         assertEquals("object", roundTrip.responseSchema().schema().get("type").textValue());
         assertTrue(json.contains("\"responseSchema\""));
+    }
+
+    @Test
+    void copyHelpersPreserveResponseSchema() {
+        var spec = new JobSpec(
+                "write final report",
+                false,
+                true,
+                "planner",
+                null,
+                null,
+                false,
+                Map.of("github_token", "secret"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY),
+                ResponseSchemaFixtures.validResponseSchema());
+
+        var retagged = spec.withTags(Map.of("mode", "ASK"));
+        var redacted = spec.withRedactedTags();
+
+        assertEquals("StrictReport", requireNonNull(retagged.responseSchema()).name());
+        assertEquals("ASK", retagged.tags().get("mode"));
+        assertEquals("StrictReport", requireNonNull(redacted.responseSchema()).name());
+        assertEquals("[REDACTED]", redacted.tags().get("github_token"));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobSpecTest.java
@@ -105,6 +105,48 @@ class JobSpecTest {
     }
 
     @Test
+    void responseSchemaPersistsThroughJson() throws Exception {
+        var schema = MAPPER.readTree(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "summary": { "type": "string" }
+                  },
+                  "required": ["summary"],
+                  "additionalProperties": false
+                }
+                """);
+        var spec = new JobSpec(
+                "write final report",
+                false,
+                true,
+                "planner",
+                null,
+                null,
+                false,
+                Map.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY),
+                new JobSpec.ResponseSchema("SlopCopSniffTest", schema));
+
+        var json = MAPPER.writeValueAsString(spec);
+        var roundTrip = MAPPER.readValue(json, JobSpec.class);
+
+        assertEquals(
+                "SlopCopSniffTest", requireNonNull(roundTrip.responseSchema()).name());
+        assertEquals("object", roundTrip.responseSchema().schema().get("type").textValue());
+        assertTrue(json.contains("\"responseSchema\""));
+    }
+
+    @Test
     void executionPolicyRejectsMissingPreset() {
         assertThrows(Exception.class, () -> MAPPER.readValue("{\"executionPolicy\":{}}", JobSpec.class));
     }

--- a/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
@@ -69,6 +69,49 @@ class JobStoreTest {
     }
 
     @Test
+    void testCreateOrGetJob_PreservesResponseSchema(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var schema = new com.fasterxml.jackson.databind.ObjectMapper()
+                .readTree(
+                        """
+                        {
+                          "type": "object",
+                          "properties": {
+                            "summary": { "type": "string" }
+                          },
+                          "required": ["summary"],
+                          "additionalProperties": false
+                        }
+                        """);
+        var spec = new JobSpec(
+                "test task",
+                true,
+                true,
+                DEFAULT_PLANNER_MODEL,
+                null,
+                null,
+                false,
+                Map.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY),
+                new JobSpec.ResponseSchema("StrictReport", schema));
+
+        var result = store.createOrGetJob("idem-key-response-schema", spec);
+        var loadedSpec = store.loadSpec(result.jobId());
+
+        assertNotNull(loadedSpec);
+        assertEquals("StrictReport", loadedSpec.responseSchema().name());
+        assertEquals("object", loadedSpec.responseSchema().schema().get("type").textValue());
+    }
+
+    @Test
     void testPersistSessionId_PreservesExecutionPolicy(@TempDir Path tempDir) throws Exception {
         var store = new JobStore(tempDir);
         var spec = new JobSpec(

--- a/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
@@ -71,18 +71,6 @@ class JobStoreTest {
     @Test
     void testCreateOrGetJob_PreservesResponseSchema(@TempDir Path tempDir) throws Exception {
         var store = new JobStore(tempDir);
-        var schema = new com.fasterxml.jackson.databind.ObjectMapper()
-                .readTree(
-                        """
-                        {
-                          "type": "object",
-                          "properties": {
-                            "summary": { "type": "string" }
-                          },
-                          "required": ["summary"],
-                          "additionalProperties": false
-                        }
-                        """);
         var spec = new JobSpec(
                 "test task",
                 true,
@@ -101,7 +89,7 @@ class JobStoreTest {
                 false,
                 JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
                 new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY),
-                new JobSpec.ResponseSchema("StrictReport", schema));
+                ResponseSchemaFixtures.validResponseSchema());
 
         var result = store.createOrGetJob("idem-key-response-schema", spec);
         var loadedSpec = store.loadSpec(result.jobId());
@@ -109,6 +97,39 @@ class JobStoreTest {
         assertNotNull(loadedSpec);
         assertEquals("StrictReport", loadedSpec.responseSchema().name());
         assertEquals("object", loadedSpec.responseSchema().schema().get("type").textValue());
+    }
+
+    @Test
+    void testPersistSessionId_PreservesResponseSchema(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var spec = new JobSpec(
+                "test task",
+                true,
+                true,
+                DEFAULT_PLANNER_MODEL,
+                null,
+                null,
+                false,
+                Map.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
+                new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY),
+                ResponseSchemaFixtures.validResponseSchema());
+
+        var result = store.createOrGetJob("idem-key-response-schema-session", spec);
+        var sessionId = UUID.randomUUID();
+        store.persistSessionId(result.jobId(), sessionId);
+        var loadedSpec = store.loadSpec(result.jobId());
+
+        assertNotNull(loadedSpec);
+        assertEquals("StrictReport", loadedSpec.responseSchema().name());
+        assertEquals(sessionId.toString(), loadedSpec.tags().get("session_id"));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/jobs/ResponseSchemaFixtures.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/ResponseSchemaFixtures.java
@@ -1,0 +1,36 @@
+package ai.brokk.executor.jobs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+
+public final class ResponseSchemaFixtures {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ResponseSchemaFixtures() {}
+
+    public static Map<String, Object> validResponseSchemaMap() {
+        return Map.of(
+                "name",
+                "StrictReport",
+                "schema",
+                Map.of(
+                        "type",
+                        "object",
+                        "properties",
+                        Map.of("summary", Map.of("type", "string")),
+                        "required",
+                        List.of("summary"),
+                        "additionalProperties",
+                        false));
+    }
+
+    public static JobSpec.ResponseSchema validResponseSchema() {
+        try {
+            return new JobSpec.ResponseSchema(
+                    "StrictReport", MAPPER.valueToTree(validResponseSchemaMap().get("schema")));
+        } catch (IllegalArgumentException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -38,6 +38,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
@@ -163,6 +164,74 @@ class JobsRouterValidationTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"REPORT_ONLY", "ASK", "SEARCH"})
+    void postJobs_responseSchemaAllowedForDirectAndSearchModes(String mode) throws Exception {
+        var body = new HashMap<String, Object>();
+        body.put("taskInput", "test task");
+        body.put("plannerModel", "gpt-4");
+        body.put("responseSchema", validResponseSchema());
+        if (mode.equals("REPORT_ONLY")) {
+            body.put("executionPolicy", Map.of("preset", "REPORT_ONLY"));
+        } else {
+            body.put("tags", Map.of("mode", mode));
+        }
+
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
+        exchange.getRequestHeaders().set("Idempotency-Key", UUID.randomUUID().toString());
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(201, exchange.responseCode());
+        var response = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
+        var loaded = jobStore.loadSpec(response.get("jobId").toString());
+        assertNotNull(loaded.responseSchema());
+        assertEquals("StrictReport", loaded.responseSchema().name());
+    }
+
+    @Test
+    void postJobs_responseSchemaRejectedForArchitectMode() throws Exception {
+        Map<String, Object> body = Map.of(
+                "taskInput", "test task",
+                "plannerModel", "gpt-4",
+                "responseSchema", validResponseSchema());
+
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
+        exchange.getRequestHeaders().set("Idempotency-Key", UUID.randomUUID().toString());
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(400, exchange.responseCode());
+        var payload = MAPPER.readValue(exchange.responseBodyBytes(), ErrorPayload.class);
+        assertEquals(ErrorPayload.Code.VALIDATION_ERROR, payload.code());
+        assertTrue(payload.message().contains("responseSchema is only supported"), payload.message());
+        assertEquals(fsSnapshotBefore, snapshotTree(jobStoreDir), "JobStore dir changed; job may have been created");
+    }
+
+    @Test
+    void postJobs_invalidResponseSchemaReturnsValidationError() throws Exception {
+        Map<String, Object> body = Map.of(
+                "taskInput",
+                "test task",
+                "plannerModel",
+                "gpt-4",
+                "executionPolicy",
+                Map.of("preset", "REPORT_ONLY"),
+                "responseSchema",
+                Map.of("name", "StrictReport", "schema", Map.of("type", "array", "items", Map.of("type", "string"))));
+
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
+        exchange.getRequestHeaders().set("Idempotency-Key", UUID.randomUUID().toString());
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(400, exchange.responseCode());
+        var payload = MAPPER.readValue(exchange.responseBodyBytes(), ErrorPayload.class);
+        assertEquals(ErrorPayload.Code.VALIDATION_ERROR, payload.code());
+        assertTrue(payload.message().contains("root type must be object"), payload.message());
+        assertEquals(fsSnapshotBefore, snapshotTree(jobStoreDir), "JobStore dir changed; job may have been created");
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = {"TUI Session", "New Session", "Session"})
     void postJobs_withDefaultSessionName_triggersAutoRename(String defaultName) throws Exception {
         var sm = jobsRouter.contextManager.getProject().getSessionManager();
@@ -190,6 +259,22 @@ class JobsRouterValidationTest {
             Thread.sleep(20);
         }
         assertTrue(renamed, "Session '" + defaultName + "' should have been auto-renamed to '" + taskInput + "'");
+    }
+
+    private static Map<String, Object> validResponseSchema() {
+        return Map.of(
+                "name",
+                "StrictReport",
+                "schema",
+                Map.of(
+                        "type",
+                        "object",
+                        "properties",
+                        Map.of("summary", Map.of("type", "string")),
+                        "required",
+                        List.of("summary"),
+                        "additionalProperties",
+                        false));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -14,6 +14,7 @@ import ai.brokk.executor.jobs.JobRunner;
 import ai.brokk.executor.jobs.JobSpec;
 import ai.brokk.executor.jobs.JobStatus;
 import ai.brokk.executor.jobs.JobStore;
+import ai.brokk.executor.jobs.ResponseSchemaFixtures;
 import ai.brokk.project.MainProject;
 import ai.brokk.testutil.NoOpConsoleIO;
 import ai.brokk.testutil.TestService;
@@ -169,7 +170,7 @@ class JobsRouterValidationTest {
         var body = new HashMap<String, Object>();
         body.put("taskInput", "test task");
         body.put("plannerModel", "gpt-4");
-        body.put("responseSchema", validResponseSchema());
+        body.put("responseSchema", ResponseSchemaFixtures.validResponseSchemaMap());
         if (mode.equals("REPORT_ONLY")) {
             body.put("executionPolicy", Map.of("preset", "REPORT_ONLY"));
         } else {
@@ -193,7 +194,7 @@ class JobsRouterValidationTest {
         Map<String, Object> body = Map.of(
                 "taskInput", "test task",
                 "plannerModel", "gpt-4",
-                "responseSchema", validResponseSchema());
+                "responseSchema", ResponseSchemaFixtures.validResponseSchemaMap());
 
         var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
         exchange.getRequestHeaders().set("Idempotency-Key", UUID.randomUUID().toString());
@@ -231,6 +232,71 @@ class JobsRouterValidationTest {
         assertEquals(fsSnapshotBefore, snapshotTree(jobStoreDir), "JobStore dir changed; job may have been created");
     }
 
+    @Test
+    void postJobs_responseSchemaRejectsOptionalProperties() throws Exception {
+        var schema = Map.of(
+                "name",
+                "StrictReport",
+                "schema",
+                Map.of(
+                        "type",
+                        "object",
+                        "properties",
+                        Map.of("summary", Map.of("type", "string"), "confidence", Map.of("type", "number")),
+                        "required",
+                        List.of("summary"),
+                        "additionalProperties",
+                        false));
+
+        assertResponseSchemaRejected(schema, "required must include every property");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"minLength", "pattern", "minimum", "oneOf"})
+    void postJobs_responseSchemaRejectsUnsupportedKeywords(String keyword) throws Exception {
+        var property = new HashMap<String, Object>();
+        property.put("type", keyword.equals("minimum") ? "number" : "string");
+        property.put(keyword, keyword.equals("oneOf") ? List.of(Map.of("type", "string")) : 1);
+        var schema = Map.of(
+                "name",
+                "StrictReport",
+                "schema",
+                Map.of(
+                        "type",
+                        "object",
+                        "properties",
+                        Map.of("summary", property),
+                        "required",
+                        List.of("summary"),
+                        "additionalProperties",
+                        false));
+
+        assertResponseSchemaRejected(schema, keyword + " is not supported");
+    }
+
+    @Test
+    void postJobs_responseSchemaRejectsExcessiveDepth() throws Exception {
+        Map<String, Object> nested = Map.of("type", "string");
+        for (int i = 0; i < 20; i++) {
+            nested = Map.of("type", "array", "items", nested);
+        }
+        var schema = Map.of(
+                "name",
+                "StrictReport",
+                "schema",
+                Map.of(
+                        "type",
+                        "object",
+                        "properties",
+                        Map.of("summary", nested),
+                        "required",
+                        List.of("summary"),
+                        "additionalProperties",
+                        false));
+
+        assertResponseSchemaRejected(schema, "exceeds maximum schema depth");
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"TUI Session", "New Session", "Session"})
     void postJobs_withDefaultSessionName_triggersAutoRename(String defaultName) throws Exception {
@@ -261,20 +327,28 @@ class JobsRouterValidationTest {
         assertTrue(renamed, "Session '" + defaultName + "' should have been auto-renamed to '" + taskInput + "'");
     }
 
-    private static Map<String, Object> validResponseSchema() {
-        return Map.of(
-                "name",
-                "StrictReport",
-                "schema",
-                Map.of(
-                        "type",
-                        "object",
-                        "properties",
-                        Map.of("summary", Map.of("type", "string")),
-                        "required",
-                        List.of("summary"),
-                        "additionalProperties",
-                        false));
+    private void assertResponseSchemaRejected(Map<String, Object> responseSchema, String expectedMessage)
+            throws Exception {
+        Map<String, Object> body = Map.of(
+                "taskInput",
+                "test task",
+                "plannerModel",
+                "gpt-4",
+                "executionPolicy",
+                Map.of("preset", "REPORT_ONLY"),
+                "responseSchema",
+                responseSchema);
+
+        var exchange = TestHttpExchange.jsonRequest("POST", "/v1/jobs", body);
+        exchange.getRequestHeaders().set("Idempotency-Key", UUID.randomUUID().toString());
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(400, exchange.responseCode());
+        var payload = MAPPER.readValue(exchange.responseBodyBytes(), ErrorPayload.class);
+        assertEquals(ErrorPayload.Code.VALIDATION_ERROR, payload.code());
+        assertTrue(payload.message().contains(expectedMessage), payload.message());
+        assertEquals(fsSnapshotBefore, snapshotTree(jobStoreDir), "JobStore dir changed; job may have been created");
     }
 
     @Test


### PR DESCRIPTION
### Description
Adds optional `responseSchema` support for supported headless job modes and tightens the contract around structured final responses.

**Key Changes**:
- Plumbed `responseSchema` through job specs, persistence, router validation, and runner execution.
- Added strict schema validation and conversion, including limits, keyword rejection, and all-fields-required enforcement.
- Updated `SEARCH` to gather context first and then issue one structured final response when a schema is present.
- Added focused coverage for spec round-tripping, store persistence, router validation, and runner behavior.

**Testing**:
- Focused `:app:test` coverage for job spec, store, router, and runner response-schema cases passed.
- `fix`, `tidy`, and `analyze` passed locally.