### PR TITLE
Propagate coerced schema output to durable job results

### DIFF
--- a/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
+++ b/app/src/main/java/ai/brokk/executor/jobs/JobRunner.java
@@ -27,6 +27,7 @@ import ai.brokk.tasks.TaskList;
 import ai.brokk.util.Json;
 import ai.brokk.util.Messages;
 import ai.brokk.util.ReviewParser;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.SystemMessage;
@@ -435,6 +436,7 @@ public final class JobRunner {
 
                 var completed = new AtomicInteger(0);
                 var finalStopReason = new AtomicReference<String>();
+                var finalJobResult = new AtomicReference<@Nullable Object>();
 
                 var rawCodeModelName = spec.codeModel() != null
                         ? spec.codeModel()
@@ -675,7 +677,8 @@ public final class JobRunner {
                                                             "plannerModel required for REPORT_ONLY jobs"),
                                                     spec.taskInput(),
                                                     spec.responseSchema(),
-                                                    finalStopReason);
+                                                    finalStopReason,
+                                                    finalJobResult);
                                         }
                                     }
                                     case ASK -> {
@@ -811,7 +814,8 @@ public final class JobRunner {
                                                     requireNonNull(askPlannerModel),
                                                     spec.taskInput(),
                                                     spec.responseSchema(),
-                                                    finalStopReason);
+                                                    finalStopReason,
+                                                    finalJobResult);
                                         }
                                     }
                                     case SEARCH -> {
@@ -874,7 +878,8 @@ public final class JobRunner {
                                                         requireNonNull(finalAnswerModel),
                                                         spec.taskInput(),
                                                         responseSchema,
-                                                        finalStopReason);
+                                                        finalStopReason,
+                                                        finalJobResult);
                                             }
                                         }
                                     }
@@ -1388,7 +1393,7 @@ public final class JobRunner {
                         current = current.cancelled();
                         logger.info("Job {} marked as CANCELLED", jobId);
                     } else {
-                        current = current.completed(null);
+                        current = current.completed(finalJobResult.get());
                         logger.info("Job {} completed successfully", jobId);
                     }
                     store.updateStatus(jobId, enrichStatusMetadata(jobId, current, spec, finalStopReason.get()));
@@ -1695,7 +1700,8 @@ public final class JobRunner {
         List<ChatMessage> messages;
         messages = SearchPrompts.instance.buildAskPrompt(ctx, question, meta);
         // Create an LLM instance for the planner model and route output to the ContextManager IO
-        var llm = cm.getLlm(new Llm.Options(model, question, TaskResult.Type.ASK).withEcho());
+        var options = new Llm.Options(model, question, TaskResult.Type.ASK);
+        var llm = cm.getLlm(responseSchema == null ? options.withEcho() : options);
         llm.setOutput(cm.getIo());
         // Build and send the request to the LLM
         TaskResult.StopDetails stop = null;
@@ -1703,7 +1709,7 @@ public final class JobRunner {
         var activeMessages = messages;
         var maxAttempts = responseSchema == null ? 1 : 2;
         JobLevelSchemaRepairTrace schemaRepairTrace = null;
-        String coercedOutput = null;
+        String canonicalOutput = null;
         try {
             for (int attempt = 1; attempt <= maxAttempts; attempt++) {
                 response = responseFormat == null
@@ -1722,17 +1728,17 @@ public final class JobRunner {
                 var output = response.text();
                 var validationError = JobResponseSchemaSupport.validateOutput(responseSchema, output);
                 if (validationError.isEmpty()) {
+                    canonicalOutput = output;
                     break;
                 }
                 var coercion = JobResponseSchemaSupport.coerceValidOutput(responseSchema, output);
                 if (coercion.isPresent()) {
                     var coerced = coercion.get();
-                    coercedOutput = coerced.json();
+                    canonicalOutput = coerced.json();
                     logger.info(
                             "Job-level response schema output coerced deterministically: schema={} paths={}",
                             responseSchema.name(),
                             coerced.changes());
-                    cm.getIo().llmOutput(coercedOutput, ChatMessageType.AI, LlmOutputMeta.newMessage());
                     break;
                 }
                 if (schemaRepairTrace == null) {
@@ -1758,14 +1764,21 @@ public final class JobRunner {
 
         // Determine stop details based on the response
         if (response != null) {
-            stop = coercedOutput == null
-                    ? TaskResult.StopDetails.fromResponse(response)
-                    : new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, coercedOutput);
+            if (responseSchema == null) {
+                stop = TaskResult.StopDetails.fromResponse(response);
+            } else {
+                requireNonNull(canonicalOutput);
+                cm.getIo().llmOutput(canonicalOutput, ChatMessageType.AI, LlmOutputMeta.newMessage());
+                stop = new TaskResult.StopDetails(TaskResult.StopReason.SUCCESS, canonicalOutput);
+            }
         }
 
         requireNonNull(stop);
 
-        ctx = ctx.addHistoryEntry(llmRawMessagesOrEmpty(), TaskResult.Type.ASK, model, question);
+        var historyMessages = responseSchema == null
+                ? llmRawMessagesOrEmpty()
+                : List.<ChatMessage>of(AiMessage.from(stop.explanation()));
+        ctx = ctx.addHistoryEntry(historyMessages, TaskResult.Type.ASK, model, question);
         return new TaskResult(ctx, stop);
     }
 
@@ -1868,11 +1881,15 @@ public final class JobRunner {
             StreamingChatModel model,
             String question,
             @Nullable JobSpec.ResponseSchema responseSchema,
-            AtomicReference<String> finalStopReason) {
+            AtomicReference<String> finalStopReason,
+            AtomicReference<@Nullable Object> finalJobResult) {
         var responseFormat = responseSchema == null ? null : JobResponseSchemaSupport.toResponseFormat(responseSchema);
         try {
             var result = askUsingPlannerModel(context, model, question, responseSchema);
             finalStopReason.set(result.stopDetails().reason().name());
+            if (responseSchema != null && result.stopDetails().reason() == TaskResult.StopReason.SUCCESS) {
+                finalJobResult.set(Map.of("answer", result.stopDetails().explanation()));
+            }
             scope.append(result);
         } catch (Throwable t) {
             logger.error("{} direct-answer failed for job {}: {}", label, jobId, t.getMessage(), t);

--- a/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
+++ b/app/src/main/java/ai/brokk/executor/routers/JobsRouter.java
@@ -354,6 +354,9 @@ public final class JobsRouter implements SimpleHttpServer.CheckedHttpHandler {
         response.put("jobId", jobId);
         response.put("state", status.state());
         response.put("terminal", status.terminal());
+        if (status.result() != null) {
+            response.put("result", status.result());
+        }
         response.put("childAgentArtifacts", jobStore.readChildAgentArtifacts(jobId));
         SimpleHttpServer.sendJsonResponse(exchange, 200, response);
     }

--- a/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
+++ b/app/src/test/java/ai/brokk/executor/jobs/JobRunnerResponseSchemaTest.java
@@ -2,6 +2,7 @@ package ai.brokk.executor.jobs;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -225,17 +226,35 @@ class JobRunnerResponseSchemaTest {
         model.structuredResponse = "{\"findings\":[\"one\",\"two\"],\"observations\":[\"kept\"]}";
         var spec = spec(Map.of("mode", "ASK"), null, narrativeSchema());
 
-        runner.runAsync("ask-schema-coerced-string", spec, new RawMessagesConsole())
-                .get(5, TimeUnit.SECONDS);
+        runner.runAsync("ask-schema-coerced-string", spec).get(5, TimeUnit.SECONDS);
 
-        assertEquals(
-                JobStatus.State.COMPLETED.name(),
-                requireNonNull(store.loadStatus("ask-schema-coerced-string")).state());
+        var status = requireNonNull(store.loadStatus("ask-schema-coerced-string"));
+        assertEquals(JobStatus.State.COMPLETED.name(), status.state());
         assertEquals(
                 1,
                 model.requests.stream()
                         .filter(request -> request.parameters().responseFormat() != null)
                         .count());
+
+        var result = Json.getMapper().convertValue(status.result(), Map.class);
+        var answer = requireNonNull((String) result.get("answer"));
+        var answerJson = Json.getMapper().readTree(answer);
+        assertEquals("one\ntwo", answerJson.get("findings").asText());
+        assertEquals("kept", answerJson.get("observations").get(0).asText());
+        assertFalse(answer.contains("\"findings\":[\"one\",\"two\"]"));
+
+        var tokenEvents = store.readEvents("ask-schema-coerced-string", -1, 0).stream()
+                .filter(event -> event.type().equals("LLM_TOKEN"))
+                .toList();
+        assertEquals(1, tokenEvents.size());
+        var tokenData = Json.getMapper().convertValue(tokenEvents.getFirst().data(), Map.class);
+        assertEquals(answer, tokenData.get("token"));
+
+        var taskHistory = cm.liveContext().getTaskHistory();
+        assertEquals(1, taskHistory.size());
+        var historyText = requireNonNull(taskHistory.getFirst().mopMarkdown());
+        assertTrue(historyText.contains("\"findings\" : \"one\\ntwo\""), historyText);
+        assertFalse(historyText.contains("\"findings\" : [ \"one\", \"two\" ]"), historyText);
     }
 
     @Test

--- a/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
+++ b/app/src/test/java/ai/brokk/executor/routers/JobsRouterValidationTest.java
@@ -175,6 +175,7 @@ class JobsRouterValidationTest {
         assertEquals(jobId, payload.get("jobId").asText());
         assertEquals("COMPLETED", payload.get("state").asText());
         assertTrue(payload.get("terminal").asBoolean());
+        assertEquals("done", payload.get("result").get("answer").asText());
         var artifact = payload.get("childAgentArtifacts").get(0);
         assertEquals("schema-agent", artifact.get("agentName").asText());
         assertEquals("success", artifact.get("status").asText());


### PR DESCRIPTION
## Summary
- Make schema-backed direct-answer jobs publish one canonical answer after validation or deterministic coercion succeeds.
- Carry that canonical JSON through job completion and expose it from `/v1/jobs/{jobId}/result`.
- Add regression coverage for coerced schema output and the result endpoint payload.

## Testing
- `./gradlew :app:test --tests ai.brokk.executor.jobs.JobRunnerResponseSchemaTest --tests ai.brokk.executor.routers.JobsRouterValidationTest`
- `./gradlew fix tidy`
- `./gradlew analyze`