### PR TITLE
Fix schema string output coercion

### DIFF
--- a/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
+++ b/app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
@@ -379,6 +379,11 @@ public class CustomAgentExecutor {
                     return new TaskResult(
                             context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, candidate.json()));
                 }
+                var coercedResult =
+                        coerceSuccessfulOutput(schema, candidate.json(), candidate.source(), "terminal output");
+                if (coercedResult != null) {
+                    return coercedResult;
+                }
                 validationErrors.put(candidate.source(), validationError.get());
             }
 
@@ -404,6 +409,11 @@ public class CustomAgentExecutor {
                         return new TaskResult(
                                 context,
                                 new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, normalizedCandidate.json()));
+                    }
+                    var coercedResult = coerceSuccessfulOutput(
+                            schema, normalizedCandidate.json(), candidate.source(), "normalized terminal output");
+                    if (coercedResult != null) {
+                        return coercedResult;
                     }
                 }
             }
@@ -471,6 +481,11 @@ public class CustomAgentExecutor {
                     return new TaskResult(
                             context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, structuredText));
                 }
+                var coercedResult =
+                        coerceSuccessfulOutput(schema, structuredText, repairCandidate.source(), "repair output");
+                if (coercedResult != null) {
+                    return coercedResult;
+                }
                 trace.finalValidationError = validationError.get();
 
                 if (attempt == 2) {
@@ -511,6 +526,11 @@ public class CustomAgentExecutor {
                     return new TaskResult(
                             context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, salvage.json()));
                 }
+                var coercedResult =
+                        coerceSuccessfulOutput(schema, salvage.json(), repairCandidate.source(), "salvage output");
+                if (coercedResult != null) {
+                    return coercedResult;
+                }
                 trace.finalValidationError = salvageValidationError.orElse(trace.finalValidationError);
                 trace.failedRepairOutput = salvage.json();
             }
@@ -523,6 +543,22 @@ public class CustomAgentExecutor {
                     context,
                     new TaskResult.StopDetails(
                             TaskResult.StopReason.LLM_ERROR, SchemaRepairPrompts.failureMessage(schema, trace)));
+        }
+
+        private @Nullable TaskResult coerceSuccessfulOutput(
+                JobSpec.ResponseSchema schema, String output, String source, String outputKind) {
+            var coerced = coerceSchemaOutput(schema, output);
+            if (coerced == null) {
+                return null;
+            }
+            logger.info(
+                    "Schema-aware custom-agent {} coerced deterministically for schema {} from {}: {}",
+                    outputKind,
+                    schema.name(),
+                    source,
+                    coerced.changes());
+            io.llmOutput(coerced.json(), ChatMessageType.AI, LlmOutputMeta.newMessage());
+            return new TaskResult(context, new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, coerced.json()));
         }
     }
 
@@ -588,6 +624,14 @@ public class CustomAgentExecutor {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    private static @Nullable NormalizedCandidate coerceSchemaOutput(JobSpec.ResponseSchema schema, String candidate) {
+        var coerced = JobResponseSchemaSupport.coerceValidOutput(schema, candidate);
+        if (coerced.isEmpty()) {
+            return null;
+        }
+        return new NormalizedCandidate(coerced.get().json(), coerced.get().changes());
     }
 
     private static JsonNode normalizeNode(

--- a/app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
@@ -3,6 +3,8 @@ package ai.brokk.executor.jobs;
 import ai.brokk.util.Json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
@@ -35,6 +37,8 @@ public final class JobResponseSchemaSupport {
     private static final Set<String> ARRAY_KEYS = Set.of("type", "description", "items");
     private static final Set<String> STRING_KEYS = Set.of("type", "description", "enum");
     private static final Set<String> SCALAR_KEYS = Set.of("type", "description");
+
+    public record CoercedOutput(String json, List<String> changes) {}
 
     private JobResponseSchemaSupport() {}
 
@@ -94,6 +98,38 @@ public final class JobResponseSchemaSupport {
             return Optional.of(
                     Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName()));
         }
+    }
+
+    public static Optional<CoercedOutput> coerceOutput(JobSpec.ResponseSchema responseSchema, @Nullable String output) {
+        if (output == null || output.isBlank()) {
+            return Optional.empty();
+        }
+
+        JsonNode root;
+        try {
+            root = Json.getMapper().readTree(output);
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
+
+        var changes = new ArrayList<String>();
+        var coerced = coerceOutputNode(root, responseSchema.schema(), "response", changes);
+        if (changes.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new CoercedOutput(Json.toJson(coerced), List.copyOf(changes)));
+    }
+
+    public static Optional<CoercedOutput> coerceValidOutput(
+            JobSpec.ResponseSchema responseSchema, @Nullable String output) {
+        var coerced = coerceOutput(responseSchema, output);
+        if (coerced.isEmpty()) {
+            return Optional.empty();
+        }
+        if (validateOutput(responseSchema, coerced.get().json()).isPresent()) {
+            return Optional.empty();
+        }
+        return coerced;
     }
 
     private static JsonSchemaElement toElement(JsonNode node, String path, Limits limits) {
@@ -331,6 +367,101 @@ public final class JobResponseSchemaSupport {
             }
             throw new IllegalArgumentException(path + " has value outside enum");
         }
+    }
+
+    private static JsonNode coerceOutputNode(JsonNode value, JsonNode schema, String path, List<String> changes) {
+        if (value.isNull()) {
+            return value;
+        }
+
+        return switch (typeOf(schema)) {
+            case "object" -> coerceOutputObject(value, schema, path, changes);
+            case "array" -> coerceOutputArray(value, schema, path, changes);
+            case "string" -> coerceOutputString(value, schema, path, changes);
+            default -> value;
+        };
+    }
+
+    private static JsonNode coerceOutputObject(JsonNode value, JsonNode schema, String path, List<String> changes) {
+        if (!value.isObject()) {
+            return value;
+        }
+
+        var properties = schema.get("properties");
+        if (properties == null || !properties.isObject()) {
+            return value;
+        }
+
+        var object = (ObjectNode) value.deepCopy();
+        properties.properties().forEach(entry -> {
+            var child = object.get(entry.getKey());
+            if (child != null) {
+                object.set(
+                        entry.getKey(),
+                        coerceOutputNode(child, entry.getValue(), path + "." + entry.getKey(), changes));
+            }
+        });
+        return object;
+    }
+
+    private static JsonNode coerceOutputArray(JsonNode value, JsonNode schema, String path, List<String> changes) {
+        if (!value.isArray()) {
+            return value;
+        }
+
+        var items = schema.get("items");
+        if (items == null) {
+            return value;
+        }
+
+        var array = Json.getMapper().createArrayNode();
+        for (int i = 0; i < value.size(); i++) {
+            array.add(coerceOutputNode(value.get(i), items, path + "[" + i + "]", changes));
+        }
+        return array;
+    }
+
+    private static JsonNode coerceOutputString(JsonNode value, JsonNode schema, String path, List<String> changes) {
+        if (schema.get("enum") != null || value.isTextual() || value.isNull()) {
+            return value;
+        }
+
+        if (value.isArray()) {
+            var arrayString = arrayToString(value);
+            if (arrayString.isPresent()) {
+                changes.add(path + " array -> string");
+                return TextNode.valueOf(arrayString.get());
+            }
+        }
+
+        if (value.isNumber() || value.isBoolean()) {
+            changes.add(path + " " + outputTypeOf(value) + " -> string");
+            return TextNode.valueOf(value.asText());
+        }
+
+        return value;
+    }
+
+    private static Optional<String> arrayToString(JsonNode value) {
+        var lines = new ArrayList<String>();
+        for (var element : value) {
+            var line = nodeToString(element);
+            if (line.isEmpty()) {
+                return Optional.empty();
+            }
+            lines.add(line.get());
+        }
+        return Optional.of(String.join("\n", lines));
+    }
+
+    private static Optional<String> nodeToString(JsonNode value) {
+        if (value.isTextual()) {
+            return Optional.of(value.textValue());
+        }
+        if (value.isNumber() || value.isBoolean()) {
+            return Optional.of(value.asText());
+        }
+        return Optional.empty();
     }
 
     private static boolean additionalPropertiesDisabled(JsonNode schema) {

--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -1703,6 +1703,7 @@ public final class JobRunner {
         var activeMessages = messages;
         var maxAttempts = responseSchema == null ? 1 : 2;
         JobLevelSchemaRepairTrace schemaRepairTrace = null;
+        String coercedOutput = null;
         try {
             for (int attempt = 1; attempt <= maxAttempts; attempt++) {
                 response = responseFormat == null
@@ -1718,17 +1719,29 @@ public final class JobRunner {
                 if (responseSchema == null) {
                     break;
                 }
-                var validationError = JobResponseSchemaSupport.validateOutput(responseSchema, response.text());
+                var output = response.text();
+                var validationError = JobResponseSchemaSupport.validateOutput(responseSchema, output);
                 if (validationError.isEmpty()) {
                     break;
                 }
+                var coercion = JobResponseSchemaSupport.coerceValidOutput(responseSchema, output);
+                if (coercion.isPresent()) {
+                    var coerced = coercion.get();
+                    coercedOutput = coerced.json();
+                    logger.info(
+                            "Job-level response schema output coerced deterministically: schema={} paths={}",
+                            responseSchema.name(),
+                            coerced.changes());
+                    cm.getIo().llmOutput(coercedOutput, ChatMessageType.AI, LlmOutputMeta.newMessage());
+                    break;
+                }
                 if (schemaRepairTrace == null) {
-                    schemaRepairTrace = new JobLevelSchemaRepairTrace(
-                            responseSchema.name(), validationError.get(), response.text());
+                    schemaRepairTrace =
+                            new JobLevelSchemaRepairTrace(responseSchema.name(), validationError.get(), output);
                 }
                 schemaRepairTrace.attempts = attempt;
                 schemaRepairTrace.finalValidationError = validationError.get();
-                schemaRepairTrace.invalidOutput = response.text();
+                schemaRepairTrace.invalidOutput = output;
                 schemaRepairTrace.finishReason = finishReason(response);
                 if (attempt == maxAttempts) {
                     var message = schemaRepairTrace.failureMessage();
@@ -1736,7 +1749,7 @@ public final class JobRunner {
                     throw new IllegalArgumentException(message);
                 }
                 activeMessages = directAnswerSchemaRepairMessages(
-                        messages, responseSchema, question, response.text(), validationError.get());
+                        messages, responseSchema, question, output, validationError.get());
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -1745,7 +1758,9 @@ public final class JobRunner {
 
         // Determine stop details based on the response
         if (response != null) {
-            stop = TaskResult.StopDetails.fromResponse(response);
+            stop = coercedOutput == null
+                    ? TaskResult.StopDetails.fromResponse(response)
+                    : new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, coercedOutput);
         }
 
         requireNonNull(stop);

--- a/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
+++ b/app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java
@@ -186,6 +186,27 @@ class CustomAgentExecutorTest {
     }
 
     @Test
+    void schemaBackedExecutionCoercesArrayValuedTerminalStringFieldWithoutRewrite() throws Exception {
+        setUpHarness(true);
+        model.terminalAnswerText = "{\"summary\":[\"one\",\"two\"]}";
+        var io = new RecordingConsoleIO();
+        var executor = new CustomAgentExecutor(cm, agentDef(), model, io, ResponseSchemaFixtures.validResponseSchema());
+
+        var result = executor.executeInterruptibly("Return a strict report.");
+
+        assertEquals(TaskResult.StopReason.SUCCESS, result.stopDetails().reason());
+        var output = Json.getMapper().readTree(result.stopDetails().explanation());
+        assertEquals("one\ntwo", output.get("summary").textValue());
+        assertEquals(List.of(result.stopDetails().explanation()), io.outputs);
+        assertEquals(1, model.requests.size());
+        assertEquals(
+                0,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+    }
+
+    @Test
     void schemaBackedExecutionAcceptsValidExplanationTextEnvelopeWithoutRewrite() throws Exception {
         setUpHarness(true);
         model.terminalAnswerText = Json.toJson(Map.of("explanation", "{\"summary\":\"from-envelope\"}"));

--- a/app/src/test/java/ai/brokk/executor/jobs/JobResponseSchemaSupportTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobResponseSchemaSupportTest.java
@@ -1,0 +1,161 @@
+package ai.brokk.executor.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.brokk.util.Json;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+class JobResponseSchemaSupportTest {
+    @Test
+    void coerceOutputConvertsArrayToStringForStringField() throws Exception {
+        var schema = schema(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "findings": { "type": "string" }
+                  },
+                  "required": ["findings"],
+                  "additionalProperties": false
+                }
+                """);
+
+        var coerced = JobResponseSchemaSupport.coerceOutput(schema, "{\"findings\":[\"one\",\"two\"]}")
+                .orElseThrow();
+
+        assertEquals(
+                "one\ntwo",
+                Json.getMapper().readTree(coerced.json()).get("findings").textValue());
+        assertEquals("response.findings array -> string", coerced.changes().getFirst());
+        assertTrue(
+                JobResponseSchemaSupport.validateOutput(schema, coerced.json()).isEmpty());
+    }
+
+    @Test
+    void coerceOutputLeavesStringArraysAsArrays() throws Exception {
+        var schema = schema(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "observations": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  },
+                  "required": ["observations"],
+                  "additionalProperties": false
+                }
+                """);
+
+        var coerced = JobResponseSchemaSupport.coerceOutput(schema, "{\"observations\":[\"one\",\"two\"]}");
+
+        assertTrue(coerced.isEmpty());
+        assertTrue(JobResponseSchemaSupport.validateOutput(schema, "{\"observations\":[\"one\",\"two\"]}")
+                .isEmpty());
+    }
+
+    @Test
+    void coerceOutputConvertsScalarValuesToStringForStringField() throws Exception {
+        var schema = schema(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "count": { "type": "string" },
+                    "enabled": { "type": "string" }
+                  },
+                  "required": ["count", "enabled"],
+                  "additionalProperties": false
+                }
+                """);
+
+        var coerced = JobResponseSchemaSupport.coerceOutput(schema, "{\"count\":7,\"enabled\":true}")
+                .orElseThrow();
+        var output = Json.getMapper().readTree(coerced.json());
+
+        assertEquals("7", output.get("count").textValue());
+        assertEquals("true", output.get("enabled").textValue());
+        assertTrue(
+                JobResponseSchemaSupport.validateOutput(schema, coerced.json()).isEmpty());
+    }
+
+    @Test
+    void coerceOutputDoesNotCoerceEnumFields() throws Exception {
+        var schema = schema(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "confidence": { "type": "string", "enum": ["low", "medium", "high"] }
+                  },
+                  "required": ["confidence"],
+                  "additionalProperties": false
+                }
+                """);
+
+        assertTrue(JobResponseSchemaSupport.coerceOutput(schema, "{\"confidence\":1}")
+                .isEmpty());
+        assertTrue(JobResponseSchemaSupport.coerceOutput(schema, "{\"confidence\":[\"high\"]}")
+                .isEmpty());
+        assertEquals(
+                "response.confidence expected string, got integer",
+                JobResponseSchemaSupport.validateOutput(schema, "{\"confidence\":1}")
+                        .orElseThrow());
+        assertEquals(
+                "response.confidence expected string, got array",
+                JobResponseSchemaSupport.validateOutput(schema, "{\"confidence\":[\"high\"]}")
+                        .orElseThrow());
+        assertEquals(
+                "response.confidence has value outside enum",
+                JobResponseSchemaSupport.validateOutput(schema, "{\"confidence\":\"certain\"}")
+                        .orElseThrow());
+    }
+
+    @Test
+    void coerceOutputDoesNotCoerceObjectOrNullToString() throws Exception {
+        var schema = schema(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "findings": { "type": "string" }
+                  },
+                  "required": ["findings"],
+                  "additionalProperties": false
+                }
+                """);
+
+        assertTrue(JobResponseSchemaSupport.coerceOutput(schema, "{\"findings\":{\"text\":\"one\"}}")
+                .isEmpty());
+        assertTrue(JobResponseSchemaSupport.coerceOutput(schema, "{\"findings\":null}")
+                .isEmpty());
+        assertTrue(JobResponseSchemaSupport.coerceOutput(schema, "{\"findings\":[{\"text\":\"one\"}]}")
+                .isEmpty());
+        assertTrue(JobResponseSchemaSupport.coerceOutput(schema, "{\"findings\":[null]}")
+                .isEmpty());
+        assertEquals(
+                "response.findings expected string, got object",
+                JobResponseSchemaSupport.validateOutput(schema, "{\"findings\":{\"text\":\"one\"}}")
+                        .orElseThrow());
+        assertEquals(
+                "response.findings is required",
+                JobResponseSchemaSupport.validateOutput(schema, "{\"findings\":null}")
+                        .orElseThrow());
+        assertEquals(
+                "response.findings expected string, got array",
+                JobResponseSchemaSupport.validateOutput(schema, "{\"findings\":[{\"text\":\"one\"}]}")
+                        .orElseThrow());
+        assertEquals(
+                "response.findings expected string, got array",
+                JobResponseSchemaSupport.validateOutput(schema, "{\"findings\":[null]}")
+                        .orElseThrow());
+    }
+
+    private static JobSpec.ResponseSchema schema(String json) throws Exception {
+        JsonNode root = Json.getMapper().readTree(json);
+        return new JobSpec.ResponseSchema("TestSchema", root);
+    }
+}

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
@@ -221,6 +221,24 @@ class JobRunnerResponseSchemaTest {
     }
 
     @Test
+    void schemaBackedDirectAnswerCoercesArrayValuedStringFieldWithoutRetry() throws Exception {
+        model.structuredResponse = "{\"findings\":[\"one\",\"two\"],\"observations\":[\"kept\"]}";
+        var spec = spec(Map.of("mode", "ASK"), null, narrativeSchema());
+
+        runner.runAsync("ask-schema-coerced-string", spec, new RawMessagesConsole())
+                .get(5, TimeUnit.SECONDS);
+
+        assertEquals(
+                JobStatus.State.COMPLETED.name(),
+                requireNonNull(store.loadStatus("ask-schema-coerced-string")).state());
+        assertEquals(
+                1,
+                model.requests.stream()
+                        .filter(request -> request.parameters().responseFormat() != null)
+                        .count());
+    }
+
+    @Test
     void schemaBackedDirectAnswerInvalidOutputFailsAfterRepairAttempt() throws Exception {
         model.structuredResponse = "{\"summary\":null}";
         var spec = spec(Map.of("mode", "ASK"), null, ResponseSchemaFixtures.validResponseSchema());
@@ -350,6 +368,27 @@ class JobRunnerResponseSchemaTest {
                                     "summary": { "type": "string" }
                                   },
                                   "required": ["metadata", "summary"],
+                                  "additionalProperties": false
+                                }
+                                """));
+    }
+
+    private static JobSpec.ResponseSchema narrativeSchema() throws Exception {
+        return new JobSpec.ResponseSchema(
+                "SlopCopSynthesisNarrative",
+                Json.getMapper()
+                        .readTree(
+                                """
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "findings": { "type": "string" },
+                                    "observations": {
+                                      "type": "array",
+                                      "items": { "type": "string" }
+                                    }
+                                  },
+                                  "required": ["findings", "observations"],
                                   "additionalProperties": false
                                 }
                                 """));


### PR DESCRIPTION
### Description
Adds deterministic repair for schema-backed outputs when models return recoverable string-field shapes, such as prose arrays or scalar values where the response schema expects a non-enum string. Strict validation still runs after coercion so unrecoverable shapes continue to fail.

**Key Changes**:
- Add shared schema-output coercion for non-enum string fields, including array/scalar repair and validated-only acceptance.
- Apply the coercion path to job-level direct answers and schema-aware custom-agent terminal/repair outputs.
- Add focused unit and integration coverage for array-to-string, scalar-to-string, enum protection, and JSON object/null boundaries.

**Touch Points**:
- app/src/main/java/ai/brokk/executor/jobs/JobResponseSchemaSupport.java
- app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
- app/src/main/java/ai/brokk/executor/agents/CustomAgentExecutor.java
- app/src/test/java/ai/brokk/executor/jobs/JobResponseSchemaSupportTest.java
- app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
- app/src/test/java/ai/brokk/executor/agents/CustomAgentExecutorTest.java

Validation:
- ./gradlew :app:test --tests ai.brokk.executor.jobs.JobResponseSchemaSupportTest --tests ai.brokk.executor.jobs.JobRunnerResponseSchemaTest --tests ai.brokk.executor.agents.CustomAgentExecutorTest
- ./gradlew fix tidy
- ./gradlew analyze