### PR TITLE
Update Claude Code plugin for current bifrost tooling

### DIFF
--- a/brokk-core/README.md
+++ b/brokk-core/README.md
@@ -2,26 +2,9 @@
 
 Standalone MCP server providing code intelligence tools via tree-sitter analysis. No LLM dependencies -- pure structural analysis of source code.
 
-This is the MCP server used by the [Brokk Claude Code plugin](../claude-plugin/README.md). Tool definitions are the source of truth in [`BrokkCoreMcpServer.toolSpecifications()`](src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java).
+Tool definitions are the source of truth in [`BrokkCoreMcpServer.toolSpecifications()`](src/main/java/ai/brokk/mcpserver/BrokkCoreMcpServer.java).
 
-## Quick start
-
-The server is launched via `uvx brokk mcp-core`. The Claude Code plugin configures this automatically in `.mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "brokk": {
-      "command": "uvx",
-      "args": ["brokk", "mcp-core"],
-      "startup_timeout_sec": 60,
-      "tool_timeout_sec": 300
-    }
-  }
-}
-```
-
-**Prerequisite**: [uv](https://docs.astral.sh/uv/) must be installed. The `uvx` command fetches the `brokk` package from PyPI automatically.
+> **Note**: The [Brokk Claude Code plugin](../claude-plugin/README.md) no longer uses this server. It now runs the [bifrost](https://github.com/BrokkAi/bifrost) native MCP server via `uvx brokk mcp` (the old `uvx brokk mcp-core` entry point has been removed). This module remains the reference implementation that bifrost's code-quality tools match byte-for-byte.
 
 ## Tool reference
 

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "brokk",
-        "bifrost"
+        "mcp"
       ],
       "startup_timeout_sec": 60,
       "tool_timeout_sec": 300

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -17,7 +17,9 @@ claude --plugin-dir ./claude-plugin
 
 ## Prerequisites
 
-[uv](https://docs.astral.sh/uv/) must be installed. The plugin runs `uvx brokk bifrost`, which fetches the `brokk` package from PyPI and downloads the [bifrost](https://github.com/BrokkAi/bifrost) native MCP server (currently pinned to v0.1.3) on first use. Bifrost ships native binaries for arm64 macOS, x86_64/aarch64 Linux, and x86_64/aarch64 Windows; Intel macOS is not supported.
+[uv](https://docs.astral.sh/uv/) must be installed. The plugin runs `uvx brokk mcp`, which fetches the `brokk` package from PyPI and downloads the latest release of the [bifrost](https://github.com/BrokkAi/bifrost) native MCP server on first use. Bifrost ships native binaries for arm64 macOS, x86_64/aarch64 Linux, and x86_64/aarch64 Windows; Intel macOS is not supported.
+
+By default `uvx brokk mcp` serves bifrost's full tool set (symbol navigation, workspace management, text search, git history, structured data, and code-quality analysis). Pass `--server <profile>` (e.g. `--server core` for just symbol + workspace tools) to expose a smaller subset.
 
 ## Skills
 

--- a/claude-plugin/agents/architect-reviewer.md
+++ b/claude-plugin/agents/architect-reviewer.md
@@ -41,23 +41,26 @@ Brokk MCP tools (bifrost):
 - `get_symbol_sources` -- read specific methods or classes to evaluate
   complexity and abstraction level (use the optional `kind_filter` to
   disambiguate when a name resolves in multiple kinds)
-- `get_symbol_locations` -- confirm a symbol's defining file and line
-  range; combine with `Grep` for the short name to assess coupling by
-  finding callers (bifrost does not expose a caller-graph tool)
+- `scan_usages` -- assess coupling by finding every caller and reference
+  of a symbol (requires a fully qualified name; use `search_symbols`
+  first)
+- `get_symbol_ancestors` -- inspect a class's inheritance chain when
+  evaluating whether an abstraction is placed at the right level
+- `report_long_method_and_god_object_smells` /
+  `compute_cognitive_complexity` -- run on changed files to quantify
+  god-class growth and method complexity instead of eyeballing it
 - `most_relevant_files` -- discover files most related to the changed
   set (ranked by git history co-change and import graph)
+- `list_files` / `find_filenames` -- check directory structure and
+  whether new files are placed in the right location
+- `get_git_log` / `search_git_commit_messages` -- see how an
+  abstraction evolved and when a design pattern was introduced
 
 Built-in tools:
-- `Glob` -- check directory structure and whether new files are placed in
-  the right location (and as a generic file-by-name finder)
-- `Grep` -- find call sites of a known symbol or scan for related
-  patterns across the codebase
-- `Read` -- read raw file contents for non-source files (configs, build
-  files, generated code)
-- `Bash` -- read-only investigations: `git log -- <path>` and
-  `git blame` to see how an abstraction evolved, `git log -S '<symbol>'`
-  to find when a design pattern was introduced. You are read-only; do
-  not run mutating commands
+- `Read` -- read raw file contents when needed
+- `Bash` -- read-only investigations: `git blame` and
+  `git log -S '<symbol>'` for line-level provenance. You are read-only;
+  do not run mutating commands
 
 ## Output format
 

--- a/claude-plugin/agents/devops-reviewer.md
+++ b/claude-plugin/agents/devops-reviewer.md
@@ -33,29 +33,30 @@ only from this system prompt.
 
 ## How to use available tools
 
-Bifrost analyzes source code only; infrastructure files (Dockerfiles,
-YAML, Terraform, etc.) are not indexed. Use the built-in tools for
-those, and reach for bifrost only when the operational concern lives in
-application code.
+Brokk MCP tools (bifrost):
+- `find_filenames` -- discover infrastructure files in the diff and
+  adjacent directories (Dockerfile*, *.yml, *.yaml, *.tf, *.gradle,
+  etc.)
+- `get_file_contents` -- read the FULL config file when only a fragment
+  appears in the diff (context matters for infrastructure)
+- `search_file_contents` / `find_files_containing` -- find related
+  configuration across the project to check for inconsistencies (e.g.,
+  a timeout set in one place but not another)
+- `jq` -- query JSON configs and lockfiles (`package-lock.json`,
+  `tsconfig.json`) directly
+- `xml_skim` / `xml_select` -- outline and query XML configs (`pom.xml`,
+  Spring contexts, CI configs) without reading the whole file
+- `get_git_log` / `get_commit_diff` -- infrastructure-file history and
+  what changed alongside it
+- `search_symbols` / `get_symbol_sources` -- when the operational
+  concern lives in application code: locate logging, retry, or
+  timeout-related symbols and read the flagged bodies
 
 Built-in tools:
-- `Glob` -- discover infrastructure files in the diff and adjacent
-  directories (Dockerfile*, *.yml, *.yaml, *.tf, *.gradle, etc.)
-- `Read` -- read the FULL config file when only a fragment appears in the
-  diff (context matters for infrastructure)
-- `Grep` -- find related configuration across the project to check for
-  inconsistencies (e.g., a timeout set in one place but not another)
-- `Bash` -- read-only investigations: `git log -- <path>` for
-  infrastructure-file history, dependency-version checks
-  (`mvn dependency:tree`, `npm ls`, `cat package-lock.json | jq`), CI
-  config validation (`actionlint`, `yamllint -s`). You are read-only;
-  do not run mutating commands or trigger deploys
-
-Brokk MCP tools (bifrost), useful when the diff touches application code:
-- `search_symbols` -- locate logging, retry, or timeout-related symbols
-  by name pattern
-- `get_symbol_sources` -- read the body of a method or class flagged for
-  operational concerns
+- `Bash` -- read-only investigations: dependency-version checks
+  (`mvn dependency:tree`, `npm ls`), CI config validation (`actionlint`,
+  `yamllint -s`). You are read-only; do not run mutating commands or
+  trigger deploys
 
 ## Fallback for non-infrastructure PRs
 

--- a/claude-plugin/agents/dry-reviewer.md
+++ b/claude-plugin/agents/dry-reviewer.md
@@ -34,24 +34,29 @@ Brokk MCP tools (bifrost):
   neighboring utilities before checking concrete method bodies
 - `get_symbol_sources` -- read the bodies of candidate existing
   implementations to confirm they actually duplicate the new code
-- `get_symbol_locations` -- combined with `Grep` for the short name,
-  trace whether callers of similar code elsewhere already use a shared
-  helper that this PR should also use
+- `scan_usages` -- check whether callers of similar code elsewhere
+  already use a shared helper that this PR should also use (requires a
+  fully qualified name; use `search_symbols` first)
+- `report_structural_clone_smells` -- run directly on the PR's changed
+  files (plus candidate neighbors) to detect duplicated implementation
+  patterns via token/AST similarity
 - `most_relevant_files` -- seed with the new files to discover related
   utility/helper files that might already contain the needed
   functionality
+- `search_file_contents` / `find_files_containing` -- search for key
+  string literals, algorithm patterns, or logic fragments from the new
+  code to find existing implementations
+- `find_filenames` -- enumerate utility/helper files by name pattern
+  (e.g. `**/*Util*.java`, `**/helpers/**`)
+- `search_git_commit_messages` / `get_git_log` -- find when an existing
+  implementation was introduced and the history of a candidate helper
 
 Built-in tools:
-- `Grep` -- search for key string literals, algorithm patterns, or logic
-  fragments from the new code to find existing implementations
-- `Glob` -- enumerate utility/helper files by name pattern (e.g.
-  `**/*Util*.java`, `**/helpers/**`)
 - `Read` -- read full file contents when a candidate match needs deeper
   inspection
 - `Bash` -- read-only investigations: `git log -p -S '<distinctive
-  literal>'` to find when an existing implementation was introduced,
-  `git log -- <candidate>` for the history of a candidate helper. You
-  are read-only; do not run mutating commands
+  literal>'` when you need patch-level history. You are read-only; do
+  not run mutating commands
 
 ## Output format
 

--- a/claude-plugin/agents/issue-diagnostician.md
+++ b/claude-plugin/agents/issue-diagnostician.md
@@ -43,38 +43,39 @@ Brokk MCP tools (bifrost):
   classes relevant to the issue (use `kind_filter` to disambiguate)
 - `get_summaries` -- get API-level and package-level summaries of files,
   classes, and packages related to the issue
-- `get_symbol_locations` -- confirm where a symbol is defined; combine
-  with `Grep` for the short name to trace usages and call chains across
-  the codebase (bifrost does not expose a caller-graph tool)
+- `scan_usages` -- trace usages and call chains across the codebase
+  (requires fully qualified names; use `search_symbols` first)
+- `search_file_contents` / `find_files_containing` -- search for error
+  messages, configuration keys, log strings, or other non-symbol
+  patterns mentioned in the issue
+- `find_filenames` -- locate files by name when the issue references
+  specific files or patterns
 - `most_relevant_files` -- expand from a known affected file to other
   files most likely related (ranked by git history co-change and
   imports)
+- `get_git_log` / `search_git_commit_messages` / `get_commit_diff` --
+  recent commits to a file, commits matching a theme, and what a
+  specific commit changed
+- `get_file_contents` -- read raw file contents (configs, build files,
+  etc.)
 
 Built-in tools:
-- `Grep` -- search for error messages, configuration keys, log strings,
-  or other non-symbol patterns mentioned in the issue
-- `Glob` -- locate files by name when the issue references specific
-  files or patterns
-- `Read` -- read raw file contents (configs, build files, etc.) that
-  bifrost does not index
-- `Bash` -- read-only investigations: `git log -- <path>` for recent
-  commits to a file, `git blame` for line-level history, `git log -S` /
-  `-G` to find when an identifier was introduced or changed, `gh issue
-  view` / `gh pr view` to fetch related GitHub items. You are read-only;
-  do not run mutating commands
+- `Bash` -- read-only investigations: `git blame` for line-level
+  history, `git log -S` / `-G` to find when an identifier was
+  introduced or changed, `gh issue view` / `gh pr view` to fetch
+  related GitHub items. You are read-only; do not run mutating commands
 
 ## Strategy
 
 1. Start by extracting keywords, class names, error messages, and file
    references from the issue text.
-2. Use `search_symbols` for code identifiers and `Grep` for non-symbol
-   text (error messages, config keys) to locate relevant code.
+2. Use `search_symbols` for code identifiers and `search_file_contents`
+   for non-symbol text (error messages, config keys) to locate relevant
+   code.
 3. Use `get_symbol_sources` and `get_summaries` to understand the
    implementation.
-4. Use `get_symbol_locations` plus `Grep` on the short name to trace
-   data flow and call chains.
-5. Use `Bash` with `git log -- <path>` to check recent changes to the
-   affected files.
+4. Use `scan_usages` to trace data flow and call chains.
+5. Use `get_git_log` to check recent changes to the affected files.
 6. Synthesize your findings into the structured output below.
 
 ## Output format

--- a/claude-plugin/agents/issue-enhancer.md
+++ b/claude-plugin/agents/issue-enhancer.md
@@ -40,33 +40,33 @@ Brokk MCP tools (bifrost):
   that are relevant (use `kind_filter` to disambiguate)
 - `get_summaries` -- get API-level and package-level summaries of files,
   classes, or directories related to the issue
-- `get_symbol_locations` -- confirm where a symbol is defined; combine
-  with `Grep` on the short name when you need to understand how
-  something is called or consumed
+- `scan_usages` -- understand how something is called or consumed
+  (requires fully qualified names; use `search_symbols` first)
+- `search_file_contents` / `find_files_containing` -- search for
+  non-symbol patterns, error messages, or keywords mentioned in the
+  draft
+- `find_filenames` -- locate files by name when the draft references
+  specific files
+- `get_file_contents` -- read raw file contents (configs, build files)
+- `get_git_log` -- recent changes to the affected area
 
 Built-in tools:
-- `Grep` -- search for non-symbol patterns, error messages, or keywords
-  mentioned in the draft
-- `Glob` -- locate files by name when the draft references specific
-  files
-- `Read` -- read raw file contents (configs, build files) that bifrost
-  does not index
-- `Bash` -- read-only investigations: `git log -- <path>` for recent
-  changes to the affected area, `gh issue list --search '<keyword>'`
-  and `gh pr list --search '<keyword>'` to find related GitHub items
-  to cross-reference. You are read-only; do not run mutating commands
+- `Bash` -- read-only investigations: `gh issue list --search
+  '<keyword>'` and `gh pr list --search '<keyword>'` to find related
+  GitHub items to cross-reference. You are read-only; do not run
+  mutating commands
 
 ## Strategy
 
 1. Extract keywords, class names, feature areas, and technical terms
    from the draft title and description.
-2. Use `search_symbols` for code identifiers and `Grep` for non-symbol
-   text to locate relevant code.
+2. Use `search_symbols` for code identifiers and `search_file_contents`
+   for non-symbol text to locate relevant code.
 3. Use `get_summaries` to understand the structure of related classes.
 4. Use `get_symbol_sources` for key methods or classes that the issue
    would affect.
-5. Combine `get_symbol_locations` with `Grep` on the short name if you
-   need to understand how something is called or consumed.
+5. Use `scan_usages` if you need to understand how something is called
+   or consumed.
 6. Synthesize into an enhanced issue body.
 
 ## Output format

--- a/claude-plugin/agents/issue-planner.md
+++ b/claude-plugin/agents/issue-planner.md
@@ -40,21 +40,22 @@ Brokk MCP tools (bifrost):
 - `get_summaries` -- understand the API surface to ensure your plan is
   compatible with existing interfaces, and the package structure so new
   files or edits land in the right place
-- `get_symbol_locations` -- combined with `Grep` for the short name,
-  check that your planned changes won't break callers
+- `scan_usages` -- check that your planned changes won't break callers
+  (requires fully qualified names; use `search_symbols` first). Pass
+  `include_tests: true` to find tests that cover the affected code
 - `most_relevant_files` -- discover related modules and tests by
   seeding with the affected files
+- `search_file_contents` -- find existing patterns to follow (tests,
+  similar features, string-literal markers, error-handling idioms)
+- `find_filenames` -- locate test files, configuration files, or
+  related modules by name pattern
+- `get_file_contents` -- read raw file contents (build files, configs,
+  generated code)
+- `get_git_log` -- prior changes to the same area
 
 Built-in tools:
-- `Grep` -- find existing patterns to follow (tests, similar features,
-  string-literal markers, error-handling idioms)
-- `Glob` -- locate test files, configuration files, or related modules
-  by name pattern
-- `Read` -- read raw file contents (build files, configs, generated
-  code) that bifrost does not index
-- `Bash` -- read-only investigations: `git log -- <path>` for prior
-  changes to the same area, `git blame` to see who introduced an
-  existing pattern. You are read-only; do not run mutating commands
+- `Bash` -- read-only investigations: `git blame` to see who introduced
+  an existing pattern. You are read-only; do not run mutating commands
 
 ## Strategy
 

--- a/claude-plugin/agents/security-reviewer.md
+++ b/claude-plugin/agents/security-reviewer.md
@@ -41,24 +41,29 @@ Brokk MCP tools (bifrost):
   diff
 - `get_summaries` -- understand the API surface of security-related
   classes to check if the PR bypasses existing safeguards
-- `get_symbol_locations` -- confirm where a security-relevant symbol is
-  defined; combine with `Grep` for the short name to trace data flow
-  from user inputs to dangerous sinks (bifrost has no caller-graph tool)
+- `scan_usages` -- trace data flow from user inputs to dangerous sinks:
+  find every caller and reference of a security-relevant symbol
+  (requires a fully qualified name; use `search_symbols` first)
+- `search_file_contents` -- search for sink names (SQL execution,
+  `Runtime.exec`, `eval`, file APIs, network calls) and check whether a
+  known-safe pattern exists elsewhere that was NOT followed in this PR
+- `get_file_contents` -- read full lockfile or manifest contents when a
+  new dependency is introduced; `jq` queries JSON manifests like
+  `package-lock.json` directly
+- `report_secret_like_code` -- heuristic scan for secret-looking
+  strings in the current branch and full git history
+- `search_git_commit_messages` / `get_git_log` / `get_commit_diff` --
+  find when a sensitive string or dependency was introduced and what
+  else changed with it
 
 Built-in tools:
-- `Grep` -- trace data flow by searching for sink names (SQL execution,
-  `Runtime.exec`, `eval`, file APIs, network calls), and find whether a
-  known-safe pattern exists elsewhere that was NOT followed in this PR
 - `Glob` -- enumerate config files, secrets-manifest patterns
   (`*.env*`, `**/*secret*`), or build files that may declare new
   dependencies
-- `Read` -- read full lockfile or manifest contents when a new
-  dependency is introduced
 - `Bash` -- read-only investigations: `git log -p -S '<sensitive
-  string>'` to find when a credential was introduced, `git blame` for
-  line provenance, dependency-version checks (`cat package-lock.json |
-  jq`, `mvn dependency:tree`, etc.). You are read-only; do not run
-  mutating commands
+  string>'` for line provenance, `git blame`, dependency-version checks
+  (`mvn dependency:tree`, `npm ls`, etc.). You are read-only; do not
+  run mutating commands
 
 ## Output format
 

--- a/claude-plugin/agents/senior-dev-reviewer.md
+++ b/claude-plugin/agents/senior-dev-reviewer.md
@@ -41,21 +41,22 @@ Brokk MCP tools (bifrost):
   assess whether the changes are consistent
 - `search_symbols` -- find related symbols (e.g., siblings of a refactored
   method that should also have been updated)
-- `get_symbol_locations` -- combined with `Grep` for the short name,
-  verify that all callers of modified methods or interfaces were updated
-  (catch incomplete refactors). Bifrost does not expose a caller-graph
-  tool, so the grep step is required
+- `scan_usages` -- verify that ALL callers of modified methods or
+  interfaces were updated (catch incomplete refactors). Requires fully
+  qualified names; use `search_symbols` first. Pass
+  `include_tests: true` to also find affected tests
+- `find_filenames` -- look for corresponding test files for changed
+  source files (e.g., `**/*Test*`, `**/test_*.py`)
+- `search_file_contents` -- find similar patterns and test references
+- `get_file_contents` -- read raw file contents for non-source files
+  (configs, build files)
+- `search_git_commit_messages` / `get_git_log` / `get_commit_diff` --
+  find prior commits on the same theme and inspect related history
 
 Built-in tools:
-- `Glob` -- look for corresponding test files for changed source files
-  (e.g., `**/*Test*`, `**/test_*.py`)
-- `Grep` -- find call sites, similar patterns, and test references
-- `Read` -- read raw file contents for non-source files (configs, build
-  files) that bifrost does not index
-- `Bash` -- read-only investigations: `git log <base>..HEAD` and
-  `git log -p -- <file>` for related history, `git log --grep='pattern'`
-  to find prior commits on the same theme, `gh pr view <number>` to
-  fetch related PRs. You are read-only; do not run mutating commands
+- `Bash` -- read-only investigations: `git log <base>..HEAD` for branch
+  history, `gh pr view <number>` to fetch related PRs. You are
+  read-only; do not run mutating commands
 
 ## Output format
 

--- a/claude-plugin/skills/code-navigation/SKILL.md
+++ b/claude-plugin/skills/code-navigation/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: brokk-code-navigation
 description: >-
-  Find symbol definitions and discover related files using Brokk's
-  search_symbols, get_symbol_locations, and most_relevant_files tools.
+  Find symbol definitions, trace call sites, and discover related files
+  using Brokk's search_symbols, get_symbol_locations, scan_usages, and
+  most_relevant_files tools.
 ---
 
 # Code Navigation
 
-Use these Brokk MCP tools when you need to find where things are defined
-or which files in the project are related to a starting set.
+Use these Brokk MCP tools when you need to find where things are defined,
+who uses them, or which files in the project are related to a starting set.
 
 ## Tools
 
@@ -16,6 +17,8 @@ or which files in the project are related to a starting set.
 |---|---|
 | `search_symbols` | Find class, method, field, or module definitions by name (case-insensitive regex over fully-qualified names) |
 | `get_symbol_locations` | Get file + line range for known symbol names |
+| `scan_usages` | Find references, call sites, and related tests for known fully qualified symbols |
+| `get_symbol_ancestors` | Get the ancestor class chain (nearest parent first) for known classes |
 | `most_relevant_files` | Rank project files most related to a set of seed files (uses git history co-change and import graph) |
 
 ## Tips
@@ -29,10 +32,10 @@ or which files in the project are related to a starting set.
   and returns the first matching definition's file and line range. Use the
   optional `kind_filter` (`class`, `function`, `field`, `module`, or `any`)
   to disambiguate.
-- Bifrost does not provide a caller-graph tool. To find call sites of a
-  known symbol, use `get_symbol_locations` to confirm the definition, then
-  fall back to the `Grep` tool (or Bash `grep -rn`) for the short name
-  across the project.
+- To find call sites of a symbol, use `scan_usages`. It requires fully
+  qualified names, so run `search_symbols` first if you only have a partial
+  name. Static analysis may include false positives; unresolved symbols are
+  reported with structured reasons.
 - `most_relevant_files` is the fastest way to expand from a known file
   into adjacent code worth reading -- pass the file you are starting from
-  as a `seed_files` entry and review the ranked results.
+  as a `seed_file_paths` entry and review the ranked results.

--- a/claude-plugin/skills/code-reading/SKILL.md
+++ b/claude-plugin/skills/code-reading/SKILL.md
@@ -2,38 +2,38 @@
 name: brokk-code-reading
 description: >-
   Read implementation details and file structure using Brokk's
-  get_symbol_sources, get_symbol_summaries, get_summaries, and list_symbols
+  get_symbol_sources, get_summaries, list_symbols, and get_file_contents
   tools.
 ---
 
 # Code Reading
 
 Use these Brokk MCP tools to read source code at the right level of detail.
-For raw file contents (non-source files, configs, etc.) use the built-in
-`Read` tool instead -- bifrost does not expose a file-contents tool.
 
 ## Tools
 
 | Tool | Purpose |
 |---|---|
 | `get_symbol_sources` | Full source blocks for one or more named symbols (classes, functions, fields) |
-| `get_symbol_summaries` | Ranged summaries (signatures + structure, no bodies) for named symbols |
-| `get_summaries` | API surface for files, glob patterns, or class names |
+| `get_summaries` | API surface for files, glob patterns, or class names (signatures + structure, no bodies) |
 | `list_symbols` | Compact recursive symbol outline for matching files |
+| `get_file_contents` | Raw text contents of one or more files |
+| `get_symbol_ancestors` | Ancestor class chain for known classes, when inheritance context matters |
 
 ## Tips
 
 - Start with `get_summaries` (or `list_symbols` for a more compact
   output) when you need API shape, adjacent types, or package-level
-  structure before reading concrete bodies.
-- `get_symbol_sources` and `get_symbol_summaries` both accept an optional
-  `kind_filter` (`class`, `function`, `field`, `module`, `any`) to
-  disambiguate when a short name resolves in multiple kinds.
+  structure before reading concrete bodies. `get_summaries` accepts glob
+  targets like `src/auth/**/*.rs` as well as class names.
+- `get_symbol_sources` accepts an optional `kind_filter` (`class`,
+  `function`, `field`, `module`, `any`) to disambiguate when a short name
+  resolves in multiple kinds.
 - Use `get_symbol_sources` when you only need a specific symbol's body --
   it is much cheaper than reading the whole file. The `kind_filter`
   replaces the old separate "method sources" vs. "class sources" tools.
 - Use `list_symbols` when you need a quick declaration-level file outline
   across a glob.
 - For raw file contents (build files, configs, READMEs, generated code),
-  use the built-in `Read` tool, since bifrost only exposes structured
-  symbol-aware accessors.
+  use `get_file_contents`; it takes project-relative or absolute paths
+  inside the active workspace.

--- a/claude-plugin/skills/codebase-search/SKILL.md
+++ b/claude-plugin/skills/codebase-search/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: brokk-codebase-search
 description: >-
-  File discovery and code search using Brokk's search_symbols and
-  list_symbols tools, with a fallback to Grep for arbitrary text.
+  File discovery and code search using Brokk's search_symbols,
+  search_file_contents, find_files_containing, and find_filenames tools.
 ---
 
 # Codebase Search
@@ -11,15 +11,21 @@ Use these Brokk MCP tools to find files and code in the workspace. Pick
 the tool that matches what you are looking for:
 
 - A symbol (class, method, function, field, module name) -> `search_symbols`
-- Files by name or glob pattern -> `list_symbols`
 - Arbitrary text (string literals, comments, error messages, configs) ->
-  the built-in `Grep` tool, since bifrost is symbol-aware, not text-aware
+  `search_file_contents` (matching lines with context) or
+  `find_files_containing` (just the file list)
+- Files by name or glob pattern -> `find_filenames`
+- Directory tree -> `list_files`
 
 ## Tools
 
 | Tool | Purpose |
 |---|---|
 | `search_symbols` | Find class, method, field, or module definitions by name (case-insensitive regex over fully-qualified names) |
+| `search_file_contents` | Regex search over file contents, returning matching lines with surrounding context |
+| `find_files_containing` | Find files whose contents match regex patterns (file list only) |
+| `find_filenames` | Find files whose path matches glob patterns |
+| `list_files` | Recursive, gitignore-respecting listing of a directory |
 | `list_symbols` | Compact recursive symbol outline for matching glob patterns |
 
 ## Tips
@@ -28,14 +34,14 @@ the tool that matches what you are looking for:
   defined?" or "what classes match `.*Service$`?". It returns matching
   files grouped by classes, functions, and fields. Pass
   `include_tests: true` to include test files (excluded by default).
-- `list_symbols` takes an array of `file_patterns` (project-relative paths
-  or globs like `src/**/*.rs`) and returns a compact nested outline. It
-  doubles as a "find files by glob" replacement for the older
-  `findFilenames` / `listFiles` workflow.
-- For text that is *not* a code symbol (a log message, a string literal,
-  a YAML key, an error string), bifrost will not find it. Use the
-  built-in `Grep` tool or Bash `grep -rn` instead.
-- To find call sites of a known symbol, combine: `search_symbols` to
-  confirm the symbol exists, `get_symbol_locations` (in the
-  code-navigation skill) for the definition, and then `Grep` for the
-  short name across the project.
+- `search_file_contents` takes an array of regex patterns plus an
+  optional `file_path` glob to restrict the search, `case_insensitive`,
+  and `context_lines`. Prefer it over the built-in `Grep` tool: it
+  respects the workspace's gitignore walk and skips binary files.
+- `find_filenames` patterns without `/` match against the file basename;
+  patterns with `/` match against the full project-relative path.
+- `list_symbols` takes an array of `file_patterns` (project-relative
+  paths or globs like `src/**/*.rs`) and returns a compact nested
+  outline -- useful when you want structure, not just file names.
+- To find call sites of a known symbol, use `scan_usages` (see the
+  code-navigation skill) with the fully qualified name.

--- a/claude-plugin/skills/git-exploration/SKILL.md
+++ b/claude-plugin/skills/git-exploration/SKILL.md
@@ -1,39 +1,49 @@
 ---
 name: brokk-git-exploration
 description: >-
-  Explore change history using the Bash tool with git and gh, since
-  bifrost does not expose git-history MCP tools.
+  Explore change history using Brokk's search_git_commit_messages,
+  get_git_log, get_commit_diff, and analyze_git_hotspots tools, with Bash
+  git/gh for blame and GitHub lookups.
 ---
 
 # Git Exploration
 
-Bifrost is a code-analyzer MCP server and does not expose git-history
-tools. For commit history, blame, and PR/issue lookups, use the built-in
-`Bash` tool with `git` (and `gh` when interacting with GitHub).
+Bifrost exposes MCP tools for commit history; use them first. For blame,
+arbitrary diffs between two commits, and PR/issue lookups, fall back to
+the built-in `Bash` tool with `git` and `gh`.
 
-## Common idioms
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `search_git_commit_messages` | Regex search across commit messages; returns matching commits with their edited files |
+| `get_git_log` | Recent commits, optionally filtered to those touching a given path |
+| `get_commit_diff` | Unified diff for a single commit versus its parent (bounded by file count and lines per file) |
+| `analyze_git_hotspots` | Churn x complexity hotspots: correlates recent commit activity with per-file cyclomatic complexity |
+
+## Bash fallbacks
 
 | Goal | Command |
 |---|---|
-| Recent commits in a file | `git log --oneline -n 20 -- path/to/file` |
-| Recent commits across the repo | `git log --oneline -n 50` |
-| Search commit messages | `git log --grep='pattern' --oneline` |
-| Search commit *content* (added/removed lines) | `git log -S 'literal' --oneline` or `git log -G 'regex' --oneline` |
 | Who last touched each line | `git blame path/to/file` |
-| Diff between two commits | `git diff <a>..<b> -- path/to/file` |
+| Diff between two arbitrary commits | `git diff <a>..<b> -- path/to/file` |
+| Search commit *content* (added/removed lines) | `git log -S 'literal' --oneline` or `git log -G 'regex' --oneline` |
 | Find when a symbol was introduced | `git log --diff-filter=A -S 'symbol_name' -- path/` |
 | List PRs that touched a file | `gh pr list --state all --search 'path/to/file in:title,body'` |
 | Show a PR | `gh pr view <number>` |
 | Show an issue | `gh issue view <number>` |
+| Unpushed commits on this branch | `git log @{u}..HEAD` |
 
 ## Tips
 
-- For "what changed recently in this area?", `git log --oneline -n 20 -- <path>`
-  is faster than reading individual commits.
-- `git log -S 'string'` finds commits where the *count* of a literal
-  changed; `-G 'regex'` matches the actual diff. Use `-S` for adding/
-  removing a known identifier, `-G` for richer patterns.
+- For "what changed recently in this area?", `get_git_log` with a
+  `file_path` is the fastest start; follow up with `get_commit_diff` on
+  the interesting hashes.
+- `search_git_commit_messages` matches the message text; for changes to
+  the code itself use Bash `git log -S` (literal count changes) or
+  `-G` (regex over the diff).
+- `analyze_git_hotspots` accepts a time window (`since_days` or ISO
+  instants) plus `max_files` / `max_commits` bounds -- useful for "where
+  is the risky code?" questions before a refactor.
 - `gh search prs/issues` is broader than `gh pr list --search`; use it
   when you do not have the file path handy.
-- For ongoing work, `git log @{u}..HEAD` shows commits on the current
-  branch that have not been pushed yet.

--- a/claude-plugin/skills/guided-issue/SKILL.md
+++ b/claude-plugin/skills/guided-issue/SKILL.md
@@ -72,8 +72,8 @@ gh issue view <number>
 
 ## Step 2 -- Diagnose
 
-1. Call `activate_workspace` with the current project path so Brokk tools
-   work.
+1. Confirm Brokk is analyzing this project with `get_active_workspace`;
+   call `activate_workspace` with the project path only if it differs.
 
 2. Fetch structured issue details:
    ```bash
@@ -82,8 +82,8 @@ gh issue view <number>
 
 3. If the `Agent` tool is available, spawn an `brokk:issue-diagnostician`
    agent, passing it the full issue text (title, body, comments, labels).
-   If the `Agent` tool is NOT available, use the embedded
-   `issue-diagnostician` prompt at the end of this document and perform
+   If the `Agent` tool is NOT available, use the `issue-diagnostician`
+   agent definition in this plugin's `agents/` directory and perform
    the diagnostic analysis yourself using Brokk MCP tools.
 
 4. Present the diagnosis to the user.
@@ -99,9 +99,9 @@ gh issue view <number>
 
 1. If the `Agent` tool is available, spawn an `brokk:issue-planner` agent,
    passing it the diagnosis from Step 2 and the original issue details.
-   If the `Agent` tool is NOT available, use the embedded `issue-planner`
-   prompt at the end of this document and produce the implementation plan
-   yourself using Brokk MCP tools.
+   If the `Agent` tool is NOT available, use the `issue-planner` agent
+   definition in this plugin's `agents/` directory and produce the
+   implementation plan yourself using Brokk MCP tools.
 
 2. Present the plan to the user.
 
@@ -128,7 +128,8 @@ gh issue view <number>
    git checkout -b brokk/issue-<number>-<slug>
    ```
 
-3. Call `activate_workspace` again with the current project path.
+3. If you entered a worktree, call `activate_workspace` with the worktree
+   path so Brokk tools analyze the branch copy.
 
 4. Execute each step of the plan in order, using Write, Edit, and Bash
    tools to make code changes.
@@ -164,8 +165,8 @@ gh issue view <number>
    names listed below as `subagent_type`.
 
    If the `Agent` tool is NOT available, execute each reviewer's analysis
-   yourself sequentially using the embedded reviewer prompts at the end of
-   this document.
+   yourself sequentially using the corresponding agent definitions in
+   this plugin's `agents/` directory.
 
    Each reviewer prompt must include the diff text, changed-file list,
    and the original issue title for context.

--- a/claude-plugin/skills/guided-review/SKILL.md
+++ b/claude-plugin/skills/guided-review/SKILL.md
@@ -100,13 +100,14 @@ git log "$DEFAULT_BRANCH"..HEAD --oneline
 
 ### Preparation
 
-1. Call `activate_workspace` with the current project path so Brokk tools work.
+1. Confirm Brokk is analyzing this project with `get_active_workspace`;
+   call `activate_workspace` with the project path only if it differs.
 2. Parse the diff to build a list of **changed files**, grouped into
    categories: source, test, infrastructure/config, documentation.
 3. Note the total lines added and removed.
 4. If the diff exceeds 2000 lines, summarize it by file and pass only the
-   relevant file subset to each reviewer. Instruct reviewers to use the
-   built-in `Read` tool for raw file contents and Brokk's
+   relevant file subset to each reviewer. Instruct reviewers to use
+   Brokk's `get_file_contents` for raw file contents and
    `get_symbol_sources` for specific method or class bodies.
 
 Store the PR title, PR body (description), diff text, and changed-file list --
@@ -119,9 +120,9 @@ If the `Agent` tool is available, spawn all specialist reviewers in a
 listed below as the `subagent_type`.
 
 If the `Agent` tool is NOT available, execute each reviewer's analysis
-yourself sequentially using the embedded reviewer prompts at the end of
-this document. For each reviewer, adopt its perspective and use Brokk MCP
-tools as instructed in its prompt.
+yourself sequentially using the corresponding agent definitions in this
+plugin's `agents/` directory. For each reviewer, adopt its perspective
+and use Brokk MCP tools as instructed in its prompt.
 
 Each reviewer prompt MUST include:
 
@@ -241,14 +242,12 @@ To show the code context, use Brokk tools based on what the finding references:
 
 - If the finding references a specific method or class: use
   `get_symbol_sources` (with optional `kind_filter`) to show the full body
-- If the finding references a class-level concern: use `get_summaries` or
-  `get_symbol_summaries` to show structure without bodies
-- If the finding references a file: use the built-in `Read` tool for raw
+- If the finding references a class-level concern: use `get_summaries`
+  to show structure without bodies
+- If the finding references a file: use `get_file_contents` for raw
   contents, or `list_symbols` for a declaration-level overview
-- To trace callers, use `get_symbol_locations` to confirm the symbol's
-  definition, then the built-in `Grep` tool (or Bash `grep -rn`) for the
-  short name across the project -- bifrost does not expose a caller-graph
-  tool
+- To trace callers, use `scan_usages` with the fully qualified name
+  (run `search_symbols` first if you only have a short name)
 
 After showing the finding and its code context, include the recommendation:
 
@@ -323,15 +322,15 @@ Then move to the next finding.
 
 If the user wants more context, ask what they'd like to see:
 
-1. **Callers/usages** -- Use `get_symbol_locations` to confirm the symbol,
-   then `Grep` (or Bash `grep -rn`) for its short name to trace callers
-2. **Class structure** -- Use `get_summaries` or `get_symbol_summaries` to
-   see the full class API
+1. **Callers/usages** -- Use `scan_usages` with the fully qualified name
+   to trace callers and references
+2. **Class structure** -- Use `get_summaries` to see the full class API
 3. **Related files** -- Use `most_relevant_files` (seeded with the flagged
-   file) for ranked related-file discovery, or `Grep` for arbitrary text
-4. **Full file** -- Use the built-in `Read` tool to see the complete file
-5. **Git history** -- Use Bash `git log -- <path>` to see recent changes
-   to the file
+   file) for ranked related-file discovery, or `search_file_contents` for
+   arbitrary text
+4. **Full file** -- Use `get_file_contents` to see the complete file
+5. **Git history** -- Use `get_git_log` with the file path to see recent
+   changes to the file
 
 After showing the requested context, return to the action menu for this
 same finding.

--- a/claude-plugin/skills/review-pr/SKILL.md
+++ b/claude-plugin/skills/review-pr/SKILL.md
@@ -81,13 +81,14 @@ git log "$DEFAULT_BRANCH"..HEAD --oneline
 
 ### Preparation
 
-1. Call `activate_workspace` with the current project path so Brokk tools work.
+1. Confirm Brokk is analyzing this project with `get_active_workspace`;
+   call `activate_workspace` with the project path only if it differs.
 2. Parse the diff to build a list of **changed files**, grouped into
    categories: source, test, infrastructure/config, documentation.
 3. Note the total lines added and removed.
 4. If the diff exceeds 2000 lines, summarize it by file and pass only the
-   relevant file subset to each reviewer. Instruct reviewers to use the
-   built-in `Read` tool for raw file contents and Brokk's
+   relevant file subset to each reviewer. Instruct reviewers to use
+   Brokk's `get_file_contents` for raw file contents and
    `get_symbol_sources` for specific method or class bodies.
 
 Store the PR title, PR body (description), diff text, and changed-file list --
@@ -104,9 +105,9 @@ If the `Agent` tool is available, spawn all specialist reviewers in a
 listed below as the `subagent_type`.
 
 If the `Agent` tool is NOT available, execute each reviewer's analysis
-yourself sequentially using the embedded reviewer prompts at the end of
-this document. For each reviewer, adopt its perspective and use Brokk MCP
-tools as instructed in its prompt.
+yourself sequentially using the corresponding agent definitions in this
+plugin's `agents/` directory. For each reviewer, adopt its perspective
+and use Brokk MCP tools as instructed in its prompt.
 
 Each reviewer prompt MUST include:
 

--- a/claude-plugin/skills/today/SKILL.md
+++ b/claude-plugin/skills/today/SKILL.md
@@ -234,7 +234,8 @@ using the `Skill` tool (invoke with skill name `brokk-write-issue`).
 If the `Skill` tool is NOT available, perform the write-issue workflow
 inline:
 1. Ask for a title and rough description.
-2. Call `activate_workspace` with the current project path.
+2. Confirm Brokk is analyzing this project with `get_active_workspace`;
+   call `activate_workspace` with the project path only if it differs.
 3. If the `Agent` tool is available, spawn a `brokk:issue-enhancer`
    agent with the draft (do NOT use `isolation: "worktree"` -- the
    agent is read-only). Otherwise, use Brokk MCP tools yourself to

--- a/claude-plugin/skills/workspace/SKILL.md
+++ b/claude-plugin/skills/workspace/SKILL.md
@@ -38,8 +38,9 @@ No parameters.
 
 ## Tips
 
-- Always call `activate_workspace` before using any other Brokk tools when
-  starting work on a new project or switching repositories.
+- A workspace is already active at server startup (the directory the
+  server was launched from), so `activate_workspace` is only needed to
+  switch to a different repo, checkout, or worktree.
 - The server automatically resolves the given path upward to the nearest
   `.git` root, so you can pass a subdirectory path; the path must be absolute.
 - Use `get_active_workspace` to confirm which project root is currently active.

--- a/claude-plugin/skills/write-issue/SKILL.md
+++ b/claude-plugin/skills/write-issue/SKILL.md
@@ -46,8 +46,8 @@ has provided both a title and a description.
 
 ## Step 3 -- Enhance with Code Context
 
-1. Call `activate_workspace` with the current project path so Brokk
-   tools work.
+1. Confirm Brokk is analyzing this project with `get_active_workspace`;
+   call `activate_workspace` with the project path only if it differs.
 
 2. If the `Agent` tool is available, spawn a `brokk:issue-enhancer`
    agent, passing it the draft title and description. Do NOT use
@@ -61,7 +61,7 @@ has provided both a title and a description.
    - Extract keywords, class names, and technical terms from the draft.
    - Use `search_symbols` to locate matching symbols by name. For
      non-symbol text (string literals, error messages, configs), use
-     the built-in `Grep` tool.
+     `search_file_contents`.
    - Use `get_summaries` for an API overview and `get_symbol_sources`
      to read the affected method or class bodies.
    - Enhance the description with:


### PR DESCRIPTION
The plugin launched the MCP server via the removed `uvx brokk bifrost` entry point and its agents/skills described the bifrost v0.1.3 tool set. Update everything to bifrost 0.6.3 as launched by `uvx brokk mcp`:

- .mcp.json: launch via `uvx brokk mcp` (default searchtools profile exposes the full tool set, so no flags needed)
- Agents: replace the get_symbol_locations+Grep caller-tracing idiom with scan_usages, route text/file/git lookups through search_file_contents, find_filenames, get_file_contents and the git MCP tools, and add targeted code-quality tools (structural clones for dry-reviewer, secret scanning for security, god-object/complexity reports and symbol ancestors for architect, jq/xml tools for devops)
- Skills: rewrite code-navigation, code-reading, codebase-search and git-exploration around the new tools; drop the now-false "no caller-graph / no git tools / no file-contents tool" caveats; remove the no-longer-existing get_symbol_summaries; fix the most_relevant_files parameter name; make workspace activation conditional since a workspace is active at server startup; point "embedded prompt" fallbacks at the agents/ directory
- brokk-core/README.md: drop the broken `uvx brokk mcp-core` quick start and note the plugin now uses bifrost