### PR TITLE
Disable the automated daily analyzer perf workflow

### DIFF
--- a/.github/workflows/daily-perf-test.yml
+++ b/.github/workflows/daily-perf-test.yml
@@ -1,9 +1,10 @@
-name: Daily Performance Test
+name: Manual Analyzer Performance Test
 
 on:
-  schedule:
-    - cron: '0 3 * * *' # Run daily at 3 AM UTC
-  workflow_dispatch: # Allow manual triggering
+  # Keep a manual trigger during the bifrost benchmark handoff tracked in
+  # BrokkAi/bifrost#170. Remove this workflow entirely once the replacement
+  # signal is trusted.
+  workflow_dispatch:
 
 jobs:
   performance-test:

--- a/scripts/compare-perf-results.py
+++ b/scripts/compare-perf-results.py
@@ -118,7 +118,7 @@ def generate_markdown_report(base_avg: Dict[str, float], head_avg: Dict[str, flo
     base_sha = os.environ.get("BASE_SHA_SHORT", "BASE")
 
     lines: List[str] = []
-    lines.append(":rocket: **Daily Performance Report**")
+    lines.append(":rocket: **Analyzer Performance Report**")
     lines.append("")
     lines.append(f"Comparison between `master@{head_sha}` and `master@{base_sha}`.")
     lines.append("")
@@ -151,7 +151,7 @@ def generate_blockkit_report(base_avg: Dict[str, float], head_avg: Dict[str, flo
     blocks = []
     blocks.append({
         "type": "header",
-        "text": {"type": "plain_text", "text": "Daily Performance Report"}
+        "text": {"type": "plain_text", "text": "Analyzer Performance Report"}
     })
     blocks.append({
         "type": "context",


### PR DESCRIPTION
### Description
Disable the scheduled analyzer perf workflow in `brokk` now that ownership is moving to `bifrost`, while keeping the manual workflow and helper scripts available during the transition.

Closes #3698.

**Key Changes**:
- Remove the daily cron from `.github/workflows/daily-perf-test.yml` and rename the workflow to make it manual-only.
- Document in the workflow that it remains only as a temporary manual trigger during the `BrokkAi/bifrost#170` handoff.
- Rename the generated report title from `Daily Performance Report` to `Analyzer Performance Report` so manual runs are not mislabeled.

**Touch Points**:
- `.github/workflows/daily-perf-test.yml`
- `scripts/compare-perf-results.py`