### PR TITLE
Enforce schema validation on headless structured outputs

### DIFF
--- a/app/src/main/java/ai/brokk/Llm.java
+++ b/app/src/main/java/ai/brokk/Llm.java
@@ -608,24 +608,32 @@ public class Llm {
     }
 
     public RequestOptions requestOptions() {
-        return new RequestOptions(null, ToolContext.empty(), MAX_ATTEMPTS);
+        return new RequestOptions(null, ToolContext.empty(), MAX_ATTEMPTS, null);
     }
 
     /**
      * Per-call options for a single sendRequest invocation. Controls structured output, tool usage, and retry count.
      * Build via the static factory methods or the constructor.
      */
-    public record RequestOptions(@Nullable ResponseFormat responseFormat, ToolContext toolContext, int maxAttempts) {
+    public record RequestOptions(
+            @Nullable ResponseFormat responseFormat,
+            ToolContext toolContext,
+            int maxAttempts,
+            @Nullable Integer maxCompletionTokens) {
         public RequestOptions withResponseFormat(@Nullable ResponseFormat responseFormat) {
-            return new RequestOptions(responseFormat, toolContext, maxAttempts);
+            return new RequestOptions(responseFormat, toolContext, maxAttempts, maxCompletionTokens);
         }
 
         public RequestOptions withToolContext(ToolContext toolContext) {
-            return new RequestOptions(responseFormat, toolContext, maxAttempts);
+            return new RequestOptions(responseFormat, toolContext, maxAttempts, maxCompletionTokens);
         }
 
         public RequestOptions withMaxAttempts(int maxAttempts) {
-            return new RequestOptions(responseFormat, toolContext, maxAttempts);
+            return new RequestOptions(responseFormat, toolContext, maxAttempts, maxCompletionTokens);
+        }
+
+        public RequestOptions withMaxCompletionTokens(@Nullable Integer maxCompletionTokens) {
+            return new RequestOptions(responseFormat, toolContext, maxAttempts, maxCompletionTokens);
         }
     }
 
@@ -926,6 +934,9 @@ public class Llm {
 
         if (options.responseFormat() != null) {
             builder.responseFormat(options.responseFormat());
+        }
+        if (options.maxCompletionTokens() != null) {
+            builder.maxCompletionTokens(options.maxCompletionTokens());
         }
 
         return builder;

--- a/app/src/main/java/ai/brokk/agents/ArchitectAgent.java
+++ b/app/src/main/java/ai/brokk/agents/ArchitectAgent.java
@@ -19,6 +19,7 @@ import ai.brokk.context.ContextFragment;
 import ai.brokk.context.SpecialTextType;
 import ai.brokk.exception.GlobalExceptionHandler;
 import ai.brokk.executor.agents.ParallelCustomAgent;
+import ai.brokk.executor.jobs.ChildAgentArtifactSink;
 import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.project.ModelProperties.ModelType;
 import ai.brokk.prompts.ArchitectPrompts;
@@ -103,6 +104,7 @@ public class ArchitectAgent {
     // scope is explicit so we can use its changed-files-tracking feature w/ Code Agent's results
     private final ContextManager.TaskScope scope;
     private final ResponseSchemaRegistry responseSchemaRegistry;
+    private final ChildAgentArtifactSink childAgentArtifactSink;
     // Local working context snapshot for this agent
     private Context context;
     // History of this agent's interactions
@@ -259,6 +261,30 @@ public class ArchitectAgent {
             @Nullable CompletableFuture<List<TaskEntry>> compressedHistoryFuture,
             IConsoleIO io,
             ResponseSchemaRegistry responseSchemaRegistry) {
+        this(
+                contextManager,
+                planningModel,
+                codeModel,
+                goal,
+                scope,
+                initialContext,
+                compressedHistoryFuture,
+                io,
+                responseSchemaRegistry,
+                ChildAgentArtifactSink.noop());
+    }
+
+    public ArchitectAgent(
+            IAppContextManager contextManager,
+            StreamingChatModel planningModel,
+            StreamingChatModel codeModel,
+            String goal,
+            ContextManager.TaskScope scope,
+            Context initialContext,
+            @Nullable CompletableFuture<List<TaskEntry>> compressedHistoryFuture,
+            IConsoleIO io,
+            ResponseSchemaRegistry responseSchemaRegistry,
+            ChildAgentArtifactSink childAgentArtifactSink) {
         this.cm = contextManager;
         this.planningModel = planningModel;
         this.codeModel = codeModel;
@@ -266,6 +292,7 @@ public class ArchitectAgent {
         this.io = io;
         this.scope = scope;
         this.responseSchemaRegistry = responseSchemaRegistry;
+        this.childAgentArtifactSink = childAgentArtifactSink;
         this.context = initialContext;
         this.compressedHistoryFuture = compressedHistoryFuture;
         this.verifyCommand = null;
@@ -975,7 +1002,7 @@ public class ArchitectAgent {
             WorkspaceTools wst = new WorkspaceTools(this.context);
             ParallelSearch parallelSearch = new ParallelSearch(context.forSearchAgent(), goal, delegatedSearchModel());
             ParallelCustomAgent parallelCustomAgent =
-                    new ParallelCustomAgent(cm, planningModel, responseSchemaRegistry);
+                    new ParallelCustomAgent(cm, planningModel, responseSchemaRegistry, childAgentArtifactSink);
 
             var depTools = DependencyTools.isSupported(cm.getProject())
                     ? Optional.of(new DependencyTools(cm))

--- a/app/src/main/java/ai/brokk/agents/ArchitectAgent.java
+++ b/app/src/main/java/ai/brokk/agents/ArchitectAgent.java
@@ -892,11 +892,11 @@ public class ArchitectAgent {
             // Handle read-only custom agent requests in parallel
             if (!readOnlyCustomAgentReqs.isEmpty()) {
                 var customResult = parallelCustomAgent.execute(readOnlyCustomAgentReqs, tr);
+                architectMessages.addAll(customResult.toolExecutionMessages());
                 if (customResult.stopDetails().reason() == StopReason.LLM_ERROR) {
                     return resultWithMessages(
                             StopReason.LLM_ERROR, customResult.stopDetails().explanation());
                 }
-                architectMessages.addAll(customResult.toolExecutionMessages());
             }
 
             // code agent calls are done serially

--- a/app/src/main/java/ai/brokk/agents/ArchitectAgent.java
+++ b/app/src/main/java/ai/brokk/agents/ArchitectAgent.java
@@ -19,6 +19,7 @@ import ai.brokk.context.ContextFragment;
 import ai.brokk.context.SpecialTextType;
 import ai.brokk.exception.GlobalExceptionHandler;
 import ai.brokk.executor.agents.ParallelCustomAgent;
+import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.project.ModelProperties.ModelType;
 import ai.brokk.prompts.ArchitectPrompts;
 import ai.brokk.prompts.WorkspacePrompts;
@@ -101,6 +102,7 @@ public class ArchitectAgent {
     private final String goal;
     // scope is explicit so we can use its changed-files-tracking feature w/ Code Agent's results
     private final ContextManager.TaskScope scope;
+    private final ResponseSchemaRegistry responseSchemaRegistry;
     // Local working context snapshot for this agent
     private Context context;
     // History of this agent's interactions
@@ -215,12 +217,55 @@ public class ArchitectAgent {
             Context initialContext,
             @Nullable CompletableFuture<List<TaskEntry>> compressedHistoryFuture,
             IConsoleIO io) {
+        this(
+                contextManager,
+                planningModel,
+                codeModel,
+                goal,
+                scope,
+                initialContext,
+                compressedHistoryFuture,
+                io,
+                ResponseSchemaRegistry.empty());
+    }
+
+    public ArchitectAgent(
+            IAppContextManager contextManager,
+            StreamingChatModel planningModel,
+            StreamingChatModel codeModel,
+            String goal,
+            ContextManager.TaskScope scope,
+            Context initialContext,
+            ResponseSchemaRegistry responseSchemaRegistry) {
+        this(
+                contextManager,
+                planningModel,
+                codeModel,
+                goal,
+                scope,
+                initialContext,
+                null,
+                contextManager.getIo(),
+                responseSchemaRegistry);
+    }
+
+    public ArchitectAgent(
+            IAppContextManager contextManager,
+            StreamingChatModel planningModel,
+            StreamingChatModel codeModel,
+            String goal,
+            ContextManager.TaskScope scope,
+            Context initialContext,
+            @Nullable CompletableFuture<List<TaskEntry>> compressedHistoryFuture,
+            IConsoleIO io,
+            ResponseSchemaRegistry responseSchemaRegistry) {
         this.cm = contextManager;
         this.planningModel = planningModel;
         this.codeModel = codeModel;
         this.goal = goal;
         this.io = io;
         this.scope = scope;
+        this.responseSchemaRegistry = responseSchemaRegistry;
         this.context = initialContext;
         this.compressedHistoryFuture = compressedHistoryFuture;
         this.verifyCommand = null;
@@ -929,7 +974,8 @@ public class ArchitectAgent {
 
             WorkspaceTools wst = new WorkspaceTools(this.context);
             ParallelSearch parallelSearch = new ParallelSearch(context.forSearchAgent(), goal, delegatedSearchModel());
-            ParallelCustomAgent parallelCustomAgent = new ParallelCustomAgent(cm, planningModel, goal);
+            ParallelCustomAgent parallelCustomAgent =
+                    new ParallelCustomAgent(cm, planningModel, responseSchemaRegistry);
 
             var depTools = DependencyTools.isSupported(cm.getProject())
                     ? Optional.of(new DependencyTools(cm))

--- a/app/src/main/java/ai/brokk/agents/LutzAgent.java
+++ b/app/src/main/java/ai/brokk/agents/LutzAgent.java
@@ -1176,6 +1176,7 @@ public class LutzAgent {
             // Handle read-only custom agent requests in parallel
             if (!readOnlyCustomAgentReqs.isEmpty()) {
                 var customResult = parallelCustomAgent.execute(readOnlyCustomAgentReqs, tr);
+                sessionMessages.addAll(customResult.toolExecutionMessages());
                 if (customResult.stopDetails().reason() == TaskResult.StopReason.LLM_ERROR) {
                     return new TurnOutcome.Final(agent.errorResult(
                             new TaskResult.StopDetails(
@@ -1183,7 +1184,6 @@ public class LutzAgent {
                                     customResult.stopDetails().explanation()),
                             context));
                 }
-                sessionMessages.addAll(customResult.toolExecutionMessages());
 
                 executedNonHygiene = true;
                 nonHygieneToolCalls.addAll(readOnlyCustomAgentReqs.stream()

--- a/app/src/main/java/ai/brokk/agents/LutzAgent.java
+++ b/app/src/main/java/ai/brokk/agents/LutzAgent.java
@@ -19,6 +19,7 @@ import ai.brokk.context.ContextFragment;
 import ai.brokk.context.ContextFragments;
 import ai.brokk.context.ContextHistory;
 import ai.brokk.executor.agents.ParallelCustomAgent;
+import ai.brokk.executor.jobs.ChildAgentArtifactSink;
 import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.git.GitWorkflow;
 import ai.brokk.gui.Chrome;
@@ -133,6 +134,7 @@ public class LutzAgent {
     private final List<McpPrompts.McpTool> mcpTools;
     private final SearchTools searchTools;
     private final ResponseSchemaRegistry responseSchemaRegistry;
+    private final ChildAgentArtifactSink childAgentArtifactSink;
     private List<String> staticTools;
     private List<String> terminalTools;
     private Set<String> terminalToolNames;
@@ -238,6 +240,29 @@ public class LutzAgent {
         this(initialContext, goal, model, null, objective, scope, io, scanConfig, responseSchemaRegistry);
     }
 
+    public LutzAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            Objective objective,
+            ContextManager.TaskScope scope,
+            IConsoleIO io,
+            ScanConfig scanConfig,
+            ResponseSchemaRegistry responseSchemaRegistry,
+            ChildAgentArtifactSink childAgentArtifactSink) {
+        this(
+                initialContext,
+                goal,
+                model,
+                null,
+                objective,
+                scope,
+                io,
+                scanConfig,
+                responseSchemaRegistry,
+                childAgentArtifactSink);
+    }
+
     /**
      * Primary constructor.
      *
@@ -268,12 +293,37 @@ public class LutzAgent {
             IConsoleIO io,
             ScanConfig scanConfig,
             ResponseSchemaRegistry responseSchemaRegistry) {
+        this(
+                initialContext,
+                goal,
+                model,
+                codeModel,
+                objective,
+                scope,
+                io,
+                scanConfig,
+                responseSchemaRegistry,
+                ChildAgentArtifactSink.noop());
+    }
+
+    public LutzAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            @Nullable StreamingChatModel codeModel,
+            Objective objective,
+            ContextManager.TaskScope scope,
+            IConsoleIO io,
+            ScanConfig scanConfig,
+            ResponseSchemaRegistry responseSchemaRegistry,
+            ChildAgentArtifactSink childAgentArtifactSink) {
         this.goal = goal;
         this.cm = initialContext.getContextManager();
         this.model = model;
         this.codeModel = codeModel;
         this.scope = scope;
         this.responseSchemaRegistry = responseSchemaRegistry;
+        this.childAgentArtifactSink = childAgentArtifactSink;
 
         this.io = io;
         this.scanConfig = scanConfig;
@@ -849,7 +899,16 @@ public class LutzAgent {
             throw new IllegalStateException("LutzAgent.callCodeAgent invoked while read-only mode is active");
         }
         ArchitectAgent architect = new ArchitectAgent(
-                cm, model, effectiveCodeModel(), instructions, scope, currentState.context(), responseSchemaRegistry);
+                cm,
+                model,
+                effectiveCodeModel(),
+                instructions,
+                scope,
+                currentState.context(),
+                null,
+                cm.getIo(),
+                responseSchemaRegistry,
+                childAgentArtifactSink);
 
         return architect.execute();
     }
@@ -903,7 +962,8 @@ public class LutzAgent {
 
             this.parallelSearch =
                     new ParallelSearch(context.forSearchAgent(), agent.goal, agent.delegatedSearchModel());
-            this.parallelCustomAgent = new ParallelCustomAgent(agent.cm, agent.model, agent.responseSchemaRegistry);
+            this.parallelCustomAgent = new ParallelCustomAgent(
+                    agent.cm, agent.model, agent.responseSchemaRegistry, agent.childAgentArtifactSink);
             this.tr = agent.createToolRegistry(new WorkspaceTools(context), this, parallelSearch, parallelCustomAgent);
         }
 
@@ -1485,7 +1545,10 @@ public class LutzAgent {
                     instructions,
                     agent.scope,
                     agent.resetPinsToOriginal(context),
-                    agent.responseSchemaRegistry);
+                    null,
+                    agent.cm.getIo(),
+                    agent.responseSchemaRegistry,
+                    agent.childAgentArtifactSink);
             var buildDetails = agent.cm.getProject().awaitBuildDetails();
             String verifyCommand = buildDetails.afterTaskListCommand();
             if (!verifyCommand.isBlank()) {

--- a/app/src/main/java/ai/brokk/agents/LutzAgent.java
+++ b/app/src/main/java/ai/brokk/agents/LutzAgent.java
@@ -19,6 +19,7 @@ import ai.brokk.context.ContextFragment;
 import ai.brokk.context.ContextFragments;
 import ai.brokk.context.ContextHistory;
 import ai.brokk.executor.agents.ParallelCustomAgent;
+import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.git.GitWorkflow;
 import ai.brokk.gui.Chrome;
 import ai.brokk.mcpclient.McpUtils;
@@ -131,6 +132,7 @@ public class LutzAgent {
     private final String goal;
     private final List<McpPrompts.McpTool> mcpTools;
     private final SearchTools searchTools;
+    private final ResponseSchemaRegistry responseSchemaRegistry;
     private List<String> staticTools;
     private List<String> terminalTools;
     private Set<String> terminalToolNames;
@@ -221,7 +223,19 @@ public class LutzAgent {
             ContextManager.TaskScope scope,
             IConsoleIO io,
             ScanConfig scanConfig) {
-        this(initialContext, goal, model, null, objective, scope, io, scanConfig);
+        this(initialContext, goal, model, null, objective, scope, io, scanConfig, ResponseSchemaRegistry.empty());
+    }
+
+    public LutzAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            Objective objective,
+            ContextManager.TaskScope scope,
+            IConsoleIO io,
+            ScanConfig scanConfig,
+            ResponseSchemaRegistry responseSchemaRegistry) {
+        this(initialContext, goal, model, null, objective, scope, io, scanConfig, responseSchemaRegistry);
     }
 
     /**
@@ -241,11 +255,25 @@ public class LutzAgent {
             ContextManager.TaskScope scope,
             IConsoleIO io,
             ScanConfig scanConfig) {
+        this(initialContext, goal, model, codeModel, objective, scope, io, scanConfig, ResponseSchemaRegistry.empty());
+    }
+
+    public LutzAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            @Nullable StreamingChatModel codeModel,
+            Objective objective,
+            ContextManager.TaskScope scope,
+            IConsoleIO io,
+            ScanConfig scanConfig,
+            ResponseSchemaRegistry responseSchemaRegistry) {
         this.goal = goal;
         this.cm = initialContext.getContextManager();
         this.model = model;
         this.codeModel = codeModel;
         this.scope = scope;
+        this.responseSchemaRegistry = responseSchemaRegistry;
 
         this.io = io;
         this.scanConfig = scanConfig;
@@ -820,8 +848,8 @@ public class LutzAgent {
         if (readOnly) {
             throw new IllegalStateException("LutzAgent.callCodeAgent invoked while read-only mode is active");
         }
-        ArchitectAgent architect =
-                new ArchitectAgent(cm, model, effectiveCodeModel(), instructions, scope, currentState.context());
+        ArchitectAgent architect = new ArchitectAgent(
+                cm, model, effectiveCodeModel(), instructions, scope, currentState.context(), responseSchemaRegistry);
 
         return architect.execute();
     }
@@ -875,7 +903,7 @@ public class LutzAgent {
 
             this.parallelSearch =
                     new ParallelSearch(context.forSearchAgent(), agent.goal, agent.delegatedSearchModel());
-            this.parallelCustomAgent = new ParallelCustomAgent(agent.cm, agent.model, agent.goal);
+            this.parallelCustomAgent = new ParallelCustomAgent(agent.cm, agent.model, agent.responseSchemaRegistry);
             this.tr = agent.createToolRegistry(new WorkspaceTools(context), this, parallelSearch, parallelCustomAgent);
         }
 
@@ -1456,7 +1484,8 @@ public class LutzAgent {
                     agent.effectiveCodeModel(),
                     instructions,
                     agent.scope,
-                    agent.resetPinsToOriginal(context));
+                    agent.resetPinsToOriginal(context),
+                    agent.responseSchemaRegistry);
             var buildDetails = agent.cm.getProject().awaitBuildDetails();
             String verifyCommand = buildDetails.afterTaskListCommand();
             if (!verifyCommand.isBlank()) {

--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -11,6 +11,7 @@ import ai.brokk.context.Context;
 import ai.brokk.context.ContextFragment;
 import ai.brokk.context.ContextHistory;
 import ai.brokk.executor.agents.ParallelCustomAgent;
+import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.metrics.SearchMetrics;
 import ai.brokk.project.IProject;
 import ai.brokk.project.ModelProperties;
@@ -80,6 +81,7 @@ public class SearchAgent {
     private final Llm llm;
     private final SearchTools searchTools;
     private final Context initialContext;
+    private final ResponseSchemaRegistry responseSchemaRegistry;
 
     private final SearchMetrics metrics;
 
@@ -107,7 +109,17 @@ public class SearchAgent {
 
     public SearchAgent(
             Context initialContext, String goal, StreamingChatModel model, Objective objective, IConsoleIO io) {
-        this(initialContext, goal, model, objective, io, null);
+        this(initialContext, goal, model, objective, io, null, ResponseSchemaRegistry.empty());
+    }
+
+    public SearchAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            Objective objective,
+            IConsoleIO io,
+            ResponseSchemaRegistry responseSchemaRegistry) {
+        this(initialContext, goal, model, objective, io, null, responseSchemaRegistry);
     }
 
     SearchAgent(
@@ -117,6 +129,17 @@ public class SearchAgent {
             Objective objective,
             IConsoleIO io,
             @Nullable SearchMetrics metrics) {
+        this(initialContext, goal, model, objective, io, metrics, ResponseSchemaRegistry.empty());
+    }
+
+    SearchAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            Objective objective,
+            IConsoleIO io,
+            @Nullable SearchMetrics metrics,
+            ResponseSchemaRegistry responseSchemaRegistry) {
         if (objective != Objective.ANSWER_ONLY && objective != Objective.WORKSPACE_ONLY) {
             throw new IllegalArgumentException("SearchAgent only supports ANSWER_ONLY and WORKSPACE_ONLY objectives");
         }
@@ -131,6 +154,7 @@ public class SearchAgent {
                         ? SearchMetrics.tracking()
                         : SearchMetrics.noOp();
         this.initialContext = initialContext;
+        this.responseSchemaRegistry = responseSchemaRegistry;
         this.context = initialContext;
         this.llm = cm.getLlm(new Llm.Options(model, goal, TaskResult.Type.SEARCH).withEcho());
         this.llm.setOutput(io);
@@ -165,7 +189,7 @@ public class SearchAgent {
 
     private TaskResult executeSearch() throws InterruptedException {
         var workspaceTools = new WorkspaceTools(context);
-        var parallelCustomAgent = new ParallelCustomAgent(cm, model, goal);
+        var parallelCustomAgent = new ParallelCustomAgent(cm, model, responseSchemaRegistry);
         var toolRegistry = cm.getToolRegistry()
                 .builder()
                 .register(searchTools)

--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -335,13 +335,13 @@ public class SearchAgent {
                 if (!readOnlyCustomAgentReqs.isEmpty()) {
                     readOnlyCustomAgentReqs.forEach(req -> metrics.recordToolCall(req.name()));
                     var customResult = parallelCustomAgent.execute(readOnlyCustomAgentReqs, toolRegistry);
+                    messages.addAll(customResult.toolExecutionMessages());
                     if (customResult.stopDetails().reason() == TaskResult.StopReason.LLM_ERROR) {
                         cancelOutstandingParallelFutures.run();
                         return errorResult(new TaskResult.StopDetails(
                                 TaskResult.StopReason.LLM_ERROR,
                                 customResult.stopDetails().explanation()));
                     }
-                    messages.addAll(customResult.toolExecutionMessages());
                 }
 
                 previousTurnAdditions = List.copyOf(additionsThisTurn);

--- a/app/src/main/java/ai/brokk/agents/SearchAgent.java
+++ b/app/src/main/java/ai/brokk/agents/SearchAgent.java
@@ -11,6 +11,7 @@ import ai.brokk.context.Context;
 import ai.brokk.context.ContextFragment;
 import ai.brokk.context.ContextHistory;
 import ai.brokk.executor.agents.ParallelCustomAgent;
+import ai.brokk.executor.jobs.ChildAgentArtifactSink;
 import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.metrics.SearchMetrics;
 import ai.brokk.project.IProject;
@@ -82,6 +83,7 @@ public class SearchAgent {
     private final SearchTools searchTools;
     private final Context initialContext;
     private final ResponseSchemaRegistry responseSchemaRegistry;
+    private final ChildAgentArtifactSink childAgentArtifactSink;
 
     private final SearchMetrics metrics;
 
@@ -122,6 +124,17 @@ public class SearchAgent {
         this(initialContext, goal, model, objective, io, null, responseSchemaRegistry);
     }
 
+    public SearchAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            Objective objective,
+            IConsoleIO io,
+            ResponseSchemaRegistry responseSchemaRegistry,
+            ChildAgentArtifactSink childAgentArtifactSink) {
+        this(initialContext, goal, model, objective, io, null, responseSchemaRegistry, childAgentArtifactSink);
+    }
+
     SearchAgent(
             Context initialContext,
             String goal,
@@ -140,6 +153,26 @@ public class SearchAgent {
             IConsoleIO io,
             @Nullable SearchMetrics metrics,
             ResponseSchemaRegistry responseSchemaRegistry) {
+        this(
+                initialContext,
+                goal,
+                model,
+                objective,
+                io,
+                metrics,
+                responseSchemaRegistry,
+                ChildAgentArtifactSink.noop());
+    }
+
+    SearchAgent(
+            Context initialContext,
+            String goal,
+            StreamingChatModel model,
+            Objective objective,
+            IConsoleIO io,
+            @Nullable SearchMetrics metrics,
+            ResponseSchemaRegistry responseSchemaRegistry,
+            ChildAgentArtifactSink childAgentArtifactSink) {
         if (objective != Objective.ANSWER_ONLY && objective != Objective.WORKSPACE_ONLY) {
             throw new IllegalArgumentException("SearchAgent only supports ANSWER_ONLY and WORKSPACE_ONLY objectives");
         }
@@ -155,6 +188,7 @@ public class SearchAgent {
                         : SearchMetrics.noOp();
         this.initialContext = initialContext;
         this.responseSchemaRegistry = responseSchemaRegistry;
+        this.childAgentArtifactSink = childAgentArtifactSink;
         this.context = initialContext;
         this.llm = cm.getLlm(new Llm.Options(model, goal, TaskResult.Type.SEARCH).withEcho());
         this.llm.setOutput(io);
@@ -189,7 +223,7 @@ public class SearchAgent {
 
     private TaskResult executeSearch() throws InterruptedException {
         var workspaceTools = new WorkspaceTools(context);
-        var parallelCustomAgent = new ParallelCustomAgent(cm, model, responseSchemaRegistry);
+        var parallelCustomAgent = new ParallelCustomAgent(cm, model, responseSchemaRegistry, childAgentArtifactSink);
         var toolRegistry = cm.getToolRegistry()
                 .builder()
                 .register(searchTools)

--- a/app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java
+++ b/app/src/main/java/ai/brokk/executor/HeadlessExecutorMain.java
@@ -560,6 +560,7 @@ public final class HeadlessExecutorMain {
             System.out.println("    POST /v1/jobs                     - create and start a job");
             System.out.println("    POST /v1/jobs/pr-review           - create a PR review job");
             System.out.println("    GET  /v1/jobs/{jobId}             - get job status");
+            System.out.println("    GET  /v1/jobs/{jobId}/result      - get job result and child artifacts");
             System.out.println("    GET  /v1/jobs/{jobId}/events      - stream job execution events");
             System.out.println("    POST /v1/jobs/{jobId}/cancel      - cancel job execution");
             System.out.println("    GET  /v1/jobs/{jobId}/diff        - get git diff for job");

--- a/app/src/main/java/ai/brokk/executor/agents/ChildAgentArtifactFactory.java
+++ b/app/src/main/java/ai/brokk/executor/agents/ChildAgentArtifactFactory.java
@@ -1,0 +1,247 @@
+package ai.brokk.executor.agents;
+
+import ai.brokk.executor.jobs.ChildAgentArtifact;
+import ai.brokk.tools.ToolExecutionResult;
+import ai.brokk.util.Json;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Locale;
+import org.jetbrains.annotations.Nullable;
+
+final class ChildAgentArtifactFactory {
+    private static final int EXCERPT_MAX_CHARS = 2_000;
+
+    private ChildAgentArtifactFactory() {}
+
+    static ChildAgentArtifact fromToolResult(
+            String parentJobId,
+            String childRunId,
+            @Nullable String toolCallId,
+            String agentName,
+            String responseSchemaName,
+            String modelName,
+            long elapsedMs,
+            ToolExecutionResult result) {
+        var resultText = result.resultText();
+        if (result.status() == ToolExecutionResult.Status.SUCCESS) {
+            return successFromText(
+                    parentJobId,
+                    childRunId,
+                    toolCallId,
+                    agentName,
+                    responseSchemaName,
+                    modelName,
+                    elapsedMs,
+                    resultText);
+        }
+        if (result.status() == ToolExecutionResult.Status.FATAL
+                && resultText.contains("RESPONSE_SCHEMA_OUTPUT_INVALID")) {
+            return schemaInvalidFromFailureText(
+                    parentJobId,
+                    childRunId,
+                    toolCallId,
+                    agentName,
+                    responseSchemaName,
+                    modelName,
+                    elapsedMs,
+                    resultText);
+        }
+        return genericFailure(
+                parentJobId,
+                childRunId,
+                toolCallId,
+                agentName,
+                responseSchemaName,
+                modelName,
+                elapsedMs,
+                statusForNonSchemaFailure(resultText),
+                resultText);
+    }
+
+    static ChildAgentArtifact successFromText(
+            String parentJobId,
+            String childRunId,
+            @Nullable String toolCallId,
+            String agentName,
+            String responseSchemaName,
+            String modelName,
+            long elapsedMs,
+            String text) {
+        try {
+            var parsed = Json.getMapper().readTree(text);
+            if (parsed.isObject()) {
+                return artifact(
+                        parentJobId,
+                        childRunId,
+                        toolCallId,
+                        agentName,
+                        responseSchemaName,
+                        ChildAgentArtifact.STATUS_SUCCESS,
+                        parsed,
+                        null,
+                        null,
+                        null,
+                        elapsedMs,
+                        modelName);
+            }
+            return schemaInvalid(
+                    parentJobId,
+                    childRunId,
+                    toolCallId,
+                    agentName,
+                    responseSchemaName,
+                    modelName,
+                    elapsedMs,
+                    "validated child response was not a JSON object",
+                    text);
+        } catch (Exception e) {
+            return schemaInvalid(
+                    parentJobId,
+                    childRunId,
+                    toolCallId,
+                    agentName,
+                    responseSchemaName,
+                    modelName,
+                    elapsedMs,
+                    "validated child response could not be parsed as JSON: " + e.getMessage(),
+                    text);
+        }
+    }
+
+    static ChildAgentArtifact schemaInvalidFromFailureText(
+            String parentJobId,
+            String childRunId,
+            @Nullable String toolCallId,
+            String agentName,
+            String responseSchemaName,
+            String modelName,
+            long elapsedMs,
+            String failureText) {
+        var validationError = SchemaFailureDiagnostics.validationError(failureText);
+        if (validationError == null) {
+            validationError = failureText.lines().findFirst().orElse("RESPONSE_SCHEMA_OUTPUT_INVALID");
+        }
+        var invalidOutputExcerpt = SchemaFailureDiagnostics.invalidOutputExcerpt(failureText);
+        if (invalidOutputExcerpt == null) {
+            invalidOutputExcerpt = SchemaFailureDiagnostics.originalOutputExcerpt(failureText);
+        }
+        if (invalidOutputExcerpt == null) {
+            invalidOutputExcerpt = excerpt(failureText);
+        }
+        return artifact(
+                parentJobId,
+                childRunId,
+                toolCallId,
+                agentName,
+                responseSchemaName,
+                ChildAgentArtifact.STATUS_SCHEMA_INVALID,
+                null,
+                validationError,
+                invalidOutputExcerpt,
+                null,
+                elapsedMs,
+                modelName);
+    }
+
+    static ChildAgentArtifact genericFailure(
+            String parentJobId,
+            String childRunId,
+            @Nullable String toolCallId,
+            String agentName,
+            String responseSchemaName,
+            String modelName,
+            long elapsedMs,
+            String status,
+            String errorText) {
+        return artifact(
+                parentJobId,
+                childRunId,
+                toolCallId,
+                agentName,
+                responseSchemaName,
+                status,
+                null,
+                null,
+                null,
+                excerpt(errorText),
+                elapsedMs,
+                modelName);
+    }
+
+    private static ChildAgentArtifact schemaInvalid(
+            String parentJobId,
+            String childRunId,
+            @Nullable String toolCallId,
+            String agentName,
+            String responseSchemaName,
+            String modelName,
+            long elapsedMs,
+            String validationError,
+            String invalidOutput) {
+        return artifact(
+                parentJobId,
+                childRunId,
+                toolCallId,
+                agentName,
+                responseSchemaName,
+                ChildAgentArtifact.STATUS_SCHEMA_INVALID,
+                null,
+                validationError,
+                excerpt(invalidOutput),
+                null,
+                elapsedMs,
+                modelName);
+    }
+
+    private static ChildAgentArtifact artifact(
+            String parentJobId,
+            String childRunId,
+            @Nullable String toolCallId,
+            String agentName,
+            String responseSchemaName,
+            String status,
+            @Nullable JsonNode validatedResponse,
+            @Nullable String validationError,
+            @Nullable String invalidOutputExcerpt,
+            @Nullable String errorMessage,
+            long elapsedMs,
+            String modelName) {
+        return new ChildAgentArtifact(
+                parentJobId,
+                childRunId,
+                toolCallId,
+                agentName,
+                responseSchemaName,
+                status,
+                validatedResponse,
+                validationError,
+                invalidOutputExcerpt,
+                errorMessage,
+                elapsedMs,
+                modelName,
+                null,
+                null,
+                null);
+    }
+
+    static String statusForNonSchemaFailure(String resultText) {
+        var lower = resultText.toLowerCase(Locale.ROOT);
+        if (lower.contains("cancel")) {
+            return ChildAgentArtifact.STATUS_CANCELLED;
+        }
+        if (lower.contains("timeout") || lower.contains("timed out")) {
+            return ChildAgentArtifact.STATUS_TIMEOUT;
+        }
+        return ChildAgentArtifact.STATUS_FAILED;
+    }
+
+    private static String excerpt(String text) {
+        var normalized = text.strip();
+        if (normalized.length() <= EXCERPT_MAX_CHARS) {
+            return normalized;
+        }
+        return normalized.substring(0, EXCERPT_MAX_CHARS)
+                + "...[truncated "
+                + (normalized.length() - EXCERPT_MAX_CHARS)
+                + " chars]";
+    }
+}

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -20,6 +20,9 @@ import ai.brokk.tools.ToolOutput;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.tools.WorkspaceTools;
 import ai.brokk.util.Json;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolContext;
@@ -33,13 +36,17 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.Nullable;
 
@@ -49,11 +56,17 @@ import org.jetbrains.annotations.Nullable;
  * terminal detection) but parameterized by user-supplied configuration.
  */
 public class CustomAgentExecutor {
+    private static final Logger logger = LogManager.getLogger(CustomAgentExecutor.class);
+
     private record TerminalStopOutput(String llmText, TaskResult.StopDetails stopDetails) implements ToolOutput {}
+
+    private record NormalizedCandidate(String json, List<String> changes) {}
 
     private static final Set<String> TERMINAL_TOOL_NAMES = Set.of("answer", "abortSearch");
     private static final Set<String> PARALLEL_SAFE_SEARCH_TOOL_NAMES = AgentDefinition.PARALLEL_SAFE_SEARCH_TOOL_NAMES;
-    private static final int STRUCTURED_FINAL_MAX_COMPLETION_TOKENS = 4096;
+    private static final int STRUCTURED_REPAIR_MIN_COMPLETION_TOKENS = 192;
+    private static final int STRUCTURED_REPAIR_MAX_COMPLETION_TOKENS = 1024;
+    private static final int STRUCTURED_REPAIR_TOKENS_PER_SCHEMA_NODE = 24;
     private static final int INVALID_PREVIOUS_RESPONSE_MAX_CHARS = 8000;
 
     private final IAppContextManager cm;
@@ -259,9 +272,30 @@ public class CustomAgentExecutor {
 
     private TaskResult structuredFinalAnswer(String taskInput, String finalNotes) throws InterruptedException {
         var schema = Objects.requireNonNull(responseSchema);
+        var directCandidate = extractTerminalSchemaCandidate(finalNotes);
+        var directValidationError = JobResponseSchemaSupport.validateOutput(schema, directCandidate);
+        if (directValidationError.isEmpty()) {
+            io.llmOutput(directCandidate, ChatMessageType.AI, LlmOutputMeta.newMessage());
+            return new TaskResult(context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, directCandidate));
+        }
+        var normalizedCandidate = deterministicNormalize(schema, directCandidate);
+        if (normalizedCandidate != null) {
+            var normalizedValidationError = JobResponseSchemaSupport.validateOutput(schema, normalizedCandidate.json());
+            if (normalizedValidationError.isEmpty()) {
+                logger.info(
+                        "Schema-aware custom-agent terminal output normalized deterministically for schema {}: {}",
+                        schema.name(),
+                        normalizedCandidate.changes());
+                io.llmOutput(normalizedCandidate.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
+                return new TaskResult(
+                        context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, normalizedCandidate.json()));
+            }
+        }
+
         var structuredLlm = cm.getLlm(
                 new Llm.Options(model, agentDef.name() + " structured answer", TaskResult.Type.SEARCH).withEcho());
         structuredLlm.setOutput(io);
+        var repairMaxCompletionTokens = repairMaxCompletionTokens(schema);
 
         var toc = WorkspacePrompts.formatToc(context).trim();
         var messages = List.<ChatMessage>of(
@@ -276,7 +310,7 @@ public class CustomAgentExecutor {
                             .requestOptions()
                             .withResponseFormat(responseFormat)
                             .withMaxAttempts(1)
-                            .withMaxCompletionTokens(STRUCTURED_FINAL_MAX_COMPLETION_TOKENS));
+                            .withMaxCompletionTokens(repairMaxCompletionTokens));
             if (response.error() != null) {
                 return new TaskResult(context, TaskResult.StopDetails.fromResponse(response));
             }
@@ -287,9 +321,13 @@ public class CustomAgentExecutor {
                         context,
                         new TaskResult.StopDetails(
                                 TaskResult.StopReason.LLM_ERROR,
-                                "RESPONSE_SCHEMA_OUTPUT_INVALID: structured response exceeded "
-                                        + STRUCTURED_FINAL_MAX_COMPLETION_TOKENS
-                                        + " completion tokens before producing valid JSON"));
+                                repairFailureMessage(
+                                        schema,
+                                        directValidationError.orElse("unknown validation error"),
+                                        normalizedCandidate != null,
+                                        true,
+                                        "LENGTH",
+                                        structuredText)));
             }
 
             var validationError = JobResponseSchemaSupport.validateOutput(schema, structuredText);
@@ -304,7 +342,13 @@ public class CustomAgentExecutor {
                         context,
                         new TaskResult.StopDetails(
                                 TaskResult.StopReason.LLM_ERROR,
-                                "RESPONSE_SCHEMA_OUTPUT_INVALID: " + validationError.get()));
+                                repairFailureMessage(
+                                        schema,
+                                        validationError.get(),
+                                        normalizedCandidate != null,
+                                        true,
+                                        "complete",
+                                        structuredText)));
             }
 
             messages = List.of(
@@ -318,6 +362,241 @@ public class CustomAgentExecutor {
         }
 
         throw new IllegalStateException("unreachable structured answer retry state");
+    }
+
+    private static String extractTerminalSchemaCandidate(String finalNotes) {
+        try {
+            var node = Json.getMapper().readTree(finalNotes);
+            var explanation = node.get("explanation");
+            if (explanation != null && explanation.isTextual()) {
+                return explanation.asText().trim();
+            }
+        } catch (Exception ignored) {
+            // Not an answer-tool envelope. Validate the raw text below.
+        }
+        return finalNotes.trim();
+    }
+
+    private static @Nullable NormalizedCandidate deterministicNormalize(
+            JobSpec.ResponseSchema schema, String candidate) {
+        try {
+            var root = Json.getMapper().readTree(candidate);
+            var changes = new ArrayList<String>();
+            var normalized = normalizeNode(root, schema.schema(), "response", "", changes);
+            if (changes.isEmpty()) {
+                return null;
+            }
+            return new NormalizedCandidate(Json.toJson(normalized), List.copyOf(changes));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static JsonNode normalizeNode(
+            JsonNode value, JsonNode schema, String path, String propertyName, List<String> changes) {
+        if (value.isNull()) {
+            return value;
+        }
+
+        return switch (schemaType(schema)) {
+            case "object" -> normalizeObject(value, schema, path, changes);
+            case "array" -> normalizeArray(value, schema, path, propertyName, changes);
+            case "string" -> normalizeString(value, schema, path, propertyName, changes);
+            default -> value;
+        };
+    }
+
+    private static JsonNode normalizeObject(JsonNode value, JsonNode schema, String path, List<String> changes) {
+        if (!value.isObject()) {
+            return value;
+        }
+
+        var object = (ObjectNode) value.deepCopy();
+        var properties = schema.get("properties");
+        if (properties != null && properties.isObject()) {
+            if (additionalPropertiesDisabled(schema) && allRequiredPropertiesPresent(object, schema)) {
+                var allowedNames = new HashSet<String>();
+                properties.properties().forEach(entry -> allowedNames.add(entry.getKey()));
+                var namesToRemove = new ArrayList<String>();
+                object.properties().forEach(entry -> {
+                    if (!allowedNames.contains(entry.getKey())) {
+                        namesToRemove.add(entry.getKey());
+                    }
+                });
+                namesToRemove.forEach(name -> {
+                    object.remove(name);
+                    changes.add(path + "." + name + " unknown property dropped");
+                });
+            }
+
+            properties.properties().forEach(entry -> {
+                var child = object.get(entry.getKey());
+                if (child != null) {
+                    object.set(
+                            entry.getKey(),
+                            normalizeNode(
+                                    child, entry.getValue(), path + "." + entry.getKey(), entry.getKey(), changes));
+                }
+            });
+        }
+        return object;
+    }
+
+    private static JsonNode normalizeArray(
+            JsonNode value, JsonNode schema, String path, String propertyName, List<String> changes) {
+        var items = schema.get("items");
+        if (value.isArray()) {
+            var array = Json.getMapper().createArrayNode();
+            for (int i = 0; i < value.size(); i++) {
+                array.add(
+                        items == null
+                                ? value.get(i)
+                                : normalizeNode(value.get(i), items, path + "[" + i + "]", propertyName, changes));
+            }
+            return array;
+        }
+
+        if (!value.isObject()) {
+            var array = Json.getMapper().createArrayNode();
+            array.add(items == null ? value : normalizeNode(value, items, path + "[0]", propertyName, changes));
+            changes.add(path + " scalar -> array");
+            return array;
+        }
+
+        return value;
+    }
+
+    private static JsonNode normalizeString(
+            JsonNode value, JsonNode schema, String path, String propertyName, List<String> changes) {
+        if (value.isTextual()) {
+            return value;
+        }
+
+        if (isConfidenceProperty(propertyName) && value.isNumber()) {
+            var confidence = confidenceLabel(value.doubleValue(), schema);
+            if (confidence != null) {
+                changes.add(path + " numeric confidence -> string enum");
+                return TextNode.valueOf(confidence);
+            }
+        }
+
+        if (value.isNumber() || value.isBoolean()) {
+            changes.add(path + " " + outputType(value) + " -> string");
+            return TextNode.valueOf(value.asText());
+        }
+
+        return value;
+    }
+
+    private static boolean isConfidenceProperty(String propertyName) {
+        return "confidence".equals(propertyName);
+    }
+
+    private static @Nullable String confidenceLabel(double value, JsonNode schema) {
+        var enumNode = schema.get("enum");
+        if (enumNode == null || !enumNode.isArray()) {
+            return null;
+        }
+        var labels = Json.stringArrayToSet(enumNode);
+        if (!labels.containsAll(Set.of("low", "medium", "high"))) {
+            return null;
+        }
+        if (Double.compare(value, 1.0) == 0) {
+            return "high";
+        }
+        if (Double.compare(value, 0.5) == 0) {
+            return "medium";
+        }
+        if (Double.compare(value, 0.0) == 0) {
+            return "low";
+        }
+        return null;
+    }
+
+    private static boolean allRequiredPropertiesPresent(ObjectNode value, JsonNode schema) {
+        var required = schema.get("required");
+        if (required == null || !required.isArray()) {
+            return true;
+        }
+        for (var requiredName : required) {
+            if (!requiredName.isTextual() || !value.hasNonNull(requiredName.textValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean additionalPropertiesDisabled(JsonNode schema) {
+        var additionalProperties = schema.get("additionalProperties");
+        return additionalProperties != null && additionalProperties.isBoolean() && !additionalProperties.booleanValue();
+    }
+
+    private static String schemaType(JsonNode schema) {
+        var type = schema.get("type");
+        return type != null && type.isTextual() ? type.textValue() : "";
+    }
+
+    private static String outputType(JsonNode value) {
+        if (value.isNumber()) {
+            return value.isIntegralNumber() ? "integer" : "number";
+        }
+        if (value.isBoolean()) {
+            return "boolean";
+        }
+        if (value.isArray()) {
+            return "array";
+        }
+        if (value.isObject()) {
+            return "object";
+        }
+        return value.getNodeType().name().toLowerCase(Locale.ROOT);
+    }
+
+    private static int repairMaxCompletionTokens(JobSpec.ResponseSchema schema) {
+        return Math.min(
+                STRUCTURED_REPAIR_MAX_COMPLETION_TOKENS,
+                Math.max(
+                        STRUCTURED_REPAIR_MIN_COMPLETION_TOKENS,
+                        countSchemaNodes(schema.schema()) * STRUCTURED_REPAIR_TOKENS_PER_SCHEMA_NODE));
+    }
+
+    private static int countSchemaNodes(JsonNode schema) {
+        var type = schemaType(schema);
+        return switch (type) {
+            case "object" -> {
+                var properties = schema.get("properties");
+                if (properties == null || !properties.isObject()) {
+                    yield 1;
+                }
+                var count = 1;
+                for (var entry : properties.properties()) {
+                    count += countSchemaNodes(entry.getValue());
+                }
+                yield count;
+            }
+            case "array" -> {
+                var items = schema.get("items");
+                yield items == null ? 1 : 1 + countSchemaNodes(items);
+            }
+            default -> 1;
+        };
+    }
+
+    private static String repairFailureMessage(
+            JobSpec.ResponseSchema schema,
+            String validationError,
+            boolean deterministicRepairAttempted,
+            boolean llmRepairAttempted,
+            String finishReason,
+            String invalidOutput) {
+        return "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=%s validation=%s deterministicRepairAttempted=%s llmRepairAttempted=%s finishReason=%s invalidOutputExcerpt=%s"
+                .formatted(
+                        schema.name(),
+                        validationError,
+                        deterministicRepairAttempted,
+                        llmRepairAttempted,
+                        finishReason,
+                        abbreviateInvalidOutput(invalidOutput));
     }
 
     private static String abbreviateInvalidOutput(String invalidOutput) {
@@ -343,6 +622,10 @@ public class CustomAgentExecutor {
                 %s
 
                 Produce the final custom-agent result according to the supplied response schema.
+                Return only the JSON object.
+                Do not include markdown, commentary, copied schema, or explanation.
+                Preserve all evidence from the candidate.
+                Only fix JSON shape/types to match the schema.
                 """
                 .formatted(taskInput, finalNotes, toc);
     }
@@ -368,7 +651,10 @@ public class CustomAgentExecutor {
                 </invalid_previous_response>
 
                 Produce a corrected final custom-agent result according to the supplied response schema.
-                Do not change the evidence meaning. Convert incorrectly shaped fields to the schema shape.
+                Return only the JSON object.
+                Do not include markdown, commentary, copied schema, or explanation.
+                Preserve all evidence from the candidate.
+                Only fix JSON shape/types to match the schema.
                 """
                 .formatted(taskInput, finalNotes, toc, validationError, invalidOutput);
     }

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -53,6 +53,8 @@ public class CustomAgentExecutor {
 
     private static final Set<String> TERMINAL_TOOL_NAMES = Set.of("answer", "abortSearch");
     private static final Set<String> PARALLEL_SAFE_SEARCH_TOOL_NAMES = AgentDefinition.PARALLEL_SAFE_SEARCH_TOOL_NAMES;
+    private static final int STRUCTURED_FINAL_MAX_COMPLETION_TOKENS = 4096;
+    private static final int INVALID_PREVIOUS_RESPONSE_MAX_CHARS = 8000;
 
     private final IAppContextManager cm;
     private final AgentDefinition agentDef;
@@ -273,12 +275,23 @@ public class CustomAgentExecutor {
                     structuredLlm
                             .requestOptions()
                             .withResponseFormat(responseFormat)
-                            .withMaxAttempts(1));
+                            .withMaxAttempts(1)
+                            .withMaxCompletionTokens(STRUCTURED_FINAL_MAX_COMPLETION_TOKENS));
             if (response.error() != null) {
                 return new TaskResult(context, TaskResult.StopDetails.fromResponse(response));
             }
 
             structuredText = response.text();
+            if (response.isPartial()) {
+                return new TaskResult(
+                        context,
+                        new TaskResult.StopDetails(
+                                TaskResult.StopReason.LLM_ERROR,
+                                "RESPONSE_SCHEMA_OUTPUT_INVALID: structured response exceeded "
+                                        + STRUCTURED_FINAL_MAX_COMPLETION_TOKENS
+                                        + " completion tokens before producing valid JSON"));
+            }
+
             var validationError = JobResponseSchemaSupport.validateOutput(schema, structuredText);
             if (validationError.isEmpty()) {
                 io.llmOutput(structuredText, ChatMessageType.AI, LlmOutputMeta.newMessage());
@@ -297,10 +310,24 @@ public class CustomAgentExecutor {
             messages = List.of(
                     new SystemMessage(agentDef.systemPrompt()),
                     new UserMessage(formatStructuredFinalRetryPrompt(
-                            taskInput, finalNotes, toc, structuredText, validationError.get())));
+                            taskInput,
+                            finalNotes,
+                            toc,
+                            abbreviateInvalidOutput(structuredText),
+                            validationError.get())));
         }
 
         throw new IllegalStateException("unreachable structured answer retry state");
+    }
+
+    private static String abbreviateInvalidOutput(String invalidOutput) {
+        if (invalidOutput.length() <= INVALID_PREVIOUS_RESPONSE_MAX_CHARS) {
+            return invalidOutput;
+        }
+        return invalidOutput.substring(0, INVALID_PREVIOUS_RESPONSE_MAX_CHARS)
+                + "\n\n[truncated invalid response: "
+                + (invalidOutput.length() - INVALID_PREVIOUS_RESPONSE_MAX_CHARS)
+                + " chars omitted]";
     }
 
     static String formatStructuredFinalPrompt(String taskInput, String finalNotes, String toc) {

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -64,6 +64,27 @@ public class CustomAgentExecutor {
 
     private record NormalizedCandidate(String json, List<String> changes) {}
 
+    private static final class RepairTrace {
+        private final String candidateSource;
+        private final String originalValidationError;
+        private final String originalOutput;
+        private boolean deterministicRepairAttempted;
+        private boolean llmRepairAttempted;
+        private boolean salvageAttempted;
+        private List<String> deterministicChanges = List.of();
+        private List<String> salvageChanges = List.of();
+        private String finishReason = "not_attempted";
+        private String finalValidationError;
+        private String failedRepairOutput = "";
+
+        private RepairTrace(String candidateSource, String originalValidationError, String originalOutput) {
+            this.candidateSource = candidateSource;
+            this.originalValidationError = originalValidationError;
+            this.originalOutput = originalOutput;
+            this.finalValidationError = originalValidationError;
+        }
+    }
+
     private static final Set<String> TERMINAL_TOOL_NAMES = Set.of("answer", "abortSearch");
     private static final Set<String> PARALLEL_SAFE_SEARCH_TOOL_NAMES = AgentDefinition.PARALLEL_SAFE_SEARCH_TOOL_NAMES;
     private static final int STRUCTURED_REPAIR_MIN_COMPLETION_TOKENS = 192;
@@ -297,10 +318,14 @@ public class CustomAgentExecutor {
 
         var repairCandidates = repairCandidateOrder(candidates);
         boolean deterministicRepairAttempted = false;
+        NormalizedCandidate repairCandidateNormalization = null;
         for (var candidate : repairCandidates) {
             deterministicRepairAttempted = true;
             var normalizedCandidate = deterministicNormalize(schema, candidate.json());
             if (normalizedCandidate != null) {
+                if (candidate.equals(repairCandidates.getFirst())) {
+                    repairCandidateNormalization = normalizedCandidate;
+                }
                 var normalizedValidationError =
                         JobResponseSchemaSupport.validateOutput(schema, normalizedCandidate.json());
                 if (normalizedValidationError.isEmpty()) {
@@ -320,6 +345,15 @@ public class CustomAgentExecutor {
         var repairCandidate = repairCandidates.getFirst();
         var initialValidationError =
                 validationErrors.getOrDefault(repairCandidate.source(), "unknown validation error");
+        var trace = new RepairTrace(repairCandidate.source(), initialValidationError, repairCandidate.json());
+        trace.deterministicRepairAttempted = deterministicRepairAttempted;
+        if (repairCandidateNormalization != null) {
+            trace.deterministicChanges = repairCandidateNormalization.changes();
+            trace.failedRepairOutput = repairCandidateNormalization.json();
+            trace.finalValidationError = JobResponseSchemaSupport.validateOutput(
+                            schema, repairCandidateNormalization.json())
+                    .orElse(initialValidationError);
+        }
         var structuredLlm = cm.getLlm(
                 new Llm.Options(model, agentDef.name() + " structured answer", TaskResult.Type.SEARCH).withEcho());
         structuredLlm.setOutput(io);
@@ -328,10 +362,12 @@ public class CustomAgentExecutor {
         var toc = WorkspacePrompts.formatToc(context).trim();
         var messages = List.<ChatMessage>of(
                 new SystemMessage(agentDef.systemPrompt()),
-                new UserMessage(formatStructuredFinalPrompt(taskInput, repairCandidate.json(), toc)));
+                new UserMessage(formatStructuredFinalPrompt(
+                        taskInput, repairCandidate.json(), toc, schema.schema(), initialValidationError)));
 
         String structuredText = "";
         for (int attempt = 1; attempt <= 2; attempt++) {
+            trace.llmRepairAttempted = true;
             var response = structuredLlm.sendRequest(
                     messages,
                     structuredLlm
@@ -344,19 +380,13 @@ public class CustomAgentExecutor {
             }
 
             structuredText = response.text();
+            trace.failedRepairOutput = structuredText;
             if (response.isPartial()) {
+                trace.finishReason = "LENGTH";
                 return new TaskResult(
                         context,
                         new TaskResult.StopDetails(
-                                TaskResult.StopReason.LLM_ERROR,
-                                repairFailureMessage(
-                                        schema,
-                                        repairCandidate.source(),
-                                        initialValidationError,
-                                        deterministicRepairAttempted,
-                                        true,
-                                        "LENGTH",
-                                        structuredText)));
+                                TaskResult.StopReason.LLM_ERROR, repairFailureMessage(schema, trace)));
             }
 
             var validationError = JobResponseSchemaSupport.validateOutput(schema, structuredText);
@@ -365,20 +395,32 @@ public class CustomAgentExecutor {
                 return new TaskResult(
                         context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, structuredText));
             }
+            trace.finalValidationError = validationError.get();
 
             if (attempt == 2) {
+                var salvage = salvageNormalize(schema, structuredText);
+                trace.salvageAttempted = true;
+                if (salvage != null) {
+                    trace.salvageChanges = salvage.changes();
+                    var salvageValidationError = JobResponseSchemaSupport.validateOutput(schema, salvage.json());
+                    if (salvageValidationError.isEmpty()) {
+                        logger.info(
+                                "Schema-aware custom-agent repair output salvaged deterministically for schema {} from {}: {}",
+                                schema.name(),
+                                repairCandidate.source(),
+                                salvage.changes());
+                        io.llmOutput(salvage.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
+                        return new TaskResult(
+                                context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, salvage.json()));
+                    }
+                    trace.finalValidationError = salvageValidationError.orElse(trace.finalValidationError);
+                    trace.failedRepairOutput = salvage.json();
+                }
+                trace.finishReason = "complete";
                 return new TaskResult(
                         context,
                         new TaskResult.StopDetails(
-                                TaskResult.StopReason.LLM_ERROR,
-                                repairFailureMessage(
-                                        schema,
-                                        repairCandidate.source(),
-                                        validationError.get(),
-                                        deterministicRepairAttempted,
-                                        true,
-                                        "complete",
-                                        structuredText)));
+                                TaskResult.StopReason.LLM_ERROR, repairFailureMessage(schema, trace)));
             }
 
             messages = List.of(
@@ -387,6 +429,7 @@ public class CustomAgentExecutor {
                             taskInput,
                             repairCandidate.json(),
                             toc,
+                            schema.schema(),
                             abbreviateInvalidOutput(structuredText),
                             validationError.get())));
         }
@@ -436,10 +479,19 @@ public class CustomAgentExecutor {
 
     private static @Nullable NormalizedCandidate deterministicNormalize(
             JobSpec.ResponseSchema schema, String candidate) {
+        return normalizeCandidate(schema, candidate, false);
+    }
+
+    private static @Nullable NormalizedCandidate salvageNormalize(JobSpec.ResponseSchema schema, String candidate) {
+        return normalizeCandidate(schema, candidate, true);
+    }
+
+    private static @Nullable NormalizedCandidate normalizeCandidate(
+            JobSpec.ResponseSchema schema, String candidate, boolean dropInvalidArrayObjectItems) {
         try {
             var root = Json.getMapper().readTree(candidate);
             var changes = new ArrayList<String>();
-            var normalized = normalizeNode(root, schema.schema(), "response", "", changes);
+            var normalized = normalizeNode(root, schema.schema(), "response", "", changes, dropInvalidArrayObjectItems);
             if (changes.isEmpty()) {
                 return null;
             }
@@ -450,20 +502,26 @@ public class CustomAgentExecutor {
     }
 
     private static JsonNode normalizeNode(
-            JsonNode value, JsonNode schema, String path, String propertyName, List<String> changes) {
+            JsonNode value,
+            JsonNode schema,
+            String path,
+            String propertyName,
+            List<String> changes,
+            boolean dropInvalidArrayObjectItems) {
         if (value.isNull()) {
             return value;
         }
 
         return switch (schemaType(schema)) {
-            case "object" -> normalizeObject(value, schema, path, changes);
-            case "array" -> normalizeArray(value, schema, path, propertyName, changes);
+            case "object" -> normalizeObject(value, schema, path, changes, dropInvalidArrayObjectItems);
+            case "array" -> normalizeArray(value, schema, path, propertyName, changes, dropInvalidArrayObjectItems);
             case "string" -> normalizeString(value, schema, path, propertyName, changes);
             default -> value;
         };
     }
 
-    private static JsonNode normalizeObject(JsonNode value, JsonNode schema, String path, List<String> changes) {
+    private static JsonNode normalizeObject(
+            JsonNode value, JsonNode schema, String path, List<String> changes, boolean dropInvalidArrayObjectItems) {
         if (!value.isObject()) {
             return value;
         }
@@ -471,20 +529,8 @@ public class CustomAgentExecutor {
         var object = (ObjectNode) value.deepCopy();
         var properties = schema.get("properties");
         if (properties != null && properties.isObject()) {
-            if (additionalPropertiesDisabled(schema) && allRequiredPropertiesPresent(object, schema)) {
-                var allowedNames = new HashSet<String>();
-                properties.properties().forEach(entry -> allowedNames.add(entry.getKey()));
-                var namesToRemove = new ArrayList<String>();
-                object.properties().forEach(entry -> {
-                    if (!allowedNames.contains(entry.getKey())) {
-                        namesToRemove.add(entry.getKey());
-                    }
-                });
-                namesToRemove.forEach(name -> {
-                    object.remove(name);
-                    changes.add(path + "." + name + " unknown property dropped");
-                });
-            }
+            normalizeSchemaAliases(object, properties, path, changes, dropInvalidArrayObjectItems);
+            normalizeFlattenedArrayObject(object, properties, path, changes, dropInvalidArrayObjectItems);
 
             properties.properties().forEach(entry -> {
                 var child = object.get(entry.getKey());
@@ -492,29 +538,177 @@ public class CustomAgentExecutor {
                     object.set(
                             entry.getKey(),
                             normalizeNode(
-                                    child, entry.getValue(), path + "." + entry.getKey(), entry.getKey(), changes));
+                                    child,
+                                    entry.getValue(),
+                                    path + "." + entry.getKey(),
+                                    entry.getKey(),
+                                    changes,
+                                    dropInvalidArrayObjectItems));
                 }
             });
+
+            if (additionalPropertiesDisabled(schema) && allRequiredPropertiesPresent(object, schema)) {
+                dropUnknownProperties(object, properties, path, changes);
+            }
         }
         return object;
     }
 
+    private static void normalizeSchemaAliases(
+            ObjectNode object,
+            JsonNode properties,
+            String path,
+            List<String> changes,
+            boolean dropInvalidArrayObjectItems) {
+        properties.properties().forEach(entry -> {
+            var propertyName = entry.getKey();
+            var propertySchema = entry.getValue();
+            if (!"array".equals(schemaType(propertySchema))
+                    || valueMatchesSchemaShape(object.get(propertyName), propertySchema)) {
+                return;
+            }
+
+            for (var alias : List.of(propertyName + "_items", propertyName + "_item")) {
+                var aliasValue = object.get(alias);
+                if (aliasValue != null && !aliasValue.isNull()) {
+                    object.set(
+                            propertyName,
+                            normalizeNode(
+                                    aliasValue,
+                                    propertySchema,
+                                    path + "." + propertyName,
+                                    propertyName,
+                                    changes,
+                                    dropInvalidArrayObjectItems));
+                    changes.add(path + "." + alias + " alias -> " + path + "." + propertyName);
+                    return;
+                }
+            }
+        });
+    }
+
+    private static void normalizeFlattenedArrayObject(
+            ObjectNode object,
+            JsonNode properties,
+            String path,
+            List<String> changes,
+            boolean dropInvalidArrayObjectItems) {
+        var candidates = new ArrayList<FlattenedArrayObjectCandidate>();
+        properties.properties().forEach(entry -> {
+            var propertyName = entry.getKey();
+            var propertySchema = entry.getValue();
+            var items = propertySchema.get("items");
+            if (!"array".equals(schemaType(propertySchema))
+                    || items == null
+                    || !"object".equals(schemaType(items))
+                    || valueMatchesSchemaShape(object.get(propertyName), propertySchema)) {
+                return;
+            }
+
+            var itemProperties = items.get("properties");
+            if (itemProperties == null || !itemProperties.isObject()) {
+                return;
+            }
+
+            var allowedItemNames = propertyNames(itemProperties);
+            var prefix = propertyName + "_";
+            var values = new LinkedHashMap<String, JsonNode>();
+            var hasUnknownPrefixedField = false;
+            for (var objectEntry : object.properties()) {
+                var name = objectEntry.getKey();
+                if (!name.startsWith(prefix)) {
+                    continue;
+                }
+                var itemName = name.substring(prefix.length());
+                if (!allowedItemNames.contains(itemName)) {
+                    hasUnknownPrefixedField = true;
+                    continue;
+                }
+                values.put(itemName, objectEntry.getValue());
+            }
+
+            if (!values.isEmpty() && !hasUnknownPrefixedField && values.keySet().containsAll(requiredNames(items))) {
+                candidates.add(new FlattenedArrayObjectCandidate(propertyName, items, values));
+            }
+        });
+
+        if (candidates.size() != 1) {
+            return;
+        }
+
+        var candidate = candidates.getFirst();
+        var item = Json.getMapper().createObjectNode();
+        candidate.values().forEach(item::set);
+        var normalizedItem = normalizeNode(
+                item,
+                candidate.itemSchema(),
+                path + "." + candidate.propertyName() + "[0]",
+                candidate.propertyName(),
+                changes,
+                dropInvalidArrayObjectItems);
+        var array = Json.getMapper().createArrayNode();
+        array.add(normalizedItem);
+        object.set(candidate.propertyName(), array);
+        changes.add(path + "." + candidate.propertyName() + "_* flattened -> " + path + "." + candidate.propertyName()
+                + "[0]");
+    }
+
+    private record FlattenedArrayObjectCandidate(
+            String propertyName, JsonNode itemSchema, Map<String, JsonNode> values) {}
+
+    private static void dropUnknownProperties(
+            ObjectNode object, JsonNode properties, String path, List<String> changes) {
+        var allowedNames = propertyNames(properties);
+        var namesToRemove = new ArrayList<String>();
+        object.properties().forEach(entry -> {
+            if (!allowedNames.contains(entry.getKey())) {
+                namesToRemove.add(entry.getKey());
+            }
+        });
+        namesToRemove.forEach(name -> {
+            object.remove(name);
+            changes.add(path + "." + name + " unknown property dropped");
+        });
+    }
+
     private static JsonNode normalizeArray(
-            JsonNode value, JsonNode schema, String path, String propertyName, List<String> changes) {
+            JsonNode value,
+            JsonNode schema,
+            String path,
+            String propertyName,
+            List<String> changes,
+            boolean dropInvalidArrayObjectItems) {
         var items = schema.get("items");
         if (value.isArray()) {
             var array = Json.getMapper().createArrayNode();
             for (int i = 0; i < value.size(); i++) {
+                if (dropInvalidArrayObjectItems && items != null && "object".equals(schemaType(items))) {
+                    var item = value.get(i);
+                    if (!item.isObject()) {
+                        changes.add(path + "[" + i + "] " + outputType(item) + " dropped from object array");
+                        continue;
+                    }
+                }
                 array.add(
                         items == null
                                 ? value.get(i)
-                                : normalizeNode(value.get(i), items, path + "[" + i + "]", propertyName, changes));
+                                : normalizeNode(
+                                        value.get(i),
+                                        items,
+                                        path + "[" + i + "]",
+                                        propertyName,
+                                        changes,
+                                        dropInvalidArrayObjectItems));
             }
             return array;
         }
 
         var array = Json.getMapper().createArrayNode();
-        array.add(items == null ? value : normalizeNode(value, items, path + "[0]", propertyName, changes));
+        array.add(
+                items == null
+                        ? value
+                        : normalizeNode(
+                                value, items, path + "[0]", propertyName, changes, dropInvalidArrayObjectItems));
         changes.add(path + " " + outputType(value) + " -> array");
         return array;
     }
@@ -522,6 +716,13 @@ public class CustomAgentExecutor {
     private static JsonNode normalizeString(
             JsonNode value, JsonNode schema, String path, String propertyName, List<String> changes) {
         if (value.isTextual()) {
+            if (isConfidenceProperty(propertyName)) {
+                var confidence = confidenceLabel(value.textValue(), schema);
+                if (confidence != null && !confidence.equals(value.textValue())) {
+                    changes.add(path + " textual confidence -> string enum");
+                    return TextNode.valueOf(confidence);
+                }
+            }
             return value;
         }
 
@@ -541,17 +742,93 @@ public class CustomAgentExecutor {
         return value;
     }
 
+    private static boolean valueMatchesSchemaShape(@Nullable JsonNode value, JsonNode schema) {
+        if (value == null || value.isNull()) {
+            return false;
+        }
+        return switch (schemaType(schema)) {
+            case "object" -> {
+                if (!value.isObject()) {
+                    yield false;
+                }
+                var properties = schema.get("properties");
+                var required = requiredNames(schema);
+                if (!required.stream().allMatch(name -> value.hasNonNull(name))) {
+                    yield false;
+                }
+                if (properties == null || !properties.isObject()) {
+                    yield true;
+                }
+                var propertyNames = propertyNames(properties);
+                if (additionalPropertiesDisabled(schema)) {
+                    var hasUnknown = false;
+                    for (var entry : value.properties()) {
+                        if (!propertyNames.contains(entry.getKey())) {
+                            hasUnknown = true;
+                            break;
+                        }
+                    }
+                    if (hasUnknown) {
+                        yield false;
+                    }
+                }
+                var matches = true;
+                for (var entry : properties.properties()) {
+                    var child = value.get(entry.getKey());
+                    if (child != null && !valueMatchesSchemaShape(child, entry.getValue())) {
+                        matches = false;
+                        break;
+                    }
+                }
+                yield matches;
+            }
+            case "array" -> {
+                if (!value.isArray()) {
+                    yield false;
+                }
+                var items = schema.get("items");
+                if (items == null) {
+                    yield true;
+                }
+                var matches = true;
+                for (var child : value) {
+                    if (!valueMatchesSchemaShape(child, items)) {
+                        matches = false;
+                        break;
+                    }
+                }
+                yield matches;
+            }
+            case "string" ->
+                value.isTextual()
+                        && (schema.get("enum") == null
+                                || Json.stringArrayToSet(schema.get("enum")).contains(value.textValue()));
+            case "integer" -> value.isIntegralNumber();
+            case "number" -> value.isNumber();
+            case "boolean" -> value.isBoolean();
+            default -> true;
+        };
+    }
+
     private static boolean isConfidenceProperty(String propertyName) {
         return "confidence".equals(propertyName);
     }
 
-    private static @Nullable String confidenceLabel(double value, JsonNode schema) {
-        var enumNode = schema.get("enum");
-        if (enumNode == null || !enumNode.isArray()) {
+    private static @Nullable String confidenceLabel(String value, JsonNode schema) {
+        if (!hasConfidenceEnum(schema)) {
             return null;
         }
-        var labels = Json.stringArrayToSet(enumNode);
-        if (!labels.containsAll(Set.of("low", "medium", "high"))) {
+        var normalized = value.strip().toLowerCase(Locale.ROOT).replace('_', ' ');
+        return switch (normalized) {
+            case "1", "1.0", "high", "high confidence", "very high" -> "high";
+            case "0.5", "medium", "medium confidence", "moderate", "moderate confidence", "med" -> "medium";
+            case "0", "0.0", "low", "low confidence", "very low" -> "low";
+            default -> null;
+        };
+    }
+
+    private static @Nullable String confidenceLabel(double value, JsonNode schema) {
+        if (!hasConfidenceEnum(schema)) {
             return null;
         }
         if (Double.compare(value, 1.0) == 0) {
@@ -566,22 +843,48 @@ public class CustomAgentExecutor {
         return null;
     }
 
-    private static boolean allRequiredPropertiesPresent(ObjectNode value, JsonNode schema) {
-        var required = schema.get("required");
-        if (required == null || !required.isArray()) {
-            return true;
+    private static boolean hasConfidenceEnum(JsonNode schema) {
+        var enumNode = schema.get("enum");
+        if (enumNode == null || !enumNode.isArray()) {
+            return false;
         }
-        for (var requiredName : required) {
-            if (!requiredName.isTextual() || !value.hasNonNull(requiredName.textValue())) {
+        var labels = Json.stringArrayToSet(enumNode);
+        return labels.containsAll(Set.of("low", "medium", "high"));
+    }
+
+    private static boolean allRequiredPropertiesPresent(ObjectNode value, JsonNode schema) {
+        for (var requiredName : requiredNames(schema)) {
+            if (!value.hasNonNull(requiredName)) {
                 return false;
             }
         }
         return true;
     }
 
+    private static Set<String> requiredNames(JsonNode schema) {
+        var required = schema.get("required");
+        if (required == null || !required.isArray()) {
+            return Set.of();
+        }
+        var names = new HashSet<String>();
+        for (var requiredName : required) {
+            if (requiredName.isTextual()) {
+                names.add(requiredName.textValue());
+            }
+        }
+        return Set.copyOf(names);
+    }
+
+    private static Set<String> propertyNames(JsonNode properties) {
+        var names = new HashSet<String>();
+        properties.properties().forEach(entry -> names.add(entry.getKey()));
+        return Set.copyOf(names);
+    }
+
     private static boolean additionalPropertiesDisabled(JsonNode schema) {
         var additionalProperties = schema.get("additionalProperties");
-        return additionalProperties != null && additionalProperties.isBoolean() && !additionalProperties.booleanValue();
+        return additionalProperties == null
+                || (additionalProperties.isBoolean() && !additionalProperties.booleanValue());
     }
 
     private static String schemaType(JsonNode schema) {
@@ -635,23 +938,21 @@ public class CustomAgentExecutor {
         };
     }
 
-    private static String repairFailureMessage(
-            JobSpec.ResponseSchema schema,
-            String candidateSource,
-            String validationError,
-            boolean deterministicRepairAttempted,
-            boolean llmRepairAttempted,
-            String finishReason,
-            String invalidOutput) {
-        return "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=%s candidateSource=%s validation=%s deterministicRepairAttempted=%s llmRepairAttempted=%s finishReason=%s invalidOutputExcerpt=%s"
+    private static String repairFailureMessage(JobSpec.ResponseSchema schema, RepairTrace trace) {
+        return "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=%s candidateSource=%s originalValidation=%s finalValidation=%s deterministicRepairAttempted=%s deterministicChanges=%s llmRepairAttempted=%s salvageAttempted=%s salvageChanges=%s finishReason=%s originalOutputExcerpt=%s invalidOutputExcerpt=%s"
                 .formatted(
                         schema.name(),
-                        candidateSource,
-                        validationError,
-                        deterministicRepairAttempted,
-                        llmRepairAttempted,
-                        finishReason,
-                        abbreviateInvalidOutput(invalidOutput));
+                        trace.candidateSource,
+                        trace.originalValidationError,
+                        trace.finalValidationError,
+                        trace.deterministicRepairAttempted,
+                        trace.deterministicChanges,
+                        trace.llmRepairAttempted,
+                        trace.salvageAttempted,
+                        trace.salvageChanges,
+                        trace.finishReason,
+                        abbreviateInvalidOutput(trace.originalOutput),
+                        abbreviateInvalidOutput(trace.failedRepairOutput));
     }
 
     private static String abbreviateInvalidOutput(String invalidOutput) {
@@ -664,7 +965,8 @@ public class CustomAgentExecutor {
                 + " chars omitted]";
     }
 
-    static String formatStructuredFinalPrompt(String taskInput, String finalNotes, String toc) {
+    static String formatStructuredFinalPrompt(
+            String taskInput, String finalNotes, String toc, JsonNode schema, String validationError) {
         return """
                 <task>
                 %s
@@ -675,18 +977,34 @@ public class CustomAgentExecutor {
                 </custom_agent_final_notes>
 
                 %s
+
+                <response_schema>
+                %s
+                </response_schema>
+
+                The candidate did not satisfy the supplied response schema.
+                Validation error: %s
 
                 Produce the final custom-agent result according to the supplied response schema.
                 Return only the JSON object.
                 Do not include markdown, commentary, copied schema, or explanation.
                 Preserve all evidence from the candidate.
                 Only fix JSON shape/types to match the schema.
+                Array fields must remain arrays. Array item objects must be JSON objects, never strings.
+                Enum fields must use only declared enum values.
+                Unknown properties are forbidden when additionalProperties is false.
+                Do not invent prose, generated statistics, flattened key/value reconstructions, or copied schema.
                 """
-                .formatted(taskInput, finalNotes, toc);
+                .formatted(taskInput, finalNotes, toc, schemaExcerpt(schema), validationError);
     }
 
     static String formatStructuredFinalRetryPrompt(
-            String taskInput, String finalNotes, String toc, String invalidOutput, String validationError) {
+            String taskInput,
+            String finalNotes,
+            String toc,
+            JsonNode schema,
+            String invalidOutput,
+            String validationError) {
         return """
                 <task>
                 %s
@@ -697,6 +1015,10 @@ public class CustomAgentExecutor {
                 </custom_agent_final_notes>
 
                 %s
+
+                <response_schema>
+                %s
+                </response_schema>
 
                 Your previous structured response did not satisfy the supplied response schema.
                 Validation error: %s
@@ -710,8 +1032,16 @@ public class CustomAgentExecutor {
                 Do not include markdown, commentary, copied schema, or explanation.
                 Preserve all evidence from the candidate.
                 Only fix JSON shape/types to match the schema.
+                Array fields must remain arrays. Array item objects must be JSON objects, never strings.
+                Enum fields must use only declared enum values.
+                Unknown properties are forbidden when additionalProperties is false.
+                Do not invent prose, generated statistics, flattened key/value reconstructions, or copied schema.
                 """
-                .formatted(taskInput, finalNotes, toc, validationError, invalidOutput);
+                .formatted(taskInput, finalNotes, toc, schemaExcerpt(schema), validationError, invalidOutput);
+    }
+
+    private static String schemaExcerpt(JsonNode schema) {
+        return abbreviateInvalidOutput(Json.toJson(schema));
     }
 
     private static ToolRegistry registryForContext(ToolRegistry baseRegistry, Context context) {

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -56,6 +56,7 @@ public class CustomAgentExecutor {
     private final IAppContextManager cm;
     private final AgentDefinition agentDef;
     private final StreamingChatModel model;
+    private final @Nullable JobSpec.ResponseSchema responseSchema;
     private final @Nullable ResponseFormat responseFormat;
     private final Llm llm;
     private final SearchTools searchTools;
@@ -82,6 +83,7 @@ public class CustomAgentExecutor {
         this.agentDef = agentDef;
         this.model = model;
         this.io = io;
+        this.responseSchema = responseSchema;
         this.responseFormat = responseSchema == null ? null : JobResponseSchemaSupport.toResponseFormat(responseSchema);
         this.context = cm.liveContext();
         this.llm = cm.getLlm(new Llm.Options(model, agentDef.name(), TaskResult.Type.SEARCH).withEcho());
@@ -275,6 +277,16 @@ public class CustomAgentExecutor {
         }
 
         var structuredText = response.text();
+        if (responseSchema != null) {
+            var validationError = JobResponseSchemaSupport.validateOutput(responseSchema, structuredText);
+            if (validationError.isPresent()) {
+                return new TaskResult(
+                        context,
+                        new TaskResult.StopDetails(
+                                TaskResult.StopReason.LLM_ERROR,
+                                "RESPONSE_SCHEMA_OUTPUT_INVALID: " + validationError.get()));
+            }
+        }
         io.llmOutput(structuredText, ChatMessageType.AI, LlmOutputMeta.newMessage());
         return new TaskResult(context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, structuredText));
     }

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -85,6 +85,58 @@ public class CustomAgentExecutor {
         }
     }
 
+    private static final class SchemaCandidateExtractor {
+        private SchemaCandidateExtractor() {}
+
+        private static List<SchemaCandidate> extract(String finalNotes) {
+            return schemaCandidates(finalNotes);
+        }
+
+        private static List<SchemaCandidate> repairOrder(List<SchemaCandidate> candidates) {
+            return repairCandidateOrder(candidates);
+        }
+    }
+
+    private static final class SchemaOutputNormalizer {
+        private SchemaOutputNormalizer() {}
+
+        private static @Nullable NormalizedCandidate deterministic(JobSpec.ResponseSchema schema, String candidate) {
+            return deterministicNormalize(schema, candidate);
+        }
+
+        private static @Nullable NormalizedCandidate salvage(JobSpec.ResponseSchema schema, String candidate) {
+            return salvageNormalize(schema, candidate);
+        }
+    }
+
+    private static final class SchemaRepairPrompts {
+        private SchemaRepairPrompts() {}
+
+        private static int maxCompletionTokens(JobSpec.ResponseSchema schema) {
+            return repairMaxCompletionTokens(schema);
+        }
+
+        private static String failureMessage(JobSpec.ResponseSchema schema, RepairTrace trace) {
+            return repairFailureMessage(schema, trace);
+        }
+
+        private static String initial(
+                String taskInput, String finalNotes, String toc, JsonNode schema, String validationError) {
+            return formatStructuredFinalPrompt(taskInput, finalNotes, toc, schema, validationError);
+        }
+
+        private static String retry(
+                String taskInput,
+                String finalNotes,
+                String toc,
+                JsonNode schema,
+                String previousRepairOutput,
+                String validationError) {
+            return formatStructuredFinalRetryPrompt(
+                    taskInput, finalNotes, toc, schema, previousRepairOutput, validationError);
+        }
+    }
+
     private static final Set<String> TERMINAL_TOOL_NAMES = Set.of("answer", "abortSearch");
     private static final Set<String> PARALLEL_SAFE_SEARCH_TOOL_NAMES = AgentDefinition.PARALLEL_SAFE_SEARCH_TOOL_NAMES;
     private static final int STRUCTURED_REPAIR_MIN_COMPLETION_TOKENS = 192;
@@ -295,146 +347,183 @@ public class CustomAgentExecutor {
     }
 
     private TaskResult structuredFinalAnswer(String taskInput, String finalNotes) throws InterruptedException {
-        var schema = Objects.requireNonNull(responseSchema);
-        var candidates = schemaCandidates(finalNotes);
-        if (candidates.isEmpty()) {
+        return new SchemaFinalizer(taskInput, finalNotes).execute();
+    }
+
+    private final class SchemaFinalizer {
+        private final String taskInput;
+        private final String finalNotes;
+
+        private SchemaFinalizer(String taskInput, String finalNotes) {
+            this.taskInput = taskInput;
+            this.finalNotes = finalNotes;
+        }
+
+        private TaskResult execute() throws InterruptedException {
+            var schema = Objects.requireNonNull(responseSchema);
+            var candidates = SchemaCandidateExtractor.extract(finalNotes);
+            if (candidates.isEmpty()) {
+                return new TaskResult(
+                        context,
+                        new TaskResult.StopDetails(
+                                TaskResult.StopReason.LLM_ERROR,
+                                "RESPONSE_SCHEMA_OUTPUT_MISSING: schema=%s candidateSource=none"
+                                        .formatted(schema.name())));
+            }
+
+            var validationErrors = new LinkedHashMap<String, String>();
+            for (var candidate : candidates) {
+                var validationError = JobResponseSchemaSupport.validateOutput(schema, candidate.json());
+                if (validationError.isEmpty()) {
+                    io.llmOutput(candidate.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
+                    return new TaskResult(
+                            context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, candidate.json()));
+                }
+                validationErrors.put(candidate.source(), validationError.get());
+            }
+
+            var repairCandidates = SchemaCandidateExtractor.repairOrder(candidates);
+            boolean deterministicRepairAttempted = false;
+            NormalizedCandidate repairCandidateNormalization = null;
+            for (var candidate : repairCandidates) {
+                deterministicRepairAttempted = true;
+                var normalizedCandidate = SchemaOutputNormalizer.deterministic(schema, candidate.json());
+                if (normalizedCandidate != null) {
+                    if (candidate.equals(repairCandidates.getFirst())) {
+                        repairCandidateNormalization = normalizedCandidate;
+                    }
+                    var normalizedValidationError =
+                            JobResponseSchemaSupport.validateOutput(schema, normalizedCandidate.json());
+                    if (normalizedValidationError.isEmpty()) {
+                        logger.info(
+                                "Schema-aware custom-agent terminal output normalized deterministically for schema {} from {}: {}",
+                                schema.name(),
+                                candidate.source(),
+                                normalizedCandidate.changes());
+                        io.llmOutput(normalizedCandidate.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
+                        return new TaskResult(
+                                context,
+                                new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, normalizedCandidate.json()));
+                    }
+                }
+            }
+
+            return repairWithLlm(
+                    schema,
+                    repairCandidates.getFirst(),
+                    validationErrors,
+                    deterministicRepairAttempted,
+                    repairCandidateNormalization);
+        }
+
+        private TaskResult repairWithLlm(
+                JobSpec.ResponseSchema schema,
+                SchemaCandidate repairCandidate,
+                Map<String, String> validationErrors,
+                boolean deterministicRepairAttempted,
+                @Nullable NormalizedCandidate repairCandidateNormalization)
+                throws InterruptedException {
+            var initialValidationError =
+                    validationErrors.getOrDefault(repairCandidate.source(), "unknown validation error");
+            var trace = new RepairTrace(repairCandidate.source(), initialValidationError, repairCandidate.json());
+            trace.deterministicRepairAttempted = deterministicRepairAttempted;
+            if (repairCandidateNormalization != null) {
+                trace.deterministicChanges = repairCandidateNormalization.changes();
+                trace.failedRepairOutput = repairCandidateNormalization.json();
+                trace.finalValidationError = JobResponseSchemaSupport.validateOutput(
+                                schema, repairCandidateNormalization.json())
+                        .orElse(initialValidationError);
+            }
+            var structuredLlm = cm.getLlm(
+                    new Llm.Options(model, agentDef.name() + " structured answer", TaskResult.Type.SEARCH).withEcho());
+            structuredLlm.setOutput(io);
+            var repairMaxCompletionTokens = SchemaRepairPrompts.maxCompletionTokens(schema);
+
+            var toc = WorkspacePrompts.formatToc(context).trim();
+            var messages = List.<ChatMessage>of(
+                    new SystemMessage(agentDef.systemPrompt()),
+                    new UserMessage(SchemaRepairPrompts.initial(
+                            taskInput, repairCandidate.json(), toc, schema.schema(), initialValidationError)));
+
+            for (int attempt = 1; attempt <= 2; attempt++) {
+                trace.llmRepairAttempted = true;
+                var response = structuredLlm.sendRequest(
+                        messages,
+                        structuredLlm
+                                .requestOptions()
+                                .withResponseFormat(responseFormat)
+                                .withMaxAttempts(1)
+                                .withMaxCompletionTokens(repairMaxCompletionTokens));
+                if (response.error() != null) {
+                    return new TaskResult(context, TaskResult.StopDetails.fromResponse(response));
+                }
+
+                var structuredText = response.text();
+                trace.failedRepairOutput = structuredText;
+                if (response.isPartial()) {
+                    trace.finishReason = "LENGTH";
+                    return repairFailure(schema, trace);
+                }
+
+                var validationError = JobResponseSchemaSupport.validateOutput(schema, structuredText);
+                if (validationError.isEmpty()) {
+                    io.llmOutput(structuredText, ChatMessageType.AI, LlmOutputMeta.newMessage());
+                    return new TaskResult(
+                            context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, structuredText));
+                }
+                trace.finalValidationError = validationError.get();
+
+                if (attempt == 2) {
+                    return salvageOrFail(schema, repairCandidate, trace, structuredText);
+                }
+
+                messages = List.of(
+                        new SystemMessage(agentDef.systemPrompt()),
+                        new UserMessage(SchemaRepairPrompts.retry(
+                                taskInput,
+                                repairCandidate.json(),
+                                toc,
+                                schema.schema(),
+                                abbreviateInvalidOutput(structuredText),
+                                validationError.get())));
+            }
+
+            throw new IllegalStateException("unreachable structured answer retry state");
+        }
+
+        private TaskResult salvageOrFail(
+                JobSpec.ResponseSchema schema,
+                SchemaCandidate repairCandidate,
+                RepairTrace trace,
+                String structuredText) {
+            var salvage = SchemaOutputNormalizer.salvage(schema, structuredText);
+            trace.salvageAttempted = true;
+            if (salvage != null) {
+                trace.salvageChanges = salvage.changes();
+                var salvageValidationError = JobResponseSchemaSupport.validateOutput(schema, salvage.json());
+                if (salvageValidationError.isEmpty()) {
+                    logger.info(
+                            "Schema-aware custom-agent repair output salvaged deterministically for schema {} from {}: {}",
+                            schema.name(),
+                            repairCandidate.source(),
+                            salvage.changes());
+                    io.llmOutput(salvage.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
+                    return new TaskResult(
+                            context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, salvage.json()));
+                }
+                trace.finalValidationError = salvageValidationError.orElse(trace.finalValidationError);
+                trace.failedRepairOutput = salvage.json();
+            }
+            trace.finishReason = "complete";
+            return repairFailure(schema, trace);
+        }
+
+        private TaskResult repairFailure(JobSpec.ResponseSchema schema, RepairTrace trace) {
             return new TaskResult(
                     context,
                     new TaskResult.StopDetails(
-                            TaskResult.StopReason.LLM_ERROR,
-                            "RESPONSE_SCHEMA_OUTPUT_MISSING: schema=%s candidateSource=none".formatted(schema.name())));
+                            TaskResult.StopReason.LLM_ERROR, SchemaRepairPrompts.failureMessage(schema, trace)));
         }
-
-        var validationErrors = new LinkedHashMap<String, String>();
-        for (var candidate : candidates) {
-            var validationError = JobResponseSchemaSupport.validateOutput(schema, candidate.json());
-            if (validationError.isEmpty()) {
-                io.llmOutput(candidate.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
-                return new TaskResult(
-                        context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, candidate.json()));
-            }
-            validationErrors.put(candidate.source(), validationError.get());
-        }
-
-        var repairCandidates = repairCandidateOrder(candidates);
-        boolean deterministicRepairAttempted = false;
-        NormalizedCandidate repairCandidateNormalization = null;
-        for (var candidate : repairCandidates) {
-            deterministicRepairAttempted = true;
-            var normalizedCandidate = deterministicNormalize(schema, candidate.json());
-            if (normalizedCandidate != null) {
-                if (candidate.equals(repairCandidates.getFirst())) {
-                    repairCandidateNormalization = normalizedCandidate;
-                }
-                var normalizedValidationError =
-                        JobResponseSchemaSupport.validateOutput(schema, normalizedCandidate.json());
-                if (normalizedValidationError.isEmpty()) {
-                    logger.info(
-                            "Schema-aware custom-agent terminal output normalized deterministically for schema {} from {}: {}",
-                            schema.name(),
-                            candidate.source(),
-                            normalizedCandidate.changes());
-                    io.llmOutput(normalizedCandidate.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
-                    return new TaskResult(
-                            context,
-                            new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, normalizedCandidate.json()));
-                }
-            }
-        }
-
-        var repairCandidate = repairCandidates.getFirst();
-        var initialValidationError =
-                validationErrors.getOrDefault(repairCandidate.source(), "unknown validation error");
-        var trace = new RepairTrace(repairCandidate.source(), initialValidationError, repairCandidate.json());
-        trace.deterministicRepairAttempted = deterministicRepairAttempted;
-        if (repairCandidateNormalization != null) {
-            trace.deterministicChanges = repairCandidateNormalization.changes();
-            trace.failedRepairOutput = repairCandidateNormalization.json();
-            trace.finalValidationError = JobResponseSchemaSupport.validateOutput(
-                            schema, repairCandidateNormalization.json())
-                    .orElse(initialValidationError);
-        }
-        var structuredLlm = cm.getLlm(
-                new Llm.Options(model, agentDef.name() + " structured answer", TaskResult.Type.SEARCH).withEcho());
-        structuredLlm.setOutput(io);
-        var repairMaxCompletionTokens = repairMaxCompletionTokens(schema);
-
-        var toc = WorkspacePrompts.formatToc(context).trim();
-        var messages = List.<ChatMessage>of(
-                new SystemMessage(agentDef.systemPrompt()),
-                new UserMessage(formatStructuredFinalPrompt(
-                        taskInput, repairCandidate.json(), toc, schema.schema(), initialValidationError)));
-
-        String structuredText = "";
-        for (int attempt = 1; attempt <= 2; attempt++) {
-            trace.llmRepairAttempted = true;
-            var response = structuredLlm.sendRequest(
-                    messages,
-                    structuredLlm
-                            .requestOptions()
-                            .withResponseFormat(responseFormat)
-                            .withMaxAttempts(1)
-                            .withMaxCompletionTokens(repairMaxCompletionTokens));
-            if (response.error() != null) {
-                return new TaskResult(context, TaskResult.StopDetails.fromResponse(response));
-            }
-
-            structuredText = response.text();
-            trace.failedRepairOutput = structuredText;
-            if (response.isPartial()) {
-                trace.finishReason = "LENGTH";
-                return new TaskResult(
-                        context,
-                        new TaskResult.StopDetails(
-                                TaskResult.StopReason.LLM_ERROR, repairFailureMessage(schema, trace)));
-            }
-
-            var validationError = JobResponseSchemaSupport.validateOutput(schema, structuredText);
-            if (validationError.isEmpty()) {
-                io.llmOutput(structuredText, ChatMessageType.AI, LlmOutputMeta.newMessage());
-                return new TaskResult(
-                        context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, structuredText));
-            }
-            trace.finalValidationError = validationError.get();
-
-            if (attempt == 2) {
-                var salvage = salvageNormalize(schema, structuredText);
-                trace.salvageAttempted = true;
-                if (salvage != null) {
-                    trace.salvageChanges = salvage.changes();
-                    var salvageValidationError = JobResponseSchemaSupport.validateOutput(schema, salvage.json());
-                    if (salvageValidationError.isEmpty()) {
-                        logger.info(
-                                "Schema-aware custom-agent repair output salvaged deterministically for schema {} from {}: {}",
-                                schema.name(),
-                                repairCandidate.source(),
-                                salvage.changes());
-                        io.llmOutput(salvage.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
-                        return new TaskResult(
-                                context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, salvage.json()));
-                    }
-                    trace.finalValidationError = salvageValidationError.orElse(trace.finalValidationError);
-                    trace.failedRepairOutput = salvage.json();
-                }
-                trace.finishReason = "complete";
-                return new TaskResult(
-                        context,
-                        new TaskResult.StopDetails(
-                                TaskResult.StopReason.LLM_ERROR, repairFailureMessage(schema, trace)));
-            }
-
-            messages = List.of(
-                    new SystemMessage(agentDef.systemPrompt()),
-                    new UserMessage(formatStructuredFinalRetryPrompt(
-                            taskInput,
-                            repairCandidate.json(),
-                            toc,
-                            schema.schema(),
-                            abbreviateInvalidOutput(structuredText),
-                            validationError.get())));
-        }
-
-        throw new IllegalStateException("unreachable structured answer retry state");
     }
 
     static List<SchemaCandidate> schemaCandidates(String finalNotes) {

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -255,40 +256,51 @@ public class CustomAgentExecutor {
     }
 
     private TaskResult structuredFinalAnswer(String taskInput, String finalNotes) throws InterruptedException {
+        var schema = Objects.requireNonNull(responseSchema);
         var structuredLlm = cm.getLlm(
                 new Llm.Options(model, agentDef.name() + " structured answer", TaskResult.Type.SEARCH).withEcho());
         structuredLlm.setOutput(io);
 
+        var toc = WorkspacePrompts.formatToc(context).trim();
         var messages = List.<ChatMessage>of(
                 new SystemMessage(agentDef.systemPrompt()),
-                new UserMessage(formatStructuredFinalPrompt(
-                        taskInput,
-                        finalNotes,
-                        WorkspacePrompts.formatToc(context).trim())));
+                new UserMessage(formatStructuredFinalPrompt(taskInput, finalNotes, toc)));
 
-        var response = structuredLlm.sendRequest(
-                messages,
-                structuredLlm
-                        .requestOptions()
-                        .withResponseFormat(responseFormat)
-                        .withMaxAttempts(1));
-        if (response.error() != null) {
-            return new TaskResult(context, TaskResult.StopDetails.fromResponse(response));
-        }
+        String structuredText = "";
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            var response = structuredLlm.sendRequest(
+                    messages,
+                    structuredLlm
+                            .requestOptions()
+                            .withResponseFormat(responseFormat)
+                            .withMaxAttempts(1));
+            if (response.error() != null) {
+                return new TaskResult(context, TaskResult.StopDetails.fromResponse(response));
+            }
 
-        var structuredText = response.text();
-        if (responseSchema != null) {
-            var validationError = JobResponseSchemaSupport.validateOutput(responseSchema, structuredText);
-            if (validationError.isPresent()) {
+            structuredText = response.text();
+            var validationError = JobResponseSchemaSupport.validateOutput(schema, structuredText);
+            if (validationError.isEmpty()) {
+                io.llmOutput(structuredText, ChatMessageType.AI, LlmOutputMeta.newMessage());
+                return new TaskResult(
+                        context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, structuredText));
+            }
+
+            if (attempt == 2) {
                 return new TaskResult(
                         context,
                         new TaskResult.StopDetails(
                                 TaskResult.StopReason.LLM_ERROR,
                                 "RESPONSE_SCHEMA_OUTPUT_INVALID: " + validationError.get()));
             }
+
+            messages = List.of(
+                    new SystemMessage(agentDef.systemPrompt()),
+                    new UserMessage(formatStructuredFinalRetryPrompt(
+                            taskInput, finalNotes, toc, structuredText, validationError.get())));
         }
-        io.llmOutput(structuredText, ChatMessageType.AI, LlmOutputMeta.newMessage());
-        return new TaskResult(context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, structuredText));
+
+        throw new IllegalStateException("unreachable structured answer retry state");
     }
 
     static String formatStructuredFinalPrompt(String taskInput, String finalNotes, String toc) {
@@ -306,6 +318,32 @@ public class CustomAgentExecutor {
                 Produce the final custom-agent result according to the supplied response schema.
                 """
                 .formatted(taskInput, finalNotes, toc);
+    }
+
+    static String formatStructuredFinalRetryPrompt(
+            String taskInput, String finalNotes, String toc, String invalidOutput, String validationError) {
+        return """
+                <task>
+                %s
+                </task>
+
+                <custom_agent_final_notes>
+                %s
+                </custom_agent_final_notes>
+
+                %s
+
+                Your previous structured response did not satisfy the supplied response schema.
+                Validation error: %s
+
+                <invalid_previous_response>
+                %s
+                </invalid_previous_response>
+
+                Produce a corrected final custom-agent result according to the supplied response schema.
+                Do not change the evidence meaning. Convert incorrectly shaped fields to the schema shape.
+                """
+                .formatted(taskInput, finalNotes, toc, validationError, invalidOutput);
     }
 
     private static ToolRegistry registryForContext(ToolRegistry baseRegistry, Context context) {

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -60,6 +60,8 @@ public class CustomAgentExecutor {
 
     private record TerminalStopOutput(String llmText, TaskResult.StopDetails stopDetails) implements ToolOutput {}
 
+    private record SchemaCandidate(String source, String json) {}
+
     private record NormalizedCandidate(String json, List<String> changes) {}
 
     private static final Set<String> TERMINAL_TOOL_NAMES = Set.of("answer", "abortSearch");
@@ -237,7 +239,6 @@ public class CustomAgentExecutor {
                     }
                 }
                 llm.recordToolExecution(toolResult);
-                messages.add(toolResult.toMessage());
 
                 if (toolResult.result() instanceof WorkspaceTools.WorkspaceMutationOutput output) {
                     context = output.context();
@@ -262,6 +263,8 @@ public class CustomAgentExecutor {
                     }
                     return new TaskResult(context, tso.stopDetails());
                 }
+
+                messages.add(toolResult.toMessage());
             }
 
             previousTurnAdditions = List.copyOf(additionsThisTurn);
@@ -272,26 +275,51 @@ public class CustomAgentExecutor {
 
     private TaskResult structuredFinalAnswer(String taskInput, String finalNotes) throws InterruptedException {
         var schema = Objects.requireNonNull(responseSchema);
-        var directCandidate = extractTerminalSchemaCandidate(finalNotes);
-        var directValidationError = JobResponseSchemaSupport.validateOutput(schema, directCandidate);
-        if (directValidationError.isEmpty()) {
-            io.llmOutput(directCandidate, ChatMessageType.AI, LlmOutputMeta.newMessage());
-            return new TaskResult(context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, directCandidate));
+        var candidates = schemaCandidates(finalNotes);
+        if (candidates.isEmpty()) {
+            return new TaskResult(
+                    context,
+                    new TaskResult.StopDetails(
+                            TaskResult.StopReason.LLM_ERROR,
+                            "RESPONSE_SCHEMA_OUTPUT_MISSING: schema=%s candidateSource=none".formatted(schema.name())));
         }
-        var normalizedCandidate = deterministicNormalize(schema, directCandidate);
-        if (normalizedCandidate != null) {
-            var normalizedValidationError = JobResponseSchemaSupport.validateOutput(schema, normalizedCandidate.json());
-            if (normalizedValidationError.isEmpty()) {
-                logger.info(
-                        "Schema-aware custom-agent terminal output normalized deterministically for schema {}: {}",
-                        schema.name(),
-                        normalizedCandidate.changes());
-                io.llmOutput(normalizedCandidate.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
+
+        var validationErrors = new LinkedHashMap<String, String>();
+        for (var candidate : candidates) {
+            var validationError = JobResponseSchemaSupport.validateOutput(schema, candidate.json());
+            if (validationError.isEmpty()) {
+                io.llmOutput(candidate.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
                 return new TaskResult(
-                        context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, normalizedCandidate.json()));
+                        context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, candidate.json()));
+            }
+            validationErrors.put(candidate.source(), validationError.get());
+        }
+
+        var repairCandidates = repairCandidateOrder(candidates);
+        boolean deterministicRepairAttempted = false;
+        for (var candidate : repairCandidates) {
+            deterministicRepairAttempted = true;
+            var normalizedCandidate = deterministicNormalize(schema, candidate.json());
+            if (normalizedCandidate != null) {
+                var normalizedValidationError =
+                        JobResponseSchemaSupport.validateOutput(schema, normalizedCandidate.json());
+                if (normalizedValidationError.isEmpty()) {
+                    logger.info(
+                            "Schema-aware custom-agent terminal output normalized deterministically for schema {} from {}: {}",
+                            schema.name(),
+                            candidate.source(),
+                            normalizedCandidate.changes());
+                    io.llmOutput(normalizedCandidate.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
+                    return new TaskResult(
+                            context,
+                            new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, normalizedCandidate.json()));
+                }
             }
         }
 
+        var repairCandidate = repairCandidates.getFirst();
+        var initialValidationError =
+                validationErrors.getOrDefault(repairCandidate.source(), "unknown validation error");
         var structuredLlm = cm.getLlm(
                 new Llm.Options(model, agentDef.name() + " structured answer", TaskResult.Type.SEARCH).withEcho());
         structuredLlm.setOutput(io);
@@ -300,7 +328,7 @@ public class CustomAgentExecutor {
         var toc = WorkspacePrompts.formatToc(context).trim();
         var messages = List.<ChatMessage>of(
                 new SystemMessage(agentDef.systemPrompt()),
-                new UserMessage(formatStructuredFinalPrompt(taskInput, finalNotes, toc)));
+                new UserMessage(formatStructuredFinalPrompt(taskInput, repairCandidate.json(), toc)));
 
         String structuredText = "";
         for (int attempt = 1; attempt <= 2; attempt++) {
@@ -323,8 +351,9 @@ public class CustomAgentExecutor {
                                 TaskResult.StopReason.LLM_ERROR,
                                 repairFailureMessage(
                                         schema,
-                                        directValidationError.orElse("unknown validation error"),
-                                        normalizedCandidate != null,
+                                        repairCandidate.source(),
+                                        initialValidationError,
+                                        deterministicRepairAttempted,
                                         true,
                                         "LENGTH",
                                         structuredText)));
@@ -344,8 +373,9 @@ public class CustomAgentExecutor {
                                 TaskResult.StopReason.LLM_ERROR,
                                 repairFailureMessage(
                                         schema,
+                                        repairCandidate.source(),
                                         validationError.get(),
-                                        normalizedCandidate != null,
+                                        deterministicRepairAttempted,
                                         true,
                                         "complete",
                                         structuredText)));
@@ -355,7 +385,7 @@ public class CustomAgentExecutor {
                     new SystemMessage(agentDef.systemPrompt()),
                     new UserMessage(formatStructuredFinalRetryPrompt(
                             taskInput,
-                            finalNotes,
+                            repairCandidate.json(),
                             toc,
                             abbreviateInvalidOutput(structuredText),
                             validationError.get())));
@@ -364,17 +394,44 @@ public class CustomAgentExecutor {
         throw new IllegalStateException("unreachable structured answer retry state");
     }
 
-    private static String extractTerminalSchemaCandidate(String finalNotes) {
+    static List<SchemaCandidate> schemaCandidates(String finalNotes) {
+        var candidates = new ArrayList<SchemaCandidate>();
+        var raw = finalNotes.trim();
+        if (!raw.isBlank()) {
+            candidates.add(new SchemaCandidate("raw", raw));
+        }
+
         try {
             var node = Json.getMapper().readTree(finalNotes);
             var explanation = node.get("explanation");
             if (explanation != null && explanation.isTextual()) {
-                return explanation.asText().trim();
+                var text = explanation.asText().trim();
+                if (!text.isBlank()) {
+                    candidates.add(new SchemaCandidate("answer.explanation.text", text));
+                }
+            } else if (explanation != null && explanation.isObject()) {
+                candidates.add(new SchemaCandidate("answer.explanation.object", Json.toJson(explanation)));
             }
         } catch (Exception ignored) {
-            // Not an answer-tool envelope. Validate the raw text below.
+            // Not an answer-tool envelope. Validate the raw text above.
         }
-        return finalNotes.trim();
+
+        return candidates.stream().distinct().toList();
+    }
+
+    private static List<SchemaCandidate> repairCandidateOrder(List<SchemaCandidate> candidates) {
+        var extracted = candidates.stream()
+                .filter(candidate -> !"raw".equals(candidate.source()))
+                .toList();
+        if (extracted.isEmpty()) {
+            return candidates;
+        }
+
+        var ordered = new ArrayList<>(extracted);
+        candidates.stream()
+                .filter(candidate -> "raw".equals(candidate.source()))
+                .forEach(ordered::add);
+        return List.copyOf(ordered);
     }
 
     private static @Nullable NormalizedCandidate deterministicNormalize(
@@ -456,14 +513,10 @@ public class CustomAgentExecutor {
             return array;
         }
 
-        if (!value.isObject()) {
-            var array = Json.getMapper().createArrayNode();
-            array.add(items == null ? value : normalizeNode(value, items, path + "[0]", propertyName, changes));
-            changes.add(path + " scalar -> array");
-            return array;
-        }
-
-        return value;
+        var array = Json.getMapper().createArrayNode();
+        array.add(items == null ? value : normalizeNode(value, items, path + "[0]", propertyName, changes));
+        changes.add(path + " " + outputType(value) + " -> array");
+        return array;
     }
 
     private static JsonNode normalizeString(
@@ -584,14 +637,16 @@ public class CustomAgentExecutor {
 
     private static String repairFailureMessage(
             JobSpec.ResponseSchema schema,
+            String candidateSource,
             String validationError,
             boolean deterministicRepairAttempted,
             boolean llmRepairAttempted,
             String finishReason,
             String invalidOutput) {
-        return "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=%s validation=%s deterministicRepairAttempted=%s llmRepairAttempted=%s finishReason=%s invalidOutputExcerpt=%s"
+        return "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=%s candidateSource=%s validation=%s deterministicRepairAttempted=%s llmRepairAttempted=%s finishReason=%s invalidOutputExcerpt=%s"
                 .formatted(
                         schema.name(),
+                        candidateSource,
                         validationError,
                         deterministicRepairAttempted,
                         llmRepairAttempted,
@@ -741,6 +796,6 @@ public class CustomAgentExecutor {
         if (responseFormat == null) {
             io.llmOutput("# Answer\n\n" + explanation, ChatMessageType.AI, LlmOutputMeta.newMessage());
         }
-        return new TerminalStopOutput(details, stopDetails);
+        return new TerminalStopOutput(responseFormat == null ? details : explanation, stopDetails);
     }
 }

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentResponseSchemaResolver.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentResponseSchemaResolver.java
@@ -1,103 +1,21 @@
 package ai.brokk.executor.agents;
 
-import ai.brokk.executor.jobs.JobResponseSchemaSupport;
 import ai.brokk.executor.jobs.JobSpec;
+import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.tools.ToolRegistry;
-import ai.brokk.util.Json;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.util.HashMap;
-import java.util.Map;
-import org.jetbrains.annotations.Nullable;
 
 final class CustomAgentResponseSchemaResolver {
     private CustomAgentResponseSchemaResolver() {}
 
-    static JobSpec.ResponseSchema resolve(String responseSchemaName, @Nullable String schemaSource) {
+    static JobSpec.ResponseSchema resolve(String responseSchemaName, ResponseSchemaRegistry registry) {
         var name = responseSchemaName.strip();
         if (name.isBlank()) {
             throw new ToolRegistry.ToolValidationException("responseSchemaName is required");
         }
 
-        var resolved = schemasByName(schemaSource).get(name);
-        if (resolved == null) {
-            throw new ToolRegistry.ToolValidationException(
-                    "responseSchemaName '%s' was not found in the parent task schemas".formatted(name));
-        }
-        return resolved;
-    }
-
-    private static Map<String, JobSpec.ResponseSchema> schemasByName(@Nullable String schemaSource) {
-        if (schemaSource == null || schemaSource.isBlank()) {
-            return Map.of();
-        }
-
-        var schemas = new HashMap<String, JobSpec.ResponseSchema>();
-        for (int i = 0; i < schemaSource.length(); i++) {
-            if (schemaSource.charAt(i) != '{') {
-                continue;
-            }
-            int end = findMatchingBrace(schemaSource, i);
-            if (end < 0) {
-                continue;
-            }
-            collectSchema(schemaSource.substring(i, end + 1), schemas);
-        }
-        return schemas;
-    }
-
-    private static void collectSchema(String candidateJson, Map<String, JobSpec.ResponseSchema> schemas) {
-        try {
-            var node = Json.getMapper().readTree(candidateJson);
-            collectSchema(node, schemas);
-        } catch (Exception ignored) {
-            // The parent prompt is free-form text. Most brace-delimited snippets are not response schemas.
-        }
-    }
-
-    private static void collectSchema(JsonNode node, Map<String, JobSpec.ResponseSchema> schemas) {
-        if (!node.isObject()) {
-            return;
-        }
-
-        var nameNode = node.get("name");
-        var schemaNode = node.get("schema");
-        if (nameNode != null && nameNode.isTextual() && schemaNode != null) {
-            var schema = new JobSpec.ResponseSchema(nameNode.asText(), schemaNode);
-            if (JobResponseSchemaSupport.validate(schema).isEmpty()) {
-                schemas.putIfAbsent(schema.name().strip(), schema);
-            }
-        }
-
-        node.properties().forEach(entry -> collectSchema(entry.getValue(), schemas));
-    }
-
-    private static int findMatchingBrace(String text, int start) {
-        int depth = 0;
-        boolean inString = false;
-        boolean escaped = false;
-        for (int i = start; i < text.length(); i++) {
-            char ch = text.charAt(i);
-            if (inString) {
-                if (escaped) {
-                    escaped = false;
-                } else if (ch == '\\') {
-                    escaped = true;
-                } else if (ch == '"') {
-                    inString = false;
-                }
-                continue;
-            }
-            if (ch == '"') {
-                inString = true;
-            } else if (ch == '{') {
-                depth++;
-            } else if (ch == '}') {
-                depth--;
-                if (depth == 0) {
-                    return i;
-                }
-            }
-        }
-        return -1;
+        return registry.resolve(name)
+                .orElseThrow(() -> new ToolRegistry.ToolValidationException(
+                        "responseSchemaName '%s' was not found in the parent task schemas. Available schemas: %s"
+                                .formatted(name, registry.names())));
     }
 }

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentTools.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentTools.java
@@ -9,12 +9,9 @@ import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.Json;
-import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.model.chat.StreamingChatModel;
-import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
@@ -89,19 +86,37 @@ public class CustomAgentTools {
             resolvedSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, responseSchemaRegistry);
         } catch (ToolRegistry.ToolValidationException e) {
             var errorMessage = Objects.requireNonNullElse(e.getMessage(), "Invalid responseSchemaName");
-            recordArtifact(
+            recordArtifact(ChildAgentArtifactFactory.genericFailure(
+                    childAgentArtifactSink.parentJobId(),
                     childRunId,
+                    null,
                     agentName,
                     responseSchemaName,
+                    cm.getService().nameOf(model),
+                    elapsedMs(startNanos),
                     ChildAgentArtifact.STATUS_FAILED,
-                    null,
-                    null,
-                    null,
-                    errorMessage,
-                    elapsedMs(startNanos));
+                    errorMessage));
             throw new ToolRegistry.ToolCallException(ToolExecutionResult.Status.REQUEST_ERROR, errorMessage);
         }
-        var result = executeCustomAgent(agentName, task, resolvedSchema);
+
+        TaskResult result;
+        try {
+            result = executeCustomAgent(agentName, task, resolvedSchema);
+        } catch (RuntimeException e) {
+            var errorMessage = "Error executing custom agent '%s': %s"
+                    .formatted(agentName, Objects.requireNonNullElse(e.getMessage(), "Unknown error"));
+            recordArtifact(ChildAgentArtifactFactory.genericFailure(
+                    childAgentArtifactSink.parentJobId(),
+                    childRunId,
+                    null,
+                    agentName,
+                    responseSchemaName,
+                    cm.getService().nameOf(model),
+                    elapsedMs(startNanos),
+                    ChildAgentArtifact.STATUS_FAILED,
+                    errorMessage));
+            throw e;
+        }
         if (result.stopDetails().reason() != TaskResult.StopReason.SUCCESS) {
             recordFailureArtifact(
                     childRunId,
@@ -112,196 +127,51 @@ public class CustomAgentTools {
             throw new ToolRegistry.ToolCallException(
                     ToolExecutionResult.Status.FATAL, result.stopDetails().explanation());
         }
+
         var explanation = result.stopDetails().explanation();
-        recordSuccessArtifact(childRunId, agentName, responseSchemaName, explanation, elapsedMs(startNanos));
-        return explanation;
-    }
-
-    private void recordSuccessArtifact(
-            String childRunId, String agentName, String responseSchemaName, String explanation, long elapsedMs) {
-        try {
-            var parsed = Json.getMapper().readTree(explanation);
-            if (parsed.isObject()) {
-                recordArtifact(
-                        childRunId,
-                        agentName,
-                        responseSchemaName,
-                        ChildAgentArtifact.STATUS_SUCCESS,
-                        parsed,
-                        null,
-                        null,
-                        null,
-                        elapsedMs);
-            } else {
-                recordArtifact(
-                        childRunId,
-                        agentName,
-                        responseSchemaName,
-                        ChildAgentArtifact.STATUS_SCHEMA_INVALID,
-                        null,
-                        "validated child response was not a JSON object",
-                        excerpt(explanation),
-                        null,
-                        elapsedMs);
-            }
-        } catch (Exception e) {
-            recordArtifact(
-                    childRunId,
-                    agentName,
-                    responseSchemaName,
-                    ChildAgentArtifact.STATUS_SCHEMA_INVALID,
-                    null,
-                    "validated child response could not be parsed as JSON: " + e.getMessage(),
-                    excerpt(explanation),
-                    null,
-                    elapsedMs);
-        }
-    }
-
-    private void recordFailureArtifact(
-            String childRunId, String agentName, String responseSchemaName, String explanation, long elapsedMs) {
-        if (explanation.contains("RESPONSE_SCHEMA_OUTPUT_INVALID")) {
-            recordArtifact(
-                    childRunId,
-                    agentName,
-                    responseSchemaName,
-                    ChildAgentArtifact.STATUS_SCHEMA_INVALID,
-                    null,
-                    extractSchemaValidationError(explanation),
-                    Objects.requireNonNullElseGet(
-                            extractDiagnosticValue(explanation, "invalidOutputExcerpt"), () -> excerpt(explanation)),
-                    null,
-                    elapsedMs);
-            return;
-        }
-        recordArtifact(
-                childRunId,
-                agentName,
-                responseSchemaName,
-                statusForNonSchemaFailure(explanation),
-                null,
-                null,
-                null,
-                excerpt(explanation),
-                elapsedMs);
-    }
-
-    private void recordArtifact(
-            String childRunId,
-            String agentName,
-            String responseSchemaName,
-            String status,
-            @Nullable JsonNode validatedResponse,
-            @Nullable String validationError,
-            @Nullable String invalidOutputExcerpt,
-            @Nullable String errorMessage,
-            long elapsedMs) {
-        childAgentArtifactSink.record(new ChildAgentArtifact(
+        recordArtifact(ChildAgentArtifactFactory.successFromText(
                 childAgentArtifactSink.parentJobId(),
                 childRunId,
                 null,
                 agentName,
                 responseSchemaName,
-                status,
-                validatedResponse,
-                validationError,
-                invalidOutputExcerpt,
-                errorMessage,
-                elapsedMs,
                 cm.getService().nameOf(model),
-                null,
-                null,
-                null));
+                elapsedMs(startNanos),
+                explanation));
+        return explanation;
     }
 
-    private static String statusForNonSchemaFailure(String explanation) {
-        var lower = explanation.toLowerCase(Locale.ROOT);
-        if (lower.contains("cancel")) {
-            return ChildAgentArtifact.STATUS_CANCELLED;
-        }
-        if (lower.contains("timeout") || lower.contains("timed out")) {
-            return ChildAgentArtifact.STATUS_TIMEOUT;
-        }
-        return ChildAgentArtifact.STATUS_FAILED;
+    private void recordFailureArtifact(
+            String childRunId, String agentName, String responseSchemaName, String explanation, long elapsedMs) {
+        var artifact = explanation.contains("RESPONSE_SCHEMA_OUTPUT_INVALID")
+                ? ChildAgentArtifactFactory.schemaInvalidFromFailureText(
+                        childAgentArtifactSink.parentJobId(),
+                        childRunId,
+                        null,
+                        agentName,
+                        responseSchemaName,
+                        cm.getService().nameOf(model),
+                        elapsedMs,
+                        explanation)
+                : ChildAgentArtifactFactory.genericFailure(
+                        childAgentArtifactSink.parentJobId(),
+                        childRunId,
+                        null,
+                        agentName,
+                        responseSchemaName,
+                        cm.getService().nameOf(model),
+                        elapsedMs,
+                        ChildAgentArtifactFactory.statusForNonSchemaFailure(explanation),
+                        explanation);
+        recordArtifact(artifact);
+    }
+
+    private void recordArtifact(ChildAgentArtifact artifact) {
+        childAgentArtifactSink.record(artifact);
     }
 
     private static long elapsedMs(long startNanos) {
         return Math.max(0L, (System.nanoTime() - startNanos) / 1_000_000L);
-    }
-
-    private static @Nullable String extractDiagnosticValue(String text, String key) {
-        var prefix = key + "=";
-        var start = findDiagnosticKeyStart(text, key);
-        if (start < 0) {
-            return null;
-        }
-        var valueStart = start + prefix.length();
-        var nextKeyStart = nextDiagnosticKeyStart(text, valueStart);
-        if (nextKeyStart < 0) {
-            return text.substring(valueStart).strip();
-        }
-        return text.substring(valueStart, nextKeyStart).strip();
-    }
-
-    private static int nextDiagnosticKeyStart(String text, int valueStart) {
-        return diagnosticKeys().stream()
-                .flatMap(key -> List.of(" " + key + "=", "\n" + key + "=").stream())
-                .mapToInt(key -> text.indexOf(key, valueStart))
-                .filter(index -> index >= 0)
-                .min()
-                .orElse(-1);
-    }
-
-    private static int findDiagnosticKeyStart(String text, String key) {
-        var prefix = key + "=";
-        var start = text.indexOf(prefix);
-        while (start >= 0) {
-            if (start == 0 || Character.isWhitespace(text.charAt(start - 1))) {
-                return start;
-            }
-            start = text.indexOf(prefix, start + prefix.length());
-        }
-        return -1;
-    }
-
-    private static @Nullable String extractSchemaValidationError(String text) {
-        var finalValidation = extractDiagnosticValue(text, "finalValidation");
-        if (finalValidation != null && !finalValidation.isBlank() && !"null".equals(finalValidation)) {
-            return finalValidation;
-        }
-        var originalValidation = extractDiagnosticValue(text, "originalValidation");
-        if (originalValidation != null && !originalValidation.isBlank() && !"null".equals(originalValidation)) {
-            return originalValidation;
-        }
-        return extractDiagnosticValue(text, "validation");
-    }
-
-    private static List<String> diagnosticKeys() {
-        return List.of(
-                "schema",
-                "candidateSource",
-                "originalValidation",
-                "finalValidation",
-                "validation",
-                "attempts",
-                "finishReason",
-                "initialInvalidOutputExcerpt",
-                "originalOutputExcerpt",
-                "invalidOutputExcerpt",
-                "finalValidationError",
-                "llmRepairAttempted",
-                "deterministicRepairAttempted",
-                "deterministicChanges",
-                "salvageAttempted",
-                "salvageChanges");
-    }
-
-    private static String excerpt(String text) {
-        var normalized = text.strip();
-        if (normalized.length() <= 2_000) {
-            return normalized;
-        }
-        return normalized.substring(0, 2_000) + "...[truncated " + (normalized.length() - 2_000) + " chars]";
     }
 
     private TaskResult executeCustomAgent(
@@ -338,7 +208,7 @@ public class CustomAgentTools {
                 return explanation.asText();
             }
         } catch (Exception ignored) {
-            // Not JSON — return as-is
+            // Not JSON -- return as-is
         }
         return raw;
     }

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentTools.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentTools.java
@@ -2,15 +2,21 @@ package ai.brokk.executor.agents;
 
 import ai.brokk.IAppContextManager;
 import ai.brokk.TaskResult;
+import ai.brokk.executor.jobs.ChildAgentArtifact;
+import ai.brokk.executor.jobs.ChildAgentArtifactSink;
 import ai.brokk.executor.jobs.JobSpec;
 import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.Json;
+import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -28,6 +34,7 @@ public class CustomAgentTools {
     private final IAppContextManager cm;
     private final StreamingChatModel model;
     private final ResponseSchemaRegistry responseSchemaRegistry;
+    private final ChildAgentArtifactSink childAgentArtifactSink;
 
     public CustomAgentTools(IAppContextManager cm, StreamingChatModel model) {
         this(cm, model, ResponseSchemaRegistry.empty());
@@ -35,9 +42,18 @@ public class CustomAgentTools {
 
     public CustomAgentTools(
             IAppContextManager cm, StreamingChatModel model, ResponseSchemaRegistry responseSchemaRegistry) {
+        this(cm, model, responseSchemaRegistry, ChildAgentArtifactSink.noop());
+    }
+
+    public CustomAgentTools(
+            IAppContextManager cm,
+            StreamingChatModel model,
+            ResponseSchemaRegistry responseSchemaRegistry,
+            ChildAgentArtifactSink childAgentArtifactSink) {
         this.cm = cm;
         this.model = model;
         this.responseSchemaRegistry = responseSchemaRegistry;
+        this.childAgentArtifactSink = childAgentArtifactSink;
     }
 
     @Tool(
@@ -59,26 +75,198 @@ public class CustomAgentTools {
             """
             Invoke a custom agent by name and require its final answer to match a JSON response schema.
             Use this when the caller needs a typed child-agent result instead of Markdown findings.
-            The agent still uses its normal tools to gather context, then produces one schema-constrained final result.""")
+            The agent still uses its normal tools to gather context, then produces one schema-constrained final result.
+            Summarize child dispatch outcomes in your final answer; do not reconstruct or relay the child JSON.""")
     public String callCustomAgentWithSchema(
             @P("Name of the custom agent to invoke (e.g., 'security-auditor')") String agentName,
             @P("Complete task description for the agent") String task,
             @P("Name of an available parent response schema") String responseSchemaName)
             throws InterruptedException {
+        var childRunId = UUID.randomUUID().toString();
+        var startNanos = System.nanoTime();
         JobSpec.ResponseSchema resolvedSchema;
         try {
             resolvedSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, responseSchemaRegistry);
         } catch (ToolRegistry.ToolValidationException e) {
-            throw new ToolRegistry.ToolCallException(
-                    ToolExecutionResult.Status.REQUEST_ERROR,
-                    Objects.requireNonNullElse(e.getMessage(), "Invalid responseSchemaName"));
+            var errorMessage = Objects.requireNonNullElse(e.getMessage(), "Invalid responseSchemaName");
+            recordArtifact(
+                    childRunId,
+                    agentName,
+                    responseSchemaName,
+                    ChildAgentArtifact.STATUS_FAILED,
+                    null,
+                    null,
+                    null,
+                    errorMessage,
+                    elapsedMs(startNanos));
+            throw new ToolRegistry.ToolCallException(ToolExecutionResult.Status.REQUEST_ERROR, errorMessage);
         }
         var result = executeCustomAgent(agentName, task, resolvedSchema);
         if (result.stopDetails().reason() != TaskResult.StopReason.SUCCESS) {
+            recordFailureArtifact(
+                    childRunId,
+                    agentName,
+                    responseSchemaName,
+                    result.stopDetails().explanation(),
+                    elapsedMs(startNanos));
             throw new ToolRegistry.ToolCallException(
                     ToolExecutionResult.Status.FATAL, result.stopDetails().explanation());
         }
-        return result.stopDetails().explanation();
+        var explanation = result.stopDetails().explanation();
+        recordSuccessArtifact(childRunId, agentName, responseSchemaName, explanation, elapsedMs(startNanos));
+        return explanation;
+    }
+
+    private void recordSuccessArtifact(
+            String childRunId, String agentName, String responseSchemaName, String explanation, long elapsedMs) {
+        try {
+            var parsed = Json.getMapper().readTree(explanation);
+            if (parsed.isObject()) {
+                recordArtifact(
+                        childRunId,
+                        agentName,
+                        responseSchemaName,
+                        ChildAgentArtifact.STATUS_SUCCESS,
+                        parsed,
+                        null,
+                        null,
+                        null,
+                        elapsedMs);
+            } else {
+                recordArtifact(
+                        childRunId,
+                        agentName,
+                        responseSchemaName,
+                        ChildAgentArtifact.STATUS_SCHEMA_INVALID,
+                        null,
+                        "validated child response was not a JSON object",
+                        excerpt(explanation),
+                        null,
+                        elapsedMs);
+            }
+        } catch (Exception e) {
+            recordArtifact(
+                    childRunId,
+                    agentName,
+                    responseSchemaName,
+                    ChildAgentArtifact.STATUS_SCHEMA_INVALID,
+                    null,
+                    "validated child response could not be parsed as JSON: " + e.getMessage(),
+                    excerpt(explanation),
+                    null,
+                    elapsedMs);
+        }
+    }
+
+    private void recordFailureArtifact(
+            String childRunId, String agentName, String responseSchemaName, String explanation, long elapsedMs) {
+        if (explanation.contains("RESPONSE_SCHEMA_OUTPUT_INVALID")) {
+            recordArtifact(
+                    childRunId,
+                    agentName,
+                    responseSchemaName,
+                    ChildAgentArtifact.STATUS_SCHEMA_INVALID,
+                    null,
+                    extractDiagnosticValue(explanation, "validation"),
+                    Objects.requireNonNullElseGet(
+                            extractDiagnosticValue(explanation, "invalidOutputExcerpt"), () -> excerpt(explanation)),
+                    null,
+                    elapsedMs);
+            return;
+        }
+        recordArtifact(
+                childRunId,
+                agentName,
+                responseSchemaName,
+                statusForNonSchemaFailure(explanation),
+                null,
+                null,
+                null,
+                excerpt(explanation),
+                elapsedMs);
+    }
+
+    private void recordArtifact(
+            String childRunId,
+            String agentName,
+            String responseSchemaName,
+            String status,
+            @Nullable JsonNode validatedResponse,
+            @Nullable String validationError,
+            @Nullable String invalidOutputExcerpt,
+            @Nullable String errorMessage,
+            long elapsedMs) {
+        childAgentArtifactSink.record(new ChildAgentArtifact(
+                childAgentArtifactSink.parentJobId(),
+                childRunId,
+                null,
+                agentName,
+                responseSchemaName,
+                status,
+                validatedResponse,
+                validationError,
+                invalidOutputExcerpt,
+                errorMessage,
+                elapsedMs,
+                cm.getService().nameOf(model),
+                null,
+                null,
+                null));
+    }
+
+    private static String statusForNonSchemaFailure(String explanation) {
+        var lower = explanation.toLowerCase(Locale.ROOT);
+        if (lower.contains("cancel")) {
+            return ChildAgentArtifact.STATUS_CANCELLED;
+        }
+        if (lower.contains("timeout") || lower.contains("timed out")) {
+            return ChildAgentArtifact.STATUS_TIMEOUT;
+        }
+        return ChildAgentArtifact.STATUS_FAILED;
+    }
+
+    private static long elapsedMs(long startNanos) {
+        return Math.max(0L, (System.nanoTime() - startNanos) / 1_000_000L);
+    }
+
+    private static @Nullable String extractDiagnosticValue(String text, String key) {
+        var prefix = key + "=";
+        var start = text.indexOf(prefix);
+        if (start < 0) {
+            return null;
+        }
+        var valueStart = start + prefix.length();
+        var nextKeyStart = nextDiagnosticKeyStart(text, valueStart);
+        if (nextKeyStart < 0) {
+            return text.substring(valueStart).strip();
+        }
+        return text.substring(valueStart, nextKeyStart).strip();
+    }
+
+    private static int nextDiagnosticKeyStart(String text, int valueStart) {
+        var keys = List.of(
+                "\nschema=",
+                "\nvalidation=",
+                "\nattempts=",
+                "\nfinishReason=",
+                "\ninitialInvalidOutputExcerpt=",
+                "\ninvalidOutputExcerpt=",
+                "\nfinalValidationError=",
+                "\nllmRepairAttempted=",
+                "\ndeterministicRepairAttempted=");
+        return keys.stream()
+                .mapToInt(key -> text.indexOf(key, valueStart))
+                .filter(index -> index >= 0)
+                .min()
+                .orElse(-1);
+    }
+
+    private static String excerpt(String text) {
+        var normalized = text.strip();
+        if (normalized.length() <= 2_000) {
+            return normalized;
+        }
+        return normalized.substring(0, 2_000) + "...[truncated " + (normalized.length() - 2_000) + " chars]";
     }
 
     private TaskResult executeCustomAgent(

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentTools.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentTools.java
@@ -3,6 +3,7 @@ package ai.brokk.executor.agents;
 import ai.brokk.IAppContextManager;
 import ai.brokk.TaskResult;
 import ai.brokk.executor.jobs.JobSpec;
+import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.Json;
@@ -26,16 +27,17 @@ public class CustomAgentTools {
 
     private final IAppContextManager cm;
     private final StreamingChatModel model;
-    private final @Nullable String schemaSource;
+    private final ResponseSchemaRegistry responseSchemaRegistry;
 
     public CustomAgentTools(IAppContextManager cm, StreamingChatModel model) {
-        this(cm, model, null);
+        this(cm, model, ResponseSchemaRegistry.empty());
     }
 
-    public CustomAgentTools(IAppContextManager cm, StreamingChatModel model, @Nullable String schemaSource) {
+    public CustomAgentTools(
+            IAppContextManager cm, StreamingChatModel model, ResponseSchemaRegistry responseSchemaRegistry) {
         this.cm = cm;
         this.model = model;
-        this.schemaSource = schemaSource;
+        this.responseSchemaRegistry = responseSchemaRegistry;
     }
 
     @Tool(
@@ -61,11 +63,11 @@ public class CustomAgentTools {
     public String callCustomAgentWithSchema(
             @P("Name of the custom agent to invoke (e.g., 'security-auditor')") String agentName,
             @P("Complete task description for the agent") String task,
-            @P("Name of a response schema embedded in the parent task instructions") String responseSchemaName)
+            @P("Name of an available parent response schema") String responseSchemaName)
             throws InterruptedException {
         JobSpec.ResponseSchema resolvedSchema;
         try {
-            resolvedSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, schemaSource);
+            resolvedSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, responseSchemaRegistry);
         } catch (ToolRegistry.ToolValidationException e) {
             throw new ToolRegistry.ToolCallException(
                     ToolExecutionResult.Status.REQUEST_ERROR,

--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentTools.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentTools.java
@@ -167,7 +167,7 @@ public class CustomAgentTools {
                     responseSchemaName,
                     ChildAgentArtifact.STATUS_SCHEMA_INVALID,
                     null,
-                    extractDiagnosticValue(explanation, "validation"),
+                    extractSchemaValidationError(explanation),
                     Objects.requireNonNullElseGet(
                             extractDiagnosticValue(explanation, "invalidOutputExcerpt"), () -> excerpt(explanation)),
                     null,
@@ -231,7 +231,7 @@ public class CustomAgentTools {
 
     private static @Nullable String extractDiagnosticValue(String text, String key) {
         var prefix = key + "=";
-        var start = text.indexOf(prefix);
+        var start = findDiagnosticKeyStart(text, key);
         if (start < 0) {
             return null;
         }
@@ -244,21 +244,56 @@ public class CustomAgentTools {
     }
 
     private static int nextDiagnosticKeyStart(String text, int valueStart) {
-        var keys = List.of(
-                "\nschema=",
-                "\nvalidation=",
-                "\nattempts=",
-                "\nfinishReason=",
-                "\ninitialInvalidOutputExcerpt=",
-                "\ninvalidOutputExcerpt=",
-                "\nfinalValidationError=",
-                "\nllmRepairAttempted=",
-                "\ndeterministicRepairAttempted=");
-        return keys.stream()
+        return diagnosticKeys().stream()
+                .flatMap(key -> List.of(" " + key + "=", "\n" + key + "=").stream())
                 .mapToInt(key -> text.indexOf(key, valueStart))
                 .filter(index -> index >= 0)
                 .min()
                 .orElse(-1);
+    }
+
+    private static int findDiagnosticKeyStart(String text, String key) {
+        var prefix = key + "=";
+        var start = text.indexOf(prefix);
+        while (start >= 0) {
+            if (start == 0 || Character.isWhitespace(text.charAt(start - 1))) {
+                return start;
+            }
+            start = text.indexOf(prefix, start + prefix.length());
+        }
+        return -1;
+    }
+
+    private static @Nullable String extractSchemaValidationError(String text) {
+        var finalValidation = extractDiagnosticValue(text, "finalValidation");
+        if (finalValidation != null && !finalValidation.isBlank() && !"null".equals(finalValidation)) {
+            return finalValidation;
+        }
+        var originalValidation = extractDiagnosticValue(text, "originalValidation");
+        if (originalValidation != null && !originalValidation.isBlank() && !"null".equals(originalValidation)) {
+            return originalValidation;
+        }
+        return extractDiagnosticValue(text, "validation");
+    }
+
+    private static List<String> diagnosticKeys() {
+        return List.of(
+                "schema",
+                "candidateSource",
+                "originalValidation",
+                "finalValidation",
+                "validation",
+                "attempts",
+                "finishReason",
+                "initialInvalidOutputExcerpt",
+                "originalOutputExcerpt",
+                "invalidOutputExcerpt",
+                "finalValidationError",
+                "llmRepairAttempted",
+                "deterministicRepairAttempted",
+                "deterministicChanges",
+                "salvageAttempted",
+                "salvageChanges");
     }
 
     private static String excerpt(String text) {

--- a/app/src/main/java/ai/brokk/executor/agents/ParallelCustomAgent.java
+++ b/app/src/main/java/ai/brokk/executor/agents/ParallelCustomAgent.java
@@ -7,11 +7,14 @@ import ai.brokk.MutedConsoleIO;
 import ai.brokk.TaskResult;
 import ai.brokk.TaskResult.StopReason;
 import ai.brokk.concurrent.LoggingFuture;
+import ai.brokk.executor.jobs.ChildAgentArtifact;
+import ai.brokk.executor.jobs.ChildAgentArtifactSink;
 import ai.brokk.executor.jobs.JobSpec;
 import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.Json;
+import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -20,8 +23,10 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,6 +47,7 @@ public class ParallelCustomAgent {
     private final IAppContextManager cm;
     private final StreamingChatModel model;
     private final ResponseSchemaRegistry responseSchemaRegistry;
+    private final ChildAgentArtifactSink childAgentArtifactSink;
 
     public ParallelCustomAgent(IAppContextManager cm, StreamingChatModel model) {
         this(cm, model, ResponseSchemaRegistry.empty());
@@ -49,9 +55,18 @@ public class ParallelCustomAgent {
 
     public ParallelCustomAgent(
             IAppContextManager cm, StreamingChatModel model, ResponseSchemaRegistry responseSchemaRegistry) {
+        this(cm, model, responseSchemaRegistry, ChildAgentArtifactSink.noop());
+    }
+
+    public ParallelCustomAgent(
+            IAppContextManager cm,
+            StreamingChatModel model,
+            ResponseSchemaRegistry responseSchemaRegistry,
+            ChildAgentArtifactSink childAgentArtifactSink) {
         this.cm = cm;
         this.model = model;
         this.responseSchemaRegistry = responseSchemaRegistry;
+        this.childAgentArtifactSink = childAgentArtifactSink;
     }
 
     @Tool(
@@ -73,7 +88,8 @@ public class ParallelCustomAgent {
             """
             Invoke a custom agent by name and require its final answer to match a JSON response schema.
             Use this when the caller needs a typed child-agent result instead of Markdown findings.
-            The agent still uses its normal tools to gather context, then produces one schema-constrained final result.""")
+            The agent still uses its normal tools to gather context, then produces one schema-constrained final result.
+            Summarize child dispatch outcomes in your final answer; do not reconstruct or relay the child JSON.""")
     public String callCustomAgentWithSchema(
             @P("Name of the custom agent to invoke (e.g., 'security-auditor')") String agentName,
             @P("Complete task description for the agent") String task,
@@ -223,9 +239,12 @@ public class ParallelCustomAgent {
     private CustomAgentTaskResult executeCustomAgentRequest(
             ToolExecutionRequest request, ToolRegistry tr, IConsoleIO taskIo) throws InterruptedException {
         taskIo.beforeToolCall(request, false);
+        var childRunId = UUID.randomUUID().toString();
+        var startNanos = System.nanoTime();
 
         String agentName;
         String task;
+        String responseSchemaName = "";
         JobSpec.@Nullable ResponseSchema responseSchema = null;
         try {
             var validated = tr.validateTool(request);
@@ -233,13 +252,20 @@ public class ParallelCustomAgent {
             agentName = (String) parameters.getFirst();
             task = (String) parameters.get(1);
             if ("callCustomAgentWithSchema".equals(request.name())) {
-                responseSchema =
-                        CustomAgentResponseSchemaResolver.resolve((String) parameters.get(2), responseSchemaRegistry);
+                responseSchemaName = (String) parameters.get(2);
+                responseSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, responseSchemaRegistry);
             }
         } catch (RuntimeException e) {
             var errorMessage = "Failed to parse custom agent arguments: " + e.getMessage();
             logger.debug(errorMessage, e);
             var failure = ToolExecutionResult.requestError(request, errorMessage);
+            maybeRecordArtifact(
+                    request,
+                    childRunId,
+                    extractStringArgument(request, "agentName", "unknown"),
+                    extractStringArgument(request, "responseSchemaName", responseSchemaName),
+                    failure,
+                    elapsedMs(startNanos));
             taskIo.afterToolOutput(failure);
             return new CustomAgentTaskResult(failure, "unknown");
         }
@@ -254,6 +280,7 @@ public class ParallelCustomAgent {
                                     .map(AgentDefinition::name)
                                     .toList());
             var failure = ToolExecutionResult.requestError(request, errorMessage);
+            maybeRecordArtifact(request, childRunId, agentName, responseSchemaName, failure, elapsedMs(startNanos));
             taskIo.afterToolOutput(failure);
             return new CustomAgentTaskResult(failure, agentName);
         }
@@ -272,6 +299,7 @@ public class ParallelCustomAgent {
             var toolResult = responseSchema == null
                     ? toToolExecutionResult(request, result.stopDetails(), explanation)
                     : toSchemaToolExecutionResult(request, result.stopDetails(), explanation);
+            maybeRecordArtifact(request, childRunId, agentName, responseSchemaName, toolResult, elapsedMs(startNanos));
             taskIo.afterToolOutput(toolResult);
             return new CustomAgentTaskResult(toolResult, agentName);
         } catch (RuntimeException e) {
@@ -279,9 +307,154 @@ public class ParallelCustomAgent {
                     .formatted(agentName, Objects.toString(e.getMessage(), "Unknown error"));
             logger.debug(errorMessage, e);
             var failure = ToolExecutionResult.requestError(request, errorMessage);
+            maybeRecordArtifact(request, childRunId, agentName, responseSchemaName, failure, elapsedMs(startNanos));
             taskIo.afterToolOutput(failure);
             return new CustomAgentTaskResult(failure, agentName);
         }
+    }
+
+    private void maybeRecordArtifact(
+            ToolExecutionRequest request,
+            String childRunId,
+            String agentName,
+            String responseSchemaName,
+            ToolExecutionResult result,
+            long elapsedMs) {
+        if (!"callCustomAgentWithSchema".equals(request.name())) {
+            return;
+        }
+        childAgentArtifactSink.record(
+                toArtifact(childRunId, request, agentName, responseSchemaName, result, elapsedMs));
+    }
+
+    private ChildAgentArtifact toArtifact(
+            String childRunId,
+            ToolExecutionRequest request,
+            String agentName,
+            String responseSchemaName,
+            ToolExecutionResult result,
+            long elapsedMs) {
+        var resultText = result.resultText();
+        JsonNode validatedResponse = null;
+        String validationError = null;
+        String invalidOutputExcerpt = null;
+        String errorMessage = null;
+        String status;
+
+        if (result.status() == ToolExecutionResult.Status.SUCCESS) {
+            try {
+                var parsed = Json.getMapper().readTree(resultText);
+                if (parsed.isObject()) {
+                    validatedResponse = parsed;
+                    status = ChildAgentArtifact.STATUS_SUCCESS;
+                } else {
+                    status = ChildAgentArtifact.STATUS_SCHEMA_INVALID;
+                    validationError = "validated child response was not a JSON object";
+                    invalidOutputExcerpt = excerpt(resultText);
+                }
+            } catch (Exception e) {
+                status = ChildAgentArtifact.STATUS_SCHEMA_INVALID;
+                validationError = "validated child response could not be parsed as JSON: " + e.getMessage();
+                invalidOutputExcerpt = excerpt(resultText);
+            }
+        } else if (result.status() == ToolExecutionResult.Status.FATAL
+                && resultText.contains("RESPONSE_SCHEMA_OUTPUT_INVALID")) {
+            status = ChildAgentArtifact.STATUS_SCHEMA_INVALID;
+            validationError = extractDiagnosticValue(resultText, "validation");
+            if (validationError == null) {
+                validationError = resultText.lines().findFirst().orElse("RESPONSE_SCHEMA_OUTPUT_INVALID");
+            }
+            invalidOutputExcerpt = Objects.requireNonNullElseGet(
+                    extractDiagnosticValue(resultText, "invalidOutputExcerpt"), () -> excerpt(resultText));
+        } else {
+            status = statusForNonSchemaFailure(resultText);
+            errorMessage = excerpt(resultText);
+        }
+
+        return new ChildAgentArtifact(
+                childAgentArtifactSink.parentJobId(),
+                childRunId,
+                request.id(),
+                agentName,
+                responseSchemaName,
+                status,
+                validatedResponse,
+                validationError,
+                invalidOutputExcerpt,
+                errorMessage,
+                elapsedMs,
+                cm.getService().nameOf(model),
+                null,
+                null,
+                null);
+    }
+
+    private static String statusForNonSchemaFailure(String resultText) {
+        var lower = resultText.toLowerCase(Locale.ROOT);
+        if (lower.contains("cancel")) {
+            return ChildAgentArtifact.STATUS_CANCELLED;
+        }
+        if (lower.contains("timeout") || lower.contains("timed out")) {
+            return ChildAgentArtifact.STATUS_TIMEOUT;
+        }
+        return ChildAgentArtifact.STATUS_FAILED;
+    }
+
+    private static long elapsedMs(long startNanos) {
+        return Math.max(0L, (System.nanoTime() - startNanos) / 1_000_000L);
+    }
+
+    private static String extractStringArgument(ToolExecutionRequest request, String key, String fallback) {
+        try {
+            var node = Json.getMapper().readTree(request.arguments());
+            var value = node.get(key);
+            if (value != null && value.isTextual()) {
+                return value.asText();
+            }
+        } catch (Exception ignored) {
+            // Fall through to fallback.
+        }
+        return fallback;
+    }
+
+    private static @Nullable String extractDiagnosticValue(String text, String key) {
+        var prefix = key + "=";
+        var start = text.indexOf(prefix);
+        if (start < 0) {
+            return null;
+        }
+        var valueStart = start + prefix.length();
+        var nextKeyStart = nextDiagnosticKeyStart(text, valueStart);
+        if (nextKeyStart < 0) {
+            return text.substring(valueStart).strip();
+        }
+        return text.substring(valueStart, nextKeyStart).strip();
+    }
+
+    private static int nextDiagnosticKeyStart(String text, int valueStart) {
+        var keys = List.of(
+                "\nschema=",
+                "\nvalidation=",
+                "\nattempts=",
+                "\nfinishReason=",
+                "\ninitialInvalidOutputExcerpt=",
+                "\ninvalidOutputExcerpt=",
+                "\nfinalValidationError=",
+                "\nllmRepairAttempted=",
+                "\ndeterministicRepairAttempted=");
+        return keys.stream()
+                .mapToInt(key -> text.indexOf(key, valueStart))
+                .filter(index -> index >= 0)
+                .min()
+                .orElse(-1);
+    }
+
+    private static String excerpt(String text) {
+        var normalized = text.strip();
+        if (normalized.length() <= 2_000) {
+            return normalized;
+        }
+        return normalized.substring(0, 2_000) + "...[truncated " + (normalized.length() - 2_000) + " chars]";
     }
 
     private static String extractExplanation(String raw) {

--- a/app/src/main/java/ai/brokk/executor/agents/ParallelCustomAgent.java
+++ b/app/src/main/java/ai/brokk/executor/agents/ParallelCustomAgent.java
@@ -7,14 +7,12 @@ import ai.brokk.MutedConsoleIO;
 import ai.brokk.TaskResult;
 import ai.brokk.TaskResult.StopReason;
 import ai.brokk.concurrent.LoggingFuture;
-import ai.brokk.executor.jobs.ChildAgentArtifact;
 import ai.brokk.executor.jobs.ChildAgentArtifactSink;
 import ai.brokk.executor.jobs.JobSpec;
 import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.Json;
-import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -23,7 +21,6 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -43,6 +40,12 @@ import org.jetbrains.annotations.Nullable;
 public class ParallelCustomAgent {
     private static final Logger logger = LogManager.getLogger(ParallelCustomAgent.class);
     public static final Set<String> TOOL_NAMES = Set.of("callCustomAgent", "callCustomAgentWithSchema");
+
+    private record ParsedCustomAgentRequest(
+            String agentName,
+            String task,
+            String responseSchemaName,
+            JobSpec.@Nullable ResponseSchema responseSchema) {}
 
     private final IAppContextManager cm;
     private final StreamingChatModel model;
@@ -249,19 +252,9 @@ public class ParallelCustomAgent {
         var childRunId = UUID.randomUUID().toString();
         var startNanos = System.nanoTime();
 
-        String agentName;
-        String task;
-        String responseSchemaName = "";
-        JobSpec.@Nullable ResponseSchema responseSchema = null;
+        ParsedCustomAgentRequest parsedRequest;
         try {
-            var validated = tr.validateTool(request);
-            var parameters = validated.parameters();
-            agentName = (String) parameters.getFirst();
-            task = (String) parameters.get(1);
-            if ("callCustomAgentWithSchema".equals(request.name())) {
-                responseSchemaName = (String) parameters.get(2);
-                responseSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, responseSchemaRegistry);
-            }
+            parsedRequest = parseCustomAgentRequest(request, tr);
         } catch (RuntimeException e) {
             var errorMessage = "Failed to parse custom agent arguments: " + e.getMessage();
             logger.debug(errorMessage, e);
@@ -270,7 +263,7 @@ public class ParallelCustomAgent {
                     request,
                     childRunId,
                     extractStringArgument(request, "agentName", "unknown"),
-                    extractStringArgument(request, "responseSchemaName", responseSchemaName),
+                    extractStringArgument(request, "responseSchemaName", ""),
                     failure,
                     elapsedMs(startNanos));
             taskIo.afterToolOutput(failure);
@@ -278,46 +271,78 @@ public class ParallelCustomAgent {
         }
 
         var agentStore = cm.getAgentStore();
-        var agentDef = agentStore.get(agentName).orElse(null);
+        var agentDef = agentStore.get(parsedRequest.agentName()).orElse(null);
         if (agentDef == null) {
             var errorMessage = "Custom agent not found: '%s'. Available agents: %s"
                     .formatted(
-                            agentName,
+                            parsedRequest.agentName(),
                             agentStore.list().stream()
                                     .map(AgentDefinition::name)
                                     .toList());
             var failure = ToolExecutionResult.requestError(request, errorMessage);
-            maybeRecordArtifact(request, childRunId, agentName, responseSchemaName, failure, elapsedMs(startNanos));
+            maybeRecordArtifact(
+                    request,
+                    childRunId,
+                    parsedRequest.agentName(),
+                    parsedRequest.responseSchemaName(),
+                    failure,
+                    elapsedMs(startNanos));
             taskIo.afterToolOutput(failure);
-            return new CustomAgentTaskResult(failure, agentName);
+            return new CustomAgentTaskResult(failure, parsedRequest.agentName());
         }
 
         logger.info(
                 "Invoking custom agent '{}' in parallel with model {}",
-                agentName,
+                parsedRequest.agentName(),
                 cm.getService().nameOf(model));
 
         try {
-            var executor = new CustomAgentExecutor(cm, agentDef, model, taskIo, responseSchema);
-            var result = executor.executeInterruptibly(task);
-            var explanation = responseSchema == null
+            var executor = new CustomAgentExecutor(cm, agentDef, model, taskIo, parsedRequest.responseSchema());
+            var result = executor.executeInterruptibly(parsedRequest.task());
+            var explanation = parsedRequest.responseSchema() == null
                     ? extractExplanation(result.stopDetails().explanation())
                     : result.stopDetails().explanation();
-            var toolResult = responseSchema == null
+            var toolResult = parsedRequest.responseSchema() == null
                     ? toToolExecutionResult(request, result.stopDetails(), explanation)
                     : toSchemaToolExecutionResult(request, result.stopDetails(), explanation);
-            maybeRecordArtifact(request, childRunId, agentName, responseSchemaName, toolResult, elapsedMs(startNanos));
+            maybeRecordArtifact(
+                    request,
+                    childRunId,
+                    parsedRequest.agentName(),
+                    parsedRequest.responseSchemaName(),
+                    toolResult,
+                    elapsedMs(startNanos));
             taskIo.afterToolOutput(toolResult);
-            return new CustomAgentTaskResult(toolResult, agentName);
+            return new CustomAgentTaskResult(toolResult, parsedRequest.agentName());
         } catch (RuntimeException e) {
             var errorMessage = "Error executing custom agent '%s': %s"
-                    .formatted(agentName, Objects.toString(e.getMessage(), "Unknown error"));
+                    .formatted(parsedRequest.agentName(), Objects.toString(e.getMessage(), "Unknown error"));
             logger.debug(errorMessage, e);
             var failure = ToolExecutionResult.requestError(request, errorMessage);
-            maybeRecordArtifact(request, childRunId, agentName, responseSchemaName, failure, elapsedMs(startNanos));
+            maybeRecordArtifact(
+                    request,
+                    childRunId,
+                    parsedRequest.agentName(),
+                    parsedRequest.responseSchemaName(),
+                    failure,
+                    elapsedMs(startNanos));
             taskIo.afterToolOutput(failure);
-            return new CustomAgentTaskResult(failure, agentName);
+            return new CustomAgentTaskResult(failure, parsedRequest.agentName());
         }
+    }
+
+    private ParsedCustomAgentRequest parseCustomAgentRequest(ToolExecutionRequest request, ToolRegistry tr) {
+        var validated = tr.validateTool(request);
+        var parameters = validated.parameters();
+        var agentName = (String) parameters.getFirst();
+        var task = (String) parameters.get(1);
+        if (!"callCustomAgentWithSchema".equals(request.name())) {
+            return new ParsedCustomAgentRequest(agentName, task, "", null);
+        }
+
+        var responseSchemaName = (String) parameters.get(2);
+        var responseSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, responseSchemaRegistry);
+        return new ParsedCustomAgentRequest(agentName, task, responseSchemaName, responseSchema);
     }
 
     private void maybeRecordArtifact(
@@ -330,81 +355,15 @@ public class ParallelCustomAgent {
         if (!"callCustomAgentWithSchema".equals(request.name())) {
             return;
         }
-        childAgentArtifactSink.record(
-                toArtifact(childRunId, request, agentName, responseSchemaName, result, elapsedMs));
-    }
-
-    private ChildAgentArtifact toArtifact(
-            String childRunId,
-            ToolExecutionRequest request,
-            String agentName,
-            String responseSchemaName,
-            ToolExecutionResult result,
-            long elapsedMs) {
-        var resultText = result.resultText();
-        JsonNode validatedResponse = null;
-        String validationError = null;
-        String invalidOutputExcerpt = null;
-        String errorMessage = null;
-        String status;
-
-        if (result.status() == ToolExecutionResult.Status.SUCCESS) {
-            try {
-                var parsed = Json.getMapper().readTree(resultText);
-                if (parsed.isObject()) {
-                    validatedResponse = parsed;
-                    status = ChildAgentArtifact.STATUS_SUCCESS;
-                } else {
-                    status = ChildAgentArtifact.STATUS_SCHEMA_INVALID;
-                    validationError = "validated child response was not a JSON object";
-                    invalidOutputExcerpt = excerpt(resultText);
-                }
-            } catch (Exception e) {
-                status = ChildAgentArtifact.STATUS_SCHEMA_INVALID;
-                validationError = "validated child response could not be parsed as JSON: " + e.getMessage();
-                invalidOutputExcerpt = excerpt(resultText);
-            }
-        } else if (result.status() == ToolExecutionResult.Status.FATAL
-                && resultText.contains("RESPONSE_SCHEMA_OUTPUT_INVALID")) {
-            status = ChildAgentArtifact.STATUS_SCHEMA_INVALID;
-            validationError = extractSchemaValidationError(resultText);
-            if (validationError == null) {
-                validationError = resultText.lines().findFirst().orElse("RESPONSE_SCHEMA_OUTPUT_INVALID");
-            }
-            invalidOutputExcerpt = Objects.requireNonNullElseGet(
-                    extractDiagnosticValue(resultText, "invalidOutputExcerpt"), () -> excerpt(resultText));
-        } else {
-            status = statusForNonSchemaFailure(resultText);
-            errorMessage = excerpt(resultText);
-        }
-
-        return new ChildAgentArtifact(
+        childAgentArtifactSink.record(ChildAgentArtifactFactory.fromToolResult(
                 childAgentArtifactSink.parentJobId(),
                 childRunId,
                 request.id(),
                 agentName,
                 responseSchemaName,
-                status,
-                validatedResponse,
-                validationError,
-                invalidOutputExcerpt,
-                errorMessage,
-                elapsedMs,
                 cm.getService().nameOf(model),
-                null,
-                null,
-                null);
-    }
-
-    private static String statusForNonSchemaFailure(String resultText) {
-        var lower = resultText.toLowerCase(Locale.ROOT);
-        if (lower.contains("cancel")) {
-            return ChildAgentArtifact.STATUS_CANCELLED;
-        }
-        if (lower.contains("timeout") || lower.contains("timed out")) {
-            return ChildAgentArtifact.STATUS_TIMEOUT;
-        }
-        return ChildAgentArtifact.STATUS_FAILED;
+                elapsedMs,
+                result));
     }
 
     private static long elapsedMs(long startNanos) {
@@ -422,81 +381,6 @@ public class ParallelCustomAgent {
             // Fall through to fallback.
         }
         return fallback;
-    }
-
-    private static @Nullable String extractDiagnosticValue(String text, String key) {
-        var prefix = key + "=";
-        var start = findDiagnosticKeyStart(text, key);
-        if (start < 0) {
-            return null;
-        }
-        var valueStart = start + prefix.length();
-        var nextKeyStart = nextDiagnosticKeyStart(text, valueStart);
-        if (nextKeyStart < 0) {
-            return text.substring(valueStart).strip();
-        }
-        return text.substring(valueStart, nextKeyStart).strip();
-    }
-
-    private static int nextDiagnosticKeyStart(String text, int valueStart) {
-        return diagnosticKeys().stream()
-                .flatMap(key -> List.of(" " + key + "=", "\n" + key + "=").stream())
-                .mapToInt(key -> text.indexOf(key, valueStart))
-                .filter(index -> index >= 0)
-                .min()
-                .orElse(-1);
-    }
-
-    private static int findDiagnosticKeyStart(String text, String key) {
-        var prefix = key + "=";
-        var start = text.indexOf(prefix);
-        while (start >= 0) {
-            if (start == 0 || Character.isWhitespace(text.charAt(start - 1))) {
-                return start;
-            }
-            start = text.indexOf(prefix, start + prefix.length());
-        }
-        return -1;
-    }
-
-    private static @Nullable String extractSchemaValidationError(String text) {
-        var finalValidation = extractDiagnosticValue(text, "finalValidation");
-        if (finalValidation != null && !finalValidation.isBlank() && !"null".equals(finalValidation)) {
-            return finalValidation;
-        }
-        var originalValidation = extractDiagnosticValue(text, "originalValidation");
-        if (originalValidation != null && !originalValidation.isBlank() && !"null".equals(originalValidation)) {
-            return originalValidation;
-        }
-        return extractDiagnosticValue(text, "validation");
-    }
-
-    private static List<String> diagnosticKeys() {
-        return List.of(
-                "schema",
-                "candidateSource",
-                "originalValidation",
-                "finalValidation",
-                "validation",
-                "attempts",
-                "finishReason",
-                "initialInvalidOutputExcerpt",
-                "originalOutputExcerpt",
-                "invalidOutputExcerpt",
-                "finalValidationError",
-                "llmRepairAttempted",
-                "deterministicRepairAttempted",
-                "deterministicChanges",
-                "salvageAttempted",
-                "salvageChanges");
-    }
-
-    private static String excerpt(String text) {
-        var normalized = text.strip();
-        if (normalized.length() <= 2_000) {
-            return normalized;
-        }
-        return normalized.substring(0, 2_000) + "...[truncated " + (normalized.length() - 2_000) + " chars]";
     }
 
     private static String extractExplanation(String raw) {

--- a/app/src/main/java/ai/brokk/executor/agents/ParallelCustomAgent.java
+++ b/app/src/main/java/ai/brokk/executor/agents/ParallelCustomAgent.java
@@ -217,6 +217,13 @@ public class ParallelCustomAgent {
                                 e.getCause() != null ? e.getCause().getMessage() : "Unknown error"));
                 logger.debug(errorMessage, e);
                 var failure = ToolExecutionResult.requestError(task.request(), errorMessage);
+                maybeRecordArtifact(
+                        task.request(),
+                        UUID.randomUUID().toString(),
+                        extractStringArgument(task.request(), "agentName", "unknown"),
+                        extractStringArgument(task.request(), "responseSchemaName", ""),
+                        failure,
+                        0L);
                 toolExecutionMessages.add(failure.toMessage());
             }
         }
@@ -360,7 +367,7 @@ public class ParallelCustomAgent {
         } else if (result.status() == ToolExecutionResult.Status.FATAL
                 && resultText.contains("RESPONSE_SCHEMA_OUTPUT_INVALID")) {
             status = ChildAgentArtifact.STATUS_SCHEMA_INVALID;
-            validationError = extractDiagnosticValue(resultText, "validation");
+            validationError = extractSchemaValidationError(resultText);
             if (validationError == null) {
                 validationError = resultText.lines().findFirst().orElse("RESPONSE_SCHEMA_OUTPUT_INVALID");
             }
@@ -419,7 +426,7 @@ public class ParallelCustomAgent {
 
     private static @Nullable String extractDiagnosticValue(String text, String key) {
         var prefix = key + "=";
-        var start = text.indexOf(prefix);
+        var start = findDiagnosticKeyStart(text, key);
         if (start < 0) {
             return null;
         }
@@ -432,21 +439,56 @@ public class ParallelCustomAgent {
     }
 
     private static int nextDiagnosticKeyStart(String text, int valueStart) {
-        var keys = List.of(
-                "\nschema=",
-                "\nvalidation=",
-                "\nattempts=",
-                "\nfinishReason=",
-                "\ninitialInvalidOutputExcerpt=",
-                "\ninvalidOutputExcerpt=",
-                "\nfinalValidationError=",
-                "\nllmRepairAttempted=",
-                "\ndeterministicRepairAttempted=");
-        return keys.stream()
+        return diagnosticKeys().stream()
+                .flatMap(key -> List.of(" " + key + "=", "\n" + key + "=").stream())
                 .mapToInt(key -> text.indexOf(key, valueStart))
                 .filter(index -> index >= 0)
                 .min()
                 .orElse(-1);
+    }
+
+    private static int findDiagnosticKeyStart(String text, String key) {
+        var prefix = key + "=";
+        var start = text.indexOf(prefix);
+        while (start >= 0) {
+            if (start == 0 || Character.isWhitespace(text.charAt(start - 1))) {
+                return start;
+            }
+            start = text.indexOf(prefix, start + prefix.length());
+        }
+        return -1;
+    }
+
+    private static @Nullable String extractSchemaValidationError(String text) {
+        var finalValidation = extractDiagnosticValue(text, "finalValidation");
+        if (finalValidation != null && !finalValidation.isBlank() && !"null".equals(finalValidation)) {
+            return finalValidation;
+        }
+        var originalValidation = extractDiagnosticValue(text, "originalValidation");
+        if (originalValidation != null && !originalValidation.isBlank() && !"null".equals(originalValidation)) {
+            return originalValidation;
+        }
+        return extractDiagnosticValue(text, "validation");
+    }
+
+    private static List<String> diagnosticKeys() {
+        return List.of(
+                "schema",
+                "candidateSource",
+                "originalValidation",
+                "finalValidation",
+                "validation",
+                "attempts",
+                "finishReason",
+                "initialInvalidOutputExcerpt",
+                "originalOutputExcerpt",
+                "invalidOutputExcerpt",
+                "finalValidationError",
+                "llmRepairAttempted",
+                "deterministicRepairAttempted",
+                "deterministicChanges",
+                "salvageAttempted",
+                "salvageChanges");
     }
 
     private static String excerpt(String text) {

--- a/app/src/main/java/ai/brokk/executor/agents/ParallelCustomAgent.java
+++ b/app/src/main/java/ai/brokk/executor/agents/ParallelCustomAgent.java
@@ -8,6 +8,7 @@ import ai.brokk.TaskResult;
 import ai.brokk.TaskResult.StopReason;
 import ai.brokk.concurrent.LoggingFuture;
 import ai.brokk.executor.jobs.JobSpec;
+import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.Json;
@@ -40,16 +41,17 @@ public class ParallelCustomAgent {
 
     private final IAppContextManager cm;
     private final StreamingChatModel model;
-    private final @Nullable String schemaSource;
+    private final ResponseSchemaRegistry responseSchemaRegistry;
 
     public ParallelCustomAgent(IAppContextManager cm, StreamingChatModel model) {
-        this(cm, model, null);
+        this(cm, model, ResponseSchemaRegistry.empty());
     }
 
-    public ParallelCustomAgent(IAppContextManager cm, StreamingChatModel model, @Nullable String schemaSource) {
+    public ParallelCustomAgent(
+            IAppContextManager cm, StreamingChatModel model, ResponseSchemaRegistry responseSchemaRegistry) {
         this.cm = cm;
         this.model = model;
-        this.schemaSource = schemaSource;
+        this.responseSchemaRegistry = responseSchemaRegistry;
     }
 
     @Tool(
@@ -75,11 +77,11 @@ public class ParallelCustomAgent {
     public String callCustomAgentWithSchema(
             @P("Name of the custom agent to invoke (e.g., 'security-auditor')") String agentName,
             @P("Complete task description for the agent") String task,
-            @P("Name of a response schema embedded in the parent task instructions") String responseSchemaName)
+            @P("Name of an available parent response schema") String responseSchemaName)
             throws InterruptedException {
         JobSpec.ResponseSchema resolvedSchema;
         try {
-            resolvedSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, schemaSource);
+            resolvedSchema = CustomAgentResponseSchemaResolver.resolve(responseSchemaName, responseSchemaRegistry);
         } catch (ToolRegistry.ToolValidationException e) {
             throw new ToolRegistry.ToolCallException(
                     ToolExecutionResult.Status.REQUEST_ERROR,
@@ -176,12 +178,10 @@ public class ParallelCustomAgent {
                 toolExecutionMessages.add(outcome.toolResult().toMessage());
                 descriptions.add(outcome.agentName());
 
+                // Keep collecting sibling results after a fatal child result. Callers need the
+                // full batch of tool messages for attribution and retry diagnostics.
                 if (outcome.toolResult().status() == ToolExecutionResult.Status.FATAL && firstFatalMessage == null) {
                     firstFatalMessage = outcome.toolResult().resultText();
-                    for (int j = i + 1; j < batchSize; j++) {
-                        tasks.get(j).future().cancel(true);
-                    }
-                    break;
                 }
             } catch (InterruptedException e) {
                 interrupted = true;
@@ -233,7 +233,8 @@ public class ParallelCustomAgent {
             agentName = (String) parameters.getFirst();
             task = (String) parameters.get(1);
             if ("callCustomAgentWithSchema".equals(request.name())) {
-                responseSchema = CustomAgentResponseSchemaResolver.resolve((String) parameters.get(2), schemaSource);
+                responseSchema =
+                        CustomAgentResponseSchemaResolver.resolve((String) parameters.get(2), responseSchemaRegistry);
             }
         } catch (RuntimeException e) {
             var errorMessage = "Failed to parse custom agent arguments: " + e.getMessage();

--- a/app/src/main/java/ai/brokk/executor/agents/SchemaFailureDiagnostics.java
+++ b/app/src/main/java/ai/brokk/executor/agents/SchemaFailureDiagnostics.java
@@ -1,0 +1,91 @@
+package ai.brokk.executor.agents;
+
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
+
+final class SchemaFailureDiagnostics {
+    private SchemaFailureDiagnostics() {}
+
+    static @Nullable String validationError(String text) {
+        var finalValidation = value(text, "finalValidation");
+        if (hasDiagnosticValue(finalValidation)) {
+            return finalValidation;
+        }
+        var originalValidation = value(text, "originalValidation");
+        if (hasDiagnosticValue(originalValidation)) {
+            return originalValidation;
+        }
+        return value(text, "validation");
+    }
+
+    static @Nullable String invalidOutputExcerpt(String text) {
+        return value(text, "invalidOutputExcerpt");
+    }
+
+    static @Nullable String originalOutputExcerpt(String text) {
+        return value(text, "originalOutputExcerpt");
+    }
+
+    static @Nullable String finishReason(String text) {
+        return value(text, "finishReason");
+    }
+
+    static @Nullable String value(String text, String key) {
+        var prefix = key + "=";
+        var start = findDiagnosticKeyStart(text, key);
+        if (start < 0) {
+            return null;
+        }
+        var valueStart = start + prefix.length();
+        var nextKeyStart = nextDiagnosticKeyStart(text, valueStart);
+        if (nextKeyStart < 0) {
+            return text.substring(valueStart).strip();
+        }
+        return text.substring(valueStart, nextKeyStart).strip();
+    }
+
+    private static boolean hasDiagnosticValue(@Nullable String value) {
+        return value != null && !value.isBlank() && !"null".equals(value);
+    }
+
+    private static int findDiagnosticKeyStart(String text, String key) {
+        var prefix = key + "=";
+        var start = text.indexOf(prefix);
+        while (start >= 0) {
+            if (start == 0 || Character.isWhitespace(text.charAt(start - 1))) {
+                return start;
+            }
+            start = text.indexOf(prefix, start + prefix.length());
+        }
+        return -1;
+    }
+
+    private static int nextDiagnosticKeyStart(String text, int valueStart) {
+        return diagnosticKeys().stream()
+                .flatMap(key -> List.of(" " + key + "=", "\n" + key + "=").stream())
+                .mapToInt(key -> text.indexOf(key, valueStart))
+                .filter(index -> index >= 0)
+                .min()
+                .orElse(-1);
+    }
+
+    private static List<String> diagnosticKeys() {
+        return List.of(
+                "schema",
+                "candidateSource",
+                "originalValidation",
+                "finalValidation",
+                "validation",
+                "attempts",
+                "finishReason",
+                "initialInvalidOutputExcerpt",
+                "originalOutputExcerpt",
+                "invalidOutputExcerpt",
+                "finalValidationError",
+                "llmRepairAttempted",
+                "deterministicRepairAttempted",
+                "deterministicChanges",
+                "salvageAttempted",
+                "salvageChanges");
+    }
+}

--- a/app/src/main/java/ai/brokk/executor/jobs/ChildAgentArtifact.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/ChildAgentArtifact.java
@@ -1,0 +1,31 @@
+package ai.brokk.executor.jobs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Durable status record for one schema-aware custom-agent child run.
+ */
+public record ChildAgentArtifact(
+        @JsonProperty("parentJobId") String parentJobId,
+        @JsonProperty("childRunId") String childRunId,
+        @JsonProperty("toolCallId") @Nullable String toolCallId,
+        @JsonProperty("agentName") String agentName,
+        @JsonProperty("responseSchemaName") String responseSchemaName,
+        @JsonProperty("status") String status,
+        @JsonProperty("validatedResponse") @Nullable JsonNode validatedResponse,
+        @JsonProperty("validationError") @Nullable String validationError,
+        @JsonProperty("invalidOutputExcerpt") @Nullable String invalidOutputExcerpt,
+        @JsonProperty("errorMessage") @Nullable String errorMessage,
+        @JsonProperty("elapsedMs") @Nullable Long elapsedMs,
+        @JsonProperty("model") @Nullable String model,
+        @JsonProperty("cost") @Nullable Double cost,
+        @JsonProperty("inputTokens") @Nullable Integer inputTokens,
+        @JsonProperty("outputTokens") @Nullable Integer outputTokens) {
+    public static final String STATUS_SUCCESS = "success";
+    public static final String STATUS_SCHEMA_INVALID = "schema_invalid";
+    public static final String STATUS_FAILED = "failed";
+    public static final String STATUS_CANCELLED = "cancelled";
+    public static final String STATUS_TIMEOUT = "timeout";
+}

--- a/app/src/main/java/ai/brokk/executor/jobs/ChildAgentArtifactSink.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/ChildAgentArtifactSink.java
@@ -1,0 +1,26 @@
+package ai.brokk.executor.jobs;
+
+/**
+ * Receiver for durable schema-aware custom-agent child artifacts.
+ */
+public interface ChildAgentArtifactSink {
+    void record(ChildAgentArtifact artifact);
+
+    String parentJobId();
+
+    static ChildAgentArtifactSink noop() {
+        return NoopChildAgentArtifactSink.INSTANCE;
+    }
+
+    enum NoopChildAgentArtifactSink implements ChildAgentArtifactSink {
+        INSTANCE;
+
+        @Override
+        public void record(ChildAgentArtifact artifact) {}
+
+        @Override
+        public String parentJobId() {
+            return "";
+        }
+    }
+}

--- a/app/src/main/java/ai/brokk/executor/jobs/JobChildAgentArtifactSink.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobChildAgentArtifactSink.java
@@ -1,0 +1,38 @@
+package ai.brokk.executor.jobs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Best-effort job-backed artifact sink. Persistence failure must not change child-agent execution semantics.
+ */
+public final class JobChildAgentArtifactSink implements ChildAgentArtifactSink {
+    private static final Logger logger = LogManager.getLogger(JobChildAgentArtifactSink.class);
+
+    private final JobStore store;
+    private final String parentJobId;
+
+    public JobChildAgentArtifactSink(JobStore store, String parentJobId) {
+        this.store = store;
+        this.parentJobId = parentJobId;
+    }
+
+    @Override
+    public void record(ChildAgentArtifact artifact) {
+        try {
+            store.appendChildAgentArtifact(parentJobId, artifact);
+        } catch (Exception e) {
+            logger.warn(
+                    "Failed to persist child agent artifact for job {} childRunId={}: {}",
+                    parentJobId,
+                    artifact.childRunId(),
+                    e.getMessage(),
+                    e);
+        }
+    }
+
+    @Override
+    public String parentJobId() {
+        return parentJobId;
+    }
+}

--- a/app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
@@ -1,5 +1,7 @@
 package ai.brokk.executor.jobs;
 
+import ai.brokk.util.Json;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
@@ -15,6 +17,7 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -70,6 +73,27 @@ public final class JobResponseSchemaSupport {
                 .type(ResponseFormatType.JSON)
                 .jsonSchema(schema)
                 .build();
+    }
+
+    public static Optional<String> validateOutput(JobSpec.ResponseSchema responseSchema, @Nullable String output) {
+        if (output == null || output.isBlank()) {
+            return Optional.of("response is empty");
+        }
+
+        JsonNode root;
+        try {
+            root = Json.getMapper().readTree(output);
+        } catch (JsonProcessingException e) {
+            return Optional.of("response is not valid JSON: " + e.getOriginalMessage());
+        }
+
+        try {
+            validateOutputNode(root, responseSchema.schema(), "response");
+            return Optional.empty();
+        } catch (IllegalArgumentException e) {
+            return Optional.of(
+                    Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName()));
+        }
     }
 
     private static JsonSchemaElement toElement(JsonNode node, String path, Limits limits) {
@@ -213,6 +237,131 @@ public final class JobResponseSchemaSupport {
                 .description(description(node, path))
                 .enumValues(values)
                 .build();
+    }
+
+    private static void validateOutputNode(JsonNode value, JsonNode schema, String path) {
+        if (value.isNull()) {
+            throw new IllegalArgumentException(path + " expected " + typeOf(schema) + ", got null");
+        }
+
+        switch (typeOf(schema)) {
+            case "object" -> validateOutputObject(value, schema, path);
+            case "array" -> validateOutputArray(value, schema, path);
+            case "string" -> validateOutputString(value, schema, path);
+            case "integer" -> {
+                if (!value.isIntegralNumber()) {
+                    throw new IllegalArgumentException(path + " expected integer, got " + outputTypeOf(value));
+                }
+            }
+            case "number" -> {
+                if (!value.isNumber()) {
+                    throw new IllegalArgumentException(path + " expected number, got " + outputTypeOf(value));
+                }
+            }
+            case "boolean" -> {
+                if (!value.isBoolean()) {
+                    throw new IllegalArgumentException(path + " expected boolean, got " + outputTypeOf(value));
+                }
+            }
+            default -> throw new IllegalArgumentException(path + " has unsupported schema type: " + typeOf(schema));
+        }
+    }
+
+    private static void validateOutputObject(JsonNode value, JsonNode schema, String path) {
+        if (!value.isObject()) {
+            throw new IllegalArgumentException(path + " expected object, got " + outputTypeOf(value));
+        }
+
+        var properties = schema.get("properties");
+        if (properties != null && !properties.isObject()) {
+            throw new IllegalArgumentException(path + " schema properties must be an object");
+        }
+
+        for (var requiredName : required(schema, path + " schema")) {
+            var child = value.get(requiredName);
+            if (child == null || child.isNull()) {
+                throw new IllegalArgumentException(path + "." + requiredName + " is required");
+            }
+        }
+
+        if (properties != null) {
+            var propertyNames = new HashSet<String>();
+            properties.properties().forEach(entry -> propertyNames.add(entry.getKey()));
+            if (additionalPropertiesDisabled(schema)) {
+                value.properties().forEach(entry -> {
+                    if (!propertyNames.contains(entry.getKey())) {
+                        throw new IllegalArgumentException(path + "." + entry.getKey() + " is not allowed");
+                    }
+                });
+            }
+            properties.properties().forEach(entry -> {
+                var child = value.get(entry.getKey());
+                if (child != null) {
+                    validateOutputNode(child, entry.getValue(), path + "." + entry.getKey());
+                }
+            });
+        } else if (additionalPropertiesDisabled(schema) && value.size() > 0) {
+            throw new IllegalArgumentException(path + " does not allow properties");
+        }
+    }
+
+    private static void validateOutputArray(JsonNode value, JsonNode schema, String path) {
+        if (!value.isArray()) {
+            throw new IllegalArgumentException(path + " expected array, got " + outputTypeOf(value));
+        }
+        var items = schema.get("items");
+        if (items == null) {
+            throw new IllegalArgumentException(path + " schema items is required");
+        }
+        for (int i = 0; i < value.size(); i++) {
+            validateOutputNode(value.get(i), items, path + "[" + i + "]");
+        }
+    }
+
+    private static void validateOutputString(JsonNode value, JsonNode schema, String path) {
+        if (!value.isTextual()) {
+            throw new IllegalArgumentException(path + " expected string, got " + outputTypeOf(value));
+        }
+        var enumNode = schema.get("enum");
+        if (enumNode != null) {
+            for (var enumValue : enumNode) {
+                if (enumValue.isTextual() && enumValue.textValue().equals(value.textValue())) {
+                    return;
+                }
+            }
+            throw new IllegalArgumentException(path + " has value outside enum");
+        }
+    }
+
+    private static boolean additionalPropertiesDisabled(JsonNode schema) {
+        var additionalProperties = schema.get("additionalProperties");
+        return additionalProperties == null
+                || (additionalProperties.isBoolean() && !additionalProperties.booleanValue());
+    }
+
+    private static String outputTypeOf(JsonNode value) {
+        if (value.isNull()) {
+            return "null";
+        }
+        if (value.isObject()) {
+            return "object";
+        }
+        if (value.isArray()) {
+            return "array";
+        }
+        if (value.isTextual()) {
+            return "string";
+        }
+        if (value.isIntegralNumber()) {
+            return "integer";
+        }
+        if (value.isNumber()) {
+            return "number";
+        }
+        if (value.isBoolean()) {
+            return "boolean";
+        }
+        return value.getNodeType().name().toLowerCase(Locale.ROOT);
     }
 
     private static List<String> required(JsonNode node, String path) {

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -545,6 +545,7 @@ public final class JobRunner {
                         mode,
                         plannerModelNameForLog,
                         codeModelNameForLog);
+                var responseSchemaRegistry = responseSchemaRegistry(spec);
 
                 // Execute within submitLlmAction to honor cancellation semantics
                 cm.setAutoCommit(spec.autoCommit());
@@ -588,7 +589,10 @@ public final class JobRunner {
                                                             architectPlannerModel,
                                                             "plannerModel required for PLAN jobs"),
                                                     objectiveForMode(Mode.PLAN),
-                                                    scope);
+                                                    scope,
+                                                    cm.getIo(),
+                                                    LutzAgent.ScanConfig.defaults(),
+                                                    responseSchemaRegistry);
                                             if (readOnly) {
                                                 searchAgent.setReadOnly(true);
                                             }
@@ -631,7 +635,9 @@ public final class JobRunner {
                                                     architectGoal,
                                                     scope,
                                                     context,
-                                                    compressedHistory);
+                                                    compressedHistory,
+                                                    cm.getIo(),
+                                                    responseSchemaRegistry);
                                             architectAgent.setAlwaysDeferBuild(true);
                                             architectAgent.setBuildToolsEnabled(false);
                                             if (mode == Mode.LITE_PLAN) {
@@ -686,7 +692,10 @@ public final class JobRunner {
                                                         requireNonNull(
                                                                 askPlannerModel, "plannerModel required for ASK jobs"),
                                                         objectiveForMode(Mode.ASK),
-                                                        scope);
+                                                        scope,
+                                                        cm.getIo(),
+                                                        LutzAgent.ScanConfig.defaults(),
+                                                        responseSchemaRegistry);
                                                 if (readOnly) {
                                                     searchAgent.setReadOnly(true);
                                                 }
@@ -838,7 +847,8 @@ public final class JobRunner {
                                                     objectiveForMode(Mode.SEARCH),
                                                     scope,
                                                     cm.getIo(),
-                                                    scanConfig);
+                                                    scanConfig,
+                                                    responseSchemaRegistry);
                                             if (readOnly) {
                                                 searchAgent.setReadOnly(true);
                                             }
@@ -1774,6 +1784,12 @@ public final class JobRunner {
             throw new IllegalArgumentException(
                     "MODEL_UNSUPPORTED_RESPONSE_SCHEMA: " + cm.getService().nameOf(model));
         }
+    }
+
+    private static ResponseSchemaRegistry responseSchemaRegistry(JobSpec spec) {
+        return spec.responseSchema() == null
+                ? ResponseSchemaRegistry.empty()
+                : ResponseSchemaRegistry.of(List.of(spec.responseSchema()));
     }
 
     private List<ChatMessage> llmRawMessagesOrEmpty() {

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -31,7 +31,6 @@ import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
-import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -665,7 +664,7 @@ public final class JobRunner {
                                                             askPlannerModel,
                                                             "plannerModel required for REPORT_ONLY jobs"),
                                                     spec.taskInput(),
-                                                    responseFormatOrNull(spec),
+                                                    spec.responseSchema(),
                                                     finalStopReason);
                                         }
                                     }
@@ -797,7 +796,7 @@ public final class JobRunner {
                                                     context,
                                                     requireNonNull(askPlannerModel),
                                                     spec.taskInput(),
-                                                    responseFormatOrNull(spec),
+                                                    spec.responseSchema(),
                                                     finalStopReason);
                                         }
                                     }
@@ -817,18 +816,18 @@ public final class JobRunner {
                                                             trimmedScanModel, spec.reasoningLevel(), spec.temperature())
                                                     : defaultScanModel(spec);
 
-                                            var responseFormat = responseFormatOrNull(spec);
-                                            var finalAnswerModel = responseFormat == null
+                                            var responseSchema = spec.responseSchema();
+                                            var finalAnswerModel = responseSchema == null
                                                     ? null
                                                     : resolveModelOrThrow(
                                                             spec.plannerModel(),
                                                             spec.reasoningLevel(),
                                                             spec.temperature());
-                                            if (responseFormat != null) {
+                                            if (responseSchema != null) {
                                                 ensureResponseSchemaSupported(requireNonNull(finalAnswerModel));
                                             }
 
-                                            var scanConfig = responseFormat == null
+                                            var scanConfig = responseSchema == null
                                                     ? LutzAgent.ScanConfig.withModel(scanModelToUse)
                                                     : new LutzAgent.ScanConfig(true, scanModelToUse, false, true);
                                             var searchAgent = new LutzAgent(
@@ -843,7 +842,7 @@ public final class JobRunner {
                                             if (readOnly) {
                                                 searchAgent.setReadOnly(true);
                                             }
-                                            if (responseFormat == null) {
+                                            if (responseSchema == null) {
                                                 var result = searchAgent.execute();
                                                 scope.append(result);
                                                 finalStopReason.set(result.stopDetails()
@@ -858,7 +857,7 @@ public final class JobRunner {
                                                         context,
                                                         requireNonNull(finalAnswerModel),
                                                         spec.taskInput(),
-                                                        responseFormat,
+                                                        responseSchema,
                                                         finalStopReason);
                                             }
                                         }
@@ -1668,8 +1667,9 @@ public final class JobRunner {
      * @return a TaskResult suitable for appending to a TaskScope
      */
     private TaskResult askUsingPlannerModel(
-            Context ctx, StreamingChatModel model, String question, @Nullable ResponseFormat responseFormat) {
-        if (responseFormat != null) {
+            Context ctx, StreamingChatModel model, String question, @Nullable JobSpec.ResponseSchema responseSchema) {
+        var responseFormat = responseSchema == null ? null : JobResponseSchemaSupport.toResponseFormat(responseSchema);
+        if (responseSchema != null) {
             ensureResponseSchemaSupported(model);
         }
 
@@ -1702,6 +1702,12 @@ public final class JobRunner {
             if (responseFormat != null && response.error() != null) {
                 throw new RuntimeException(response.error());
             }
+            if (responseSchema != null) {
+                var validationError = JobResponseSchemaSupport.validateOutput(responseSchema, response.text());
+                if (validationError.isPresent()) {
+                    throw new IllegalArgumentException("RESPONSE_SCHEMA_OUTPUT_INVALID: " + validationError.get());
+                }
+            }
             stop = TaskResult.StopDetails.fromResponse(response);
         }
 
@@ -1718,10 +1724,11 @@ public final class JobRunner {
             Context context,
             StreamingChatModel model,
             String question,
-            @Nullable ResponseFormat responseFormat,
+            @Nullable JobSpec.ResponseSchema responseSchema,
             AtomicReference<String> finalStopReason) {
+        var responseFormat = responseSchema == null ? null : JobResponseSchemaSupport.toResponseFormat(responseSchema);
         try {
-            var result = askUsingPlannerModel(context, model, question, responseFormat);
+            var result = askUsingPlannerModel(context, model, question, responseSchema);
             finalStopReason.set(result.stopDetails().reason().name());
             scope.append(result);
         } catch (Throwable t) {
@@ -1760,10 +1767,6 @@ public final class JobRunner {
                 logger.warn("Failed to append {} failure result for job {}: {}", label, jobId, e2.getMessage(), e2);
             }
         }
-    }
-
-    private static @Nullable ResponseFormat responseFormatOrNull(JobSpec spec) {
-        return spec.responseSchema() == null ? null : JobResponseSchemaSupport.toResponseFormat(spec.responseSchema());
     }
 
     private void ensureResponseSchemaSupported(StreamingChatModel model) {

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -547,6 +547,7 @@ public final class JobRunner {
                         plannerModelNameForLog,
                         codeModelNameForLog);
                 var responseSchemaRegistry = responseSchemaRegistry(spec);
+                var childAgentArtifactSink = new JobChildAgentArtifactSink(store, jobId);
 
                 // Execute within submitLlmAction to honor cancellation semantics
                 cm.setAutoCommit(spec.autoCommit());
@@ -593,7 +594,8 @@ public final class JobRunner {
                                                     scope,
                                                     cm.getIo(),
                                                     LutzAgent.ScanConfig.defaults(),
-                                                    responseSchemaRegistry);
+                                                    responseSchemaRegistry,
+                                                    childAgentArtifactSink);
                                             if (readOnly) {
                                                 searchAgent.setReadOnly(true);
                                             }
@@ -638,7 +640,8 @@ public final class JobRunner {
                                                     context,
                                                     compressedHistory,
                                                     cm.getIo(),
-                                                    responseSchemaRegistry);
+                                                    responseSchemaRegistry,
+                                                    childAgentArtifactSink);
                                             architectAgent.setAlwaysDeferBuild(true);
                                             architectAgent.setBuildToolsEnabled(false);
                                             if (mode == Mode.LITE_PLAN) {
@@ -696,7 +699,8 @@ public final class JobRunner {
                                                         scope,
                                                         cm.getIo(),
                                                         LutzAgent.ScanConfig.defaults(),
-                                                        responseSchemaRegistry);
+                                                        responseSchemaRegistry,
+                                                        childAgentArtifactSink);
                                                 if (readOnly) {
                                                     searchAgent.setReadOnly(true);
                                                 }
@@ -849,7 +853,8 @@ public final class JobRunner {
                                                     scope,
                                                     cm.getIo(),
                                                     scanConfig,
-                                                    responseSchemaRegistry);
+                                                    responseSchemaRegistry,
+                                                    childAgentArtifactSink);
                                             if (readOnly) {
                                                 searchAgent.setReadOnly(true);
                                             }

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -1694,14 +1694,33 @@ public final class JobRunner {
         // Build and send the request to the LLM
         TaskResult.StopDetails stop = null;
         Llm.StreamingResult response = null;
+        var activeMessages = messages;
+        var maxAttempts = responseSchema == null ? 1 : 2;
         try {
-            response = responseFormat == null
-                    ? llm.sendRequest(messages)
-                    : llm.sendRequest(
-                            messages,
-                            llm.requestOptions()
-                                    .withResponseFormat(responseFormat)
-                                    .withMaxAttempts(1));
+            for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+                response = responseFormat == null
+                        ? llm.sendRequest(activeMessages)
+                        : llm.sendRequest(
+                                activeMessages,
+                                llm.requestOptions()
+                                        .withResponseFormat(responseFormat)
+                                        .withMaxAttempts(1));
+                if (responseFormat != null && response.error() != null) {
+                    throw new RuntimeException(response.error());
+                }
+                if (responseSchema == null) {
+                    break;
+                }
+                var validationError = JobResponseSchemaSupport.validateOutput(responseSchema, response.text());
+                if (validationError.isEmpty()) {
+                    break;
+                }
+                if (attempt == maxAttempts) {
+                    throw new IllegalArgumentException("RESPONSE_SCHEMA_OUTPUT_INVALID: " + validationError.get());
+                }
+                activeMessages = directAnswerSchemaRepairMessages(
+                        messages, responseSchema, question, response.text(), validationError.get());
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             stop = new TaskResult.StopDetails(TaskResult.StopReason.INTERRUPTED);
@@ -1709,15 +1728,6 @@ public final class JobRunner {
 
         // Determine stop details based on the response
         if (response != null) {
-            if (responseFormat != null && response.error() != null) {
-                throw new RuntimeException(response.error());
-            }
-            if (responseSchema != null) {
-                var validationError = JobResponseSchemaSupport.validateOutput(responseSchema, response.text());
-                if (validationError.isPresent()) {
-                    throw new IllegalArgumentException("RESPONSE_SCHEMA_OUTPUT_INVALID: " + validationError.get());
-                }
-            }
             stop = TaskResult.StopDetails.fromResponse(response);
         }
 
@@ -1725,6 +1735,52 @@ public final class JobRunner {
 
         ctx = ctx.addHistoryEntry(llmRawMessagesOrEmpty(), TaskResult.Type.ASK, model, question);
         return new TaskResult(ctx, stop);
+    }
+
+    private static List<ChatMessage> directAnswerSchemaRepairMessages(
+            List<ChatMessage> originalMessages,
+            JobSpec.ResponseSchema responseSchema,
+            String question,
+            String invalidOutput,
+            String validationError) {
+        var messages = new ArrayList<>(originalMessages);
+        messages.add(new UserMessage(
+                """
+                The previous response did not satisfy the required `%s` response schema.
+                Validation error: %s
+
+                <original_question>
+                %s
+                </original_question>
+
+                <invalid_previous_response>
+                %s
+                </invalid_previous_response>
+
+                Return only a complete JSON object matching the `%s` response schema.
+                Include every required top-level field and every required nested field.
+                If the schema expects an object, emit an object; if it expects an array, emit an array.
+                Use empty arrays for unavailable array evidence and concise strings for sparse required prose fields.
+                Do not return markdown, fenced JSON, explanations, or legacy component wrappers.
+                """
+                        .formatted(
+                                responseSchema.name(),
+                                validationError,
+                                question,
+                                abbreviateInvalidSchemaOutput(invalidOutput),
+                                responseSchema.name())));
+        return messages;
+    }
+
+    private static String abbreviateInvalidSchemaOutput(String invalidOutput) {
+        var maxChars = 6_000;
+        if (invalidOutput.length() <= maxChars) {
+            return invalidOutput;
+        }
+        return invalidOutput.substring(0, maxChars)
+                + "\n\n[truncated invalid response: "
+                + (invalidOutput.length() - maxChars)
+                + " chars omitted]";
     }
 
     private void runDirectAnswer(
@@ -1787,9 +1843,12 @@ public final class JobRunner {
     }
 
     private static ResponseSchemaRegistry responseSchemaRegistry(JobSpec spec) {
-        return spec.responseSchema() == null
-                ? ResponseSchemaRegistry.empty()
-                : ResponseSchemaRegistry.of(List.of(spec.responseSchema()));
+        var schemas = new ArrayList<JobSpec.ResponseSchema>();
+        if (spec.responseSchema() != null) {
+            schemas.add(spec.responseSchema());
+        }
+        schemas.addAll(spec.responseSchemas());
+        return ResponseSchemaRegistry.of(schemas);
     }
 
     private List<ChatMessage> llmRawMessagesOrEmpty() {

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -24,6 +24,7 @@ import ai.brokk.issues.GitHubIssueService;
 import ai.brokk.issues.IssueHeader;
 import ai.brokk.prompts.SearchPrompts;
 import ai.brokk.tasks.TaskList;
+import ai.brokk.util.Json;
 import ai.brokk.util.Messages;
 import ai.brokk.util.ReviewParser;
 import dev.langchain4j.data.message.ChatMessage;
@@ -1696,6 +1697,7 @@ public final class JobRunner {
         Llm.StreamingResult response = null;
         var activeMessages = messages;
         var maxAttempts = responseSchema == null ? 1 : 2;
+        JobLevelSchemaRepairTrace schemaRepairTrace = null;
         try {
             for (int attempt = 1; attempt <= maxAttempts; attempt++) {
                 response = responseFormat == null
@@ -1715,8 +1717,18 @@ public final class JobRunner {
                 if (validationError.isEmpty()) {
                     break;
                 }
+                if (schemaRepairTrace == null) {
+                    schemaRepairTrace = new JobLevelSchemaRepairTrace(
+                            responseSchema.name(), validationError.get(), response.text());
+                }
+                schemaRepairTrace.attempts = attempt;
+                schemaRepairTrace.finalValidationError = validationError.get();
+                schemaRepairTrace.invalidOutput = response.text();
+                schemaRepairTrace.finishReason = finishReason(response);
                 if (attempt == maxAttempts) {
-                    throw new IllegalArgumentException("RESPONSE_SCHEMA_OUTPUT_INVALID: " + validationError.get());
+                    var message = schemaRepairTrace.failureMessage();
+                    logger.warn("Job-level response schema repair failed: {}", message);
+                    throw new IllegalArgumentException(message);
                 }
                 activeMessages = directAnswerSchemaRepairMessages(
                         messages, responseSchema, question, response.text(), validationError.get());
@@ -1735,6 +1747,45 @@ public final class JobRunner {
 
         ctx = ctx.addHistoryEntry(llmRawMessagesOrEmpty(), TaskResult.Type.ASK, model, question);
         return new TaskResult(ctx, stop);
+    }
+
+    private static final class JobLevelSchemaRepairTrace {
+        private final String schemaName;
+        private final String originalValidationError;
+        private final String initialInvalidOutput;
+        private int attempts;
+        private String finalValidationError;
+        private String finishReason = "unknown";
+        private String invalidOutput;
+
+        private JobLevelSchemaRepairTrace(
+                String schemaName, String originalValidationError, String initialInvalidOutput) {
+            this.schemaName = schemaName;
+            this.originalValidationError = originalValidationError;
+            this.initialInvalidOutput = initialInvalidOutput;
+            this.finalValidationError = originalValidationError;
+            this.invalidOutput = initialInvalidOutput;
+        }
+
+        private String failureMessage() {
+            return "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=%s validation=%s originalValidation=%s attempts=%d finishReason=%s initialInvalidOutputExcerpt=%s invalidOutputExcerpt=%s"
+                    .formatted(
+                            schemaName,
+                            finalValidationError,
+                            originalValidationError,
+                            attempts,
+                            finishReason,
+                            abbreviateInvalidSchemaOutput(initialInvalidOutput),
+                            abbreviateInvalidSchemaOutput(invalidOutput));
+        }
+    }
+
+    private static String finishReason(Llm.StreamingResult response) {
+        var originalResponse = response.originalResponse();
+        if (originalResponse == null || originalResponse.finishReason() == null) {
+            return "unknown";
+        }
+        return originalResponse.finishReason().name();
     }
 
     private static List<ChatMessage> directAnswerSchemaRepairMessages(
@@ -1757,8 +1808,13 @@ public final class JobRunner {
                 %s
                 </invalid_previous_response>
 
+                <response_schema>
+                %s
+                </response_schema>
+
                 Return only a complete JSON object matching the `%s` response schema.
-                Include every required top-level field and every required nested field.
+                Include every required top-level field and every required nested field from the schema.
+                If the schema requires `metadata`, the root object must include `metadata`.
                 If the schema expects an object, emit an object; if it expects an array, emit an array.
                 Use empty arrays for unavailable array evidence and concise strings for sparse required prose fields.
                 Do not return markdown, fenced JSON, explanations, or legacy component wrappers.
@@ -1768,6 +1824,7 @@ public final class JobRunner {
                                 validationError,
                                 question,
                                 abbreviateInvalidSchemaOutput(invalidOutput),
+                                abbreviateInvalidSchemaOutput(Json.toJson(responseSchema.schema())),
                                 responseSchema.name())));
         return messages;
     }

--- a/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobSpec.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -34,7 +35,8 @@ public record JobSpec(
         @JsonProperty("skipVerification") boolean skipVerification,
         @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts,
         @JsonProperty("executionPolicy") @Nullable ExecutionPolicy executionPolicy,
-        @JsonProperty("responseSchema") @Nullable ResponseSchema responseSchema) {
+        @JsonProperty("responseSchema") @Nullable ResponseSchema responseSchema,
+        @JsonProperty("responseSchemas") List<ResponseSchema> responseSchemas) {
 
     public static final int DEFAULT_MAX_ISSUE_FIX_ATTEMPTS = 20;
 
@@ -103,6 +105,7 @@ public record JobSpec(
                 skipVerification,
                 maxIssueFixAttempts,
                 null,
+                null,
                 null);
     }
 
@@ -143,6 +146,7 @@ public record JobSpec(
                 skipVerification,
                 maxIssueFixAttempts,
                 executionPolicy,
+                null,
                 null);
     }
 
@@ -165,7 +169,8 @@ public record JobSpec(
             @JsonProperty("skipVerification") boolean skipVerification,
             @JsonProperty("maxIssueFixAttempts") @Nullable Integer maxIssueFixAttempts,
             @JsonProperty("executionPolicy") @Nullable ExecutionPolicy executionPolicy,
-            @JsonProperty("responseSchema") @Nullable ResponseSchema responseSchema) {
+            @JsonProperty("responseSchema") @Nullable ResponseSchema responseSchema,
+            @JsonProperty("responseSchemas") @Nullable List<ResponseSchema> responseSchemas) {
         this.taskInput = taskInput;
         this.autoCommit = autoCommit;
         this.autoCompress = autoCompress;
@@ -184,6 +189,49 @@ public record JobSpec(
         this.maxIssueFixAttempts = maxIssueFixAttempts;
         this.executionPolicy = executionPolicy;
         this.responseSchema = responseSchema;
+        this.responseSchemas = responseSchemas == null ? List.of() : List.copyOf(responseSchemas);
+    }
+
+    /** Backward-compatible constructor for callers that do not specify child response schemas. */
+    public JobSpec(
+            String taskInput,
+            boolean autoCommit,
+            boolean autoCompress,
+            String plannerModel,
+            @Nullable String scanModel,
+            @Nullable String codeModel,
+            boolean preScan,
+            @Nullable Map<String, String> tags,
+            @Nullable String sourceBranch,
+            @Nullable String targetBranch,
+            @Nullable String reasoningLevel,
+            @Nullable String reasoningLevelCode,
+            @Nullable Double temperature,
+            @Nullable Double temperatureCode,
+            boolean skipVerification,
+            @Nullable Integer maxIssueFixAttempts,
+            @Nullable ExecutionPolicy executionPolicy,
+            @Nullable ResponseSchema responseSchema) {
+        this(
+                taskInput,
+                autoCommit,
+                autoCompress,
+                plannerModel,
+                scanModel,
+                codeModel,
+                preScan,
+                tags,
+                sourceBranch,
+                targetBranch,
+                reasoningLevel,
+                reasoningLevelCode,
+                temperature,
+                temperatureCode,
+                skipVerification,
+                maxIssueFixAttempts,
+                executionPolicy,
+                responseSchema,
+                null);
     }
 
     public Map<String, String> redactedTags() {
@@ -215,7 +263,8 @@ public record JobSpec(
                 skipVerification,
                 maxIssueFixAttempts,
                 executionPolicy,
-                responseSchema);
+                responseSchema,
+                responseSchemas);
     }
 
     public JobSpec withRedactedTags() {

--- a/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobStore.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
 public final class JobStore {
     private static final Logger logger = LogManager.getLogger(JobStore.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String CHILD_AGENT_ARTIFACTS_NAME = "child-agent-artifacts.jsonl";
 
     private final Path jobsDir;
     private final Path idempotencyDir;
@@ -338,6 +339,43 @@ public final class JobStore {
             return null;
         }
         return Files.readAllBytes(artifactFile);
+    }
+
+    public synchronized void appendChildAgentArtifact(String jobId, ChildAgentArtifact artifact) throws IOException {
+        var artifactFile = jobsDir.resolve(jobId).resolve("artifacts").resolve(CHILD_AGENT_ARTIFACTS_NAME);
+        Files.createDirectories(artifactFile.getParent());
+        var line = objectMapper.writeValueAsString(artifact) + "\n";
+        Files.writeString(artifactFile, line, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        logger.debug(
+                "Appended child agent artifact job={} childRunId={} agent={} status={}",
+                jobId,
+                artifact.childRunId(),
+                artifact.agentName(),
+                artifact.status());
+    }
+
+    public synchronized List<ChildAgentArtifact> readChildAgentArtifacts(String jobId) throws IOException {
+        var artifactFile = jobsDir.resolve(jobId).resolve("artifacts").resolve(CHILD_AGENT_ARTIFACTS_NAME);
+        if (!Files.exists(artifactFile)) {
+            return List.of();
+        }
+
+        var result = new ArrayList<ChildAgentArtifact>();
+        try (Stream<String> lines = Files.lines(artifactFile, StandardCharsets.UTF_8)) {
+            var iterator = lines.iterator();
+            while (iterator.hasNext()) {
+                var line = iterator.next();
+                if (line.isBlank()) {
+                    continue;
+                }
+                try {
+                    result.add(objectMapper.readValue(line, ChildAgentArtifact.class));
+                } catch (JsonProcessingException e) {
+                    logger.debug("Skipping malformed child agent artifact line: {}", e.getMessage());
+                }
+            }
+        }
+        return List.copyOf(result);
     }
 
     /**

--- a/app/src/main/java/ai/brokk/executor/jobs/ResponseSchemaRegistry.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/ResponseSchemaRegistry.java
@@ -1,0 +1,52 @@
+package ai.brokk.executor.jobs;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public final class ResponseSchemaRegistry {
+    private static final ResponseSchemaRegistry EMPTY = new ResponseSchemaRegistry(Map.of());
+
+    private final Map<String, JobSpec.ResponseSchema> schemasByName;
+
+    private ResponseSchemaRegistry(Map<String, JobSpec.ResponseSchema> schemasByName) {
+        this.schemasByName = schemasByName;
+    }
+
+    public static ResponseSchemaRegistry empty() {
+        return EMPTY;
+    }
+
+    public static ResponseSchemaRegistry of(Collection<JobSpec.ResponseSchema> schemas) {
+        if (schemas.isEmpty()) {
+            return empty();
+        }
+
+        var byName = new LinkedHashMap<String, JobSpec.ResponseSchema>();
+        for (var schema : schemas) {
+            var name = schema.name().strip();
+            if (name.isBlank()) {
+                throw new IllegalArgumentException("responseSchema.name is required");
+            }
+            var error = JobResponseSchemaSupport.validate(schema);
+            if (error.isPresent()) {
+                throw new IllegalArgumentException(error.get());
+            }
+            if (byName.putIfAbsent(name, schema) != null) {
+                throw new IllegalArgumentException("Duplicate response schema name: " + name);
+            }
+        }
+        return new ResponseSchemaRegistry(Collections.unmodifiableMap(new LinkedHashMap<>(byName)));
+    }
+
+    public Optional<JobSpec.ResponseSchema> resolve(String name) {
+        return Optional.ofNullable(schemasByName.get(name.strip()));
+    }
+
+    public Set<String> names() {
+        return Collections.unmodifiableSet(schemasByName.keySet());
+    }
+}

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -178,6 +178,9 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         var parsedResponseSchema = parseResponseSchema(exchange, request.responseSchema());
         if (parsedResponseSchema.invalid()) return;
         var responseSchema = parsedResponseSchema.responseSchema();
+        var parsedResponseSchemas = parseResponseSchemas(exchange, request.responseSchemas());
+        if (parsedResponseSchemas.invalid()) return;
+        var responseSchemas = parsedResponseSchemas.responseSchemas();
 
         // If an agent is specified, validate it exists and route to SEARCH mode with an instruction
         String effectiveTaskInput = request.taskInput();
@@ -198,8 +201,20 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
                     exchange, "responseSchema is only supported for REPORT_ONLY, ASK, and SEARCH jobs");
             return;
         }
+        if (!responseSchemas.isEmpty() && !allowsResponseSchema(executionPolicy, tags)) {
+            RouterUtil.sendValidationError(
+                    exchange, "responseSchemas is only supported for REPORT_ONLY, ASK, and SEARCH jobs");
+            return;
+        }
         if (responseSchema != null) {
             var responseSchemaError = JobResponseSchemaSupport.validate(responseSchema);
+            if (responseSchemaError.isPresent()) {
+                RouterUtil.sendValidationError(exchange, responseSchemaError.get());
+                return;
+            }
+        }
+        for (var schema : responseSchemas) {
+            var responseSchemaError = JobResponseSchemaSupport.validate(schema);
             if (responseSchemaError.isPresent()) {
                 RouterUtil.sendValidationError(exchange, responseSchemaError.get());
                 return;
@@ -234,7 +249,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
                 skipVerificationFlag,
                 JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
                 executionPolicy,
-                responseSchema);
+                responseSchema,
+                responseSchemas);
 
         if (awaitHeadlessInitOrRespond(exchange, null)) return;
 
@@ -683,6 +699,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
 
     private record ParsedResponseSchema(JobSpec.@Nullable ResponseSchema responseSchema, boolean invalid) {}
 
+    private record ParsedResponseSchemas(List<JobSpec.ResponseSchema> responseSchemas, boolean invalid) {}
+
     private static ParsedResponseSchema parseResponseSchema(HttpExchange exchange, @Nullable JsonNode rawResponseSchema)
             throws IOException {
         if (rawResponseSchema == null || rawResponseSchema.isNull()) {
@@ -694,6 +712,27 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         } catch (JsonProcessingException | IllegalArgumentException e) {
             RouterUtil.sendValidationError(exchange, "Invalid responseSchema");
             return new ParsedResponseSchema(null, true);
+        }
+    }
+
+    private static ParsedResponseSchemas parseResponseSchemas(
+            HttpExchange exchange, @Nullable JsonNode rawResponseSchemas) throws IOException {
+        if (rawResponseSchemas == null || rawResponseSchemas.isNull()) {
+            return new ParsedResponseSchemas(List.of(), false);
+        }
+        if (!rawResponseSchemas.isArray()) {
+            RouterUtil.sendValidationError(exchange, "responseSchemas must be an array");
+            return new ParsedResponseSchemas(List.of(), true);
+        }
+        try {
+            var responseSchemas = new ArrayList<JobSpec.ResponseSchema>();
+            for (var rawSchema : rawResponseSchemas) {
+                responseSchemas.add(OBJECT_MAPPER.treeToValue(rawSchema, JobSpec.ResponseSchema.class));
+            }
+            return new ParsedResponseSchemas(List.copyOf(responseSchemas), false);
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            RouterUtil.sendValidationError(exchange, "Invalid responseSchemas");
+            return new ParsedResponseSchemas(List.of(), true);
         }
     }
 
@@ -797,7 +836,8 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             JobSpec.@Nullable ExecutionPolicy executionPolicy,
             JobSpec.@Nullable ExecutionPolicy jobPolicy,
             @Nullable String agent,
-            @JsonProperty("responseSchema") @Nullable JsonNode responseSchema) {}
+            @JsonProperty("responseSchema") @Nullable JsonNode responseSchema,
+            @JsonProperty("responseSchemas") @Nullable JsonNode responseSchemas) {}
 
     private record ContextPayload(@Nullable List<String> text) {}
 

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -113,6 +114,11 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
 
         if (path.equals("/v1/jobs/" + jobId) && method.equals("GET")) {
             handleGetJob(exchange, jobId);
+            return;
+        }
+
+        if (path.equals("/v1/jobs/" + jobId + "/result") && method.equals("GET")) {
+            handleGetJobResult(exchange, jobId);
             return;
         }
 
@@ -335,6 +341,21 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
             SimpleHttpServer.sendJsonResponse(
                     exchange, 500, ErrorPayload.internalError("Failed to resolve session", e));
         }
+    }
+
+    private void handleGetJobResult(HttpExchange exchange, String jobId) throws IOException {
+        var status = jobStore.loadStatus(jobId);
+        if (status == null) {
+            SimpleHttpServer.sendJsonResponse(
+                    exchange, 404, ErrorPayload.of(ErrorPayload.Code.NOT_FOUND, "Job not found: " + jobId));
+            return;
+        }
+        var response = new LinkedHashMap<String, Object>();
+        response.put("jobId", jobId);
+        response.put("state", status.state());
+        response.put("terminal", status.terminal());
+        response.put("childAgentArtifacts", jobStore.readChildAgentArtifacts(jobId));
+        SimpleHttpServer.sendJsonResponse(exchange, 200, response);
     }
 
     private void handlePostIssueJob(HttpExchange exchange) throws IOException {

--- a/app/src/test/java/ai/brokk/executor/agents/ChildAgentArtifactFactoryTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/ChildAgentArtifactFactoryTest.java
@@ -1,0 +1,104 @@
+package ai.brokk.executor.agents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.executor.jobs.ChildAgentArtifact;
+import ai.brokk.tools.ToolExecutionResult;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import org.junit.jupiter.api.Test;
+
+class ChildAgentArtifactFactoryTest {
+    private static ToolExecutionRequest request() {
+        return ToolExecutionRequest.builder()
+                .id("tool-call-1")
+                .name("callCustomAgentWithSchema")
+                .arguments("{}")
+                .build();
+    }
+
+    @Test
+    void successPreservesValidatedJsonObject() {
+        var result = ToolExecutionResult.success(request(), "{\"summary\":\"ok\"}", 37L);
+
+        var artifact = ChildAgentArtifactFactory.fromToolResult(
+                "parent-job", "child-run", "tool-call-1", "agent", "StrictReport", "model", 37L, result);
+
+        assertEquals(ChildAgentArtifact.STATUS_SUCCESS, artifact.status());
+        assertNotNull(artifact.validatedResponse());
+        assertEquals("ok", artifact.validatedResponse().get("summary").asText());
+        assertNull(artifact.validationError());
+        assertEquals(37L, artifact.elapsedMs());
+        assertEquals("model", artifact.model());
+    }
+
+    @Test
+    void schemaInvalidFailureUsesStructuredDiagnostics() {
+        var failureText = "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=StrictReport "
+                + "originalValidation=response.summary expected string "
+                + "finalValidation=response.summary is required "
+                + "invalidOutputExcerpt={\"summary\":null} finishReason=complete";
+        var result = ToolExecutionResult.fatal(request(), failureText, 12L);
+
+        var artifact = ChildAgentArtifactFactory.fromToolResult(
+                "parent-job", "child-run", "tool-call-1", "agent", "StrictReport", "model", 12L, result);
+
+        assertEquals(ChildAgentArtifact.STATUS_SCHEMA_INVALID, artifact.status());
+        assertEquals("response.summary is required", artifact.validationError());
+        assertEquals("{\"summary\":null}", artifact.invalidOutputExcerpt());
+        assertNull(artifact.errorMessage());
+    }
+
+    @Test
+    void schemaInvalidFailureFallsBackToOriginalValidationAndBoundedExcerpt() {
+        var failureText = "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=StrictReport "
+                + "originalValidation=response.summary expected string "
+                + "originalOutputExcerpt={\"summary\":null}";
+        var result = ToolExecutionResult.fatal(request(), failureText);
+
+        var artifact = ChildAgentArtifactFactory.fromToolResult(
+                "parent-job", "child-run", "tool-call-1", "agent", "StrictReport", "model", 0L, result);
+
+        assertEquals(ChildAgentArtifact.STATUS_SCHEMA_INVALID, artifact.status());
+        assertEquals("response.summary expected string", artifact.validationError());
+        assertEquals("{\"summary\":null}", artifact.invalidOutputExcerpt());
+    }
+
+    @Test
+    void genericFailuresMapStatusFromFailureText() {
+        assertEquals(
+                ChildAgentArtifact.STATUS_TIMEOUT,
+                ChildAgentArtifactFactory.statusForNonSchemaFailure("child timed out"));
+        assertEquals(
+                ChildAgentArtifact.STATUS_CANCELLED,
+                ChildAgentArtifactFactory.statusForNonSchemaFailure("child was cancelled"));
+        assertEquals(ChildAgentArtifact.STATUS_FAILED, ChildAgentArtifactFactory.statusForNonSchemaFailure("boom"));
+    }
+
+    @Test
+    void requestErrorBecomesFailedArtifact() {
+        var result = ToolExecutionResult.requestError(request(), "responseSchemaName is required");
+
+        var artifact = ChildAgentArtifactFactory.fromToolResult(
+                "parent-job", "child-run", "tool-call-1", "agent", "StrictReport", "model", 0L, result);
+
+        assertEquals(ChildAgentArtifact.STATUS_FAILED, artifact.status());
+        assertNotNull(artifact.errorMessage());
+        assertTrue(artifact.errorMessage().contains("responseSchemaName is required"));
+    }
+
+    @Test
+    void malformedSuccessfulTextBecomesSchemaInvalidArtifact() {
+        var result = ToolExecutionResult.success(request(), "not json");
+
+        var artifact = ChildAgentArtifactFactory.fromToolResult(
+                "parent-job", "child-run", "tool-call-1", "agent", "StrictReport", "model", 0L, result);
+
+        assertEquals(ChildAgentArtifact.STATUS_SCHEMA_INVALID, artifact.status());
+        assertNotNull(artifact.validationError());
+        assertTrue(artifact.validationError().contains("could not be parsed as JSON"));
+        assertEquals("not json", artifact.invalidOutputExcerpt());
+    }
+}

--- a/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
@@ -17,6 +17,7 @@ import ai.brokk.testutil.NoOpConsoleIO;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessageType;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -24,6 +25,7 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -146,7 +148,31 @@ class CustomAgentExecutorTest {
     }
 
     @Test
-    void schemaBackedInvalidFinalAnswerReturnsHardErrorWithoutMarkdownFallback() throws Exception {
+    void schemaBackedInvalidFinalAnswerRetriesWithSchemaFeedback() throws Exception {
+        setUpHarness(true);
+        model.structuredResponses.add("{\"summary\":null}");
+        model.structuredResponses.add("{\"summary\":\"repaired\"}");
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals("{\"summary\":\"repaired\"}", result.stopDetails().explanation());
+        assertEquals(List.of("{\"summary\":\"repaired\"}"), io.outputs);
+        assertEquals(3, model.requests.size());
+        assertEquals(
+                2,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+        var retryRequestText = ((UserMessage) model.requests.get(2).messages().get(1)).singleText();
+        assertTrue(retryRequestText.contains("response.summary is required"));
+        assertTrue(retryRequestText.contains("<invalid_previous_response>"));
+    }
+
+    @Test
+    void schemaBackedInvalidFinalAnswerFailsAfterRepairAttemptWithoutMarkdownFallback() throws Exception {
         setUpHarness(true);
         model.structuredResponse = "{\"summary\":null}";
         var io = new RecordingConsoleIO();
@@ -158,7 +184,12 @@ class CustomAgentExecutorTest {
         assertTrue(result.stopDetails().explanation().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"));
         assertTrue(result.stopDetails().explanation().contains("response.summary is required"));
         assertTrue(io.outputs.isEmpty());
-        assertEquals(2, model.requests.size());
+        assertEquals(3, model.requests.size());
+        assertEquals(
+                2,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
     }
 
     @AfterEach
@@ -221,6 +252,7 @@ class CustomAgentExecutorTest {
 
     private static final class CapturingModel implements StreamingChatModel {
         private final CopyOnWriteArrayList<ChatRequest> requests = new CopyOnWriteArrayList<>();
+        private final ArrayDeque<String> structuredResponses = new ArrayDeque<>();
         private boolean throwOnResponseFormat;
         private String structuredResponse = "{\"summary\":\"structured\"}";
 
@@ -231,8 +263,9 @@ class CustomAgentExecutorTest {
                 if (throwOnResponseFormat) {
                     throw new IllegalArgumentException("provider rejected response schema");
                 }
+                var responseText = structuredResponses.isEmpty() ? structuredResponse : structuredResponses.remove();
                 handler.onCompleteResponse(ChatResponse.builder()
-                        .aiMessage(new AiMessage(structuredResponse))
+                        .aiMessage(new AiMessage(responseText))
                         .build());
                 return;
             }

--- a/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
@@ -22,6 +22,7 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -88,6 +89,7 @@ class CustomAgentExecutorTest {
         assertEquals(2, model.requests.size());
         assertNull(model.requests.getFirst().parameters().responseFormat());
         assertTrue(model.requests.get(1).parameters().responseFormat() != null);
+        assertEquals(4096, model.requests.get(1).parameters().maxCompletionTokens());
         assertEquals(
                 1,
                 model.requests.stream()
@@ -169,6 +171,8 @@ class CustomAgentExecutorTest {
         var retryRequestText = ((UserMessage) model.requests.get(2).messages().get(1)).singleText();
         assertTrue(retryRequestText.contains("response.summary is required"));
         assertTrue(retryRequestText.contains("<invalid_previous_response>"));
+        assertEquals(4096, model.requests.get(1).parameters().maxCompletionTokens());
+        assertEquals(4096, model.requests.get(2).parameters().maxCompletionTokens());
     }
 
     @Test
@@ -190,6 +194,28 @@ class CustomAgentExecutorTest {
                 model.requests.stream()
                         .filter(request -> request.parameters().responseFormat() != null)
                         .count());
+    }
+
+    @Test
+    void schemaBackedPartialFinalAnswerFailsWithoutRepairRetry() throws Exception {
+        setUpHarness(true);
+        model.structuredLengthResponse = true;
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.LLM_ERROR, result.stopDetails().reason());
+        assertTrue(result.stopDetails().explanation().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"));
+        assertTrue(result.stopDetails().explanation().contains("exceeded 4096 completion tokens"));
+        assertTrue(io.outputs.isEmpty());
+        assertEquals(2, model.requests.size());
+        assertEquals(
+                1,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+        assertEquals(4096, model.requests.get(1).parameters().maxCompletionTokens());
     }
 
     @AfterEach
@@ -254,6 +280,7 @@ class CustomAgentExecutorTest {
         private final CopyOnWriteArrayList<ChatRequest> requests = new CopyOnWriteArrayList<>();
         private final ArrayDeque<String> structuredResponses = new ArrayDeque<>();
         private boolean throwOnResponseFormat;
+        private boolean structuredLengthResponse;
         private String structuredResponse = "{\"summary\":\"structured\"}";
 
         @Override
@@ -262,6 +289,13 @@ class CustomAgentExecutorTest {
             if (chatRequest.parameters().responseFormat() != null) {
                 if (throwOnResponseFormat) {
                     throw new IllegalArgumentException("provider rejected response schema");
+                }
+                if (structuredLengthResponse) {
+                    handler.onCompleteResponse(ChatResponse.builder()
+                            .aiMessage(new AiMessage("{\"summary\":\"unterminated"))
+                            .finishReason(FinishReason.LENGTH)
+                            .build());
+                    return;
                 }
                 var responseText = structuredResponses.isEmpty() ? structuredResponse : structuredResponses.remove();
                 handler.onCompleteResponse(ChatResponse.builder()

--- a/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
@@ -10,10 +10,12 @@ import ai.brokk.ContextManager;
 import ai.brokk.LlmOutputMeta;
 import ai.brokk.Service;
 import ai.brokk.TaskResult;
+import ai.brokk.executor.jobs.JobSpec;
 import ai.brokk.executor.jobs.ResponseSchemaFixtures;
 import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
 import ai.brokk.testutil.NoOpConsoleIO;
+import ai.brokk.util.Json;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessageType;
@@ -76,6 +78,34 @@ class CustomAgentExecutorTest {
     }
 
     @Test
+    void structuredFinalPromptKeepsRepairInstructionsStrictAndMinimal() {
+        var prompt = CustomAgentExecutor.formatStructuredFinalPrompt(
+                "Return a lane summary.",
+                "{\"limits\":\"only one file reviewed\"}",
+                "<workspace_toc>app.js</workspace_toc>");
+
+        assertTrue(prompt.contains("Return only the JSON object"));
+        assertTrue(prompt.contains("Do not include markdown, commentary, copied schema, or explanation"));
+        assertTrue(prompt.contains("Preserve all evidence from the candidate"));
+        assertTrue(prompt.contains("Only fix JSON shape/types to match the schema"));
+    }
+
+    @Test
+    void structuredFinalRetryPromptKeepsRepairInstructionsStrictAndMinimal() {
+        var prompt = CustomAgentExecutor.formatStructuredFinalRetryPrompt(
+                "Return a lane summary.",
+                "{\"limits\":\"only one file reviewed\"}",
+                "<workspace_toc>app.js</workspace_toc>",
+                "{\"limits\":\"only one file reviewed\"}",
+                "response.limits expected array, got string");
+
+        assertTrue(prompt.contains("Return only the JSON object"));
+        assertTrue(prompt.contains("Do not include markdown, commentary, copied schema, or explanation"));
+        assertTrue(prompt.contains("Preserve all evidence from the candidate"));
+        assertTrue(prompt.contains("Only fix JSON shape/types to match the schema"));
+    }
+
+    @Test
     void schemaBackedExecutionAppliesResponseFormatToFinalRequest() throws Exception {
         setUpHarness(true);
         var io = new RecordingConsoleIO();
@@ -89,7 +119,91 @@ class CustomAgentExecutorTest {
         assertEquals(2, model.requests.size());
         assertNull(model.requests.getFirst().parameters().responseFormat());
         assertTrue(model.requests.get(1).parameters().responseFormat() != null);
-        assertEquals(4096, model.requests.get(1).parameters().maxCompletionTokens());
+        assertEquals(192, model.requests.get(1).parameters().maxCompletionTokens());
+        assertEquals(
+                1,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+    }
+
+    @Test
+    void schemaBackedExecutionAcceptsValidTerminalJsonWithoutRewrite() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = "{\"summary\":\"from-terminal\"}";
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals("{\"summary\":\"from-terminal\"}", result.stopDetails().explanation());
+        assertEquals(List.of("{\"summary\":\"from-terminal\"}"), io.outputs);
+        assertEquals(1, model.requests.size());
+        assertEquals(
+                0,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+    }
+
+    @Test
+    void schemaBackedExecutionDeterministicallyNormalizesTerminalJsonWithoutRewrite() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText =
+                """
+                {
+                  "role": "code-quality-comment-intent",
+                  "completion_reason": "done",
+                  "found": [{
+                    "confidence": 1.0,
+                    "metric_value": 0,
+                    "path": "app.js",
+                    "metric_source": "reportCommentDensityForFiles",
+                    "extra": "drop me"
+                  }],
+                  "limits": "only app.js reviewed"
+                }
+                """
+                        .stripIndent();
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals(1, model.requests.size());
+        assertEquals(
+                0,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertEquals("0", output.get("found").get(0).get("metric_value").textValue());
+        assertEquals("high", output.get("found").get(0).get("confidence").textValue());
+        assertEquals("only app.js reviewed", output.get("limits").get(0).textValue());
+        assertEquals("app.js", output.get("found").get(0).get("path").textValue());
+        assertEquals(
+                "reportCommentDensityForFiles",
+                output.get("found").get(0).get("metric_source").textValue());
+        assertFalse(output.get("found").get(0).has("extra"));
+        assertEquals(List.of(result.stopDetails().explanation()), io.outputs);
+    }
+
+    @Test
+    void schemaBackedExecutionStillRepairsInvalidTerminalJson() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = "{\"summary\":null}";
+        model.structuredResponse = "{\"summary\":\"repaired\"}";
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals("{\"summary\":\"repaired\"}", result.stopDetails().explanation());
+        assertEquals(List.of("{\"summary\":\"repaired\"}"), io.outputs);
+        assertEquals(2, model.requests.size());
         assertEquals(
                 1,
                 model.requests.stream()
@@ -171,8 +285,8 @@ class CustomAgentExecutorTest {
         var retryRequestText = ((UserMessage) model.requests.get(2).messages().get(1)).singleText();
         assertTrue(retryRequestText.contains("response.summary is required"));
         assertTrue(retryRequestText.contains("<invalid_previous_response>"));
-        assertEquals(4096, model.requests.get(1).parameters().maxCompletionTokens());
-        assertEquals(4096, model.requests.get(2).parameters().maxCompletionTokens());
+        assertEquals(192, model.requests.get(1).parameters().maxCompletionTokens());
+        assertEquals(192, model.requests.get(2).parameters().maxCompletionTokens());
     }
 
     @Test
@@ -207,7 +321,8 @@ class CustomAgentExecutorTest {
 
         assertEquals(TaskResult.StopReason.LLM_ERROR, result.stopDetails().reason());
         assertTrue(result.stopDetails().explanation().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"));
-        assertTrue(result.stopDetails().explanation().contains("exceeded 4096 completion tokens"));
+        assertTrue(result.stopDetails().explanation().contains("finishReason=LENGTH"));
+        assertTrue(result.stopDetails().explanation().contains("schema=StrictReport"));
         assertTrue(io.outputs.isEmpty());
         assertEquals(2, model.requests.size());
         assertEquals(
@@ -215,7 +330,7 @@ class CustomAgentExecutorTest {
                 model.requests.stream()
                         .filter(request -> request.parameters().responseFormat() != null)
                         .count());
-        assertEquals(4096, model.requests.get(1).parameters().maxCompletionTokens());
+        assertEquals(192, model.requests.get(1).parameters().maxCompletionTokens());
     }
 
     @AfterEach
@@ -253,6 +368,42 @@ class CustomAgentExecutorTest {
                 "schema-agent", "desc", List.of("answer"), 1, "You are a custom test agent.", "project");
     }
 
+    private static JobSpec.ResponseSchema specialistSchema() throws Exception {
+        return new JobSpec.ResponseSchema(
+                "SlopCopSpecialist",
+                Json.getMapper()
+                        .readTree(
+                                """
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "role": { "type": "string" },
+                                    "completion_reason": { "type": "string" },
+                                    "found": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "confidence": { "type": "string", "enum": ["low", "medium", "high"] },
+                                          "metric_value": { "type": "string" },
+                                          "path": { "type": "string" },
+                                          "metric_source": { "type": "string" }
+                                        },
+                                        "required": ["confidence", "metric_value", "path", "metric_source"],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "limits": {
+                                      "type": "array",
+                                      "items": { "type": "string" }
+                                    }
+                                  },
+                                  "required": ["role", "completion_reason", "found", "limits"],
+                                  "additionalProperties": false
+                                }
+                                """));
+    }
+
     private static final class CapturingService extends ai.brokk.testutil.TestService {
         private final StreamingChatModel model;
         private final boolean supportsJsonSchema;
@@ -282,6 +433,7 @@ class CustomAgentExecutorTest {
         private boolean throwOnResponseFormat;
         private boolean structuredLengthResponse;
         private String structuredResponse = "{\"summary\":\"structured\"}";
+        private String terminalAnswerText = "plain notes";
 
         @Override
         public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
@@ -307,7 +459,7 @@ class CustomAgentExecutorTest {
                     .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
                             .id("answer-1")
                             .name("answer")
-                            .arguments(ai.brokk.util.Json.toJson(Map.of("explanation", "plain notes")))
+                            .arguments(ai.brokk.util.Json.toJson(Map.of("explanation", terminalAnswerText)))
                             .build()))
                     .build());
         }

--- a/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
@@ -145,6 +145,22 @@ class CustomAgentExecutorTest {
                         .count());
     }
 
+    @Test
+    void schemaBackedInvalidFinalAnswerReturnsHardErrorWithoutMarkdownFallback() throws Exception {
+        setUpHarness(true);
+        model.structuredResponse = "{\"summary\":null}";
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.LLM_ERROR, result.stopDetails().reason());
+        assertTrue(result.stopDetails().explanation().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"));
+        assertTrue(result.stopDetails().explanation().contains("response.summary is required"));
+        assertTrue(io.outputs.isEmpty());
+        assertEquals(2, model.requests.size());
+    }
+
     @AfterEach
     void tearDown() {
         if (cm != null) {
@@ -206,6 +222,7 @@ class CustomAgentExecutorTest {
     private static final class CapturingModel implements StreamingChatModel {
         private final CopyOnWriteArrayList<ChatRequest> requests = new CopyOnWriteArrayList<>();
         private boolean throwOnResponseFormat;
+        private String structuredResponse = "{\"summary\":\"structured\"}";
 
         @Override
         public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
@@ -215,7 +232,7 @@ class CustomAgentExecutorTest {
                     throw new IllegalArgumentException("provider rejected response schema");
                 }
                 handler.onCompleteResponse(ChatResponse.builder()
-                        .aiMessage(new AiMessage("{\"summary\":\"structured\"}"))
+                        .aiMessage(new AiMessage(structuredResponse))
                         .build());
                 return;
             }

--- a/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
@@ -22,6 +22,9 @@ import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
@@ -78,24 +81,31 @@ class CustomAgentExecutorTest {
     }
 
     @Test
-    void structuredFinalPromptKeepsRepairInstructionsStrictAndMinimal() {
+    void structuredFinalPromptKeepsRepairInstructionsStrictAndMinimal() throws Exception {
         var prompt = CustomAgentExecutor.formatStructuredFinalPrompt(
                 "Return a lane summary.",
                 "{\"limits\":\"only one file reviewed\"}",
-                "<workspace_toc>app.js</workspace_toc>");
+                "<workspace_toc>app.js</workspace_toc>",
+                ResponseSchemaFixtures.validResponseSchema().schema(),
+                "response.limits expected array, got string");
 
         assertTrue(prompt.contains("Return only the JSON object"));
         assertTrue(prompt.contains("Do not include markdown, commentary, copied schema, or explanation"));
         assertTrue(prompt.contains("Preserve all evidence from the candidate"));
         assertTrue(prompt.contains("Only fix JSON shape/types to match the schema"));
+        assertTrue(prompt.contains("<response_schema>"));
+        assertTrue(prompt.contains("Validation error: response.limits expected array, got string"));
+        assertTrue(prompt.contains("Array fields must remain arrays"));
+        assertTrue(prompt.contains("Unknown properties are forbidden"));
     }
 
     @Test
-    void structuredFinalRetryPromptKeepsRepairInstructionsStrictAndMinimal() {
+    void structuredFinalRetryPromptKeepsRepairInstructionsStrictAndMinimal() throws Exception {
         var prompt = CustomAgentExecutor.formatStructuredFinalRetryPrompt(
                 "Return a lane summary.",
                 "{\"limits\":\"only one file reviewed\"}",
                 "<workspace_toc>app.js</workspace_toc>",
+                ResponseSchemaFixtures.validResponseSchema().schema(),
                 "{\"limits\":\"only one file reviewed\"}",
                 "response.limits expected array, got string");
 
@@ -103,6 +113,10 @@ class CustomAgentExecutorTest {
         assertTrue(prompt.contains("Do not include markdown, commentary, copied schema, or explanation"));
         assertTrue(prompt.contains("Preserve all evidence from the candidate"));
         assertTrue(prompt.contains("Only fix JSON shape/types to match the schema"));
+        assertTrue(prompt.contains("<response_schema>"));
+        assertTrue(prompt.contains("Validation error: response.limits expected array, got string"));
+        assertTrue(prompt.contains("Enum fields must use only declared enum values"));
+        assertTrue(prompt.contains("Do not invent prose"));
     }
 
     @Test
@@ -125,6 +139,30 @@ class CustomAgentExecutorTest {
                 model.requests.stream()
                         .filter(request -> request.parameters().responseFormat() != null)
                         .count());
+    }
+
+    @Test
+    void schemaBackedExecutionPreservesStrictArrayObjectSchemaInResponseFormat() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = "{\"role\":null}";
+        model.structuredResponse = validLaneJson();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, new RecordingConsoleIO(), specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict lane summary.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        var responseFormat = model.requests.get(1).parameters().responseFormat();
+        assertTrue(responseFormat != null);
+        var root = (JsonObjectSchema) responseFormat.jsonSchema().rootElement();
+        assertEquals(
+                List.of("role", "tool_call_count", "completion_reason", "tried", "found", "looked", "limits"),
+                root.required());
+        assertEquals(Boolean.FALSE, root.additionalProperties());
+        var found = (JsonArraySchema) root.properties().get("found");
+        var foundItem = (JsonObjectSchema) found.items();
+        assertEquals(Boolean.FALSE, foundItem.additionalProperties());
+        assertTrue(foundItem.properties().get("confidence") instanceof JsonEnumSchema);
+        assertEquals(List.of("confidence", "metric_value", "path", "metric_source"), foundItem.required());
     }
 
     @Test
@@ -185,7 +223,9 @@ class CustomAgentExecutorTest {
                 """
                 {
                   "role": "code-quality-comment-intent",
+                  "tool_call_count": 9,
                   "completion_reason": "done",
+                  "tried": ["reportCommentDensityForFiles"],
                   "found": [{
                     "confidence": 1.0,
                     "metric_value": 0,
@@ -193,6 +233,7 @@ class CustomAgentExecutorTest {
                     "metric_source": "reportCommentDensityForFiles",
                     "extra": "drop me"
                   }],
+                  "looked": ["app.js"],
                   "limits": "only app.js reviewed"
                 }
                 """
@@ -228,13 +269,16 @@ class CustomAgentExecutorTest {
                 """
                 {
                   "role": "code-quality-comment-intent",
+                  "tool_call_count": 9,
                   "completion_reason": "done",
+                  "tried": ["reportCommentDensityForFiles"],
                   "found": {
                     "confidence": 1.0,
                     "metric_value": 0,
                     "path": "app.js",
                     "metric_source": "reportCommentDensityForFiles"
                   },
+                  "looked": ["app.js"],
                   "limits": ["only app.js reviewed"]
                 }
                 """
@@ -252,6 +296,178 @@ class CustomAgentExecutorTest {
         assertEquals("high", output.get("found").get(0).get("confidence").textValue());
         assertEquals("app.js", output.get("found").get(0).get("path").textValue());
         assertEquals(List.of(result.stopDetails().explanation()), io.outputs);
+    }
+
+    @Test
+    void schemaBackedExecutionRepairsArrayAliasFieldWithoutLlmRepair() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText =
+                """
+                {
+                  "role": "code-quality-comment-intent",
+                  "tool_call_count": 9,
+                  "completion_reason": "done",
+                  "tried": ["reportCommentDensityForFiles"],
+                  "found_items": [{
+                    "confidence": "high",
+                    "metric_value": 0,
+                    "path": "app.js",
+                    "metric_source": "reportCommentDensityForFiles"
+                  }],
+                  "looked": ["app.js"],
+                  "limits": ["only app.js reviewed"]
+                }
+                """
+                        .stripIndent();
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals(1, model.requests.size());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertTrue(output.get("found").isArray());
+        assertFalse(output.has("found_items"));
+        assertEquals("0", output.get("found").get(0).get("metric_value").textValue());
+    }
+
+    @Test
+    void schemaBackedExecutionRepairsFlattenedArrayObjectFieldsWithoutLlmRepair() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText =
+                """
+                {
+                  "role": "code-quality-comment-intent",
+                  "tool_call_count": 9,
+                  "completion_reason": "done",
+                  "tried": ["reportCommentDensityForFiles"],
+                  "found_confidence": "high confidence",
+                  "found_metric_value": 0,
+                  "found_path": "app.js",
+                  "found_metric_source": "reportCommentDensityForFiles",
+                  "looked": ["app.js"],
+                  "limits": ["only app.js reviewed"]
+                }
+                """
+                        .stripIndent();
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals(1, model.requests.size());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertEquals("high", output.get("found").get(0).get("confidence").textValue());
+        assertEquals("0", output.get("found").get(0).get("metric_value").textValue());
+        assertFalse(output.has("found_path"));
+    }
+
+    @Test
+    void schemaBackedExecutionSalvagesInvalidStringItemsAfterLlmRepairFails() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = laneJsonWithFound("[\"status\", \"confidence\"]");
+        model.structuredResponses.add(laneJsonWithFound("[\"status\", \"confidence\"]"));
+        model.structuredResponses.add(laneJsonWithFound("[\"status\", \"confidence\"]"));
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals(3, model.requests.size());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertTrue(output.get("found").isArray());
+        assertEquals(0, output.get("found").size());
+    }
+
+    @Test
+    void schemaBackedExecutionNormalizesVerboseConfidenceOnlyUnderEnumSchema() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = laneJsonWithFound(
+                """
+                [{
+                  "confidence": "high confidence",
+                  "metric_value": 0,
+                  "path": "app.js",
+                  "metric_source": "reportCommentDensityForFiles"
+                }]
+                """
+                        .stripIndent());
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals(1, model.requests.size());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertEquals("high", output.get("found").get(0).get("confidence").textValue());
+    }
+
+    @Test
+    void schemaBackedExecutionRejectsUnsupportedConfidenceWithRepairTrace() throws Exception {
+        setUpHarness(true);
+        var invalid = laneJsonWithFound(
+                """
+                [{
+                  "confidence": "certain",
+                  "metric_value": "0",
+                  "path": "app.js",
+                  "metric_source": "reportCommentDensityForFiles"
+                }]
+                """
+                        .stripIndent());
+        model.terminalAnswerText = invalid;
+        model.structuredResponses.add(invalid);
+        model.structuredResponses.add(invalid);
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.LLM_ERROR, result.stopDetails().reason());
+        assertTrue(result.stopDetails().explanation().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"));
+        assertTrue(result.stopDetails().explanation().contains("originalValidation=response.found[0].confidence"));
+        assertTrue(result.stopDetails().explanation().contains("finalValidation=response.found[0].confidence"));
+        assertTrue(result.stopDetails().explanation().contains("llmRepairAttempted=true"));
+        assertTrue(result.stopDetails().explanation().contains("salvageAttempted=true"));
+        assertTrue(io.outputs.isEmpty());
+    }
+
+    @Test
+    void schemaBackedExecutionSalvagesFlattenedLlmRepairOutputInsteadOfAcceptingIt() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = "{\"role\":null}";
+        var flattened =
+                """
+                {
+                  "role": "code-quality-comment-intent",
+                  "tool_call_count": 9,
+                  "completion_reason": "done",
+                  "tried": ["reportCommentDensityForFiles"],
+                  "found_confidence": "high",
+                  "found_metric_value": 0,
+                  "found_path": "app.js",
+                  "found_metric_source": "reportCommentDensityForFiles",
+                  "looked": ["app.js"],
+                  "limits": ["only app.js reviewed"]
+                }
+                """
+                        .stripIndent();
+        model.structuredResponses.add(flattened);
+        model.structuredResponses.add(flattened);
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals(3, model.requests.size());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertFalse(output.has("found_path"));
+        assertEquals("app.js", output.get("found").get(0).get("path").textValue());
     }
 
     @Test
@@ -466,6 +682,35 @@ class CustomAgentExecutorTest {
                 "schema-agent", "desc", List.of("answer"), 1, "You are a custom test agent.", "project");
     }
 
+    private static String validLaneJson() {
+        return laneJsonWithFound(
+                """
+                [{
+                  "confidence": "high",
+                  "metric_value": "0",
+                  "path": "app.js",
+                  "metric_source": "reportCommentDensityForFiles"
+                }]
+                """
+                        .stripIndent());
+    }
+
+    private static String laneJsonWithFound(String foundJson) {
+        return """
+                {
+                  "role": "code-quality-comment-intent",
+                  "tool_call_count": 9,
+                  "completion_reason": "done",
+                  "tried": ["reportCommentDensityForFiles"],
+                  "found": %s,
+                  "looked": ["app.js"],
+                  "limits": ["only app.js reviewed"]
+                }
+                """
+                .formatted(foundJson)
+                .stripIndent();
+    }
+
     private static JobSpec.ResponseSchema specialistSchema() throws Exception {
         return new JobSpec.ResponseSchema(
                 "SlopCopSpecialist",
@@ -476,7 +721,12 @@ class CustomAgentExecutorTest {
                                   "type": "object",
                                   "properties": {
                                     "role": { "type": "string" },
+                                    "tool_call_count": { "type": "integer" },
                                     "completion_reason": { "type": "string" },
+                                    "tried": {
+                                      "type": "array",
+                                      "items": { "type": "string" }
+                                    },
                                     "found": {
                                       "type": "array",
                                       "items": {
@@ -494,9 +744,13 @@ class CustomAgentExecutorTest {
                                     "limits": {
                                       "type": "array",
                                       "items": { "type": "string" }
+                                    },
+                                    "looked": {
+                                      "type": "array",
+                                      "items": { "type": "string" }
                                     }
                                   },
-                                  "required": ["role", "completion_reason", "found", "limits"],
+                                  "required": ["role", "tool_call_count", "completion_reason", "tried", "found", "looked", "limits"],
                                   "additionalProperties": false
                                 }
                                 """));

--- a/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
@@ -148,6 +148,37 @@ class CustomAgentExecutorTest {
     }
 
     @Test
+    void schemaBackedExecutionAcceptsValidExplanationTextEnvelopeWithoutRewrite() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = Json.toJson(Map.of("explanation", "{\"summary\":\"from-envelope\"}"));
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals("{\"summary\":\"from-envelope\"}", result.stopDetails().explanation());
+        assertEquals(List.of("{\"summary\":\"from-envelope\"}"), io.outputs);
+        assertEquals(1, model.requests.size());
+    }
+
+    @Test
+    void schemaBackedExecutionAcceptsValidExplanationObjectEnvelopeWithoutRewrite() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = Json.toJson(Map.of("explanation", Map.of("summary", "from-object")));
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertEquals("from-object", output.get("summary").textValue());
+        assertEquals(List.of(result.stopDetails().explanation()), io.outputs);
+        assertEquals(1, model.requests.size());
+    }
+
+    @Test
     void schemaBackedExecutionDeterministicallyNormalizesTerminalJsonWithoutRewrite() throws Exception {
         setUpHarness(true);
         model.terminalAnswerText =
@@ -191,6 +222,39 @@ class CustomAgentExecutorTest {
     }
 
     @Test
+    void schemaBackedExecutionWrapsObjectWhenSchemaExpectsArray() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText =
+                """
+                {
+                  "role": "code-quality-comment-intent",
+                  "completion_reason": "done",
+                  "found": {
+                    "confidence": 1.0,
+                    "metric_value": 0,
+                    "path": "app.js",
+                    "metric_source": "reportCommentDensityForFiles"
+                  },
+                  "limits": ["only app.js reviewed"]
+                }
+                """
+                        .stripIndent();
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, specialistSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals(1, model.requests.size());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertTrue(output.get("found").isArray());
+        assertEquals("0", output.get("found").get(0).get("metric_value").textValue());
+        assertEquals("high", output.get("found").get(0).get("confidence").textValue());
+        assertEquals("app.js", output.get("found").get(0).get("path").textValue());
+        assertEquals(List.of(result.stopDetails().explanation()), io.outputs);
+    }
+
+    @Test
     void schemaBackedExecutionStillRepairsInvalidTerminalJson() throws Exception {
         setUpHarness(true);
         model.terminalAnswerText = "{\"summary\":null}";
@@ -209,6 +273,40 @@ class CustomAgentExecutorTest {
                 model.requests.stream()
                         .filter(request -> request.parameters().responseFormat() != null)
                         .count());
+    }
+
+    @Test
+    void schemaBackedExecutionRepairsExtractedCandidateInsteadOfAnswerEnvelope() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = Json.toJson(Map.of("explanation", "{\"summary\":null}"));
+        model.structuredResponse = "{\"summary\":\"repaired\"}";
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        assertEquals("{\"summary\":\"repaired\"}", result.stopDetails().explanation());
+        assertEquals(2, model.requests.size());
+        var repairRequestText = ((UserMessage) model.requests.get(1).messages().get(1)).singleText();
+        assertTrue(repairRequestText.contains("<custom_agent_final_notes>\n{\"summary\":null}"));
+        assertFalse(repairRequestText.contains("\"explanation\""));
+    }
+
+    @Test
+    void schemaBackedExecutionReportsMissingSchemaAnswerCandidate() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = " ";
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.LLM_ERROR, result.stopDetails().reason());
+        assertTrue(result.stopDetails().explanation().contains("RESPONSE_SCHEMA_OUTPUT_MISSING"));
+        assertTrue(result.stopDetails().explanation().contains("schema=StrictReport"));
+        assertTrue(io.outputs.isEmpty());
+        assertEquals(1, model.requests.size());
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/agents/ParallelCustomAgentTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/ParallelCustomAgentTest.java
@@ -153,6 +153,28 @@ class ParallelCustomAgentTest {
     }
 
     @Test
+    void sequentialSchemaBackedAgentEmitsArtifactWhenLaunchFails() throws Exception {
+        try (var harness = Harness.create(tempDir, true)) {
+            var sink = new CapturingArtifactSink("parent-job-1");
+            var tools = new CustomAgentTools(harness.cm(), harness.model(), schemaRegistry(), sink);
+
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> tools.callCustomAgentWithSchema(
+                            "missing-schema-agent", "Return a strict report.", "StrictReport"));
+
+            assertEquals(1, sink.artifacts().size());
+            var artifact = sink.artifacts().getFirst();
+            assertEquals("parent-job-1", artifact.parentJobId());
+            assertEquals("missing-schema-agent", artifact.agentName());
+            assertEquals("StrictReport", artifact.responseSchemaName());
+            assertEquals(ChildAgentArtifact.STATUS_FAILED, artifact.status());
+            assertNotNull(artifact.errorMessage());
+            assertTrue(artifact.errorMessage().contains("Custom agent not found"));
+        }
+    }
+
+    @Test
     void parallelSchemaBackedAgentsReturnOneStructuredResultPerChild() throws Exception {
         try (var harness = Harness.create(tempDir, true)) {
             harness.cm().getAgentStore().save(agentDef(), "project");

--- a/app/src/test/java/ai/brokk/executor/agents/ParallelCustomAgentTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/ParallelCustomAgentTest.java
@@ -9,6 +9,7 @@ import ai.brokk.ContextManager;
 import ai.brokk.Service;
 import ai.brokk.TaskResult;
 import ai.brokk.executor.jobs.ResponseSchemaFixtures;
+import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
 import ai.brokk.testutil.NoOpConsoleIO;
@@ -17,6 +18,7 @@ import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.Json;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
@@ -25,6 +27,7 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.Nullable;
@@ -65,9 +68,8 @@ class ParallelCustomAgentTest {
                 .build();
     }
 
-    private static String schemaSource() {
-        return "Use this response schema for child reports:\n"
-                + Json.toJson(ResponseSchemaFixtures.validResponseSchemaMap());
+    private static ResponseSchemaRegistry schemaRegistry() {
+        return ResponseSchemaRegistry.of(List.of(ResponseSchemaFixtures.validResponseSchema()));
     }
 
     @Test
@@ -132,10 +134,22 @@ class ParallelCustomAgentTest {
     }
 
     @Test
+    void sequentialSchemaBackedAgentResolvesSchemaNameFromParentRegistry() throws Exception {
+        try (var harness = Harness.create(tempDir, true)) {
+            harness.cm().getAgentStore().save(agentDef(), "project");
+            var tools = new CustomAgentTools(harness.cm(), harness.model(), schemaRegistry());
+
+            var result = tools.callCustomAgentWithSchema("schema-agent", "Return a strict report.", "StrictReport");
+
+            assertEquals("{\"summary\":\"structured\"}", result);
+        }
+    }
+
+    @Test
     void parallelSchemaBackedAgentsReturnOneStructuredResultPerChild() throws Exception {
         try (var harness = Harness.create(tempDir, true)) {
             harness.cm().getAgentStore().save(agentDef(), "project");
-            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaSource());
+            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaRegistry());
             var tr = harness.cm()
                     .getToolRegistry()
                     .builder()
@@ -157,10 +171,41 @@ class ParallelCustomAgentTest {
     }
 
     @Test
-    void parallelSchemaBackedAgentResolvesSchemaNameFromParentTask() throws Exception {
+    void parallelSchemaBackedAgentsCollectSiblingResultsAfterFatalChild() throws Exception {
+        try (var harness = Harness.create(tempDir, true)) {
+            var badAgentPrompt = "You are the bad schema test agent.";
+            var goodAgentPrompt = "You are the good schema test agent.";
+            harness.cm().getAgentStore().save(agentDef("bad-schema-agent", badAgentPrompt), "project");
+            harness.cm().getAgentStore().save(agentDef("good-schema-agent", goodAgentPrompt), "project");
+            harness.model().structuredResponsesBySystemPrompt.put(badAgentPrompt, "{\"summary\":null}");
+            harness.model().structuredResponsesBySystemPrompt.put(goodAgentPrompt, "{\"summary\":\"structured\"}");
+            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaRegistry());
+            var tr = harness.cm()
+                    .getToolRegistry()
+                    .builder()
+                    .register(parallelCustomAgent)
+                    .build();
+
+            var result = parallelCustomAgent.execute(
+                    List.of(
+                            schemaNameRequest("call-1", "bad-schema-agent"),
+                            schemaNameRequest("call-2", "good-schema-agent")),
+                    tr);
+
+            assertEquals(TaskResult.StopReason.LLM_ERROR, result.stopDetails().reason());
+            assertEquals(2, result.toolExecutionMessages().size());
+            assertTrue(result.toolExecutionMessages().getFirst().text().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"));
+            assertEquals(
+                    "{\"summary\":\"structured\"}",
+                    result.toolExecutionMessages().get(1).text());
+        }
+    }
+
+    @Test
+    void parallelSchemaBackedAgentResolvesSchemaNameFromParentRegistry() throws Exception {
         try (var harness = Harness.create(tempDir, true)) {
             harness.cm().getAgentStore().save(agentDef(), "project");
-            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaSource());
+            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaRegistry());
             var tr = harness.cm()
                     .getToolRegistry()
                     .builder()
@@ -182,7 +227,7 @@ class ParallelCustomAgentTest {
     void parallelSchemaBackedAgentRejectsBlankSchemaNameAsRequestError() throws Exception {
         try (var harness = Harness.create(tempDir, true)) {
             harness.cm().getAgentStore().save(agentDef(), "project");
-            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaSource());
+            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaRegistry());
             var tr = harness.cm()
                     .getToolRegistry()
                     .builder()
@@ -211,10 +256,33 @@ class ParallelCustomAgentTest {
 
             assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
             assertEquals(1, result.toolExecutionMessages().size());
-            assertTrue(result.toolExecutionMessages()
-                    .getFirst()
-                    .text()
-                    .contains("responseSchemaName 'StrictReport' was not found in the parent task schemas"));
+            assertTrue(
+                    result.toolExecutionMessages()
+                            .getFirst()
+                            .text()
+                            .contains(
+                                    "responseSchemaName 'StrictReport' was not found in the parent task schemas. Available schemas: []"));
+        }
+    }
+
+    @Test
+    void parallelSchemaBackedAgentDoesNotScanPromptTextForSchemas() throws Exception {
+        try (var harness = Harness.create(tempDir, true)) {
+            harness.cm().getAgentStore().save(agentDef(), "project");
+            var promptWithSchema =
+                    "Schema in text only:\n" + Json.toJson(ResponseSchemaFixtures.validResponseSchemaMap());
+            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model());
+            var tr = harness.cm()
+                    .getToolRegistry()
+                    .builder()
+                    .register(parallelCustomAgent)
+                    .build();
+
+            assertTrue(promptWithSchema.contains("StrictReport"));
+            var result = parallelCustomAgent.execute(List.of(schemaNameRequest("call-1", "schema-agent")), tr);
+
+            assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+            assertTrue(result.toolExecutionMessages().getFirst().text().contains("Available schemas: []"));
         }
     }
 
@@ -222,7 +290,7 @@ class ParallelCustomAgentTest {
     void parallelSchemaBackedAgentUnsupportedModelIsHardFailure() throws Exception {
         try (var harness = Harness.create(tempDir, false)) {
             harness.cm().getAgentStore().save(agentDef(), "project");
-            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaSource());
+            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaRegistry());
             var tr = harness.cm()
                     .getToolRegistry()
                     .builder()
@@ -242,8 +310,11 @@ class ParallelCustomAgentTest {
     }
 
     private static AgentDefinition agentDef() {
-        return new AgentDefinition(
-                "schema-agent", "desc", List.of("answer"), 1, "You are a custom test agent.", "project");
+        return agentDef("schema-agent", "You are a custom test agent.");
+    }
+
+    private static AgentDefinition agentDef(String name, String systemPrompt) {
+        return new AgentDefinition(name, "desc", List.of("answer"), 1, systemPrompt, "project");
     }
 
     private record Harness(ContextManager cm, CapturingModel model) implements AutoCloseable {
@@ -301,9 +372,20 @@ class ParallelCustomAgentTest {
     }
 
     private static final class CapturingModel implements StreamingChatModel {
+        private final Map<String, String> structuredResponsesBySystemPrompt = new HashMap<>();
+
         @Override
         public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
             if (chatRequest.parameters().responseFormat() != null) {
+                if (chatRequest.messages().getFirst() instanceof SystemMessage systemMessage) {
+                    var configuredResponse = structuredResponsesBySystemPrompt.get(systemMessage.text());
+                    if (configuredResponse != null) {
+                        handler.onCompleteResponse(ChatResponse.builder()
+                                .aiMessage(new AiMessage(configuredResponse))
+                                .build());
+                        return;
+                    }
+                }
                 handler.onCompleteResponse(ChatResponse.builder()
                         .aiMessage(new AiMessage("{\"summary\":\"structured\"}"))
                         .build());

--- a/app/src/test/java/ai/brokk/executor/agents/ParallelCustomAgentTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/ParallelCustomAgentTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.AbstractService;
 import ai.brokk.ContextManager;
+import ai.brokk.IConsoleIO;
 import ai.brokk.Service;
 import ai.brokk.TaskResult;
 import ai.brokk.executor.jobs.ChildAgentArtifact;
@@ -16,6 +17,7 @@ import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
 import ai.brokk.testutil.NoOpConsoleIO;
+import ai.brokk.tools.ApprovalResult;
 import ai.brokk.tools.ToolExecutionResult;
 import ai.brokk.tools.ToolRegistry;
 import ai.brokk.util.Json;
@@ -255,6 +257,33 @@ class ParallelCustomAgentTest {
     }
 
     @Test
+    void parallelSchemaBackedAgentEmitsArtifactWhenOuterFutureFails() throws Exception {
+        try (var harness = Harness.create(tempDir, true, new ThrowingBeforeToolCallConsole())) {
+            var sink = new CapturingArtifactSink("parent-job-1");
+            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaRegistry(), sink);
+            var tr = harness.cm()
+                    .getToolRegistry()
+                    .builder()
+                    .register(parallelCustomAgent)
+                    .build();
+
+            var result = parallelCustomAgent.execute(List.of(schemaNameRequest("call-1", "schema-agent")), tr);
+
+            assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+            assertEquals(1, result.toolExecutionMessages().size());
+            assertEquals(1, sink.artifacts().size());
+            var artifact = sink.artifacts().getFirst();
+            assertEquals("parent-job-1", artifact.parentJobId());
+            assertEquals("call-1", artifact.toolCallId());
+            assertEquals("schema-agent", artifact.agentName());
+            assertEquals("StrictReport", artifact.responseSchemaName());
+            assertEquals(ChildAgentArtifact.STATUS_FAILED, artifact.status());
+            assertNotNull(artifact.errorMessage());
+            assertTrue(artifact.errorMessage().contains("beforeToolCall failed"));
+        }
+    }
+
+    @Test
     void parallelSchemaBackedAgentResolvesSchemaNameFromParentRegistry() throws Exception {
         try (var harness = Harness.create(tempDir, true)) {
             harness.cm().getAgentStore().save(agentDef(), "project");
@@ -372,6 +401,10 @@ class ParallelCustomAgentTest {
 
     private record Harness(ContextManager cm, CapturingModel model) implements AutoCloseable {
         static Harness create(Path tempDir, boolean supportsJsonSchema) throws Exception {
+            return create(tempDir, supportsJsonSchema, new NoOpConsoleIO());
+        }
+
+        static Harness create(Path tempDir, boolean supportsJsonSchema, IConsoleIO io) throws Exception {
             var workspaceDir = tempDir.resolve("workspace");
             Files.createDirectories(workspaceDir.resolve(".brokk/llm-history"));
             Files.writeString(workspaceDir.resolve(".brokk/project.properties"), "# test", StandardCharsets.UTF_8);
@@ -391,13 +424,20 @@ class ParallelCustomAgentTest {
                 }
             };
             var cm = new ContextManager(project, provider);
-            cm.createHeadless(true, new NoOpConsoleIO());
+            cm.createHeadless(true, io);
             return new Harness(cm, model);
         }
 
         @Override
         public void close() {
             cm.close();
+        }
+    }
+
+    private static final class ThrowingBeforeToolCallConsole extends NoOpConsoleIO {
+        @Override
+        public ApprovalResult beforeToolCall(ToolExecutionRequest request, boolean destructive) {
+            throw new IllegalStateException("beforeToolCall failed");
         }
     }
 

--- a/app/src/test/java/ai/brokk/executor/agents/ParallelCustomAgentTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/ParallelCustomAgentTest.java
@@ -1,6 +1,7 @@
 package ai.brokk.executor.agents;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -8,6 +9,8 @@ import ai.brokk.AbstractService;
 import ai.brokk.ContextManager;
 import ai.brokk.Service;
 import ai.brokk.TaskResult;
+import ai.brokk.executor.jobs.ChildAgentArtifact;
+import ai.brokk.executor.jobs.ChildAgentArtifactSink;
 import ai.brokk.executor.jobs.ResponseSchemaFixtures;
 import ai.brokk.executor.jobs.ResponseSchemaRegistry;
 import ai.brokk.project.IProject;
@@ -27,6 +30,8 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -202,6 +207,54 @@ class ParallelCustomAgentTest {
     }
 
     @Test
+    void parallelSchemaBackedAgentsEmitArtifactsForValidAndInvalidSiblings() throws Exception {
+        try (var harness = Harness.create(tempDir, true)) {
+            var badAgentPrompt = "You are the bad schema artifact agent.";
+            var goodAgentPrompt = "You are the good schema artifact agent.";
+            harness.cm().getAgentStore().save(agentDef("bad-schema-agent", badAgentPrompt), "project");
+            harness.cm().getAgentStore().save(agentDef("good-schema-agent", goodAgentPrompt), "project");
+            harness.model().structuredResponsesBySystemPrompt.put(badAgentPrompt, "{\"summary\":null}");
+            harness.model().structuredResponsesBySystemPrompt.put(goodAgentPrompt, "{\"summary\":\"structured\"}");
+            var sink = new CapturingArtifactSink("parent-job-1");
+            var parallelCustomAgent = new ParallelCustomAgent(harness.cm(), harness.model(), schemaRegistry(), sink);
+            var tr = harness.cm()
+                    .getToolRegistry()
+                    .builder()
+                    .register(parallelCustomAgent)
+                    .build();
+
+            var result = parallelCustomAgent.execute(
+                    List.of(
+                            schemaNameRequest("call-1", "bad-schema-agent"),
+                            schemaNameRequest("call-2", "good-schema-agent")),
+                    tr);
+
+            assertEquals(TaskResult.StopReason.LLM_ERROR, result.stopDetails().reason());
+            assertEquals(2, sink.artifacts().size());
+            var artifacts = sink.artifacts().stream()
+                    .sorted(Comparator.comparing(ChildAgentArtifact::toolCallId))
+                    .toList();
+            var invalid = artifacts.get(0);
+            assertEquals("parent-job-1", invalid.parentJobId());
+            assertEquals("call-1", invalid.toolCallId());
+            assertEquals("bad-schema-agent", invalid.agentName());
+            assertEquals(ChildAgentArtifact.STATUS_SCHEMA_INVALID, invalid.status());
+            assertNotNull(invalid.validationError());
+            assertTrue(invalid.validationError().contains("response.summary"));
+            assertNotNull(invalid.invalidOutputExcerpt());
+            assertTrue(invalid.invalidOutputExcerpt().contains("\"summary\":null"));
+
+            var success = artifacts.get(1);
+            assertEquals("call-2", success.toolCallId());
+            assertEquals("good-schema-agent", success.agentName());
+            assertEquals(ChildAgentArtifact.STATUS_SUCCESS, success.status());
+            assertNotNull(success.validatedResponse());
+            assertEquals(
+                    "structured", success.validatedResponse().get("summary").asText());
+        }
+    }
+
+    @Test
     void parallelSchemaBackedAgentResolvesSchemaNameFromParentRegistry() throws Exception {
         try (var harness = Harness.create(tempDir, true)) {
             harness.cm().getAgentStore().save(agentDef(), "project");
@@ -345,6 +398,29 @@ class ParallelCustomAgentTest {
         @Override
         public void close() {
             cm.close();
+        }
+    }
+
+    private static final class CapturingArtifactSink implements ChildAgentArtifactSink {
+        private final String parentJobId;
+        private final List<ChildAgentArtifact> artifacts = new ArrayList<>();
+
+        CapturingArtifactSink(String parentJobId) {
+            this.parentJobId = parentJobId;
+        }
+
+        @Override
+        public void record(ChildAgentArtifact artifact) {
+            artifacts.add(artifact);
+        }
+
+        @Override
+        public String parentJobId() {
+            return parentJobId;
+        }
+
+        List<ChildAgentArtifact> artifacts() {
+            return List.copyOf(artifacts);
         }
     }
 

--- a/app/src/test/java/ai/brokk/executor/agents/SchemaFailureDiagnosticsTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/SchemaFailureDiagnosticsTest.java
@@ -1,0 +1,60 @@
+package ai.brokk.executor.agents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SchemaFailureDiagnosticsTest {
+    @Test
+    void parsesSingleLineFinalValidationAndExcerpt() {
+        var text = "RESPONSE_SCHEMA_OUTPUT_INVALID: schema=StrictReport "
+                + "finalValidation=response.found is required "
+                + "invalidOutputExcerpt={\"found\":null} finishReason=complete";
+
+        assertEquals("response.found is required", SchemaFailureDiagnostics.validationError(text));
+        assertEquals("{\"found\":null}", SchemaFailureDiagnostics.invalidOutputExcerpt(text));
+        assertEquals("complete", SchemaFailureDiagnostics.finishReason(text));
+    }
+
+    @Test
+    void parsesNewlineSeparatedDiagnostics() {
+        var text =
+                """
+                RESPONSE_SCHEMA_OUTPUT_INVALID
+                schema=StrictReport
+                candidateSource=answer.explanation.text
+                finalValidation=response.metadata is required
+                invalidOutputExcerpt={"summary":"partial"}
+                finishReason=LENGTH
+                """;
+
+        assertEquals("response.metadata is required", SchemaFailureDiagnostics.validationError(text));
+        assertEquals("{\"summary\":\"partial\"}", SchemaFailureDiagnostics.invalidOutputExcerpt(text));
+        assertEquals("LENGTH", SchemaFailureDiagnostics.finishReason(text));
+    }
+
+    @Test
+    void fallsBackFromFinalValidationToOriginalValidationToLegacyValidation() {
+        assertEquals(
+                "response.summary is required",
+                SchemaFailureDiagnostics.validationError(
+                        "originalValidation=response.summary is required invalidOutputExcerpt={}"));
+        assertEquals(
+                "response.found is required",
+                SchemaFailureDiagnostics.validationError(
+                        "validation=response.found is required invalidOutputExcerpt={}"));
+        assertEquals(
+                "response.summary is required",
+                SchemaFailureDiagnostics.validationError(
+                        "finalValidation=null originalValidation=response.summary is required"));
+    }
+
+    @Test
+    void doesNotOverrunIntoNextKeyOrMatchEmbeddedKeyName() {
+        var text = "notfinalValidation=wrong finalValidation=response.summary is required "
+                + "invalidOutputExcerpt={\"summary\":null}";
+
+        assertEquals("response.summary is required", SchemaFailureDiagnostics.validationError(text));
+        assertEquals("{\"summary\":null}", SchemaFailureDiagnostics.invalidOutputExcerpt(text));
+    }
+}

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
@@ -23,6 +23,7 @@ import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -187,12 +188,42 @@ class JobRunnerResponseSchemaTest {
     }
 
     @Test
-    void schemaBackedDirectAnswerInvalidOutputFailsJob() throws Exception {
+    void schemaBackedDirectAnswerInvalidOutputRetriesWithSchemaFeedback() throws Exception {
+        model.structuredResponses.add("{\"summary\":null}");
+        model.structuredResponses.add("{\"summary\":\"repaired\"}");
+        var spec = spec(Map.of("mode", "ASK"), null, ResponseSchemaFixtures.validResponseSchema());
+
+        runner.runAsync("ask-schema-invalid-output", spec, new RawMessagesConsole())
+                .get(5, TimeUnit.SECONDS);
+
+        assertEquals(
+                JobStatus.State.COMPLETED.name(),
+                requireNonNull(store.loadStatus("ask-schema-invalid-output")).state());
+        assertEquals(
+                2,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+        var responseFormatRequests = model.requests.stream()
+                .filter(request -> request.parameters().responseFormat() != null)
+                .toList();
+        var retryRequestText = ((dev.langchain4j.data.message.UserMessage) responseFormatRequests
+                        .get(1)
+                        .messages()
+                        .get(responseFormatRequests.get(1).messages().size() - 1))
+                .singleText();
+        assertTrue(retryRequestText.contains("response.summary"));
+        assertTrue(retryRequestText.contains("<invalid_previous_response>"));
+        assertTrue(retryRequestText.contains("Include every required top-level field"));
+    }
+
+    @Test
+    void schemaBackedDirectAnswerInvalidOutputFailsAfterRepairAttempt() throws Exception {
         model.structuredResponse = "{\"summary\":null}";
         var spec = spec(Map.of("mode", "ASK"), null, ResponseSchemaFixtures.validResponseSchema());
 
         var thrown = assertThrows(ExecutionException.class, () -> runner.runAsync(
-                        "ask-schema-invalid-output", spec, new RawMessagesConsole())
+                        "ask-schema-invalid-output-final", spec, new RawMessagesConsole())
                 .get(5, TimeUnit.SECONDS));
 
         var cause = requireNonNull(thrown.getCause());
@@ -203,7 +234,13 @@ class JobRunnerResponseSchemaTest {
         assertTrue(cause.getMessage().contains("response.summary is required"), cause.getMessage());
         assertEquals(
                 JobStatus.State.FAILED.name(),
-                requireNonNull(store.loadStatus("ask-schema-invalid-output")).state());
+                requireNonNull(store.loadStatus("ask-schema-invalid-output-final"))
+                        .state());
+        assertEquals(
+                2,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
     }
 
     private static JobSpec spec(
@@ -228,7 +265,8 @@ class JobRunnerResponseSchemaTest {
                 false,
                 JobSpec.DEFAULT_MAX_ISSUE_FIX_ATTEMPTS,
                 executionPolicy,
-                responseSchema);
+                responseSchema,
+                List.of());
     }
 
     private ChatRequest responseFormatRequest() {
@@ -261,6 +299,7 @@ class JobRunnerResponseSchemaTest {
 
     private static final class CapturingModel implements StreamingChatModel {
         private final CopyOnWriteArrayList<ChatRequest> requests = new CopyOnWriteArrayList<>();
+        private final ArrayDeque<String> structuredResponses = new ArrayDeque<>();
         private boolean throwOnResponseFormat;
         private String structuredResponse = "{\"summary\":\"ok\"}";
 
@@ -270,8 +309,11 @@ class JobRunnerResponseSchemaTest {
             if (throwOnResponseFormat && chatRequest.parameters().responseFormat() != null) {
                 throw new IllegalArgumentException("provider rejected response schema");
             }
+            var responseText = chatRequest.parameters().responseFormat() == null
+                    ? structuredResponse
+                    : structuredResponses.isEmpty() ? structuredResponse : structuredResponses.remove();
             handler.onCompleteResponse(ChatResponse.builder()
-                    .aiMessage(new AiMessage(structuredResponse))
+                    .aiMessage(new AiMessage(responseText))
                     .build());
         }
     }

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.brokk.AbstractService;
 import ai.brokk.ContextManager;
@@ -185,6 +186,26 @@ class JobRunnerResponseSchemaTest {
                 requireNonNull(store.loadStatus("ask-schema-rejected")).state());
     }
 
+    @Test
+    void schemaBackedDirectAnswerInvalidOutputFailsJob() throws Exception {
+        model.structuredResponse = "{\"summary\":null}";
+        var spec = spec(Map.of("mode", "ASK"), null, ResponseSchemaFixtures.validResponseSchema());
+
+        var thrown = assertThrows(ExecutionException.class, () -> runner.runAsync(
+                        "ask-schema-invalid-output", spec, new RawMessagesConsole())
+                .get(5, TimeUnit.SECONDS));
+
+        var cause = requireNonNull(thrown.getCause());
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        assertTrue(cause.getMessage().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("response.summary is required"), cause.getMessage());
+        assertEquals(
+                JobStatus.State.FAILED.name(),
+                requireNonNull(store.loadStatus("ask-schema-invalid-output")).state());
+    }
+
     private static JobSpec spec(
             Map<String, String> tags,
             @Nullable JobSpec.ExecutionPolicy executionPolicy,
@@ -241,6 +262,7 @@ class JobRunnerResponseSchemaTest {
     private static final class CapturingModel implements StreamingChatModel {
         private final CopyOnWriteArrayList<ChatRequest> requests = new CopyOnWriteArrayList<>();
         private boolean throwOnResponseFormat;
+        private String structuredResponse = "{\"summary\":\"ok\"}";
 
         @Override
         public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
@@ -249,7 +271,7 @@ class JobRunnerResponseSchemaTest {
                 throw new IllegalArgumentException("provider rejected response schema");
             }
             handler.onCompleteResponse(ChatResponse.builder()
-                    .aiMessage(new AiMessage("{\"summary\":\"ok\"}"))
+                    .aiMessage(new AiMessage(structuredResponse))
                     .build());
         }
     }

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
@@ -13,6 +13,7 @@ import ai.brokk.project.IProject;
 import ai.brokk.project.MainProject;
 import ai.brokk.testutil.NoOpConsoleIO;
 import ai.brokk.testutil.TestService;
+import ai.brokk.util.Json;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -214,7 +215,9 @@ class JobRunnerResponseSchemaTest {
                 .singleText();
         assertTrue(retryRequestText.contains("response.summary"));
         assertTrue(retryRequestText.contains("<invalid_previous_response>"));
+        assertTrue(retryRequestText.contains("<response_schema>"));
         assertTrue(retryRequestText.contains("Include every required top-level field"));
+        assertTrue(retryRequestText.contains("If the schema requires `metadata`"));
     }
 
     @Test
@@ -231,7 +234,12 @@ class JobRunnerResponseSchemaTest {
             cause = cause.getCause();
         }
         assertTrue(cause.getMessage().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("schema=StrictReport"), cause.getMessage());
         assertTrue(cause.getMessage().contains("response.summary is required"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("attempts=2"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("finishReason=unknown"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("initialInvalidOutputExcerpt={\"summary\":null}"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("invalidOutputExcerpt={\"summary\":null}"), cause.getMessage());
         assertEquals(
                 JobStatus.State.FAILED.name(),
                 requireNonNull(store.loadStatus("ask-schema-invalid-output-final"))
@@ -241,6 +249,44 @@ class JobRunnerResponseSchemaTest {
                 model.requests.stream()
                         .filter(request -> request.parameters().responseFormat() != null)
                         .count());
+    }
+
+    @Test
+    void reportOnlySchemaFailureIncludesMetadataValidationAndMalformedOutputExcerpt() throws Exception {
+        model.structuredResponse = "{\"summary\":\"wrong shape\"}";
+        var spec = spec(
+                Map.of(), new JobSpec.ExecutionPolicy(JobSpec.ExecutionPolicyPreset.REPORT_ONLY), synthesisSchema());
+
+        var thrown = assertThrows(ExecutionException.class, () -> runner.runAsync(
+                        "report-schema-invalid-output-final", spec, new RawMessagesConsole())
+                .get(5, TimeUnit.SECONDS));
+
+        var cause = rootCause(thrown);
+        assertTrue(cause.getMessage().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("schema=SlopCopFinalSynthesis"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("validation=response.metadata is required"), cause.getMessage());
+        assertTrue(
+                cause.getMessage().contains("invalidOutputExcerpt={\"summary\":\"wrong shape\"}"), cause.getMessage());
+        assertEquals(
+                JobStatus.State.FAILED.name(),
+                requireNonNull(store.loadStatus("report-schema-invalid-output-final"))
+                        .state());
+    }
+
+    @Test
+    void schemaBackedDirectAnswerFailureTruncatesInvalidOutputExcerpt() throws Exception {
+        var longValue = "x".repeat(7_000);
+        model.structuredResponse = "{\"summary\":\"" + longValue + "\"}";
+        var spec = spec(Map.of("mode", "ASK"), null, synthesisSchema());
+
+        var thrown = assertThrows(ExecutionException.class, () -> runner.runAsync(
+                        "ask-schema-invalid-output-truncated", spec, new RawMessagesConsole())
+                .get(5, TimeUnit.SECONDS));
+
+        var cause = rootCause(thrown);
+        assertTrue(cause.getMessage().contains("RESPONSE_SCHEMA_OUTPUT_INVALID"), cause.getMessage());
+        assertTrue(cause.getMessage().contains("[truncated invalid response: "), cause.getMessage());
+        assertTrue(cause.getMessage().contains("chars omitted]"), cause.getMessage());
     }
 
     private static JobSpec spec(
@@ -274,6 +320,39 @@ class JobRunnerResponseSchemaTest {
                 .filter(request -> request.parameters().responseFormat() != null)
                 .findFirst()
                 .orElseThrow();
+    }
+
+    private static Throwable rootCause(Throwable throwable) {
+        var cause = requireNonNull(throwable.getCause());
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
+
+    private static JobSpec.ResponseSchema synthesisSchema() throws Exception {
+        return new JobSpec.ResponseSchema(
+                "SlopCopFinalSynthesis",
+                Json.getMapper()
+                        .readTree(
+                                """
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "metadata": {
+                                      "type": "object",
+                                      "properties": {
+                                        "scan_id": { "type": "string" }
+                                      },
+                                      "required": ["scan_id"],
+                                      "additionalProperties": false
+                                    },
+                                    "summary": { "type": "string" }
+                                  },
+                                  "required": ["metadata", "summary"],
+                                  "additionalProperties": false
+                                }
+                                """));
     }
 
     private static final class CapturingService extends TestService {

--- a/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobStoreTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -163,6 +164,68 @@ class JobStoreTest {
         assertTrue(loadedSpec.isReportOnly());
         assertEquals(sessionId.toString(), loadedSpec.tags().get("session_id"));
         assertNull(loadedSpec.tags().get("github_token"));
+    }
+
+    @Test
+    void childAgentArtifacts_appendAndReadJsonl(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var result = store.createOrGetJob("idem-key-child-artifacts", JobSpec.of("test task", DEFAULT_PLANNER_MODEL));
+        var response = com.fasterxml.jackson.databind.json.JsonMapper.builder()
+                .build()
+                .readTree("{\"summary\":\"structured\"}");
+        var success = new ChildAgentArtifact(
+                result.jobId(),
+                "child-1",
+                "call-1",
+                "schema-agent",
+                "StrictReport",
+                ChildAgentArtifact.STATUS_SUCCESS,
+                response,
+                null,
+                null,
+                null,
+                12L,
+                "stub-model",
+                null,
+                null,
+                null);
+        var invalid = new ChildAgentArtifact(
+                result.jobId(),
+                "child-2",
+                "call-2",
+                "schema-agent",
+                "StrictReport",
+                ChildAgentArtifact.STATUS_SCHEMA_INVALID,
+                null,
+                "response.summary is required",
+                "{}",
+                null,
+                4L,
+                "stub-model",
+                null,
+                null,
+                null);
+
+        store.appendChildAgentArtifact(result.jobId(), success);
+        store.appendChildAgentArtifact(result.jobId(), invalid);
+
+        var artifacts = store.readChildAgentArtifacts(result.jobId());
+        assertEquals(2, artifacts.size());
+        assertEquals("child-1", artifacts.get(0).childRunId());
+        assertEquals(
+                "structured",
+                artifacts.get(0).validatedResponse().get("summary").asText());
+        assertEquals("child-2", artifacts.get(1).childRunId());
+        assertEquals("response.summary is required", artifacts.get(1).validationError());
+    }
+
+    @Test
+    void childAgentArtifacts_missingFileReturnsEmpty(@TempDir Path tempDir) throws Exception {
+        var store = new JobStore(tempDir);
+        var result =
+                store.createOrGetJob("idem-key-no-child-artifacts", JobSpec.of("test task", DEFAULT_PLANNER_MODEL));
+
+        assertEquals(List.of(), store.readChildAgentArtifacts(result.jobId()));
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/jobs/ResponseSchemaRegistryTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/ResponseSchemaRegistryTest.java
@@ -1,0 +1,62 @@
+package ai.brokk.executor.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ResponseSchemaRegistryTest {
+    @Test
+    void resolvesSchemasByStrippedName() {
+        var schema = new JobSpec.ResponseSchema(
+                " StrictReport ", ResponseSchemaFixtures.validResponseSchema().schema());
+
+        var registry = ResponseSchemaRegistry.of(List.of(schema));
+
+        assertTrue(registry.resolve("StrictReport").isPresent());
+        assertTrue(registry.resolve(" StrictReport ").isPresent());
+        assertEquals(List.of("StrictReport"), List.copyOf(registry.names()));
+    }
+
+    @Test
+    void rejectsBlankNames() {
+        var schema = new JobSpec.ResponseSchema(
+                " ", ResponseSchemaFixtures.validResponseSchema().schema());
+
+        var thrown = assertThrows(IllegalArgumentException.class, () -> ResponseSchemaRegistry.of(List.of(schema)));
+
+        assertEquals("responseSchema.name is required", thrown.getMessage());
+    }
+
+    @Test
+    void rejectsDuplicateNamesAfterStripping() {
+        var schema = ResponseSchemaFixtures.validResponseSchema();
+        var duplicate = new JobSpec.ResponseSchema(" StrictReport ", schema.schema());
+
+        var thrown = assertThrows(
+                IllegalArgumentException.class, () -> ResponseSchemaRegistry.of(List.of(schema, duplicate)));
+
+        assertEquals("Duplicate response schema name: StrictReport", thrown.getMessage());
+    }
+
+    @Test
+    void rejectsInvalidSchemas() {
+        var schema = new JobSpec.ResponseSchema(
+                "Broken", ResponseSchemaFixtures.validResponseSchema().schema().get("properties"));
+
+        var thrown = assertThrows(IllegalArgumentException.class, () -> ResponseSchemaRegistry.of(List.of(schema)));
+
+        assertTrue(thrown.getMessage().contains("schema type is required"));
+    }
+
+    @Test
+    void emptyRegistryHasNoNames() {
+        var registry = ResponseSchemaRegistry.empty();
+
+        assertFalse(registry.resolve("StrictReport").isPresent());
+        assertTrue(registry.names().isEmpty());
+    }
+}

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.brokk.ContextManager;
 import ai.brokk.Service;
 import ai.brokk.executor.JobReservation;
+import ai.brokk.executor.jobs.ChildAgentArtifact;
 import ai.brokk.executor.jobs.ErrorPayload;
 import ai.brokk.executor.jobs.JobRunner;
 import ai.brokk.executor.jobs.JobSpec;
@@ -138,6 +139,47 @@ class JobsRouterValidationTest {
         assertEquals(201, exchange.responseCode());
         var response = MAPPER.readValue(exchange.responseBodyBytes(), Map.class);
         assertNotNull(response.get("jobId"));
+    }
+
+    @Test
+    void getJobResult_includesTerminalStateAndChildAgentArtifacts() throws Exception {
+        var create = jobStore.createOrGetJob("idem-key-result", JobSpec.of("test task", "gpt-4"));
+        var jobId = create.jobId();
+        jobStore.updateStatus(jobId, JobStatus.queued(jobId).completed(Map.of("answer", "done")));
+        var validatedResponse = MAPPER.readTree("{\"summary\":\"structured\"}");
+        jobStore.appendChildAgentArtifact(
+                jobId,
+                new ChildAgentArtifact(
+                        jobId,
+                        "child-1",
+                        "call-1",
+                        "schema-agent",
+                        "StrictReport",
+                        ChildAgentArtifact.STATUS_SUCCESS,
+                        validatedResponse,
+                        null,
+                        null,
+                        null,
+                        12L,
+                        "stub-model",
+                        null,
+                        null,
+                        null));
+
+        var exchange = TestHttpExchange.request("GET", "/v1/jobs/" + jobId + "/result");
+
+        jobsRouter.handle(exchange);
+
+        assertEquals(200, exchange.responseCode());
+        var payload = MAPPER.readTree(exchange.responseBodyBytes());
+        assertEquals(jobId, payload.get("jobId").asText());
+        assertEquals("COMPLETED", payload.get("state").asText());
+        assertTrue(payload.get("terminal").asBoolean());
+        var artifact = payload.get("childAgentArtifacts").get(0);
+        assertEquals("schema-agent", artifact.get("agentName").asText());
+        assertEquals("success", artifact.get("status").asText());
+        assertEquals(
+                "structured", artifact.get("validatedResponse").get("summary").asText());
     }
 
     @Test
@@ -1012,6 +1054,13 @@ class JobsRouterValidationTest {
             ex.uri = URI.create(path);
             ex.requestHeaders.set("Content-Type", "application/json");
             ex.requestBodyBytes = MAPPER.writeValueAsBytes(body);
+            return ex;
+        }
+
+        static TestHttpExchange request(String method, String path) {
+            var ex = new TestHttpExchange();
+            ex.method = method;
+            ex.uri = URI.create(path);
             return ex;
         }
 

--- a/brokk-shared/src/main/java/ai/brokk/util/TextMatcher.java
+++ b/brokk-shared/src/main/java/ai/brokk/util/TextMatcher.java
@@ -19,11 +19,80 @@ public sealed interface TextMatcher permits TextMatcher.Literal, TextMatcher.Reg
         if (isLiteralPattern(pattern)) {
             return Literal.create(pattern, flags);
         }
+        validateSafeRegex(pattern);
         try {
             return new Regex(pattern, Pattern.compile(pattern, flags));
         } catch (PatternSyntaxException e) {
             return Literal.create(pattern, flags);
         }
+    }
+
+    static void validateSafeRegex(String pattern) {
+        if (containsBackreference(pattern)) {
+            throw new IllegalArgumentException(
+                    "regex backreferences are not supported in file-content search because they can cause excessive backtracking");
+        }
+        if (containsNestedUnboundedQuantifier(pattern)) {
+            throw new IllegalArgumentException(
+                    "nested unbounded regex quantifiers are not supported in file-content search because they can cause excessive backtracking");
+        }
+    }
+
+    private static boolean containsBackreference(String pattern) {
+        for (int i = 0; i + 1 < pattern.length(); i++) {
+            if (pattern.charAt(i) != '\\') {
+                continue;
+            }
+            char next = pattern.charAt(i + 1);
+            if (next >= '1' && next <= '9') {
+                return true;
+            }
+            if (next == 'k' && i + 2 < pattern.length() && pattern.charAt(i + 2) == '<') {
+                return true;
+            }
+            if (next == '\\') {
+                i++;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsNestedUnboundedQuantifier(String pattern) {
+        int groupStart = -1;
+        boolean groupHasUnboundedQuantifier = false;
+        boolean escaped = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char current = pattern.charAt(i);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (current == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (current == '(' && groupStart < 0) {
+                groupStart = i;
+                groupHasUnboundedQuantifier = false;
+                continue;
+            }
+            if (groupStart < 0) {
+                continue;
+            }
+            if (current == '*' || current == '+') {
+                groupHasUnboundedQuantifier = true;
+                continue;
+            }
+            if (current == ')' && i + 1 < pattern.length()) {
+                char next = pattern.charAt(i + 1);
+                if (groupHasUnboundedQuantifier && (next == '*' || next == '+')) {
+                    return true;
+                }
+                groupStart = -1;
+                groupHasUnboundedQuantifier = false;
+            }
+        }
+        return false;
     }
 
     static boolean isLiteralPattern(String pattern) {

--- a/brokk-shared/src/test/java/ai/brokk/util/TextMatcherTest.java
+++ b/brokk-shared/src/test/java/ai/brokk/util/TextMatcherTest.java
@@ -1,0 +1,41 @@
+package ai.brokk.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class TextMatcherTest {
+    @Test
+    void compileRejectsBackreferencesBeforeMatching() {
+        var error = assertThrows(
+                IllegalArgumentException.class,
+                () -> TextMatcher.compile("for\\s+(\\w+)\\s+in\\s+.*self\\.assertEqual\\(\\1,\\s*\\1\\)", 0));
+
+        assertTrue(error.getMessage().contains("backreferences"));
+    }
+
+    @Test
+    void compileRejectsNestedUnboundedQuantifiersBeforeMatching() {
+        var error = assertThrows(
+                IllegalArgumentException.class,
+                () -> TextMatcher.compile("for\\s+\\w+\\s+in\\s+.*:\\s+(?:[^\\n]+\\n\\s+)*self\\.assertEqual", 0));
+
+        assertTrue(error.getMessage().contains("nested unbounded regex quantifiers"));
+    }
+
+    @Test
+    void compileStillAllowsSimpleRegex() {
+        var matcher = TextMatcher.compile("foo.*bar", 0);
+
+        assertInstanceOf(TextMatcher.Regex.class, matcher);
+        assertTrue(matcher.find("fooXYZbar", null));
+    }
+
+    @Test
+    void compileStillFallsBackToLiteralForInvalidRegex() {
+        var matcher = TextMatcher.compile("_show_welcome_message(", 0);
+
+        assertInstanceOf(TextMatcher.Literal.class, matcher);
+        assertTrue(matcher.find("def _show_welcome_message(self):", null));
+    }
+}


### PR DESCRIPTION
### Summary
- Add post-generation validation for schema-backed outputs in `JobRunner` and `CustomAgentExecutor` so malformed JSON now fails instead of being treated as success.
- Keep the existing provider-side response format request, but surface invalid outputs as `RESPONSE_SCHEMA_OUTPUT_INVALID` with a hard failure path.
- Extend tests to cover invalid direct answers, invalid custom-agent finals, and the retry flow for schema-backed custom-agent output.

### Testing
- `./gradlew :app:test --tests ai.brokk.executor.jobs.JobRunnerResponseSchemaTest --tests ai.brokk.executor.agents.CustomAgentExecutorTest`